### PR TITLE
changed nativepath to support bindings

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -310,7 +310,8 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
 
         public string NativePath(string path)
         {
-            return ToFullPath(path);
+            return "ms-appdata:///local/" + path;
+            //return ToFullPath(path);
         }
 
         private static string ToFullPath(string path)


### PR DESCRIPTION
When binding files to views in XAML, such as image urls to be image source parameter, Windows store apps can only read urls that use "ms-appdata:///local/" instead of the absolute local path. using "ms-appdata:///local/" works fine in all other file read/write cases across the board for Windows.

How have people been dealing with this problem so far? Another solutions is to create a converter for the binding, but this seems much more elegant and would give delight to new users to see path bindings work out of the box