### PR TITLE
Email Plugin: Only show real email clients on android

### DIFF
--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -83,7 +83,7 @@ namespace Cirrious.MvvmCross.Plugins.Email.Droid
             }
 
             emailIntent.SetData(Android.Net.Uri.Parse("mailto:"));
-            StartActivity(Intent.CreateChooser(emailIntent, "Send email using:"));
+            StartActivity(Intent.CreateChooser(emailIntent, string.Empty));
         }
 
         public bool CanSendEmail


### PR DESCRIPTION
When trying to send email on android, only show apps actually capable of sending emails (instead of all apps able to simply send "data").
Bonus: Handle the case where no apps are available, by using Intent.CreateChooser instead of launching the intent directly.
