### PR TITLE
Adding DrawableId binding for binding image views to drawable resource I...

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
@@ -56,6 +56,7 @@
     <Compile Include="MvxAndroidBindingResource.cs" />
     <Compile Include="Simple\MvxSimpleAndroidBindingSetup.cs" />
     <Compile Include="Simple\MvxSimpleEmptyAndroidApp.cs" />
+    <Compile Include="Target\MvxImageViewDrawableTargetBinding.cs" />
     <Compile Include="Target\MvxListViewSelectedItemTargetBinding.cs" />
     <Compile Include="Target\MvxAdapterViewSelectedItemPositionTargetBinding.cs" />
     <Compile Include="Target\MvxAutoCompleteTextViewPartialTextTargetBinding.cs" />
@@ -78,7 +79,7 @@
     <Compile Include="Views\MvxBindingActivityView.cs" />
     <Compile Include="Target\MvxBaseAndroidTargetBinding.cs" />
     <Compile Include="Target\MvxCompoundButtonCheckedTargetBinding.cs" />
-    <Compile Include="Target\MvxImageViewDrawableTargetBinding.cs" />
+    <Compile Include="Target\MvxImageViewImageTargetBinding.cs" />
     <Compile Include="Views\MvxBindingTabActivityView.cs" />
     <Compile Include="Simple\MvxSimpleBindingActivity.cs" />
     <Compile Include="Binders\MvxBindingLayoutInflatorFactory.cs" />

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/MvxAndroidBindingBuilder.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/MvxAndroidBindingBuilder.cs
@@ -58,6 +58,10 @@ namespace Cirrious.MvvmCross.Binding.Droid
                                                               "Progress"));
             registry.RegisterFactory(new MvxCustomBindingFactory<ImageView>("AssetImagePath",
                                                                             imageView =>
+                                                                            new MvxImageViewImageTargetBinding(
+                                                                                imageView)));
+            registry.RegisterFactory(new MvxCustomBindingFactory<ImageView>("DrawableId",
+                                                                            imageView =>
                                                                             new MvxImageViewDrawableTargetBinding(
                                                                                 imageView)));
             registry.RegisterFactory(new MvxCustomBindingFactory<MvxBindableSpinner>("SelectedItem",

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxImageViewImageTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxImageViewImageTargetBinding.cs
@@ -1,0 +1,69 @@
+// MvxImageViewImageTargetBinding.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using Android.Content.Res;
+using Android.Graphics;
+using Android.Graphics.Drawables;
+using Android.Widget;
+using Cirrious.MvvmCross.Binding.Interfaces;
+using Cirrious.MvvmCross.Interfaces.Platform.Diagnostics;
+
+namespace Cirrious.MvvmCross.Binding.Droid.Target
+{
+    public class MvxImageViewImageTargetBinding
+        : MvxBaseAndroidTargetBinding
+    {
+        private readonly ImageView _imageView;
+
+        public MvxImageViewImageTargetBinding(ImageView imageView)
+        {
+            _imageView = imageView;
+        }
+
+        public override MvxBindingMode DefaultMode
+        {
+            get { return MvxBindingMode.OneWay; }
+        }
+
+        public override Type TargetType
+        {
+            get { return typeof (string); }
+        }
+
+        public override void SetValue(object value)
+        {
+            if (value == null)
+            {
+                MvxBindingTrace.Trace(MvxTraceLevel.Warning, "Null value passed to ImageView binding");
+                return;
+            }
+
+            var stringValue = value as string;
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                MvxBindingTrace.Trace(MvxTraceLevel.Warning, "Empty value passed to ImageView binding");
+                return;
+            }
+
+            var drawableResourceName = GetImageAssetName(stringValue);
+
+            var assetStream = AndroidGlobals.ApplicationContext.Assets.Open(drawableResourceName);
+
+            var options = new BitmapFactory.Options() { InPurgeable = true };
+            var bitmap = BitmapFactory.DecodeStream(assetStream, null, options);
+            var drawable = new BitmapDrawable(Resources.System, bitmap);
+            _imageView.SetImageDrawable(drawable);
+           
+        }
+
+        private static string GetImageAssetName(string rawImage)
+        {
+            return rawImage.TrimStart('/');
+        }
+    }
+}


### PR DESCRIPTION
Adding a drawableId binding - so you can bind an image view to a drawable resouce Id. Really designed to be used with a converter.
