### PR TITLE
Added UIStepper to LinkerPleaseInclude-file

### DIFF
--- a/nuspec/TouchContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/TouchContent/LinkerPleaseInclude.cs.pp
@@ -73,6 +73,12 @@ namespace $rootnamespace$
             s.ValueChanged += (sender, args) => { s.Value = 0; };
         }
 
+        public void Include(UIPageControl s)
+        {
+            s.Pages = s.Pages + 1;
+            s.ValueChanged += (sender, args) => { s.Pages = 0; };
+        }
+
         public void Include(INotifyCollectionChanged changed)
         {
             changed.CollectionChanged += (s,e) => { var test = string.Format("{0}{1}{2}{3}{4}", e.Action,e.NewItems, e.NewStartingIndex, e.OldItems, e.OldStartingIndex); } ;


### PR DESCRIPTION
UIStepper and UIPageControl would sometimes be stripped from the assemblies so bindings did fail on the Value property (UIStepper) and Pages property (UIPageControl) for a Touch project. Would work on simulator, but not on device.
