### PR TITLE
Added WindowsPhone implementation for DownloadCache

### DIFF
--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone.csproj
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone.csproj
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.20506</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F343E113-756A-4434-8EDA-AA63ADE5D98D}</ProjectGuid>
+    <ProjectTypeGuids>{C089C8C0-30E0-4E22-80C0-CE093F111A43};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone</RootNamespace>
+    <AssemblyName>Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone</AssemblyName>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+    <SilverlightVersion>
+    </SilverlightVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkIdentifier>WindowsPhone</TargetFrameworkIdentifier>
+    <SilverlightApplication>false</SilverlightApplication>
+    <ValidateXaml>true</ValidateXaml>
+    <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\..\bin\Debug\Mvx\WindowsPhone\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>True</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\..\bin\Release\Mvx\WindowsPhone\</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>True</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>Bin\x86\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>
+    </PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>Bin\x86\Release</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>
+    </PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>Bin\ARM\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>
+    </PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <OutputPath>Bin\ARM\Release</OutputPath>
+    <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>
+    </PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="MvxDownloadCacheConfiguration.cs" />
+    <Compile Include="MvxWindowsPhoneImage.cs" />
+    <Compile Include="MvxWindowsPhoneLocalFileImageLoader.cs" />
+    <Compile Include="Plugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\CrossCore\Cirrious.CrossCore.WindowsPhone\Cirrious.CrossCore.WindowsPhone.csproj">
+      <Project>{2CA6800E-2CB5-4F76-BBE3-C4F7D445AF17}</Project>
+      <Name>Cirrious.CrossCore.WindowsPhone</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\CrossCore\Cirrious.CrossCore\Cirrious.CrossCore.csproj">
+      <Project>{CFF6F25A-3C3B-44EE-A54C-2ED4AAFF3ADB}</Project>
+      <Name>Cirrious.CrossCore</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\File\Cirrious.MvvmCross.Plugins.File\Cirrious.MvvmCross.Plugins.File.csproj">
+      <Project>{19EE04D6-7EE0-4FE8-AB10-4623D93F165A}</Project>
+      <Name>Cirrious.MvvmCross.Plugins.File</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Cirrious.MvvmCross.Plugins.DownloadCache\Cirrious.MvvmCross.Plugins.DownloadCache.csproj">
+      <Project>{60A80EB8-2056-4771-8600-03A8DA417CFB}</Project>
+      <Name>Cirrious.MvvmCross.Plugins.DownloadCache</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
+  <ProjectExtensions />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/MvxDownloadCacheConfiguration.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/MvxDownloadCacheConfiguration.cs
@@ -1,0 +1,28 @@
+using System;
+using Cirrious.CrossCore.Plugins;
+
+namespace Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone
+{
+    public class MvxDownloadCacheConfiguration
+        : IMvxPluginConfiguration
+    {
+        public static readonly MvxDownloadCacheConfiguration Default = new MvxDownloadCacheConfiguration();
+
+        public string CacheName { get; set; }
+        public string CacheFolderPath { get; set; }
+        public int MaxFiles { get; set; }
+        public TimeSpan MaxFileAge { get; set; }
+        public int MaxInMemoryFiles { get; set; }
+        public int MaxInMemoryBytes { get; set; }
+
+        public MvxDownloadCacheConfiguration()
+        {
+            CacheName = "Pictures.MvvmCross";
+            CacheFolderPath = "";
+            MaxFiles = 500;
+            MaxFileAge = TimeSpan.FromDays(7);
+            MaxInMemoryBytes = 4000000; // 4 MB
+            MaxInMemoryFiles = 30;
+        }
+    }
+}

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/MvxWindowsPhoneImage.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/MvxWindowsPhoneImage.cs
@@ -1,0 +1,19 @@
+namespace Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone
+{
+    public class MvxWindowsPhoneImage
+        : MvxImage<byte[]>
+    {
+        public MvxWindowsPhoneImage(byte[] rawImage)
+            : base(rawImage)
+        {
+        }
+
+        public override int GetSizeInBytes()
+        {
+            if (RawImage == null)
+                return 0;
+
+            return RawImage.Length;
+        }
+    }
+}

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/MvxWindowsPhoneLocalFileImageLoader.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/MvxWindowsPhoneLocalFileImageLoader.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Windows;
+using Cirrious.CrossCore;
+using Cirrious.MvvmCross.Plugins.File;
+
+namespace Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone
+{
+    public class MvxWindowsPhoneLocalFileImageLoader
+        : IMvxLocalFileImageLoader<byte[]>
+    {
+        private const string ResourcePrefix = "res:";
+
+        public MvxImage<byte[]> Load(string localPath, bool shouldCache /* ignored here */)
+        {
+            byte[] bitmap;
+            if (localPath.StartsWith(ResourcePrefix))
+            {
+                var resourcePath = localPath.Substring(ResourcePrefix.Length);
+                bitmap = LoadResourceImage(resourcePath);
+            }
+            else
+            {
+                bitmap = LoadBitmapImage(localPath);
+            }
+            return new MvxWindowsPhoneImage(bitmap);
+        }
+
+        private byte[] LoadBitmapImage(string localPath)
+        {
+            var file = Mvx.Resolve<IMvxFileStore>();
+
+            byte[] bitmap = null;
+            if (!file.TryReadBinaryFile(localPath, stream =>
+            {
+                using (var memoryStream = new MemoryStream())
+                {
+                    stream.CopyTo(memoryStream);
+                    bitmap = memoryStream.ToArray();
+                }
+                return true;
+            }))
+                return null;
+
+            return bitmap;
+        }
+
+        private byte[] LoadResourceImage(string resourcePath)
+        {
+            byte[] bitmap;
+            var streamInfo = Application.GetResourceStream(new Uri(resourcePath, UriKind.Relative));
+
+            using (var memoryStream = new MemoryStream())
+            {
+                streamInfo.Stream.CopyTo(memoryStream);
+                bitmap = memoryStream.ToArray();
+            }
+
+            return bitmap;
+        }
+    }
+}

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/Plugin.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/Plugin.cs
@@ -1,0 +1,48 @@
+// Plugin.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+
+using Cirrious.CrossCore;
+using Cirrious.CrossCore.Exceptions;
+using Cirrious.CrossCore.Platform;
+using Cirrious.CrossCore.Plugins;
+using System.IO;
+
+namespace Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone
+{
+    public class Plugin
+            : IMvxConfigurablePlugin
+    {
+        private MvxDownloadCacheConfiguration _configuration;
+
+        public void Configure(IMvxPluginConfiguration configuration)
+        {
+            if (configuration != null && !(configuration is MvxDownloadCacheConfiguration))
+            {
+                throw new MvxException("You must use a MvxDownloadCacheConfiguration object for configuring the DownloadCache, but you supplied {0}", configuration.GetType().Name);
+            }
+            _configuration = (MvxDownloadCacheConfiguration)configuration;
+        }
+
+        public void Load()
+        {
+            Mvx.RegisterSingleton<IMvxHttpFileDownloader>(() => new MvxHttpFileDownloader());
+            Mvx.RegisterSingleton<IMvxImageCache<byte[]>>(CreateCache);
+            Mvx.RegisterType<IMvxImageHelper<byte[]>, MvxDynamicImageHelper<byte[]>>();
+            Mvx.RegisterSingleton<IMvxLocalFileImageLoader<byte[]>>(() => new MvxWindowsPhoneLocalFileImageLoader());
+        }
+
+        private MvxImageCache<byte[]> CreateCache()
+        {
+            var configuration = _configuration ?? MvxDownloadCacheConfiguration.Default;
+
+            var fileDownloadCache = new MvxFileDownloadCache(configuration.CacheName,
+                                                             configuration.CacheFolderPath,
+                                                             configuration.MaxFiles,
+                                                             configuration.MaxFileAge);
+            var fileCache = new MvxImageCache<byte[]>(fileDownloadCache, configuration.MaxInMemoryFiles, configuration.MaxInMemoryBytes);
+            return fileCache;
+        }
+    }
+}

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/Properties/AssemblyInfo.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.WindowsPhone/Properties/AssemblyInfo.cs
@@ -1,0 +1,47 @@
+﻿// AssemblyInfo.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System.Reflection;
+using System.Resources;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("Cirrious.MvvmCross.Plugins.Email.WindowsPhone")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Cirrious")]
+[assembly: AssemblyProduct("Cirrious.MvvmCross.Plugins.Email.WindowsPhone")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("47e3fb1e-11a7-4463-b3d5-521a85deddae")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
I added the WindowsPhone implementation for the DownloadCache plugin. I've opted to use a byte array as BitmapImage will result in cross-thread issues. The byte array can easily be used in a value converter.