### PR TITLE
Allow creation of MvxViewModelLoader to be overridden.

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/Platform/MvxSetup.cs
+++ b/Cirrious/Cirrious.MvvmCross/Platform/MvxSetup.cs
@@ -195,7 +195,6 @@ namespace Cirrious.MvvmCross.Platform
         protected virtual void InitializeViewModelFramework()
         {
             Mvx.RegisterSingleton<IMvxViewModelLoader>(this.CreateViewModelLoader());
-            //Mvx.RegisterType<IMvxViewModelLoader, MvxViewModelLoader>(;
         }
 
         protected virtual IMvxViewModelLoader CreateViewModelLoader()


### PR DESCRIPTION
I think this approach is cleaner than to override InitializeViewModelFramework and re-register a new ViewModelLoader. Please note: In the new code, a singleton is registered while in the old code, a new instance of MvxViewModelLoader would be created on each load. I figured out this was safe since the standard MvxViewModelLoader does not carry any state (except for the LocatorCollection, and that shouldn't change in a typical app I guess).
