### PR TITLE
SafeDeleteFile should return true if file doesn't exists

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -319,6 +319,10 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
             }
             catch (FileNotFoundException)
             {
+                return true;
+            }
+            catch (Exception)
+            {
                 return false;
             }
         }


### PR DESCRIPTION
TryMove fails when deleteExistingTo is true and there is no existing file.
SafeDeleteFile should return true if the file doesn't exists.
