### PR TITLE
Issue #803 - Linker stripping android property

### DIFF
--- a/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
@@ -40,6 +40,11 @@ namespace $rootnamespace$
             sb.ProgressChanged += (sender, args) => sb.Progress = sb.Progress + 1;
         }
 
+        public void Include(MvxActivity act)
+        {
+            act.Title = act.Title + "";
+        }
+
         public void Include(INotifyCollectionChanged changed)
         {
             changed.CollectionChanged += (s,e) => { var test = string.Format("{0}{1}{2}{3}{4}", e.Action,e.NewItems, e.NewStartingIndex, e.OldItems, e.OldStartingIndex); } ;


### PR DESCRIPTION
Caused by linker stripping the "Title" property from MvxActivity. Resolved by adding MvxActivity.Title to the LinkerPleaseInclude.cs.pp file.
