### PR TITLE
the ITableQuery abstraction in SQLite plugin prevents you from running anything but `select *`

### DIFF
--- a/Plugins/Cirrious/Sqlite/Cirrious.MvvmCross.Plugins.Sqlite/BaseClasses.cs
+++ b/Plugins/Cirrious/Sqlite/Cirrious.MvvmCross.Plugins.Sqlite/BaseClasses.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace Cirrious.MvvmCross.Plugins.Sqlite
 {
@@ -183,5 +184,26 @@ namespace Cirrious.MvvmCross.Plugins.Sqlite
 
     public interface ITableQuery<T> : IEnumerable<T> where T : new()
     {
+        ITableQuery<T> Where(Expression<Func<T, bool>> predExpr);
+        ITableQuery<T> Take(int n);
+        ITableQuery<T> Skip(int n);
+        T ElementAt(int index);
+        ITableQuery<T> OrderBy<U>(Expression<Func<T, U>> orderExpr);
+        ITableQuery<T> OrderByDescending<U>(Expression<Func<T, U>> orderExpr);
+
+        ITableQuery<TResult> Join<TInner, TKey, TResult>(
+            ITableQuery<TInner> inner,
+            Expression<Func<T, TKey>> outerKeySelector,
+            Expression<Func<TInner, TKey>> innerKeySelector,
+            Expression<Func<T, TInner, TResult>> resultSelector)
+            where TInner : new()
+            where TResult : new();
+
+        ITableQuery<TResult> Select<TResult>(Expression<Func<T, TResult>> selector)
+            where TResult : new();
+
+        int Count();
+        T First();
+        T FirstOrDefault();
     }
 }

--- a/Plugins/Cirrious/Sqlite/Cirrious.MvvmCross.Plugins.Sqlite/SharedFile/SQLiteNet.cs
+++ b/Plugins/Cirrious/Sqlite/Cirrious.MvvmCross.Plugins.Sqlite/SharedFile/SQLiteNet.cs
@@ -2183,7 +2183,7 @@ namespace SQLite
             return q;
         }
 
-        public TableQuery<T> Where(Expression<Func<T, bool>> predExpr)
+        public ITableQuery<T> Where(Expression<Func<T, bool>> predExpr)
         {
             if (predExpr.NodeType == ExpressionType.Lambda)
             {
@@ -2199,14 +2199,14 @@ namespace SQLite
             }
         }
 
-        public TableQuery<T> Take(int n)
+        public ITableQuery<T> Take(int n)
         {
             var q = Clone<T>();
             q._limit = n;
             return q;
         }
 
-        public TableQuery<T> Skip(int n)
+        public ITableQuery<T> Skip(int n)
         {
             var q = Clone<T>();
             q._offset = n;
@@ -2227,12 +2227,12 @@ namespace SQLite
             return q;
         }
 
-        public TableQuery<T> OrderBy<U>(Expression<Func<T, U>> orderExpr)
+        public ITableQuery<T> OrderBy<U>(Expression<Func<T, U>> orderExpr)
         {
             return AddOrderBy(orderExpr, true);
         }
 
-        public TableQuery<T> OrderByDescending<U>(Expression<Func<T, U>> orderExpr)
+        public ITableQuery<T> OrderByDescending<U>(Expression<Func<T, U>> orderExpr)
         {
             return AddOrderBy(orderExpr, false);
         }
@@ -2280,8 +2280,8 @@ namespace SQLite
             }
         }
 
-        public TableQuery<TResult> Join<TInner, TKey, TResult>(
-            TableQuery<TInner> inner,
+        public ITableQuery<TResult> Join<TInner, TKey, TResult>(
+            ITableQuery<TInner> inner,
             Expression<Func<T, TKey>> outerKeySelector,
             Expression<Func<TInner, TKey>> innerKeySelector,
             Expression<Func<T, TInner, TResult>> resultSelector)
@@ -2292,14 +2292,14 @@ namespace SQLite
                 {
                     _joinOuter = this,
                     _joinOuterKeySelector = outerKeySelector,
-                    _joinInner = inner,
+                    _joinInner = (BaseTableQuery)inner,
                     _joinInnerKeySelector = innerKeySelector,
                     _joinSelector = resultSelector,
                 };
             return q;
         }
 
-        public TableQuery<TResult> Select<TResult>(Expression<Func<T, TResult>> selector)
+        public ITableQuery<TResult> Select<TResult>(Expression<Func<T, TResult>> selector)
             where TResult : new()
         {
             var q = Clone<TResult>();


### PR DESCRIPTION
A TableQuery<T> has methods like `Where(Expression...)` and `Orderby` and `Take` that translate into SQL code so that SQLite can return you subsets of entire tables. When you hide a `TableQuery<T>` behind an `ITableQuery<T>` you prevent these methods from being called, meaning that all calls into SQLite select all rows from the entire table, which is then filtered in-memory.

This will have HUGE performance implications.
