### PR TITLE
Removing AfterBuild CustomCommands

### DIFF
--- a/PortableSupport/System.Net/System.Net.Droid.csproj
+++ b/PortableSupport/System.Net/System.Net.Droid.csproj
@@ -23,11 +23,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CustomCommands Condition="'$(OS)' != 'Windows_NT'">
-      <CustomCommands>
-        <Command type="AfterBuild" command="mv System.Net.Droid.dll System.Net.dll" workingdir="${TargetDir}" />
-      </CustomCommands>
-    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,11 +31,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CustomCommands Condition="'$(OS)' != 'Windows_NT'">
-      <CustomCommands>
-        <Command type="AfterBuild" command="mv System.Net.Droid.dll System.Net.dll" workingdir="${TargetDir}" />
-      </CustomCommands>
-    </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />


### PR DESCRIPTION
Removed the parts below (twice) as they break the build on Xamarin Studio (and removing them doesn't break the build on VS)
Also, as far as I understand, a non-Windows OS won't have that conflict and won't need using this assembly in the first place.

```
<CustomCommands Condition="'$(OS)' != 'Windows_NT'">
  <CustomCommands>
    <Command type="AfterBuild" command="mv System.Net.Droid.dll System.Net.dll" workingdir="${TargetDir}" />
  </CustomCommands>
</CustomCommands>
```
