### PR TITLE
Update MvxPhoneViewsContainer.cs

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.WindowsPhone/Views/MvxPhoneViewsContainer.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsPhone/Views/MvxPhoneViewsContainer.cs
@@ -29,9 +29,8 @@ namespace Cirrious.MvvmCross.WindowsPhone.Views
             if (!parsed.TryGetValue(QueryParameterKeyName, out queryString))
                 throw new MvxException("Unable to find incoming MvxViewModelRequest");
 
-            var text = Uri.UnescapeDataString(queryString);
             var converter = Mvx.Resolve<IMvxNavigationSerializer>();
-            return converter.Serializer.DeserializeObject<MvxViewModelRequest>(text);
+            return converter.Serializer.DeserializeObject<MvxViewModelRequest>(queryString);
         }
 
         public virtual Uri GetXamlUriFor(MvxViewModelRequest request)


### PR DESCRIPTION
Uri.ParseQueryString url-decodes the incoming url, so doing it again with UnescapeDataString is unnecessary (and a source of exception when the unescaped url contains "invalid" characters).
