### PR TITLE
Added custom binding for UiSearchBar SelectedScopeButtonIndex property.

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Cirrious.MvvmCross.Binding.Touch.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Cirrious.MvvmCross.Binding.Touch.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Target\MvxUIDatePickerDateTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerTimeTargetBinding.cs" />
     <Compile Include="Target\MvxUILabelTextTargetBinding.cs" />
+    <Compile Include="Target\MvxUISearchBarSelectedScopeButtonIndexTargetBinding.cs" />
     <Compile Include="Target\MvxUISearchBarTextTargetBinding.cs" />
     <Compile Include="Target\MvxUITextFieldShouldReturnTargetBinding.cs" />
     <Compile Include="Target\MvxUITextViewTextTargetBinding.cs" />

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/MvxTouchBindingBuilder.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/MvxTouchBindingBuilder.cs
@@ -73,6 +73,8 @@ namespace Cirrious.MvvmCross.Binding.Touch
                                                 view => new MvxUIViewLayerBorderWidthTargetBinding(view));
             registry.RegisterPropertyInfoBindingFactory(typeof (MvxUISwitchOnTargetBinding), typeof (UISwitch), "On");
             registry.RegisterPropertyInfoBindingFactory(typeof(MvxUISearchBarTextTargetBinding), typeof(UISearchBar), "Text");
+            registry.RegisterPropertyInfoBindingFactory(typeof(MvxUISearchBarSelectedScopeButtonIndexTargetBinding), typeof(UISearchBar), "SelectedScopeButtonIndex");
+          
 
             registry.RegisterCustomBindingFactory<UIButton>("Title",
                                                         (button) => new MvxUIButtonTitleTargetBinding(button));

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Target/MvxUISearchBarSelectedScopeButtonIndexTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Target/MvxUISearchBarSelectedScopeButtonIndexTargetBinding.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace Cirrious.MvvmCross.Binding.Touch.Target
+{
+  public class MvxUISearchBarSelectedScopeButtonIndexTargetBinding : MvxPropertyInfoTargetBinding<UISearchBar>
+  {
+    public MvxUISearchBarSelectedScopeButtonIndexTargetBinding(object target, PropertyInfo targetPropertyInfo)
+      : base(target, targetPropertyInfo)
+    {
+
+      var searchBar = View;
+      if (searchBar == null)
+      {
+        MvxBindingTrace.Trace(MvxTraceLevel.Error,
+                       "Error - UISearchBar is null in MvxUISearchBarSelectedScopeButtonIndexTargetBinding");
+
+      }
+      else
+      {
+        searchBar.SelectedScopeButtonIndexChanged += HandleSearchBarValueChanged;
+      }
+
+    }
+
+    private void HandleSearchBarValueChanged(object sender, System.EventArgs e)
+    {
+      FireValueChanged(View.SelectedScopeButtonIndex);
+    }
+
+    public override MvxBindingMode DefaultMode
+    {
+      get { return MvxBindingMode.TwoWay; }
+    }
+
+    protected override void Dispose(bool isDisposing)
+    {
+      base.Dispose(isDisposing);
+      if (isDisposing)
+      {
+        var searchBar = View;
+        if (searchBar != null)
+        {
+          searchBar.SelectedScopeButtonIndexChanged -= HandleSearchBarValueChanged;
+        }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
The UISearchBar supports addding filtering criteria using scope buttons. I've saw that the binding for SearchText works (thanks to mverm) but not the one for selected scope button. With this changes now we can bind like this:

set.Bind(searchBar).To (vm => vm.SearchText);
set.Bind(searchBar).For(v => v.ScopeButtonTitles).To(vm => vm.SearchCriteriaNames);
set.Bind(searchBar).For(v => v.SelectedScopeButtonIndex).To(vm => vm.SelectedSearchCriteria);
set.Apply();