### PR TITLE
Fix WriteFile flushing stream more than once

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonBlockingFileStore.cs
@@ -285,8 +285,6 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsCommon
                 using (var stream = streamWithContentType.AsStreamForWrite())
                 {
                     streamAction(stream);
-
-                    stream.Flush();
                 }
             }
             catch (Exception exception)


### PR DESCRIPTION
WriteFile creates an Action which disposes of the stream, this is then
sent to WriteFileCommon which invokes this action and attempts to flush
the stream a second time.  This can raise an ObjectDisposed Exception as
Flush will be called on a closed stream.
