### PR TITLE
Fixed FolderExists in FileStore for WindowsStore

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -163,12 +163,15 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
                 folderPath = ToFullPath(folderPath);
                 folderPath = folderPath.TrimEnd('\\');
 
-                var parent = Path.GetDirectoryName(folderPath);
-                var parentFolder = StorageFolder.GetFolderFromPathAsync(parent).Await();
-
-                var leafFolderName = Path.GetFileName(folderPath);
-
-                return parentFolder.GetFoldersAsync().Await().Any(x => x.Name == leafFolderName);
+                try
+                {
+                    var thisFolder = StorageFolder.GetFolderFromPathAsync(folderPath).Await();
+                    return true;
+                }
+                catch (System.UnauthorizedAccessException)
+                {
+                    return false;
+                }
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
The previous implementation tried to get parent folder and see if the folder asked for exists within that... If the folder passed in as FolderPath was the LocalStorage folder, then parent will become the root which the application does not have access to and throw errors such as System.UnauthorizedAccess.

Another workaround would be to give the app access to the root folder, but that seems to be not the best way to go about it. This fixed the problem for me
