### PR TITLE
Navigation cache logic for WP8.1

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
@@ -22,11 +22,6 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
     {
         private IMvxViewModel _viewModel;
 
-        protected MvxWindowsPage()
-        {
-            NavigationCacheMode = NavigationCacheMode.Required;
-        }
-
         public IMvxViewModel ViewModel
         {
             get { return _viewModel; }

--- a/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
@@ -37,7 +37,7 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
 
         public void ClearBackStack()
         {
-            throw new NotImplementedException();
+            //throw new NotImplementedException();
             /*
             // note - we do *not* use CanGoBack here - as that seems to always returns true!
             while (NavigationService.BackStack.Any())
@@ -94,6 +94,11 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
                     nextPageIndex++;
                     nextPageKey = "Page-" + nextPageIndex;
                 }
+
+             
+
+               
+
             }
             else
             {

--- a/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
@@ -22,6 +22,11 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
     {
         private IMvxViewModel _viewModel;
 
+        protected MvxWindowsPage()
+        {
+            NavigationCacheMode = NavigationCacheMode.Required;
+        }
+
         public IMvxViewModel ViewModel
         {
             get { return _viewModel; }
@@ -48,6 +53,11 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            if (e.NavigationMode == NavigationMode.New)
+            {
+                ViewModel = null;
+            }
+
             base.OnNavigatedTo(e);
 
             this.OnViewCreate(e.Parameter as MvxViewModelRequest, () => LoadStateBundle(e));

--- a/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
@@ -104,11 +104,6 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
                     nextPageIndex++;
                     nextPageKey = "Page-" + nextPageIndex;
                 }
-
-             
-
-               
-
             }
             else
             {

--- a/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsPage.cs
@@ -42,7 +42,7 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
 
         public void ClearBackStack()
         {
-            //throw new NotImplementedException();
+            throw new NotImplementedException();
             /*
             // note - we do *not* use CanGoBack here - as that seems to always returns true!
             while (NavigationService.BackStack.Any())


### PR DESCRIPTION
The navigation cache logic in WP8.1 seems to be changed.
Previously, the back button in WP8 worked without doing anything, preserving state and all.
In WP8.1 this has been revamped and caching is by default disabled: when pressing the back button it creates a new VM with a fresh new state.

I've researched this topic, but there isn't a lot of information available (too new I guess?). Some blog post suggest using the created NavigationHelper, but I think this is not the way to go... I would need to serialize the whole VM as state and then load it when needed. I've tried to fix this using a more generic approach, namely by setting the NavigationCacheMode to Required in the constructor of the MvxWindowsPage (base page for WP8.1). This will enable caching and the back button works as expected!

However, when I go from page A to B, back to A, back to B but with different parameters... it loads a cached version of B. This is correct IF we would press the back button, but otherwise I would expect it to load a new viewmodel with the different parameters. I've fixed this by checking if we are navigating to a new view, and if so, clearing the cached viewmodel so that MvvmCross instantiates it again.