### PR TITLE
When deserializing dictionary -> object, include base class properties

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/Platform/MvxSimplePropertyDictionaryExtensionMethods.cs
+++ b/Cirrious/Cirrious.MvvmCross/Platform/MvxSimplePropertyDictionaryExtensionMethods.cs
@@ -54,7 +54,7 @@ namespace Cirrious.MvvmCross.Platform
         {
             var t = Activator.CreateInstance(type);
             var propertyList =
-                type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => p.CanWrite);
+                type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy).Where(p => p.CanWrite);
 
             foreach (var propertyInfo in propertyList)
             {

--- a/Cirrious/Test/Cirrious.MvvmCross.Test/Cirrious.MvvmCross.Test.csproj
+++ b/Cirrious/Test/Cirrious.MvvmCross.Test/Cirrious.MvvmCross.Test.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Mocks\TestViews\NotTest3View.cs" />
     <Compile Include="Mocks\TestViews\OddNameOddness.cs" />
     <Compile Include="Parse\MvxStringDictionaryTextSerializerTest.cs" />
+    <Compile Include="Platform\MvxSimplePropertyDictionaryExtensionMethodsTests.cs" />
     <Compile Include="Platform\MvxStringToTypeParserTest.cs" />
     <Compile Include="Platform\MvxViewModelViewLookupBuilderTest.cs" />
     <Compile Include="Platform\MvxViewModelViewTypeFinderTest.cs" />

--- a/Cirrious/Test/Cirrious.MvvmCross.Test/Platform/MvxSimplePropertyDictionaryExtensionMethodsTests.cs
+++ b/Cirrious/Test/Cirrious.MvvmCross.Test/Platform/MvxSimplePropertyDictionaryExtensionMethodsTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Cirrious.MvvmCross.Platform;
+using Cirrious.MvvmCross.Test.Core;
+using NUnit.Framework;
+
+namespace Cirrious.MvvmCross.Test.Platform
+{
+    [TestFixture]
+    public class MvxSimplePropertyDictionaryExtensionMethodsTests : MvxIoCSupportingTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            ClearAll();
+            Ioc.RegisterSingleton<IMvxStringToTypeParser>(new MvxStringToTypeParser());
+        }
+
+        [Test]
+        public void Read_ObjectHasValidPropertiesInBaseClass_BaseClassPropertiesAreDeserialized()
+        {
+            const string value = "42";
+            var dictionary = new Dictionary<string, string>
+            {
+                {"ChildProperty", value},
+                {"BasePropertyInternalSet", value},
+                {"BasePropertyPublicSet", value}
+            };
+
+            var deserialized = dictionary.Read<ObjectWithValidPropertiesInBaseClass>();
+
+            Assert.AreEqual(value, deserialized.ChildProperty);
+            Assert.AreEqual(value, deserialized.BasePropertyInternalSet);
+            Assert.AreEqual(value, deserialized.BasePropertyPublicSet);
+        }
+
+        class ObjectWithValidPropertiesInBaseClass : ObjectWithValidPropertiesInBaseClassBase
+        {
+            public string ChildProperty { get; set; }
+        }
+
+        abstract class ObjectWithValidPropertiesInBaseClassBase
+        {
+            public string BasePropertyInternalSet { get; internal set; }
+            public string BasePropertyPublicSet { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
We ran into this issue when trying to upgrade from 3.1.2-beta1 to 3.2.1, so there was a regression somewhere in there. In certain scenarios we have some base classes for navigation parameters that contain some basic properties,  but those properties were being ignored when deserializing using this extension method.
