### PR TITLE
Implement MvxChainedSourceBinding.SourceType by asking childBinding for it

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding/Bindings/Source/MvxChainedSourceBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding/Bindings/Source/MvxChainedSourceBinding.cs
@@ -55,7 +55,12 @@ namespace Cirrious.MvvmCross.Binding.Bindings.Source
 
         public override Type SourceType
         {
-            get { throw new NotImplementedException(); }
+            get
+            {
+                if (_currentChildBinding != null)
+                    return _currentChildBinding.SourceType;
+                throw new NotImplementedException();
+            }
         }
 
         private void UpdateChildBinding()


### PR DESCRIPTION
Previously trying to use a custom converter when using a MvxChainedSourceBinding would hit the NotImplementedException trying to find out the type to convert to.

Now we ask the child for the value, which seems like the right thing to do :-)
