### PR TITLE
Remove unneeded System.ServiceModel references

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.AutoView/Cirrious.MvvmCross.AutoView.csproj
+++ b/Cirrious/Cirrious.MvvmCross.AutoView/Cirrious.MvvmCross.AutoView.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Serialization" />

--- a/CrossUI/CrossUI.Core/CrossUI.Core.csproj
+++ b/CrossUI/CrossUI.Core/CrossUI.Core.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Serialization" />
   </ItemGroup>

--- a/Plugins/Cirrious/Bookmarks/Cirrious.MvvmCross.Plugins.Bookmarks/Cirrious.MvvmCross.Plugins.Bookmarks.csproj
+++ b/Plugins/Cirrious/Bookmarks/Cirrious.MvvmCross.Plugins.Bookmarks/Cirrious.MvvmCross.Plugins.Bookmarks.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/Color/Cirrious.MvvmCross.Plugins.Color/Cirrious.MvvmCross.Plugins.Color.csproj
+++ b/Plugins/Cirrious/Color/Cirrious.MvvmCross.Plugins.Color/Cirrious.MvvmCross.Plugins.Color.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.csproj
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email/Cirrious.MvvmCross.Plugins.Email.csproj
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email/Cirrious.MvvmCross.Plugins.Email.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/Cirrious.MvvmCross.Plugins.File.csproj
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/Cirrious.MvvmCross.Plugins.File.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/Json/Cirrious.MvvmCross.Plugins.Json/Cirrious.MvvmCross.Plugins.Json.csproj
+++ b/Plugins/Cirrious/Json/Cirrious.MvvmCross.Plugins.Json/Cirrious.MvvmCross.Plugins.Json.csproj
@@ -41,7 +41,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Serialization" />
   </ItemGroup>

--- a/Plugins/Cirrious/JsonLocalisation/Cirrious.MvvmCross.Plugins.JsonLocalisation/Cirrious.MvvmCross.Plugins.JsonLocalisation.csproj
+++ b/Plugins/Cirrious/JsonLocalisation/Cirrious.MvvmCross.Plugins.JsonLocalisation/Cirrious.MvvmCross.Plugins.JsonLocalisation.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/Cirrious.MvvmCross.Plugins.Location.csproj
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/Cirrious.MvvmCross.Plugins.Location.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/PhoneCall/Cirrious.MvvmCross.Plugins.PhoneCall/Cirrious.MvvmCross.Plugins.PhoneCall.csproj
+++ b/Plugins/Cirrious/PhoneCall/Cirrious.MvvmCross.Plugins.PhoneCall/Cirrious.MvvmCross.Plugins.PhoneCall.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/PictureChooser/Cirrious.MvvmCross.Plugins.PictureChooser/Cirrious.MvvmCross.Plugins.PictureChooser.csproj
+++ b/Plugins/Cirrious/PictureChooser/Cirrious.MvvmCross.Plugins.PictureChooser/Cirrious.MvvmCross.Plugins.PictureChooser.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/ResourceLoader/Cirrious.MvvmCross.Plugins.ResourceLoader/Cirrious.MvvmCross.Plugins.ResourceLoader.csproj
+++ b/Plugins/Cirrious/ResourceLoader/Cirrious.MvvmCross.Plugins.ResourceLoader/Cirrious.MvvmCross.Plugins.ResourceLoader.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/Share/Cirrious.MvvmCross.Plugins.Share/Cirrious.MvvmCross.Plugins.Share.csproj
+++ b/Plugins/Cirrious/Share/Cirrious.MvvmCross.Plugins.Share/Cirrious.MvvmCross.Plugins.Share.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Cirrious/SoundEffects/Cirrious.MvvmCross.Plugins.SoundEffects/Cirrious.MvvmCross.Plugins.SoundEffects.csproj
+++ b/Plugins/Cirrious/SoundEffects/Cirrious.MvvmCross.Plugins.SoundEffects/Cirrious.MvvmCross.Plugins.SoundEffects.csproj
@@ -38,7 +38,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Xamarin is requiring a business license to use System.ServiceModel.

Fixes for Issue #394 (except XmlSerializerFormatAttribute in System.Xml.Serialization).
