### PR TITLE
Fixed Bug where MvxCommand Parameter could not be parsed / casted, when ...

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding/ExtensionMethods/MvxBindingExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding/ExtensionMethods/MvxBindingExtensions.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Reflection;
 using Cirrious.CrossCore;
 using Cirrious.CrossCore.IoC;
+using Cirrious.CrossCore.ExtensionMethods;
 
 namespace Cirrious.MvvmCross.Binding.ExtensionMethods
 {
@@ -49,23 +50,7 @@ namespace Cirrious.MvvmCross.Binding.ExtensionMethods
 
         public static bool ConvertToBoolean(this object result)
         {
-            if (result == null)
-                return false;
-
-            if (result is string)
-                return !string.IsNullOrEmpty((string)result);
-
-            if (result is bool)
-                return (bool)result;
-
-            var resultType = result.GetType();
-            if (resultType.GetTypeInfo().IsValueType)
-            {
-                var underlyingType = Nullable.GetUnderlyingType(resultType) ?? resultType;
-                return !result.Equals(underlyingType.CreateDefault());
-            }
-
-            return true;
+            return result.ConvertToBooleanCore();
         }
 
         public static object MakeSafeValue(this Type propertyType, object value)
@@ -82,47 +67,7 @@ namespace Cirrious.MvvmCross.Binding.ExtensionMethods
 				return autoConverter.Convert (value, propertyType, null, CultureInfo.CurrentUICulture);
 			}
 
-            var safeValue = value;
-            if (!propertyType.IsInstanceOfType(value))
-            {
-                if (propertyType == typeof (string))
-                {
-                    safeValue = value.ToString();
-                }
-                else if (propertyType.GetTypeInfo().IsEnum)
-                {
-                    if (value is string)
-                        safeValue = Enum.Parse(propertyType, (string) value, true);
-                    else
-                        safeValue = Enum.ToObject(propertyType, value);
-                }
-                else if (propertyType.GetTypeInfo().IsValueType)
-                {
-                    var underlyingType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
-                    if (underlyingType == typeof(bool))
-                        safeValue = value.ConvertToBoolean();
-                    else
-                        safeValue = ErrorMaskedConvert(value, underlyingType, CultureInfo.CurrentUICulture);
-                }
-                else
-                {
-                    safeValue = ErrorMaskedConvert(value, propertyType, CultureInfo.CurrentUICulture);
-                }
-            }
-            return safeValue;
-        }
-
-        private static object ErrorMaskedConvert(object value, Type type, CultureInfo cultureInfo)
-        {
-            try
-            {
-                return Convert.ChangeType(value, type, cultureInfo);
-            }
-            catch (Exception)
-            {
-                // pokemon - mask the error
-                return value;
-            }
+            return propertyType.MakeSafeValueCore(value);
         }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxCommand.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxCommand.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using Cirrious.CrossCore;
+using Cirrious.CrossCore.ExtensionMethods;
 
 namespace Cirrious.MvvmCross.ViewModels
 {
@@ -182,7 +183,7 @@ namespace Cirrious.MvvmCross.ViewModels
 
         public bool CanExecute(object parameter)
         {
-            return _canExecute == null || _canExecute((T) parameter);
+            return _canExecute == null || _canExecute((T)(typeof(T).MakeSafeValueCore(parameter)));
         }
 
         public bool CanExecute()
@@ -194,7 +195,7 @@ namespace Cirrious.MvvmCross.ViewModels
         {
             if (CanExecute(parameter))
             {
-                _execute((T) parameter);
+                _execute((T)(typeof(T).MakeSafeValueCore(parameter)));
             }
         }
 

--- a/CrossCore/Cirrious.CrossCore/Cirrious.CrossCore.csproj
+++ b/CrossCore/Cirrious.CrossCore/Cirrious.CrossCore.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BindingFlags.cs" />
+    <Compile Include="ExtensionMethods\MvxCrossCoreExtensions.cs" />
     <Compile Include="Converters\MvxBindingConstant.cs" />
     <Compile Include="Core\MvxDelegateExtensionMethods.cs" />
     <Compile Include="Core\MvxObjectExtensions.cs" />

--- a/CrossCore/Cirrious.CrossCore/ExtensionMethods/MvxCrossCoreExtensions.cs
+++ b/CrossCore/Cirrious.CrossCore/ExtensionMethods/MvxCrossCoreExtensions.cs
@@ -1,0 +1,91 @@
+﻿// MvxBindingExtensions.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using Cirrious.CrossCore;
+using Cirrious.CrossCore.IoC;
+
+namespace Cirrious.CrossCore.ExtensionMethods
+{
+    public static class MvxCrossCoreExtensions
+    {
+        // core implementation of ConvertToBoolean
+        public static bool ConvertToBooleanCore(this object result)
+        {
+            if (result == null)
+                return false;
+
+            if (result is string)
+                return !string.IsNullOrEmpty((string)result);
+
+            if (result is bool)
+                return (bool)result;
+
+            var resultType = result.GetType();
+            if (resultType.GetTypeInfo().IsValueType)
+            {
+                var underlyingType = Nullable.GetUnderlyingType(resultType) ?? resultType;
+                return !result.Equals(underlyingType.CreateDefault());
+            }
+
+            return true;
+        }
+
+        // core implementation of MakeSafeValue
+        public static object MakeSafeValueCore(this Type propertyType, object value)
+        {
+            if (value == null)
+            {
+                return propertyType.CreateDefault();
+            }
+
+            var safeValue = value;
+            if (!propertyType.IsInstanceOfType(value))
+            {
+                if (propertyType == typeof(string))
+                {
+                    safeValue = value.ToString();
+                }
+                else if (propertyType.GetTypeInfo().IsEnum)
+                {
+                    if (value is string)
+                        safeValue = Enum.Parse(propertyType, (string)value, true);
+                    else
+                        safeValue = Enum.ToObject(propertyType, value);
+                }
+                else if (propertyType.GetTypeInfo().IsValueType)
+                {
+                    var underlyingType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+                    if (underlyingType == typeof(bool))
+                        safeValue = value.ConvertToBooleanCore();
+                    else
+                        safeValue = ErrorMaskedConvert(value, underlyingType, CultureInfo.CurrentUICulture);
+                }
+                else
+                {
+                    safeValue = ErrorMaskedConvert(value, propertyType, CultureInfo.CurrentUICulture);
+                }
+            }
+            return safeValue;
+        }
+
+        private static object ErrorMaskedConvert(object value, Type type, CultureInfo cultureInfo)
+        {
+            try
+            {
+                return Convert.ChangeType(value, type, cultureInfo);
+            }
+            catch (Exception)
+            {
+                // pokemon - mask the error
+                return value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
...the CommandParameter was defined in XAML on WP8 and WinRT.

I was unsure about the IMvxAutoConverter-thing, because all related classes where in the Binding-Project. That's why I chose to move the "core"-Implementation of MakeSafeValue to the Core-Project and call it in the Binding-Project. I did the same with "ConvertToBoolean", because I didn't want to create breaking changes.