### PR TITLE
Added option to MvxTableViewSource to refresh on every NPC event

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxTableViewSource.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxTableViewSource.cs
@@ -53,7 +53,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
             get { return _itemsSource; }
             set
             {
-                if (_itemsSource == value)
+                if (_itemsSource == value && !RefreshOnAllUpdates)
                     return;
 
                 if (_subscription != null)
@@ -82,6 +82,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
             return ItemsSource.ElementAt(indexPath.Row);
         }
 
+        public bool RefreshOnAllUpdates { get; set; }
         public bool UseAnimations { get; set; }
         public UITableViewRowAnimation AddAnimation { get; set; }
         public UITableViewRowAnimation RemoveAnimation { get; set; }


### PR DESCRIPTION
This is an option that bypasses the optimization in line 56 of https://github.com/MvvmCross/MvvmCross/pull/619/files#diff-4d62e18711da75628a0eb7190e768e25L56. This is useful when you call RaisePropertyChanged() on a collection that is bound to a TableViewSource, because if the collection is modified (but not re-assigned) then the table will not update.

This fix is only for MvxTableViewSource, but it could be used anywhere a collection is used and this optimization exists.
