### PR TITLE
Added missing generic MvxDialogViewController

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Dialog.Touch/MvxDialogViewController.cs
+++ b/Cirrious/Cirrious.MvvmCross.Dialog.Touch/MvxDialogViewController.cs
@@ -65,4 +65,28 @@ namespace Cirrious.MvvmCross.Dialog.Touch
 
         #endregion
     }
+
+    public class MvxDialogViewController<TViewModel>
+        : MvxDialogViewController
+          , IMvxTouchView<TViewModel> where TViewModel : class, IMvxViewModel
+    {
+
+        public MvxDialogViewController(UITableViewStyle style = UITableViewStyle.Grouped,
+                                       RootElement root = null,
+                                       bool pushing = false)
+            : base(style, root, pushing)
+        {
+        }
+
+        public MvxDialogViewController(IntPtr handle)
+            : base(handle)
+        {
+        }
+
+        public new TViewModel ViewModel
+        {
+            get { return (TViewModel)base.ViewModel; }
+            set { base.ViewModel = value; }
+        }
+    }
 }


### PR DESCRIPTION
`MvxTabBarViewController`, `MvxTableViewController` and `MvxViewController` all got updates in v3.5 to be generic, was `MvxDialogViewController` left intentionally or just an oversight? :smile: 