### PR TITLE
Fix for RootElement Sections list

### DIFF
--- a/CrossUI/CrossUI.Touch/Dialog/Elements/RootElement.cs
+++ b/CrossUI/CrossUI.Touch/Dialog/Elements/RootElement.cs
@@ -97,6 +97,7 @@ namespace CrossUI.Touch.Dialog.Elements
         {
             _summarySection = section;
             _summaryElement = element;
+            Sections = new List<Section>();
         }
 
         /// <summary>
@@ -112,6 +113,7 @@ namespace CrossUI.Touch.Dialog.Elements
         public RootElement(string caption, Group group) : base(caption)
         {
             this.Group = group;
+            Sections = new List<Section>();
         }
 
         public List<Section> Sections { get; set; }


### PR DESCRIPTION
The RootElement class has a List of Sections. In MT.D this is initialised by [default](https://github.com/migueldeicaza/MonoTouch.Dialog#L2465). However in CrossUI.Dialog version of MT.D it is just a [getter/setter](https://github.com/slodge/MvvmCross/blob/vnext/CrossUI/CrossUI.Touch/Dialog/Elements/RootElement.cs#L117).

I've updated the constructors to make sure the list is initialised.
