### PR TITLE
Fully qualify the namespace of the Fragment class we are using

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxBaseFragmentAdapter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxBaseFragmentAdapter.cs
@@ -11,6 +11,8 @@ using Android.OS;
 using Android.Support.V4.App;
 using Cirrious.CrossCore.Core;
 
+using Fragment = Android.Support.V4.App.Fragment;
+
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
     public class MvxBaseFragmentAdapter

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -11,10 +11,12 @@ using Android.OS;
 using Android.Views;
 using Cirrious.CrossCore.Core;
 
+using DialogFragment = Android.Support.V4.App.DialogFragment;
+
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
     public class MvxEventSourceDialogFragment
-        : Android.Support.V4.App.DialogFragment
+        : DialogFragment
         , IMvxEventSourceFragment
     {
         public event EventHandler<MvxValueEventArgs<Activity>> AttachCalled;

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
@@ -11,10 +11,12 @@ using Android.OS;
 using Android.Views;
 using Cirrious.CrossCore.Core;
 
+using Fragment = Android.Support.V4.App.Fragment;
+
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
     public class MvxEventSourceFragment
-        : Android.Support.V4.App.Fragment
+        : Fragment
         , IMvxEventSourceFragment
     {
         public event EventHandler<MvxValueEventArgs<Activity>> AttachCalled;

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -11,10 +11,12 @@ using Android.OS;
 using Android.Views;
 using Cirrious.CrossCore.Core;
 
+using ListFragment = Android.Support.V4.App.ListFragment;
+
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
     public class MvxEventSourceListFragment
-        : Android.Support.V4.App.ListFragment
+        : ListFragment
         , IMvxEventSourceFragment
     {
         public event EventHandler<MvxValueEventArgs<Activity>> AttachCalled;


### PR DESCRIPTION
If we just inherit from 'Fragment' or one of it's children and the file has a using statement of
'Android.App' and 'Android.Support.V4.App' the App version will win if targetting an Android
version that supports native fragments.
