### PR TITLE
Performance fix for checking if file exists

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonBlockingFileStore.cs
@@ -174,13 +174,11 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsCommon
                     return false;
 
                 var directory = StorageFolder.GetFolderFromPathAsync(directoryPath).Await();
-                return directory.GetFilesAsync().Await().Any(x => x.Name == fileName);
+                directory.GetFileAsync(fileName).Await();
+                return true;
             }
             catch (FileNotFoundException)
             {
-                MvxTrace.Trace(
-                    "FileNotFoundException seen in Exists - this shouldn't really happen any more - seen for path: {0}",
-                    path);
                 return false;
             }
             catch (Exception ex)

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -174,11 +174,11 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
                     return false;
 
                 var directory = StorageFolder.GetFolderFromPathAsync(directoryPath).Await();
-                return directory.GetFilesAsync().Await().Any(x => x.Name == fileName);
+                directory.GetFileAsync(fileName).Await();
+                return true;
             }
             catch (FileNotFoundException)
             {
-                MvxTrace.Trace("FileNotFoundException seen in Exists - this shouldn't really happen any more - seen for path: {0}", path);
                 return false;
             }
             catch (Exception ex)


### PR DESCRIPTION
The current implementation of Windows Store and Windows Common enumerates all the files in the folder when checking if a single file exists. This is a huge performance drain if the folder contains many files.

The correct way to do this is to try to open the file, and if it throws `FileNotFoundException`, we can `return false`.
