### PR TITLE
fix android html email text parsing 

### DIFF
--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.Content;
+using Android.Text;
 using Cirrious.CrossCore.Droid.Platform;
 
 namespace Cirrious.MvvmCross.Plugins.Email.Droid
@@ -26,9 +27,14 @@ namespace Cirrious.MvvmCross.Plugins.Email.Droid
 
             emailIntent.PutExtra(global::Android.Content.Intent.ExtraSubject, subject ?? string.Empty);
 
-            emailIntent.SetType(isHtml ? "text/html" : "text/plain");
-
-            emailIntent.PutExtra(global::Android.Content.Intent.ExtraText, body ?? string.Empty);
+            if (isHtml) {
+                emailIntent.SetType ("text/html");
+                emailIntent.PutExtra (global::Android.Content.Intent.ExtraText,
+                    string.IsNullOrEmpty (body) ? Html.FromHtml (string.Empty) : Html.FromHtml (body));
+            } else {
+                emailIntent.SetType ("text/plain");
+                emailIntent.PutExtra (global::Android.Content.Intent.ExtraText, body ?? string.Empty);
+            }
 
             StartActivity(emailIntent);
         }


### PR DESCRIPTION
Currently android html email message is shown as text with all the tags etc...

See:
http://www.nowherenearithaca.com/2011/10/some-notes-for-sending-html-email-in.html
http://blog.iangclifton.com/2010/05/17/sending-html-email-with-android-intent/
