### PR TITLE
iOS : Load image from bundle

### DIFF
--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Touch/MvxTouchLocalFileImageLoader.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Touch/MvxTouchLocalFileImageLoader.cs
@@ -41,10 +41,7 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache.Touch
 
 		private UIImage LoadResourceImage(string resourcePath, bool shouldCache)
 		{
-			if (shouldCache)
-				return UIImage.FromFile(resourcePath);
-			else
-				return UIImage.FromFileUncached(resourcePath);
+			return UIImage.FromBundle(resourcePath);
 		}
     }
 }


### PR DESCRIPTION
This fix allows to load image from Images.xcassets.
- `UIImage.FromFile` (`[UIImage imageWithContentsOfFile:]`) can not load image from Images.xcassets. 
- `UIImage.FromBundle` (`[UIImage imageNamed:]`) can load image from Images.xcassets.
