### PR TITLE
Fix memory leak in image cache on Android Lollipop

### DIFF
--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
@@ -152,6 +152,9 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache
                         currentSizeInBytes -= toRemove.Image.GetSizeInBytes();
                         currentCountFiles--;
 
+                        if (toRemove.Image.RawImage is IDisposable)
+                            (toRemove.Image.RawImage as IDisposable).Dispose();
+
                         _entriesByHttpUrl.Remove(toRemove.Url);
                     }
                 });


### PR DESCRIPTION
Bitmaps should be Dispose()'d as in "inPurgeable" option is deprecated in Lollipop

https://github.com/MvvmCross/MvvmCross/issues/848