### PR TITLE
DeleteFile should not throw FileNotFoundException

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -245,8 +245,7 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
 
         public void DeleteFile(string path)
         {
-            var file = StorageFileFromRelativePath(path);
-            file.DeleteAsync().Await();
+            SafeDeleteFile(path);
         }
 
         public void DeleteFolder(string folderPath, bool recursive)


### PR DESCRIPTION
It doesn't throw on Android or iOS (File.Delete default behavior).
