### PR TITLE
WindowsStore file plugin, faster WriteFile

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -39,13 +39,7 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
         {
             try
             {
-                StorageFile storageFile;
-                
-                if (Exists(path))
-                    storageFile = StorageFileFromRelativePath(path);
-                else
-                    storageFile = CreateStorageFileFromRelativePath(path);
-
+                StorageFile storageFile = ApplicationData.Current.LocalFolder.CreateFileAsync(path, CreationCollisionOption.OpenIfExists).Await();
                 var streamWithContentType = storageFile.OpenAsync(FileAccessMode.ReadWrite).Await();
                 return streamWithContentType.AsStream();
             }

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -271,13 +271,9 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
 
         private void WriteFileCommon(string path, Action<Stream> streamAction)
         {
-            // from https://github.com/MvvmCross/MvvmCross/issues/500 we delete any existing file
-            // before writing the new one
-            SafeDeleteFile(path);
-
             try
             {
-                var storageFile = CreateStorageFileFromRelativePath(path);
+                var storageFile = ApplicationData.Current.LocalFolder.CreateFileAsync(path, CreationCollisionOption.ReplaceExisting).Await();
                 var streamWithContentType = storageFile.OpenAsync(FileAccessMode.ReadWrite).Await();
                 using (var stream = streamWithContentType.AsStreamForWrite())
                 {
@@ -302,9 +298,8 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
                     return streamAction(stream);
                 }
             }
-            catch (Exception exception)
+            catch (FileNotFoundException)
             {
-                MvxTrace.Trace("Error during file load {0} : {1}", path, exception.ToLongString());
                 return false;
             }
         }


### PR DESCRIPTION
The call to SafeDelete is slow when there is no file to delete (Exception handling).
The code can be done in one line using CreationCollisionOption and avoiding multiple access to the storage.
A similar improvement could be done on other implementations of this plugin to avoid multiple access to storage when only one is required.

Also, I think that ReadFile should catch only FileNotFoudException (DirectoryNotFoundException?) or maybe check FileExists intstead of catching all errors.