### PR TITLE
CheckboxElement: check if UITableViewCell is null before setting cell Accessory

### DIFF
--- a/CrossUI/CrossUI.Touch/Dialog/Elements/CheckboxElement.cs
+++ b/CrossUI/CrossUI.Touch/Dialog/Elements/CheckboxElement.cs
@@ -36,7 +36,10 @@ namespace CrossUI.Touch.Dialog.Elements
 
         private void SetCellCheckmark(UITableViewCell cell)
         {
-            cell.Accessory = Value ? UITableViewCellAccessory.Checkmark : UITableViewCellAccessory.None;
+            if (cell != null)
+            {
+                cell.Accessory = Value ? UITableViewCellAccessory.Checkmark : UITableViewCellAccessory.None;
+            }
         }
 
         protected override UITableViewCell GetCellImpl(UITableView tv)


### PR DESCRIPTION
There can be cases, depending on the order that Elements are added to Sections, where SetCellCheckmark is called before the UITableViewCell has been created.

Stuart - I've rebased my fork to your latest change, then re-committed the change, so you should be able to auto-merge now.
