### PR TITLE
Fixed stack overflow in MvxDatePicker

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxDatePicker.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxDatePicker.cs
@@ -42,7 +42,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
                     Init(javaYear, javaMonth, javaDay, new MvxDateChangedListener(this));
                     _initialised = true;
                 }
-                else
+                else if (Year!=javaYear || Month!=javaMonth||DayOfMonth!=javaDay)
                 {
                     UpdateDate(javaYear, javaMonth, javaDay);
                 }


### PR DESCRIPTION
MvxDatePicker could get stuck in a loop with its own listener calling
InternalSetValueAndRaiseChange, which sets Value, which calls
UpdateDate, which triggers the listener again, etc.
