### PR TITLE
Remove HackFileShare-Folder / Add FullPath to interface

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid/Cirrious.MvvmCross.Droid.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Cirrious.MvvmCross.Droid.csproj
@@ -87,7 +87,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\CrossCore\Cirrious.CrossCore.Droid\Cirrious.CrossCore.Droid.csproj">
-      <Project>{CAF8935F-56FE-4485-9D34-4A38FE79F6C9}</Project>
+      <Project>{caf8935f-56fe-4485-9d34-4a38fe79f6c9}</Project>
       <Name>Cirrious.CrossCore.Droid</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\CrossCore\Cirrious.CrossCore\Cirrious.CrossCore.csproj">

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Droid/Cirrious.MvvmCross.Plugins.File.Droid.csproj
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Droid/Cirrious.MvvmCross.Plugins.File.Droid.csproj
@@ -43,7 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Cirrious.MvvmCross.Plugins.File\HackFileShare\MvxBaseFileStore.cs">
+    <Compile Include="..\Cirrious.MvvmCross.Plugins.File\MvxBaseFileStore.cs">
       <Link>MvxBaseFileStore.cs</Link>
     </Compile>
     <Compile Include="MvxAndroidFileStore.cs" />

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Droid/MvxAndroidFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Droid/MvxAndroidFileStore.cs
@@ -34,7 +34,7 @@ namespace Cirrious.MvvmCross.Plugins.File.Droid
             }
         }
 
-        protected override string FullPath(string path)
+        public override string FullPath(string path)
         {
             return Path.Combine(Context.FilesDir.Path, path);
         }

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Touch/Cirrious.MvvmCross.Plugins.File.Touch.csproj
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Touch/Cirrious.MvvmCross.Plugins.File.Touch.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
-    <Compile Include="..\Cirrious.MvvmCross.Plugins.File\HackFileShare\MvxBaseFileStore.cs">
+    <Compile Include="..\Cirrious.MvvmCross.Plugins.File\MvxBaseFileStore.cs">
       <Link>MvxBaseFileStore.cs</Link>
     </Compile>
     <Compile Include="MvxTouchFileStore.cs" />
@@ -72,7 +72,7 @@
   -->
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" ProjectLinkReference="6c3da376-dc4a-4b8c-924d-070c19f72bb7" />
+      <UserProperties ProjectLinkReference="6c3da376-dc4a-4b8c-924d-070c19f72bb7" ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Touch/MvxTouchFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Touch/MvxTouchFileStore.cs
@@ -14,7 +14,7 @@ namespace Cirrious.MvvmCross.Plugins.File.Touch
     {
         public const string ResScheme = "res:";
 
-        protected override string FullPath(string path)
+        public override string FullPath(string path)
         {
             if (path.StartsWith(ResScheme))
                 return path.Substring(ResScheme.Length);

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsPhone/MvxIsolatedStorageFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsPhone/MvxIsolatedStorageFileStore.cs
@@ -46,6 +46,11 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsPhone
             return Path.Combine(items0, items1);
         }
 
+        public string FullPath(string path)
+        {
+            return path;
+        }
+
         public void EnsureFolderExists(string folderPath)
         {
             using (var isf = IsolatedStorageFile.GetUserStoreForApplication())

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -155,6 +155,11 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
             return Path.Combine(items0, items1);
         }
 
+        public string FullPath(string path)
+        {
+            return path;
+        }
+
         public void EnsureFolderExists(string folderPath)
         {
             throw new NotImplementedException("Need to implement this - doesn't seem obvious from the StorageFolder API");

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Wpf/Cirrious.MvvmCross.Plugins.File.Wpf.csproj
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Wpf/Cirrious.MvvmCross.Plugins.File.Wpf.csproj
@@ -41,7 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Cirrious.MvvmCross.Plugins.File\HackFileShare\MvxBaseFileStore.cs">
+    <Compile Include="..\Cirrious.MvvmCross.Plugins.File\MvxBaseFileStore.cs">
       <Link>MvxBaseFileStore.cs</Link>
     </Compile>
     <Compile Include="MvxWpfFileStore.cs" />

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Wpf/MvxWpfFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.Wpf/MvxWpfFileStore.cs
@@ -12,7 +12,7 @@ namespace Cirrious.MvvmCross.Plugins.File.Wpf
 {
     public class MvxWpfFileStore : MvxFileStore
     {
-        protected override string FullPath(string path)
+        public override string FullPath(string path)
         {
             return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), path);
         }

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/Cirrious.MvvmCross.Plugins.File.csproj
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/Cirrious.MvvmCross.Plugins.File.csproj
@@ -42,7 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="HackFileShare\MvxBaseFileStore.cs" />
+    <None Include="MvxBaseFileStore.cs" />
     <Compile Include="IMvxFileStore.cs" />
     <Compile Include="PluginLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/IMvxFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/IMvxFileStore.cs
@@ -28,6 +28,8 @@ namespace Cirrious.MvvmCross.Plugins.File
         bool FolderExists(string folderPath);
         string PathCombine(string items0, string items1);
 
+        string FullPath(string path);
+
         void EnsureFolderExists(string folderPath);
         IEnumerable<string> GetFilesIn(string folderPath);
         void DeleteFile(string path);

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/MvxBaseFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/MvxBaseFileStore.cs
@@ -167,7 +167,7 @@ namespace Cirrious.MvvmCross.Plugins.File
 
         #endregion
 
-        protected abstract string FullPath(string path);
+        public abstract string FullPath(string path);
 
         private void WriteFileCommon(string path, Action<Stream> streamAction)
         {


### PR DESCRIPTION
Remove the Folder HackFileShare.. why was this one there? :-)

I want to have FullPath to be on the IMvxFileStore interface. This is used to get the full path of files .

May have to find a better name for "FullPath".

Example: 
I want to extract a zip file I wrote to disk. For this I have to provide the full path to my zip-library. 
