### PR TITLE
Add more specific type constraints on IoC registration

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.OpenNetCFIoC/MvxOpenNetCfIocProvider.cs
+++ b/Cirrious/Cirrious.MvvmCross.OpenNetCFIoC/MvxOpenNetCfIocProvider.cs
@@ -40,7 +40,7 @@ namespace Cirrious.MvvmCross.OpenNetCfIoC
 
         public void RegisterServiceType<TFrom, TTo>()
             where TFrom : class
-            where TTo : class
+            where TTo : class, TFrom
         {
             MvxOpenNetCfContainer.Current.RegisterServiceType<TFrom, TTo>();
         }

--- a/Cirrious/Cirrious.MvvmCross/ExtensionMethods/MvxServiceProviderExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross/ExtensionMethods/MvxServiceProviderExtensions.cs
@@ -106,7 +106,7 @@ namespace Cirrious.MvvmCross.ExtensionMethods
 
         public static void RegisterServiceType<TInterface, TType>(this IMvxServiceProducer<TInterface> producer)
             where TInterface : class
-            where TType : class
+            where TType : class, TInterface
         {
             var registry = MvxServiceProvider.Instance;
             registry.RegisterServiceType<TInterface, TType>();
@@ -114,7 +114,7 @@ namespace Cirrious.MvvmCross.ExtensionMethods
 
         public static void RegisterServiceType<TInterface, TType>(this IMvxServiceProducer producer)
             where TInterface : class
-            where TType : class
+            where TType : class, TInterface
         {
             var registry = MvxServiceProvider.Instance;
             registry.RegisterServiceType<TInterface, TType>();

--- a/Cirrious/Cirrious.MvvmCross/Interfaces/IoC/IMvxIoCProvider.cs
+++ b/Cirrious/Cirrious.MvvmCross/Interfaces/IoC/IMvxIoCProvider.cs
@@ -23,7 +23,7 @@ namespace Cirrious.MvvmCross.Interfaces.IoC
             where T : class;
         void RegisterServiceType<TFrom, TTo>()
             where TFrom : class
-            where TTo : class;
+            where TTo : class, TFrom;
         void RegisterServiceInstance<TInterface>(TInterface theObject)
             where TInterface : class;
 		void RegisterServiceInstance<TInterface>(Func<TInterface> theConstructor)

--- a/Cirrious/Cirrious.MvvmCross/Interfaces/ServiceProvider/IMvxServiceProviderRegistry.cs
+++ b/Cirrious/Cirrious.MvvmCross/Interfaces/ServiceProvider/IMvxServiceProviderRegistry.cs
@@ -17,7 +17,7 @@ namespace Cirrious.MvvmCross.Interfaces.ServiceProvider
     {
         void RegisterServiceType<TInterface, TToConstruct>()
             where TInterface : class
-            where TToConstruct : class;
+            where TToConstruct : class, TInterface;
 		void RegisterServiceInstance<TInterface>(TInterface theObject)
 			where TInterface : class;
 		void RegisterServiceInstance<TInterface>(Func<TInterface> theConstructor)

--- a/Cirrious/Cirrious.MvvmCross/IoC/MvxSimpleIoCServiceProvider.cs
+++ b/Cirrious/Cirrious.MvvmCross/IoC/MvxSimpleIoCServiceProvider.cs
@@ -29,7 +29,7 @@ namespace Cirrious.MvvmCross.IoC
 
         public void RegisterServiceType<TFrom, TTo>() 
             where TFrom : class 
-            where TTo : class 
+            where TTo : class, TFrom
         {
             MvxSimpleIoCContainer.Instance.RegisterServiceType<TFrom, TTo>();
         }

--- a/Cirrious/Cirrious.MvvmCross/Platform/MvxServiceProvider.cs
+++ b/Cirrious/Cirrious.MvvmCross/Platform/MvxServiceProvider.cs
@@ -57,7 +57,7 @@ namespace Cirrious.MvvmCross.Platform
 
         public virtual void RegisterServiceType<TInterface, TToConstruct>()
             where TInterface : class 
-            where TToConstruct : class
+            where TToConstruct : class, TInterface
         {
 #if DEBUG
             if (_iocProvider == null)


### PR DESCRIPTION
This change just adds an extra type constraint to IoC registrations that is implied, but not actually enforced. This will allow for better compatibility with other containers that do explicitly enforce it. Either way I think it makes sense since it would stop you from creating a bad registration that could blow up at runtime.
