### PR TITLE
Infinite loop in DebugTrace.cs after a FormatException

### DIFF
--- a/nuspec/DroidContent/DebugTrace.cs.pp
+++ b/nuspec/DroidContent/DebugTrace.cs.pp
@@ -24,7 +24,7 @@ namespace $rootnamespace$
             }
             catch (FormatException)
             {
-                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1} {2}", level, message);
+                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1}", level, message);
             }
         }
     }

--- a/nuspec/MacContent/DebugTrace.cs.pp
+++ b/nuspec/MacContent/DebugTrace.cs.pp
@@ -24,7 +24,7 @@ namespace $rootnamespace$
             }
             catch (FormatException)
             {
-                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1} {2}", level, message);
+                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1}", level, message);
             }
         }
     }

--- a/nuspec/PhoneContent/DebugTrace.cs.pp
+++ b/nuspec/PhoneContent/DebugTrace.cs.pp
@@ -24,7 +24,7 @@ namespace $rootnamespace$
             }
             catch (FormatException)
             {
-                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1} {2}", level, message);
+                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1}", level, message);
             }
         }
     }

--- a/nuspec/StoreContent/DebugTrace.cs.pp
+++ b/nuspec/StoreContent/DebugTrace.cs.pp
@@ -24,7 +24,7 @@ namespace $rootnamespace$
             }
             catch (FormatException)
             {
-                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1} {2}", level, message);
+                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1}", level, message);
             }
         }
     }

--- a/nuspec/TouchContent/DebugTrace.cs.pp
+++ b/nuspec/TouchContent/DebugTrace.cs.pp
@@ -24,7 +24,7 @@ namespace $rootnamespace$
             }
             catch (FormatException)
             {
-                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1} {2}", level, message);
+                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1}", level, message);
             }
         }
     }

--- a/nuspec/WpfContent/DebugTrace.cs.pp
+++ b/nuspec/WpfContent/DebugTrace.cs.pp
@@ -24,7 +24,7 @@ namespace $rootnamespace$
             }
             catch (FormatException)
             {
-                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1} {2}", level, message);
+                Trace(MvxTraceLevel.Error, tag, "Exception during trace of {0} {1}", level, message);
             }
         }
     }


### PR DESCRIPTION
In the DebugTrace.cs.pp templates exception handling, there's an extra _unused_ format parameter (most likely a typo), that causes another FormatException. This creates an infinite loop and a stack overflow sooner or later.

This PR removes that parameter.
