### PR TITLE
adding IMvxNotifyPropertyChanged extension methods 

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/Cirrious.MvvmCross.csproj
+++ b/Cirrious/Cirrious.MvvmCross/Cirrious.MvvmCross.csproj
@@ -66,6 +66,7 @@
     <Compile Include="ViewModels\IMvxViewModelByNameLookup.cs" />
     <Compile Include="ViewModels\MvxInteraction.cs" />
     <Compile Include="ViewModels\MvxInteractionExtensionMethods.cs" />
+    <Compile Include="ViewModels\MvxNotifyPropertyChangedExtensions.cs" />
     <Compile Include="ViewModels\MvxPostfixAwareViewToViewModelNameMapping.cs" />
     <Compile Include="ViewModels\MvxPropertyChangedListener.cs" />
     <Compile Include="MvxSingletonCache.cs" />

--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxNotifyPropertyChangedExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxNotifyPropertyChangedExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Cirrious.MvvmCross.ViewModels
+{
+    public static class MvxNotifyPropertyChangedExtensions
+    {
+        private static TReturn RaiseAndSetIfChanged<T, TReturn>(T source, ref TReturn backingField, TReturn newValue, Action raiseAction)
+            where T : IMvxNotifyPropertyChanged
+        {
+            if (EqualityComparer<TReturn>.Default.Equals(backingField, newValue) == false)
+            {
+                backingField = newValue;
+
+                raiseAction();
+            }
+
+            return newValue;
+        }
+
+        public static TReturn RaiseAndSetIfChanged<T, TReturn>(this T source, ref TReturn backingField, TReturn newValue, Expression<Func<TReturn>> propertySelector)
+            where T : IMvxNotifyPropertyChanged
+        {
+            return RaiseAndSetIfChanged(source, ref backingField, newValue, () => source.RaisePropertyChanged(propertySelector));
+        }
+
+        public static TReturn RaiseAndSetIfChanged<T, TReturn>(this T source, ref TReturn backingField, TReturn newValue, string propertyName)
+            where T : IMvxNotifyPropertyChanged
+        {
+            return RaiseAndSetIfChanged(source, ref backingField, newValue, () => source.RaisePropertyChanged(propertyName));
+        }
+
+        public static TReturn RaiseAndSetIfChanged<T, TReturn>(this T source, ref TReturn backingField, TReturn newValue, PropertyChangedEventArgs args)
+            where T : IMvxNotifyPropertyChanged
+        {
+            return RaiseAndSetIfChanged(source, ref backingField, newValue, () => source.RaisePropertyChanged(args));
+        }
+    }
+}


### PR DESCRIPTION
to simplify notification property setters

e.g., 

``` csharp
        private string _hello = default(string);
        public string Hello
        {
            get { return _hello; }
            set { this.RaiseAndSetIfChanged(ref _hello, value, () => Hello); }
        }
```

Based on the work of paulcbetts in the reactiveui project
See https://github.com/reactiveui/ReactiveUI/blob/rxui6-master/ReactiveUI/ReactiveObject.cs
