### PR TITLE
Stil display older image in MvxImageView (iOS) when loading and DefaultImagePath not present

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxImageViewLoader.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxImageViewLoader.cs
@@ -26,7 +26,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
 
         private static void OnImage(UIImageView imageView, UIImage image)
         {
-            if (imageView != null && image != null)
+            if (imageView != null)
                 imageView.Image = image;
         }
     }


### PR DESCRIPTION
MvxImageView.ImageUrl behavior has difference in iOS and Android.
I consider these as it is better to unite. 
- DefaultImagePath is default value (null)
- Set ImageUrl to MvxImageView
  - Load and display image
-  Change ImageUrl to other image
- Behavior difference between iOS and Android when loading image
  -  Android: Image reseted to empty
  -  iOS: Still display first image

![](http://f.st-hatena.com/images/fotolife/i/iseebi/20140504/20140504050223.gif)
https://github.com/iseebi/MvvmCrossPlayground/tree/master/MvxImageViewBindingSample

I think that it is better to unite operation with Android. Because it use with MvxTableViewCell, display other cell image temporarily when MvxTableView scroll.
