### PR TITLE
Network Plugin, Using generic type in MvxRestClient for MvxRestResponse

### DIFF
--- a/Plugins/Cirrious/Network/Cirrious.MvvmCross.Plugins.Network/Rest/IMvxRestClient.cs
+++ b/Plugins/Cirrious/Network/Cirrious.MvvmCross.Plugins.Network/Rest/IMvxRestClient.cs
@@ -14,10 +14,7 @@ namespace Cirrious.MvvmCross.Plugins.Network.Rest
         void ClearSetting(string key);
         void SetSetting(string key, object value);
 
-        IMvxAbortable MakeRequest(MvxRestRequest restRequest, Action<MvxRestResponse> successAction,
-                         Action<Exception> errorAction);
-
-        IMvxAbortable MakeRequest(MvxRestRequest restRequest, Action<MvxStreamRestResponse> successAction,
-                         Action<Exception> errorAction);
+        IMvxAbortable MakeRequest<T>(MvxRestRequest restRequest, Action<T> successAction,
+						Action<Exception> errorAction) where T : MvxRestResponse, new();
     }
 }


### PR DESCRIPTION
I just wrote some custom classes inheriting from MvxStreamRestResponse and I was pretty confused that I was not able to pass them as callback argument into `MvxRestClients' MakeRequest()`.

Long story short: I implemented the `MakeRequest()` method in a way that it will handle any custom implementation inheriting MvxRestResponse.

Also the line indention was pretty awkward, so I normalized and code formatted the whole `MvxRestClient' class file.