### PR TITLE
Fixed an issue when INotifyCollectionChanged.CollectionChanged event stripped by Xamarin linker.

### DIFF
--- a/CrossCore/Cirrious.CrossCore/WeakSubscription/MvxNotifyCollectionChangedEventSubscription.cs
+++ b/CrossCore/Cirrious.CrossCore/WeakSubscription/MvxNotifyCollectionChangedEventSubscription.cs
@@ -16,6 +16,16 @@ namespace Cirrious.CrossCore.WeakSubscription
     {
         private static readonly EventInfo EventInfo = typeof (INotifyCollectionChanged).GetEvent("CollectionChanged");
 
+        static MvxNotifyCollectionChangedEventSubscription()
+        {
+            // This code ensures the CollectionChanged event is not stripped by Xamarin linker
+            INotifyCollectionChanged collection = null;
+            if (collection != null)
+            {
+                collection.CollectionChanged += (sender, e) => { };
+            }
+        }
+
         public MvxNotifyCollectionChangedEventSubscription(INotifyCollectionChanged source,
                                                            EventHandler<NotifyCollectionChangedEventArgs>
                                                                targetEventHandler)


### PR DESCRIPTION
Fix to the issue https://github.com/MvvmCross/MvvmCross-Binaries/issues/3

The code is stupid, but it do the job.
In case we assume the linker would be smarter in the future to understand that collection is always null maybe the next trick could be used:

``` c#
//INotifyCollectionChanged collection = null;
INotifyCollectionChanged collection = new object() as INotifyCollectionChanged;
```
