### PR TITLE
Fixed Email.Touch plugin bug for CC emails

### DIFF
--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Touch/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Touch/MvxComposeEmailTask.cs
@@ -56,8 +56,8 @@ namespace Cirrious.MvvmCross.Plugins.Email.Touch
             _mail.SetMessageBody(body ?? string.Empty, isHtml);
             _mail.SetSubject(subject ?? string.Empty);
 
-			if(cc != null)
-				_mail.SetCcRecipients(cc.ToArray());
+            if(cc != null)
+                _mail.SetCcRecipients(cc.ToArray());
 
             _mail.SetToRecipients(to == null ? new[] { string.Empty } : to.ToArray());
             if (attachments != null)


### PR DESCRIPTION
Fixed bug in Email.Touch, where the EmailCompose dialog wasn't shown due to an " is not an valid email" error in the debug window. 
It seems (iOS7 at least, haven't had a chance to test this on iOS 6.0) doesn't allow an array with an empty string in it as params to the SetCcRecipients, as it then tries to valid the empty string as an email.
