### PR TITLE
Make EntryElement.BecomeFirstResponder(bool) virtual so it can be overridden

### DIFF
--- a/CrossUI/CrossUI.Touch/Dialog/Elements/EntryElement.cs
+++ b/CrossUI/CrossUI.Touch/Dialog/Elements/EntryElement.cs
@@ -376,7 +376,7 @@ namespace CrossUI.Touch.Dialog.Elements
         /// <param name="animated">
         /// Whether scrolling to the location of this cell should be animated
         /// </param>
-        public void BecomeFirstResponder(bool animated)
+        public virtual void BecomeFirstResponder(bool animated)
         {
             _becomeResponder = true;
             var tv = GetContainerTableView();


### PR DESCRIPTION
We have a MultilineEntryElement which requires this change so it can inherit from EntryElement.

We want it to inherit from EntryElement so the loop in EntryElement:263 will consider MultilineEntryElement's to become first responder.

On a side note, we have some other local changes you may be interested in, I can send PRs for any you'd like :) (They were mostly implemented by @jacobtoye)
- Added an Ended event to EntryElement which is fired when it stops being first responder. (We use it to save the field to the DB)
- MultilineEntryElement - uses a UITextView to be a multiline EntryElement, with placeholder text:

![Screen Shot 2013-02-10 at 4 02 09 PM](https://f.cloud.github.com/assets/393086/142858/5bab125c-732e-11e2-8691-ce7b0ea16881.png)
