### PR TITLE
Initialize the media capture.

### DIFF
--- a/Plugins/Cirrious/PictureChooser/Cirrious.MvvmCross.Plugins.PictureChooser.WindowsCommon/MvxPictureChooserTask.cs
+++ b/Plugins/Cirrious/PictureChooser/Cirrious.MvvmCross.Plugins.PictureChooser.WindowsCommon/MvxPictureChooserTask.cs
@@ -117,6 +117,8 @@ namespace Cirrious.MvvmCross.Plugins.PictureChooser.WindowsPhoneStore
             var encoding = ImageEncodingProperties.CreateJpeg();
 
             var capture = new MediaCapture();
+            
+            await capture.InitializeAsync();
 
             await capture.CapturePhotoToStorageFileAsync(encoding, file);
 


### PR DESCRIPTION
MediaCapture needs to be initialized before it can be used, otherwise it throws an exception.
