### PR TITLE
Fix NullReferenceException in ReflectionExtensions.GetProperties()

### DIFF
--- a/CrossCore/Cirrious.CrossCore/ReflectionExtensions.cs
+++ b/CrossCore/Cirrious.CrossCore/ReflectionExtensions.cs
@@ -95,10 +95,13 @@ namespace Cirrious.CrossCore
                 properties = type.GetRuntimeProperties();
             }
 
-            return properties
-                .Where(p => (flags & BindingFlags.Public) != BindingFlags.Public || p.GetMethod.IsPublic)
-                .Where(p => (flags & BindingFlags.Instance) != BindingFlags.Instance || !p.GetMethod.IsStatic)
-                .Where(p => (flags & BindingFlags.Static) != BindingFlags.Static || p.GetMethod.IsStatic);
+            return from property in properties
+                   let getMethod = property.GetMethod
+                   where getMethod != null
+                   where (flags & BindingFlags.Public) != BindingFlags.Public || getMethod.IsPublic
+                   where (flags & BindingFlags.Instance) != BindingFlags.Instance || !getMethod.IsStatic
+                   where (flags & BindingFlags.Static) != BindingFlags.Static || getMethod.IsStatic
+                   select property;
         }
 
         public static PropertyInfo GetProperty(this Type type, string name, BindingFlags flags)

--- a/CrossUI/CrossUI.Core/ReflectionExtensions.cs
+++ b/CrossUI/CrossUI.Core/ReflectionExtensions.cs
@@ -98,10 +98,13 @@ namespace CrossUI.Core
                 properties = type.GetRuntimeProperties();
             }
 
-            return properties
-                .Where(p => (flags & BindingFlags.Public) != BindingFlags.Public || p.GetMethod.IsPublic)
-                .Where(p => (flags & BindingFlags.Instance) != BindingFlags.Instance || !p.GetMethod.IsStatic)
-                .Where(p => (flags & BindingFlags.Static) != BindingFlags.Static || p.GetMethod.IsStatic);
+            return from property in properties
+                   let getMethod = property.GetMethod
+                   where getMethod != null
+                   where (flags & BindingFlags.Public) != BindingFlags.Public || getMethod.IsPublic
+                   where (flags & BindingFlags.Instance) != BindingFlags.Instance || !getMethod.IsStatic
+                   where (flags & BindingFlags.Static) != BindingFlags.Static || getMethod.IsStatic
+                   select property;
         }
 
         internal static PropertyInfo GetProperty(this Type type, string name, BindingFlags flags)


### PR DESCRIPTION
In iOS, due to the way the Linker works, some PropertyInfo.GetMethod()
calls might return null, so check before use value.

MvxSetup will use reflection to get all types and then search for Views and ViewModels. Problem is when we have a class that inherits from something like `UIView`; the setup will fail due to the Linker remove some properties from compilation (thus PropertyInfo.GetMethod returns null).

This fix is to just exclude any null from the list.
