### PR TITLE
Dispose IDisposible singletons.

### DIFF
--- a/CrossCore/Cirrious.CrossCore/Core/MvxSingleton.cs
+++ b/CrossCore/Cirrious.CrossCore/Core/MvxSingleton.cs
@@ -71,6 +71,10 @@ namespace Cirrious.CrossCore.Core
         {
             if (isDisposing)
             {
+                IDisposable disposable = Instance as IDisposable;
+                if (disposable != null)
+                    disposable.Dispose();
+
                 Instance = null;
             }
         }


### PR DESCRIPTION
Since there is a Dispose() method on MvxSingleton, you should Dispose any Instance that is IDisposable.
