### PR TITLE
Supported iOS 8 LocationService setup

### DIFF
--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Touch/MvxTouchLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Touch/MvxTouchLocationWatcher.cs
@@ -5,6 +5,7 @@ using Cirrious.CrossCore.Platform;
 using Cirrious.CrossCore.Touch;
 using MonoTouch.CoreLocation;
 using MonoTouch.Foundation;
+using Cirrious.CrossCore.Touch.Platform;
 
 namespace Cirrious.MvvmCross.Plugins.Location.Touch
 {
@@ -12,6 +13,19 @@ namespace Cirrious.MvvmCross.Plugins.Location.Touch
         : MvxLocationWatcher
     {
         private CLLocationManager _locationManager;
+
+		private MvxIosMajorVersionChecker _ios8VersionChecker;
+		internal bool IsIOS8orHigher
+		{
+			get 
+			{
+				if (_ios8VersionChecker == null) 
+				{
+					_ios8VersionChecker = new MvxIosMajorVersionChecker (8);
+				}
+				return _ios8VersionChecker.IsVersionOrHigher;
+			}
+		}
 
         public MvxTouchLocationWatcher()
         {
@@ -41,6 +55,26 @@ namespace Cirrious.MvvmCross.Plugins.Location.Touch
                 {
                     Mvx.Warning("TimeBetweenUpdates specified for MvxLocationOptions - but this is not supported in iOS");
                 }
+
+
+				if (options.TrackingMode == MvxLocationTrackingMode.Background)
+				{
+					if (IsIOS8orHigher)
+					{
+						_locationManager.RequestAlwaysAuthorization ();
+					}
+					else
+					{
+						Mvx.Warning ("MvxLocationTrackingMode.Background is not supported for iOS before 8");
+					}
+				}
+				else
+				{
+					if (IsIOS8orHigher)
+					{
+						_locationManager.RequestWhenInUseAuthorization ();
+					}
+				}
 
                 if (CLLocationManager.HeadingAvailable)
                     _locationManager.StartUpdatingHeading();

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/Cirrious.MvvmCross.Plugins.Location.csproj
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/Cirrious.MvvmCross.Plugins.Location.csproj
@@ -12,8 +12,6 @@
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProductVersion>10.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -53,6 +51,7 @@
     <Compile Include="MvxLocationWatcher.cs" />
     <Compile Include="PluginLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MvxLocationTrackingMode.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\CrossCore\Cirrious.CrossCore\Cirrious.CrossCore.csproj">

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationOptions.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationOptions.cs
@@ -20,5 +20,9 @@ namespace Cirrious.MvvmCross.Plugins.Location
         /// Use 0 threshold for most frequent updates
         /// </summary>
         public int MovementThresholdInM { get; set; }
+		/// <summary>
+		/// Use MvxLocationTrackingMode.Background to enable location tracking in background.
+		/// </summary>
+		public MvxLocationTrackingMode TrackingMode { get; set; }
     }
 }

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationTrackingMode.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationTrackingMode.cs
@@ -1,0 +1,16 @@
+﻿// MvxLocationTrackingMode.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+namespace Cirrious.MvvmCross.Plugins.Location
+{
+	public enum MvxLocationTrackingMode
+	{
+		Foreground, // Foreground only
+		Background, // Foreground and background
+	}
+}
+


### PR DESCRIPTION
Fixed an issue where LocationService does not work on iOS 8 - #788

Added MvxLocationTrackingMode to activate Background service mode on iOS 8.
Potentially this flag can be used to switch to background location tracking on other platforms.
