### PR TITLE
Variable needs to be static or else there's a chance the state we store ...

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxSplashScreenActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxSplashScreenActivity.cs
@@ -22,9 +22,10 @@ namespace Cirrious.MvvmCross.Droid.Views
         private const int NoContent = 0;
 
         private static MvxAndroidSetup _setup;
+        private static bool _secondStageRequested = false;
 
         private readonly int _resourceId;
-        private bool _secondStageRequested;
+
 
         public new MvxNullViewModel ViewModel
         {


### PR DESCRIPTION
...about the MvxAndroidSetup and the sate of the setup divert if the MvxSplashScreenActivity gets garbage collected and re-created from the handle.

See #271
