### PR TITLE
DefaultViewModelLocator now chooses correct constructor

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/Application/MvxDefaultViewModelLocator.cs
+++ b/Cirrious/Cirrious.MvvmCross/Application/MvxDefaultViewModelLocator.cs
@@ -59,7 +59,7 @@ namespace Cirrious.MvvmCross.Application
             else
             {
                 // just in case there are no exact matches, just pick the first
-                var constructorParams = constructors.FirstOrDefault();
+                var constructor = constructors.FirstOrDefault();
 
                 // try and find an exact parameter-name match
                 if (specifiedParamCount > 0)
@@ -75,11 +75,11 @@ namespace Cirrious.MvvmCross.Application
                     if (exactMatch != null)
                     {
                         // there is an exact names match
-                        constructorParams = exactMatch;
+                        constructor = exactMatch;
                     }
                 }
 
-                if (constructorParams != null)
+                if (constructor != null)
                 {
                     // try and load a value out of the specifed parameters that
                     // match the constructor parameter name


### PR DESCRIPTION
This fix solves a problem where, when I have 2 constructors: `Hi()` and `Hi(string name)`, it will always choose `Hi()` even when I navigate with a parameter.

EG:

using the TweetSearch sample.
using this navigation code: `RequestNavigate<TwitterViewModel>(new { searchTerm = SearchText });`

If I add a parameterless constructor (now there are two constructors), the navigation ignores the searchTerm.
