### PR TITLE
Avoid NullReferenceException when casting null to value type

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding/ExtensionMethods/MvxTypeExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding/ExtensionMethods/MvxTypeExtensions.cs
@@ -29,8 +29,11 @@ namespace Cirrious.MvvmCross.Binding.ExtensionMethods
             {
                 if (propertyType.IsValueType && propertyType.IsGenericType)
                 {
-                    var underlyingType = Nullable.GetUnderlyingType(propertyType);
-                    safeValue = Convert.ChangeType(value, underlyingType, CultureInfo.CurrentUICulture);
+                    if (value != null)
+                    {
+                        var underlyingType = Nullable.GetUnderlyingType (propertyType);
+                        safeValue = Convert.ChangeType (value, underlyingType, CultureInfo.CurrentUICulture);
+                    }
                 }
                 else if (propertyType == typeof (string))
                 {


### PR DESCRIPTION
Hi Stuart,
Here is a pull request for a problem I often encounter with MvvmCross.
Bindings on `Nullable<>`  fail when trying to assign `null`.  This is due to the fact that casting `null` to a value type will throw a `NullReferenceException`.
