### PR TITLE
Fix for wrong inflation

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/IMvxAndroidBindingContext.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/IMvxAndroidBindingContext.cs
@@ -15,6 +15,6 @@ namespace Cirrious.MvvmCross.Binding.Droid.BindingContext
         : IMvxBindingContext
     {
         IMvxLayoutInflater LayoutInflater { get; set; }
-        View BindingInflate(int resourceId, ViewGroup viewGroup);
+        View BindingInflate(int resourceId, ViewGroup viewGroup, bool attachToParent);
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxAndroidBindingContext.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxAndroidBindingContext.cs
@@ -45,16 +45,17 @@ namespace Cirrious.MvvmCross.Binding.Droid.BindingContext
             }
         }
 
-        public virtual View BindingInflate(int resourceId, ViewGroup viewGroup)
+        public virtual View BindingInflate(int resourceId, ViewGroup viewGroup, bool attachToParent)
         {
             var view = CommonInflate(
                 resourceId,
                 viewGroup,
+                attachToParent,
                 FactoryFactory.Create(DataContext));
             return view;
         }
 
-        protected virtual View CommonInflate(int resourceId, ViewGroup viewGroup,
+        protected virtual View CommonInflate(int resourceId, ViewGroup viewGroup, bool attachToParent,
                                              IMvxLayoutInfactorFactory factory)
         {
             using (new MvxBindingContextStackRegistration<IMvxAndroidBindingContext>(this))
@@ -68,7 +69,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.BindingContext
                         {
                             clone.Factory = factory;
                         }
-                        var toReturn = clone.Inflate(resourceId, viewGroup);
+                        var toReturn = clone.Inflate(resourceId, viewGroup, attachToParent);
                         if (factory != null)
                         {
                             RegisterBindingsWithClearKey(toReturn, factory.CreatedBindings);

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxBindingContextOwnerExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxBindingContextOwnerExtensions.cs
@@ -15,7 +15,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.BindingContext
         public static View BindingInflate(this IMvxBindingContextOwner owner, int resourceId, ViewGroup viewGroup)
         {
             var context = (IMvxAndroidBindingContext) owner.BindingContext;
-            return context.BindingInflate(resourceId, viewGroup);
+            return context.BindingInflate(resourceId, viewGroup, false);
         }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAdapter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAdapter.cs
@@ -208,14 +208,14 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
 
             var source = GetRawItem(position);
 
-            return GetBindableView(convertView, source, templateId);
+            return GetBindableView(convertView, parent, source, templateId);
         }
 
-        protected virtual View GetSimpleView(View convertView, object dataContext)
+        protected virtual View GetSimpleView(View convertView, ViewGroup parent, object dataContext)
         {
             if (convertView == null)
             {
-                convertView = CreateSimpleView(dataContext);
+                convertView = CreateSimpleView(parent, dataContext);
             }
             else
             {
@@ -234,25 +234,25 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             }
         }
 
-        protected virtual View CreateSimpleView(object dataContext)
+        protected virtual View CreateSimpleView(ViewGroup parent, object dataContext)
         {
             // note - this could technically be a non-binding inflate - but the overhead is minimal
-            var view = _bindingContext.BindingInflate(_currentSimpleId, null);
+            var view = _bindingContext.BindingInflate(_currentSimpleId, parent, false);
             BindSimpleView(view, dataContext);
             return view;
         }
 
-        protected virtual View GetBindableView(View convertView, object dataContext)
+        protected virtual View GetBindableView(View convertView, ViewGroup parent, object dataContext)
         {
-            return GetBindableView(convertView, dataContext, ItemTemplateId);
+            return GetBindableView(convertView, parent, dataContext, ItemTemplateId);
         }
 
-        protected virtual View GetBindableView(View convertView, object dataContext, int templateId)
+        protected virtual View GetBindableView(View convertView, ViewGroup parent, object dataContext, int templateId)
         {
             if (templateId == 0)
             {
                 // no template seen - so use a standard string view from Android and use ToString()
-                return GetSimpleView(convertView, dataContext);
+                return GetSimpleView(convertView, parent, dataContext);
             }
 
             // we have a templateid so lets use bind and inflate on it :)
@@ -267,7 +267,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
 
             if (viewToUse == null)
             {
-                viewToUse = CreateBindableView(dataContext, templateId);
+                viewToUse = CreateBindableView(parent, dataContext, templateId);
             }
             else
             {
@@ -282,9 +282,9 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             viewToUse.DataContext = source;
         }
 
-        protected virtual IMvxListItemView CreateBindableView(object dataContext, int templateId)
+        protected virtual IMvxListItemView CreateBindableView(ViewGroup parent, object dataContext, int templateId)
         {
-            return new MvxListItemView(_context, _bindingContext.LayoutInflater, dataContext, templateId);
+            return new MvxListItemView(_context, _bindingContext.LayoutInflater, parent, dataContext, templateId);
         }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxFrameControl.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxFrameControl.cs
@@ -45,7 +45,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
                     if (Content == null && _templateId != 0)
                     {
                         Mvx.Trace("DataContext is {0}", DataContext == null ? "Null" : DataContext.ToString());
-                        Content = _bindingContext.BindingInflate(_templateId, this);
+                        Content = _bindingContext.BindingInflate(_templateId, this, true);
                     }
                 });
         }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxListItemView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxListItemView.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.Content;
+using Android.Views;
 
 namespace Cirrious.MvvmCross.Binding.Droid.Views
 {
@@ -17,12 +18,13 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
 
         public MvxListItemView(Context context,
                                IMvxLayoutInflater layoutInflater,
+                               ViewGroup parent,
                                object dataContext,
                                int templateId)
             : base(context, layoutInflater, dataContext)
         {
             _templateId = templateId;
-            Content = AndroidBindingContext.BindingInflate(templateId, this);
+            Content = AndroidBindingContext.BindingInflate(templateId, this, true);
         }
 
         public int TemplateId


### PR DESCRIPTION
Related to #507

This fixes issues with layouts being inflated incorrectly, seen especially with Spinner controls, where `LayoutParameters` are not respected, because the `MvxListItemView` did not get added to the parents view hierarchy.

`MvxFrameControl` was also altered and needs appropriate testing. However `MvxSpinner` now seems to work correctly and has been tested on 4.3.1 and 4.4.2
