### PR TITLE
Mod to additionally match *ViewController to *ViewModel for iOS and Mac

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxViewModelViewTypeFinder.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxViewModelViewTypeFinder.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Cirrious.CrossCore.IoC;
 using Cirrious.CrossCore.Platform;
 using Cirrious.MvvmCross.Views;
+using System.Text.RegularExpressions;
 
 namespace Cirrious.MvvmCross.ViewModels
 {
@@ -62,6 +63,7 @@ namespace Cirrious.MvvmCross.ViewModels
         protected virtual Type LookupNamedViewModelType(Type candidateType)
         {
             var viewName = candidateType.Name;
+			viewName = Regex.Replace (viewName, "Controller$", "");
             var viewModelName = viewName + "Model";
 
             Type toReturn;


### PR DESCRIPTION
Enables automatic matching of *ViewController to *ViewModel so that an MvxViewController doesn't have to be renamed as XView when it also has a view itself.
