### PR TITLE
Access to IMvxValueConverter from native wrapper

### DIFF
--- a/CrossCore/Cirrious.CrossCore.WindowsPhone/Converters/MvxNativeValueConverter.cs
+++ b/CrossCore/Cirrious.CrossCore.WindowsPhone/Converters/MvxNativeValueConverter.cs
@@ -18,6 +18,11 @@ namespace Cirrious.CrossCore.WindowsPhone.Converters
     {
         private readonly IMvxValueConverter _wrapped;
 
+        protected IMvxValueConverter Wrapped
+        {
+            get { return _wrapped; }
+        }
+
         public MvxNativeValueConverter(IMvxValueConverter wrapped)
         {
             _wrapped = wrapped;
@@ -56,6 +61,11 @@ namespace Cirrious.CrossCore.WindowsPhone.Converters
         : MvxNativeValueConverter
         where T : IMvxValueConverter, new()
     {
+        protected new T Wrapped
+        {
+            get { return (T)base.Wrapped; }
+        }
+
         public MvxNativeValueConverter() : base(new T())
         {
         }


### PR DESCRIPTION
Hi,

I added a protected read-only property to `MvxNativeValueConverter` to provide access to the wrapped protable `IMvxValueConverter`.

With this change it is possible to create portable converters with public properties which can be used configure the behavior of converters. A simple example:

```
public class BoolToTextConverter : MvxValueConverter<bool, string>
{
    public string TrueValue { get; set; }
    public string FalseValue { get; set; }

    protected override string Convert(bool value, Type targetType, object parameter, CultureInfo culture)
    {
        return value ? TrueValue : FalseValue;
    }
}
```

The native wrapper can now look like this:

```
public class NativeBoolToTextConverter :
    MvxNativeValueConverter<BoolToTextConverter>
{
    public string TrueValue
    {
        get { return Wrapped.TrueValue; }
        set { Wrapped.TrueValue = value; }
    }

    public string FalseValue
    {
        get { return Wrapped.FalseValue; }
        set { Wrapped.FalseValue = value; }
    }
}
```

This is how it would be instantiated in XAML:

```
<conv:NativeBoolToTextConverter x:Key="OnOffConverter" TrueValue="On" FalseValue="Off" />
```

For other binding modes one can always create derived converters which initialize the properties in their constructor as required:

```
public OnOffConverter : BoolToTextConverter
{
    public OnOffConverter
    {
        TrueValue = "On";
        FalseValue = "Off";
    }
}
```
