### PR TITLE
Do change dependency to libraries instead of Starter Package

### DIFF
--- a/nuspec/MvvmCross.HotTuna.Droid.Fragging.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Droid.Fragging.3.0.1.nuspec
@@ -9,7 +9,7 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>This package contains the 'Droid Fragment' assemblies for MvvmCross v3 - Hot Tuna. This and other packages are currently under development...</description>
 		<dependencies>
-		  <dependency id="MvvmCross.HotTuna.StarterPack" version="3.0.12" />
+		  <dependency id="MvvmCross.HotTuna.MvvmCrossLibraries" version="3.0.12" />
 		</dependencies>
 	</metadata>
 	<files>		


### PR DESCRIPTION
Use MvvmCrossLibraries as Dependency for Nuget as I do not want to include all of this "FirstView" stuff when updating or adding the fragging stuff... 
