### PR TITLE
Fix Sqlite ExecuteScalar regression.

### DIFF
--- a/Cirrious/Plugins/Sqlite/Cirrious.MvvmCross.Plugins.Sqlite/BaseClasses.cs
+++ b/Cirrious/Plugins/Sqlite/Cirrious.MvvmCross.Plugins.Sqlite/BaseClasses.cs
@@ -144,6 +144,8 @@ namespace Cirrious.MvvmCross.Plugins.Sqlite
 
         int Execute(string query, params object[] args);
 
+        T ExecuteScalar<T>(string query, params object[] args);
+
         List<T> Query<T>(string query, params object[] args) where T : new();
 
         IEnumerable<T> DeferredQuery<T>(string query, params object[] args) where T : new();


### PR DESCRIPTION
Commit [d0fe8eb6446160e117ae02ed4757e26191ecb687](https://github.com/slodge/MvvmCross/commit/d0fe8eb6446160e117ae02ed4757e26191ecb687) accidentally got rid of the ExecuteScalar method of the Sqlite plugin.
