### PR TITLE
Virtual Convert and ConvertBack methods in MvxNativeValueConverter

### DIFF
--- a/CrossCore/Cirrious.CrossCore.WindowsPhone/Converters/MvxNativeValueConverter.cs
+++ b/CrossCore/Cirrious.CrossCore.WindowsPhone/Converters/MvxNativeValueConverter.cs
@@ -28,13 +28,13 @@ namespace Cirrious.CrossCore.WindowsPhone.Converters
             _wrapped = wrapped;
         }
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public virtual object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var toReturn = _wrapped.Convert(value, targetType, parameter, culture);
             return MapIfSpecialValue(toReturn);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public virtual object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var toReturn = _wrapped.ConvertBack(value, targetType, parameter, culture);
             return MapIfSpecialValue(toReturn);

--- a/CrossCore/Cirrious.CrossCore.WindowsStore/Converters/MvxNativeValueConverter.cs
+++ b/CrossCore/Cirrious.CrossCore.WindowsStore/Converters/MvxNativeValueConverter.cs
@@ -28,14 +28,14 @@ namespace Cirrious.CrossCore.WindowsStore.Converters
             _wrapped = wrapped;
         }
 
-        public object Convert(object value, Type targetType, object parameter, string language)
+        public virtual object Convert(object value, Type targetType, object parameter, string language)
         {
             // note - Language ignored here!
             var toReturn = _wrapped.Convert(value, targetType, parameter, CultureInfo.CurrentUICulture);
             return MapIfSpecialValue(toReturn);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        public virtual object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             // note - Language ignored here!
             var toReturn = _wrapped.ConvertBack(value, targetType, parameter, CultureInfo.CurrentUICulture);

--- a/CrossCore/Cirrious.CrossCore.Wpf/Converters/MvxNativeValueConverter.cs
+++ b/CrossCore/Cirrious.CrossCore.Wpf/Converters/MvxNativeValueConverter.cs
@@ -28,13 +28,13 @@ namespace Cirrious.CrossCore.Wpf.Converters
             get { return _wrapped; }
         }
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public virtual object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var toReturn = _wrapped.Convert(value, targetType, parameter, culture);
             return MapIfSpecialValue(toReturn);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public virtual object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var toReturn = _wrapped.ConvertBack(value, targetType, parameter, culture);
             return MapIfSpecialValue(toReturn);


### PR DESCRIPTION
Hi,

I made `Convert` and `ConvertBack` methods in `MvxNativeValueConverter` virtual to make it possible to override them in the native converter class deriving from `MvxNativeValueConverter`.

This is useful when when the native converter needs to return a native class not available in a portable class library, such as `BitmapImage`. Now it's possible to create an `IMvxValueConverter` returning a `Uri` and just pass it to a `BitmapImage` in the native wrapper:

```
public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
{
    var uri =  base.Convert(value, targetType, parameter, culture) as Uri;
    return uri == null ? null : new BitmapImage(uri);
}
```

I changed all three implementations of `MvxNativeValueConverter` this time.
