### PR TITLE
Add source files to nuget symbol packages

### DIFF
--- a/nuspec/MvvmCross.BindingEx.3.0.1.nuspec
+++ b/nuspec/MvvmCross.BindingEx.3.0.1.nuspec
@@ -16,24 +16,31 @@
 		</dependencies>
 	</metadata>
 	<files>		
+	
+	    <!-- common -->
+	    <file src="..\Cirrious\Cirrious.MvvmCross.Binding\**\*.cs" target="src\Cirrious.MvvmCross.Binding" />
 
 		<!-- wpf -->
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Binding.dll" target="lib\net45\Cirrious.MvvmCross.Binding.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Binding.pdb" target="lib\net45\Cirrious.MvvmCross.Binding.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.BindingEx.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.BindingEx.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.BindingEx.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.BindingEx.Wpf.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.BindingEx.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.BindingEx.Wpf" />
+		
 
 		<!-- store -->
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Binding.dll" target="lib\netcore45\Cirrious.MvvmCross.Binding.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Binding.pdb" target="lib\netcore45\Cirrious.MvvmCross.Binding.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.BindingEx.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.BindingEx.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.BindingEx.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.BindingEx.WindowsStore.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.BindingEx.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.BindingEx.WindowsStore" />
 		
 		<!-- phone -->
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Binding.dll" target="lib\wp8\Cirrious.MvvmCross.Binding.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Binding.pdb" target="lib\wp8\Cirrious.MvvmCross.Binding.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.BindingEx.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.BindingEx.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.BindingEx.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.BindingEx.WindowsPhone.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.BindingEx.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.BindingEx.WindowsPhone" />
 			
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.AutoViews.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.AutoViews.3.0.1.nuspec
@@ -14,8 +14,10 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.AutoView.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.AutoView.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.AutoView.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.AutoView.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.AutoView\**\*.cs" target="src\Cirrious.MvvmCross.AutoView" />
 		<file src="..\bin\Release\Mvx\Portable\CrossUI.Core.dll" target="lib\portable-win+net45+wp8+win8+wpa81\CrossUI.Core.dll" />
 		<file src="..\bin\Release\Mvx\Portable\CrossUI.Core.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\CrossUI.Core.pdb" />
+		<file src="..\CrossUI\CrossUI.Core\**\*.cs" target="src\CrossUI.Core" />
 		
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.CrossCore.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.CrossCore.3.0.1.nuspec
@@ -16,12 +16,16 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.CrossCore.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.CrossCore.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore\**\*.cs" target="src\Cirrious.CrossCore" />
+		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Localization.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Localization.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Localization.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Localization.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Localization\**\*.cs" target="src\Cirrious.MvvmCross.Localization" />
 
 		<!-- wpf -->
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.CrossCore.Wpf.dll" target="lib\net45\Cirrious.CrossCore.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.CrossCore.Wpf.pdb" target="lib\net45\Cirrious.CrossCore.Wpf.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.Wpf\**\*.cs" target="src\Cirrious.CrossCore.Wpf" />
 		
 		<!-- wpf - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\net45\Cirrious.CrossCore.dll" />
@@ -32,6 +36,7 @@
 		<!-- store -->
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.CrossCore.WindowsStore.dll" target="lib\netcore45\Cirrious.CrossCore.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.CrossCore.WindowsStore.pdb" target="lib\netcore45\Cirrious.CrossCore.WindowsStore.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.WindowsStore\**\*.cs" target="src\Cirrious.CrossCore.WindowsStore" />
 
 		<!-- store - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\netcore45\Cirrious.CrossCore.dll" />
@@ -42,6 +47,7 @@
 		<!-- phone -->
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.CrossCore.WindowsPhone.dll" target="lib\wp8\Cirrious.CrossCore.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.CrossCore.WindowsPhone.pdb" target="lib\wp8\Cirrious.CrossCore.WindowsPhone.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.WindowsPhone\**\*.cs" target="src\Cirrious.CrossCore.WindowsPhone" />
 
 		<!-- phone - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\wp8\Cirrious.CrossCore.dll" />
@@ -58,6 +64,8 @@
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.CrossCore.WindowsCommon.dll" target="lib\portable-win81+wpa81\Cirrious.CrossCore.WindowsCommon.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.CrossCore.WindowsCommon.pdb" target="lib\portable-win81+wpa81\Cirrious.CrossCore.WindowsCommon.pdb" />
 		
+		<file src="..\CrossCore\Cirrious.CrossCore.WindowsCommon\**\*.cs" target="src\Cirrious.CrossCore.WindowsCommon" />
+		
 		<!-- windows common - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\win81\Cirrious.CrossCore.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.pdb" target="lib\win81\Cirrious.CrossCore.pdb" />
@@ -72,12 +80,14 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.pdb" target="lib\portable-win81+wpa81\Cirrious.CrossCore.pdb" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Localization.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Localization.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Localization.pdb" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Localization.pdb" />
-		
+
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.CrossCore.Droid.dll" target="lib\MonoAndroid\Cirrious.CrossCore.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.CrossCore.Droid.pdb" target="lib\MonoAndroid\Cirrious.CrossCore.Droid.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.Droid\**\*.cs" target="src\Cirrious.CrossCore.Droid" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Binding.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Binding.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Binding.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Binding.Droid.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Binding.Droid" />
 
 		<!-- droid - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\MonoAndroid\Cirrious.CrossCore.dll" />

--- a/nuspec/MvvmCross.HotTuna.Droid.AutoViews.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Droid.AutoViews.3.0.1.nuspec
@@ -17,7 +17,9 @@
 	
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.AutoView.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.AutoView.Droid.dll" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.AutoView.Droid\**\*.cs" target="src\Cirrious.MvvmCross.AutoView.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\CrossUI.Droid.dll" target="lib\MonoAndroid\CrossUI.Droid.dll" />
+		<file src="..\CrossUI\CrossUI.Droid\**\*.cs" target="src\CrossUI.Droid.dll"/>
 		
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.Droid.Dialog.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Droid.Dialog.3.0.1.nuspec
@@ -14,13 +14,16 @@
 	</metadata>
 	<files>		
 	
-		<!-- touch -->
+		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\CrossUI.Core.dll" target="lib\MonoAndroid\CrossUI.Core.dll" />
 		<file src="..\bin\Release\Mvx\Droid\CrossUI.Core.pdb" target="lib\MonoAndroid\CrossUI.Core.pdb" />
+		<file src="..\CrossUI\CrossUI.Core\**\*.cs" target="src\CrossUI.Core" />
 		<file src="..\bin\Release\Mvx\Droid\CrossUI.Droid.dll" target="lib\MonoAndroid\CrossUI.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\CrossUI.Droid.pdb" target="lib\MonoAndroid\CrossUI.Droid.pdb" />
+		<file src="..\CrossUI\CrossUI.Droid\**\*.cs" target="src\CrossUI.Droid" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Dialog.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Dialog.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Dialog.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Dialog.Droid.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Dialog.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Dialog.Droid" />
 		
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.Droid.Fragging.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Droid.Fragging.3.0.1.nuspec
@@ -17,6 +17,7 @@
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.Fragging.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.Fragging.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.Fragging.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.Fragging.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Droid.Fragging\**\*.cs" target="src\Cirrious.MvvmCross.Droid.Fragging" />
 		
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.Droid.FullFragging.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Droid.FullFragging.3.0.1.nuspec
@@ -17,6 +17,7 @@
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.FullFragging.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.FullFragging.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.FullFragging.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.FullFragging.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Droid.FullFragging\**\*.cs" target="src\Cirrious.MvvmCross.Droid.FullFragging" />
 		
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.Mac.CrossCore.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Mac.CrossCore.3.0.1.nuspec
@@ -12,7 +12,12 @@
 		  <dependency id="MvvmCross.Mac.PortableSupport" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\CrossCore\Cirrious.CrossCore\**\*.cs" target="src\Cirrious.CrossCore" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Localization\**\*.cs" target="src\Cirrious.MvvmCross.Localization" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding\**\*.cs" target="src\Cirrious.MvvmCross.Binding" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.CrossCore.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.pdb" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.CrossCore.pdb" />
@@ -22,8 +27,10 @@
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.CrossCore.Droid.dll" target="lib\MonoAndroid\Cirrious.CrossCore.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.CrossCore.Droid.pdb" target="lib\MonoAndroid\Cirrious.CrossCore.Droid.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.Droid\**\*.cs" target="src\Cirrious.CrossCore.Droid" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Binding.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Binding.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Binding.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Binding.Droid.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Binding.Droid" />
 
 		<!-- droid - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\MonoAndroid\Cirrious.CrossCore.dll" />
@@ -36,8 +43,10 @@
 		<!-- touch -->
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.CrossCore.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.CrossCore.Touch.dll" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.CrossCore.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.CrossCore.Touch.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.Touch\**\*.cs" target="src\Cirrious.CrossCore.Touch" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Binding.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Binding.Touch.dll" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Binding.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Binding.Touch.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Binding.Touch" />
 
 		<!-- touch - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\Xamarin.iOS10\Cirrious.CrossCore.dll" />
@@ -50,8 +59,10 @@
 		<!-- mac -->
 		<file src="..\bin\Release\Mvx\Mac\Cirrious.CrossCore.Mac.dll" target="lib\net45\Cirrious.CrossCore.Mac.dll" />
 		<file src="..\bin\Release\Mvx\Mac\Cirrious.CrossCore.Mac.pdb" target="lib\net45\Cirrious.CrossCore.Mac.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.Mac\**\*.cs" target="src\Cirrious.CrossCore.Mac" />
 		<file src="..\bin\Release\Mvx\Mac\Cirrious.MvvmCross.Binding.Mac.dll" target="lib\net45\Cirrious.MvvmCross.Binding.Mac.dll" />
 		<file src="..\bin\Release\Mvx\Mac\Cirrious.MvvmCross.Binding.Mac.pdb" target="lib\net45\Cirrious.MvvmCross.Binding.Mac.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding.Mac\**\*.cs" target="src\Cirrious.MvvmCross.Binding.Mac" />
 
 		<!-- mac - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\net45\Cirrious.CrossCore.dll" />

--- a/nuspec/MvvmCross.HotTuna.Mac.MvvmCrossLibraries.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Mac.MvvmCrossLibraries.3.0.1.nuspec
@@ -12,7 +12,10 @@
 		  <dependency id="MvvmCross.HotTuna.Mac.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Cirrious\Cirrious.MvvmCross\**\*.cs" target="src\Cirrious.MvvmCross" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.MvvmCross.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.pdb" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.MvvmCross.pdb" />
@@ -20,6 +23,7 @@
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Droid" />
 
 		<!-- droid - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.dll" />
@@ -28,6 +32,7 @@
 		<!-- touch -->
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Touch.dll" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Touch.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Touch" />
 
 		<!-- touch - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.dll" />
@@ -36,6 +41,7 @@
 		<!-- mac -->
 		<file src="..\bin\Release\Mvx\Mac\Cirrious.MvvmCross.Mac.dll" target="lib\net45\Cirrious.MvvmCross.Mac.dll" />
 		<file src="..\bin\Release\Mvx\Mac\Cirrious.MvvmCross.Mac.pdb" target="lib\net45\Cirrious.MvvmCross.Mac.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Mac\**\*.cs" target="src\Cirrious.MvvmCross.Mac" />
 
 		<!-- mac - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\net45\Cirrious.MvvmCross.dll" />

--- a/nuspec/MvvmCross.HotTuna.MvvmCrossLibraries.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.MvvmCrossLibraries.3.0.1.nuspec
@@ -16,10 +16,12 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross\**\*.cs" target="src\Cirrious.MvvmCross" />
 
 		<!-- wpf -->
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Wpf.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Wpf" />
 
 		<!-- wpf - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\net45\Cirrious.MvvmCross.dll" />
@@ -28,6 +30,7 @@
 		<!-- store -->
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.WindowsStore.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.WindowsStore" />
 
 		<!-- store - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\netcore45\Cirrious.MvvmCross.dll" />
@@ -36,6 +39,7 @@
 		<!-- phone -->
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.WindowsPhone.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.WindowsPhone" />
 
 		<!-- phone - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\wp8\Cirrious.MvvmCross.dll" />
@@ -50,6 +54,8 @@
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.WindowsCommon.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.WindowsCommon.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.WindowsCommon.pdb" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.WindowsCommon.pdb" />
 		
+		<file src="..\Cirrious\Cirrious.MvvmCross.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.WindowsCommon" />
+		
 		<!-- windows common - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\win81\Cirrious.MvvmCross.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.pdb" target="lib\win81\Cirrious.MvvmCross.pdb" />
@@ -63,6 +69,7 @@
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Droid" />
 
 		<!-- droid - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.dll" />

--- a/nuspec/MvvmCross.HotTuna.Plugin.Accelerometer.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Accelerometer.3.0.1.nuspec
@@ -19,12 +19,14 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Accelerometer.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" />
+		<file src="..\Plugins\Cirrious\Accelerometer\Cirrious.MvvmCross.Plugins.Accelerometer\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Accelerometer" />
 
     	<!-- wpf  -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Accelerometer.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Accelerometer.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Accelerometer.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Accelerometer.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Accelerometer.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Accelerometer\Cirrious.MvvmCross.Plugins.Accelerometer.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Accelerometer.Wpf" />
         <file src="BootstrapContent\AccelerometerPluginBootstrap.cs.pp" target="content\net45\Bootstrap\AccelerometerPluginBootstrap.cs.pp" />
 	
 		<!-- store -->
@@ -32,6 +34,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Accelerometer\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsStore" />
         <file src="BootstrapContent\AccelerometerPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\AccelerometerPluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -39,6 +42,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Accelerometer\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsPhone" />
         <file src="BootstrapContent\AccelerometerPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\AccelerometerPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
@@ -47,6 +51,7 @@
         <file src="BootstrapContent\AccelerometerPluginBootstrap.cs.pp" target="content\win81\Bootstrap\AccelerometerPluginBootstrap.cs.pp" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Accelerometer.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsCommon.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Accelerometer\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Accelerometer.WindowsCommon" />
         <file src="BootstrapContent\AccelerometerPluginBootstrap.cs.pp" target="content\wpa81\Bootstrap\AccelerometerPluginBootstrap.cs.pp" />
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Plugins.Accelerometer.dll" />
@@ -57,6 +62,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Accelerometer.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Accelerometer.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Accelerometer.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Accelerometer.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Accelerometer.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Accelerometer\Cirrious.MvvmCross.Plugins.Accelerometer.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Accelerometer.Droid" />
         <file src="BootstrapContent\AccelerometerPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\AccelerometerPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -66,6 +72,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Accelerometer.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Accelerometer.Touch.pdb" />
 		-->
+		<file src="..\Plugins\Cirrious\Accelerometer\Cirrious.MvvmCross.Plugins.Accelerometer.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Accelerometer.Touch" />
         <file src="TouchBootstrapContent\AccelerometerPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\AccelerometerPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.All.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.All.3.0.1.nuspec
@@ -37,6 +37,8 @@
 		</dependencies>
 	</metadata>
 	<files>		
+	    <!-- Common -->
+		<file src="..\Plugins\Cirrious\All\Cirrious.MvvmCross.Plugins.All\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.All" />
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.All.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.All.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.All.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.All.pdb" />

--- a/nuspec/MvvmCross.HotTuna.Plugin.Bookmarks.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Bookmarks.3.0.1.nuspec
@@ -19,12 +19,15 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Bookmarks.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Bookmarks.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Bookmarks.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Bookmarks.pdb" />
+		<file src="..\Plugins\Cirrious\Bookmarks\Cirrious.MvvmCross.Plugins.Bookmarks\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Bookmarks" />
+		
         
 		<!-- phone -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Bookmarks.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Bookmarks.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Bookmarks.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Bookmarks.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Bookmarks.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Bookmarks.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Bookmarks.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Bookmarks.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Bookmarks\Cirrious.MvvmCross.Plugins.Bookmarks.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Bookmarks.WindowsPhone" />
         <file src="BootstrapContent\BookmarksPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\BookmarksPluginBootstrap.cs.pp" />
 	
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.Color.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Color.3.0.1.nuspec
@@ -19,12 +19,14 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Color.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Color.pdb" />
+		<file src="..\Plugins\Cirrious\Color\Cirrious.MvvmCross.Plugins.Color\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Color" />
 
     	<!-- wpf  -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Color.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Color.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Color.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Color.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Color.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Color.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Color\Cirrious.MvvmCross.Plugins.Color.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Color.Wpf" />
         <file src="BootstrapContent\ColorPluginBootstrap.cs.pp" target="content\net45\Bootstrap\ColorPluginBootstrap.cs.pp" />
 				
 		<!-- store -->
@@ -32,6 +34,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Color.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Color.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Color.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Color.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Color.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Color\Cirrious.MvvmCross.Plugins.Color.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Color.WindowsStore" />
         <file src="BootstrapContent\ColorPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\ColorPluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -39,6 +42,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Color.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Color.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Color.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Color.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Color.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Color\Cirrious.MvvmCross.Plugins.Color.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Color.WindowsPhone" />
         <file src="BootstrapContent\ColorPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\ColorPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
@@ -47,6 +51,7 @@
         <file src="BootstrapContent\ColorPluginBootstrap.cs.pp" target="content\win81\Bootstrap\ColorPluginBootstrap.cs.pp" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Color.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Color.WindowsCommon.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Color.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Color\Cirrious.MvvmCross.Plugins.Color.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Color.WindowsCommon" />
         <file src="BootstrapContent\ColorPluginBootstrap.cs.pp" target="content\wpa81\Bootstrap\ColorPluginBootstrap.cs.pp" />
 		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Plugins.Color.dll" />
@@ -57,6 +62,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Color.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Color.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Color.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Color.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Color.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Color.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Color\Cirrious.MvvmCross.Plugins.Color.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Color.Droid" />
         <file src="BootstrapContent\ColorPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\ColorPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -66,6 +72,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Color.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Color.Touch.pdb" />
 		-->
+		<file src="..\Plugins\Cirrious\Color\Cirrious.MvvmCross.Plugins.Color.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Color.Touch" />
         <file src="TouchBootstrapContent\ColorPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\ColorPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.DownloadCache.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.DownloadCache.3.0.1.nuspec
@@ -19,17 +19,20 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.DownloadCache.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.DownloadCache.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.DownloadCache.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.DownloadCache.pdb" />
+		<file src="..\Plugins\Cirrious\DownloadCache\Cirrious.MvvmCross.Plugins.DownloadCache\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.DownloadCache" />
         
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.DownloadCache.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.DownloadCache.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.DownloadCache.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.DownloadCache.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.DownloadCache.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.DownloadCache.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.DownloadCache.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.DownloadCache.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\DownloadCache\Cirrious.MvvmCross.Plugins.DownloadCache.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.DownloadCache.Droid" />
         <file src="BootstrapContent\DownloadCachePluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\DownloadCachePluginBootstrap.cs.pp" />
 
 		<!-- touch -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.DownloadCache.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.DownloadCache.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.DownloadCache.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.DownloadCache.pdb" />
+		<file src="..\Plugins\Cirrious\DownloadCache\Cirrious.MvvmCross.Plugins.DownloadCache.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.DownloadCache.Touch" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.DownloadCache.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.DownloadCache.Touch.dll" />
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.DownloadCache.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.DownloadCache.Touch.pdb" />

--- a/nuspec/MvvmCross.HotTuna.Plugin.Email.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Email.3.0.1.nuspec
@@ -19,12 +19,14 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Email.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Email.pdb" />
+		<file src="..\Plugins\Cirrious\Email\Cirrious.MvvmCross.Plugins.Email\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Email" />
 
     	<!-- wpf  -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Email.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Email.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Email.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Email.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Email.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Email.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Email\Cirrious.MvvmCross.Plugins.Email.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Email.Wpf" />
         <file src="BootstrapContent\EmailPluginBootstrap.cs.pp" target="content\net45\Bootstrap\EmailPluginBootstrap.cs.pp" />
 		
 		<!-- store -->
@@ -32,6 +34,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Email.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Email.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Email.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Email.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Email.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Email\Cirrious.MvvmCross.Plugins.Email.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Email.WindowsStore" />
         <file src="BootstrapContent\EmailPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\EmailPluginBootstrap.cs.pp" />
 		
 		<!-- phone -->
@@ -39,6 +42,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Email.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Email.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Email.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Email.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Email.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Email\Cirrious.MvvmCross.Plugins.Email.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Email.WindowsPhone" />
         <file src="BootstrapContent\EmailPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\EmailPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
@@ -47,6 +51,7 @@
         <file src="BootstrapContent\EmailPluginBootstrap.cs.pp" target="content\win81\Bootstrap\EmailPluginBootstrap.cs.pp" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Email.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Email.WindowsCommon.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Email.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Email\Cirrious.MvvmCross.Plugins.Email.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Email.WindowsCommon" />
         <file src="BootstrapContent\EmailPluginBootstrap.cs.pp" target="content\wpa81\Bootstrap\EmailPluginBootstrap.cs.pp" />
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Plugins.Email.dll" />
@@ -57,6 +62,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Email.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Email.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Email.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Email.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Email.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Email.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Email\Cirrious.MvvmCross.Plugins.Email.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Email.Droid" />
         <file src="BootstrapContent\EmailPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\EmailPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -66,6 +72,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Email.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Email.Touch.pdb" />
 		-->
+		<file src="..\Plugins\Cirrious\Email\Cirrious.MvvmCross.Plugins.Email.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Email.Touch" />
         <file src="TouchBootstrapContent\EmailPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\EmailPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.FieldBinding.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.FieldBinding.3.0.1.nuspec
@@ -16,6 +16,10 @@
 		</dependencies>
 	</metadata>
 	<files>		
+	    <!-- Common -->
+		<file src="..\Plugins\Cirrious\FieldBinding\Cirrious.MvvmCross.FieldBinding\**\*.cs" target="src\Cirrious.MvvmCross.FieldBinding" />
+		<file src="..\Plugins\Cirrious\FieldBinding\Cirrious.MvvmCross.Plugins.FieldBinding\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.FieldBinding" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.FieldBinding.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.FieldBinding.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.FieldBinding.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.FieldBinding.pdb" />

--- a/nuspec/MvvmCross.HotTuna.Plugin.File.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.File.3.0.1.nuspec
@@ -16,6 +16,9 @@
 		</dependencies>
 	</metadata>
 	<files>		
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\File\Cirrious.MvvmCross.Plugins.File\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.File" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.File.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.File.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.File.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.File.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.File.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.File.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.File.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\File\Cirrious.MvvmCross.Plugins.File.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.File.Wpf" />
         <file src="BootstrapContent\FilePluginBootstrap.cs.pp" target="content\net45\Bootstrap\FilePluginBootstrap.cs.pp" />
 		
 		<!-- store -->
@@ -32,6 +36,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.File.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.File.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.File.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.File.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.File.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\File\Cirrious.MvvmCross.Plugins.File.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.File.WindowsStore" />
         <file src="BootstrapContent\FilePluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\FilePluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -39,11 +44,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.File.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.File.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.File.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.File.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.File.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\File\Cirrious.MvvmCross.Plugins.File.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.File.WindowsPhone" />
         <file src="BootstrapContent\FilePluginBootstrap.cs.pp" target="content\wp8\Bootstrap\FilePluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.File.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.File.WindowsCommon.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.File.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\File\Cirrious.MvvmCross.Plugins.File.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.File.WindowsCommon" />
         <file src="BootstrapContent\FilePluginBootstrap.cs.pp" target="content\win81\Bootstrap\FilePluginBootstrap.cs.pp" />
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.File.dll" />
@@ -58,6 +65,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.File.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.File.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.File.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.File.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.File.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.File.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\File\Cirrious.MvvmCross.Plugins.File.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.File.Droid" />
         <file src="BootstrapContent\FilePluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\FilePluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -67,6 +75,7 @@
         <!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.File.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.File.Touch.pdb" />
 		-->
+		<file src="..\Plugins\Cirrious\File\Cirrious.MvvmCross.Plugins.File.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.File.Touch" />
         <file src="TouchBootstrapContent\FilePluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\FilePluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.Json.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Json.3.0.1.nuspec
@@ -16,7 +16,10 @@
 		  <dependency id="Newtonsoft.Json" version="6.0.1" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\Json\Cirrious.MvvmCross.Plugins.Json\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Json" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Json.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Json.dll" />		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Json.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Json.pdb" />		

--- a/nuspec/MvvmCross.HotTuna.Plugin.Location.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Location.3.0.1.nuspec
@@ -16,6 +16,9 @@
 		</dependencies>
 	</metadata>
 	<files>		
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\Location\Cirrious.MvvmCross.Plugins.Location\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Location" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Location.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Location.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Location.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Location.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Location.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Location.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Location.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Location\Cirrious.MvvmCross.Plugins.Location.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Location.Wpf" />
         <file src="BootstrapContent\LocationPluginBootstrap.cs.pp" target="content\net45\Bootstrap\LocationPluginBootstrap.cs.pp" />
 				
 		<!-- store -->
@@ -32,6 +36,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Location.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Location.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Location.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Location.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Location.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Location\Cirrious.MvvmCross.Plugins.Location.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Location.WindowsStore" />
         <file src="BootstrapContent\LocationPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\LocationPluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -39,11 +44,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Location.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Location.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Location.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Location.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Location.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Location\Cirrious.MvvmCross.Plugins.Location.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Location.WindowsPhone" />
         <file src="BootstrapContent\LocationPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\LocationPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.Location.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Location.WindowsCommon.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.Location.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Location\Cirrious.MvvmCross.Plugins.Location.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Location.WindowsCommon" />
         <file src="BootstrapContent\LocationPluginBootstrap.cs.pp" target="content\win81\Bootstrap\LocationPluginBootstrap.cs.pp" />
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Location.dll" />
@@ -58,6 +65,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Location.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Location.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Location.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Location.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Location.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Location.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Location\Cirrious.MvvmCross.Plugins.Location.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Location.Droid" />
         <file src="BootstrapContent\LocationPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\LocationPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -67,6 +75,7 @@
         <!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Location.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Location.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\Location\Cirrious.MvvmCross.Plugins.Location.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Location.Touch" />
 		<file src="TouchBootstrapContent\LocationPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\LocationPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.Messenger.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Messenger.3.0.1.nuspec
@@ -15,7 +15,10 @@
 		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\Messenger\Cirrious.MvvmCross.Plugins.Messenger\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Messenger" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Messenger.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Messenger.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Messenger.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Messenger.pdb" />

--- a/nuspec/MvvmCross.HotTuna.Plugin.MethodBinding.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.MethodBinding.3.0.1.nuspec
@@ -15,7 +15,10 @@
 		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\MethodBinding\Cirrious.MvvmCross.Plugins.MethodBinding\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.MethodBinding" />
+	
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.MethodBinding.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.MethodBinding.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.MethodBinding.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.MethodBinding.pdb" />

--- a/nuspec/MvvmCross.HotTuna.Plugin.Network.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Network.3.0.1.nuspec
@@ -16,7 +16,10 @@
 		  <dependency id="MvvmCross.HotTuna.Plugin.File" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\Network\Cirrious.MvvmCross.Plugins.Network\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Network" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Network.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Network.pdb" />
@@ -26,6 +29,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Network.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Network.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Network.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Network.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Network.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Network\Cirrious.MvvmCross.Plugins.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Wpf" />
         <file src="BootstrapContent\NetworkPluginBootstrap.cs.pp" target="content\net45\Bootstrap\NetworkPluginBootstrap.cs.pp" />
 		
 		<!-- store -->
@@ -33,6 +37,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Network.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Network.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Network.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Network.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Network.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Network\Cirrious.MvvmCross.Plugins.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsStore" />
         <file src="BootstrapContent\NetworkPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\NetworkPluginBootstrap.cs.pp" />
 		
 		<!-- phone -->
@@ -40,11 +45,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Network.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Network.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Network.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Network.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Network.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Network\Cirrious.MvvmCross.Plugins.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsPhone" />
         <file src="BootstrapContent\NetworkPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\NetworkPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.Network.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Network.WindowsCommon.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.Network.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Network\Cirrious.MvvmCross.Plugins.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsCommon" />
         <file src="BootstrapContent\NetworkPluginBootstrap.cs.pp" target="content\win81\Bootstrap\NetworkPluginBootstrap.cs.pp" />
 		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Network.dll" />
@@ -59,6 +66,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Network.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Network.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Network.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Network.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Network.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Network.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Network\Cirrious.MvvmCross.Plugins.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Droid" />
         <file src="BootstrapContent\NetworkPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\NetworkPluginBootstrap.cs.pp" />
 		
 		<!-- touch -->
@@ -68,6 +76,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Network.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Network.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\Network\Cirrious.MvvmCross.Plugins.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Touch" />
 		<file src="TouchBootstrapContent\NetworkPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\NetworkPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.PhoneCall.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.PhoneCall.3.0.1.nuspec
@@ -16,6 +16,9 @@
 		</dependencies>
 	</metadata>
 	<files>		
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\PhoneCall\Cirrious.MvvmCross.Plugins.PhoneCall\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.PhoneCall" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PhoneCall.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.PhoneCall.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\PhoneCall\Cirrious.MvvmCross.Plugins.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsStore" />
         <file src="BootstrapContent\PhoneCallPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\PhoneCallPluginBootstrap.cs.pp" />
 		
 		<!-- phone -->
@@ -32,11 +36,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\PhoneCall\Cirrious.MvvmCross.Plugins.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsPhone" />
         <file src="BootstrapContent\PhoneCallPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\PhoneCallPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PhoneCall.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.PhoneCall.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsStore.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.PhoneCall.WindowsStore.dll" />
+		<file src="..\Plugins\Cirrious\PhoneCall\Cirrious.MvvmCross.Plugins.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsStore" />
         <file src="BootstrapContent\PhoneCallPluginBootstrap.cs.pp" target="content\win81\Bootstrap\PhoneCallPluginBootstrap.cs.pp" />
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PhoneCall.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.PhoneCall.dll" />
@@ -48,6 +54,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PhoneCall.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.PhoneCall.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PhoneCall.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.PhoneCall.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PhoneCall.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\PhoneCall\Cirrious.MvvmCross.Plugins.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Droid" />
         <file src="BootstrapContent\PhoneCallPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\PhoneCallPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -57,6 +64,8 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.PhoneCall.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.PhoneCall.Touch.pdb" />
         -->
+		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.PhoneCall.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PhoneCall.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\PhoneCall\Cirrious.MvvmCross.Plugins.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Touch" />
 		<file src="TouchBootstrapContent\PhoneCallPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\PhoneCallPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.PictureChooser.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.PictureChooser.3.0.1.nuspec
@@ -15,7 +15,10 @@
 		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\PictureChooser\Cirrious.MvvmCross.Plugins.PictureChooser\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.PictureChooser" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.PictureChooser.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\PictureChooser\Cirrious.MvvmCross.Plugins.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsStore" />
         <file src="BootstrapContent\PictureChooserPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\PictureChooserPluginBootstrap.cs.pp" />
 		
 		<!-- phone -->
@@ -32,22 +36,28 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\PictureChooser\Cirrious.MvvmCross.Plugins.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsPhone" />
         <file src="BootstrapContent\PictureChooserPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\PictureChooserPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.PictureChooser.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsStore.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsStore.dll" />
+		<file src="..\Plugins\Cirrious\PictureChooser\Cirrious.MvvmCross.Plugins.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsCommon" />
         <file src="BootstrapContent\PictureChooserPluginBootstrap.cs.pp" target="content\win81\Bootstrap\PictureChooserPluginBootstrap.cs.pp" />
 		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.PictureChooser.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhoneStore\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsPhoneStore.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.PictureChooser.WindowsPhoneStore.dll" />
+		<file src="..\Plugins\Cirrious\PictureChooser\Cirrious.MvvmCross.Plugins.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsStore" />
         <file src="BootstrapContent\PictureChooserPluginBootstrap.cs.pp" target="content\wpa81\Bootstrap\PictureChooserPluginBootstrap.cs.pp" />
+		
+		
 		
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PictureChooser.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PictureChooser.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.PictureChooser.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PictureChooser.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.PictureChooser.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.PictureChooser.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\PictureChooser\Cirrious.MvvmCross.Plugins.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Droid" />
         <file src="BootstrapContent\PictureChooserPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\PictureChooserPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -57,6 +67,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.PictureChooser.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.PictureChooser.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\PictureChooser\Cirrious.MvvmCross.Plugins.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Touch" />
 		<file src="TouchBootstrapContent\PictureChooserPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\PictureChooserPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.ReflectionEx.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.ReflectionEx.3.0.1.nuspec
@@ -16,6 +16,10 @@
 		</dependencies>
 	</metadata>
 	<files>		
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx" />
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx.Console\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx.Console" />
+				
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.ReflectionEx.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" />
@@ -25,6 +29,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.ReflectionEx.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.ReflectionEx.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.ReflectionEx.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.ReflectionEx.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx.Wpf" />
         <file src="BootstrapContent\ReflectionExPluginBootstrap.cs.pp" target="content\net45\Bootstrap\ReflectionExPluginBootstrap.cs.pp" />
 	
 		<!-- store -->
@@ -32,6 +37,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsStore" />
         <file src="BootstrapContent\ReflectionExPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\ReflectionExPluginBootstrap.cs.pp" />
 		
 		<!-- phone -->
@@ -39,11 +45,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsPhone" />
         <file src="BootstrapContent\ReflectionExPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\ReflectionExPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.ReflectionEx.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsCommon.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx.WindowsCommon" />
         <file src="BootstrapContent\ReflectionExPluginBootstrap.cs.pp" target="content\win81\Bootstrap\ReflectionExPluginBootstrap.cs.pp" />
 		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.ReflectionEx.dll" />
@@ -58,6 +66,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ReflectionEx.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.ReflectionEx.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ReflectionEx.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.ReflectionEx.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ReflectionEx.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx.Droid" />
         <file src="BootstrapContent\ReflectionExPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\ReflectionExPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -67,6 +76,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.ReflectionEx.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.ReflectionEx.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\ReflectionEx\Cirrious.MvvmCross.Plugins.ReflectionEx.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ReflectionEx.Touch" />
 		<file src="TouchBootstrapContent\ReflectionExPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\ReflectionExPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.ResourceLoader.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.ResourceLoader.3.0.1.nuspec
@@ -15,7 +15,10 @@
 		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\ResourceLoader\Cirrious.MvvmCross.Plugins.ResourceLoader\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ResourceLoader" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.ResourceLoader.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.ResourceLoader.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.ResourceLoader.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.ResourceLoader.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.ResourceLoader.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\ResourceLoader\Cirrious.MvvmCross.Plugins.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Wpf" />
 		<file src="BootstrapContent\ResourceLoaderPluginBootstrap.cs.pp" target="content\net45\Bootstrap\ResourceLoaderPluginBootstrap.cs.pp" />
 	
 		<!-- store -->
@@ -32,6 +36,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\ResourceLoader\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsStore" />
         <file src="BootstrapContent\ResourceLoaderPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\ResourceLoaderPluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -39,11 +44,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\ResourceLoader\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsPhone" />
         <file src="BootstrapContent\ResourceLoaderPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\ResourceLoaderPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.ResourceLoader.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsCommon.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\ResourceLoader\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ResourceLoader.WindowsCommon" />
         <file src="BootstrapContent\ResourceLoaderPluginBootstrap.cs.pp" target="content\win81\Bootstrap\ResourceLoaderPluginBootstrap.cs.pp" />
 		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.ResourceLoader.dll" />
@@ -58,6 +65,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ResourceLoader.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.ResourceLoader.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ResourceLoader.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.ResourceLoader.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ResourceLoader.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\ResourceLoader\Cirrious.MvvmCross.Plugins.ResourceLoader.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ResourceLoader.Droid" />
         <file src="BootstrapContent\ResourceLoaderPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\ResourceLoaderPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -67,6 +75,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.ResourceLoader.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.ResourceLoader.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\ResourceLoader\Cirrious.MvvmCross.Plugins.ResourceLoader.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ResourceLoader.Touch" />
 		<file src="TouchBootstrapContent\ResourceLoaderPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\ResourceLoaderPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.SQLite.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.SQLite.3.0.1.nuspec
@@ -16,6 +16,13 @@
 		</dependencies>
 	</metadata>
 	<files>		
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite" />
+		
+		<!-- Do we use these? -->
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.Console\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.Console" />
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.WindowsPhone.Store\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.WindowsPhone.Store" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Sqlite.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Sqlite.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Sqlite.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Sqlite.pdb" />
@@ -25,6 +32,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Sqlite.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Sqlite.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Sqlite.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Sqlite.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Sqlite.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Sqlite.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.Wpf" />
         <file src="BootstrapContent\SqlitePluginBootstrap.cs.pp" target="content\net45\Bootstrap\SqlitePluginBootstrap.cs.pp" />
 		
 		<!-- store -->
@@ -36,6 +44,7 @@
 		<file src="..\bin\Release\Mvx\WindowsStore\x64\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore.pdb" target="lib\netcore45\x64\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\ARM\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore.dll" target="lib\netcore45\ARM\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\ARM\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore.pdb" target="lib\netcore45\ARM\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.WindowsStore" />
         <file src="BootstrapContent\SqlitePluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\SqlitePluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -47,6 +56,8 @@
 <!--		
 		<file src="..\bin\Release\Mvx\WindowsPhone\Community.CsharpSqlite.WP7.pdb" target="lib\wp8\Community.CsharpSqlite.WP7.pdb" />
 -->		
+<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.WindowsPhone.Community\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.WindowsPhone.Community" />
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.WindowsPhone" />
         <file src="BootstrapContent\SqlitePluginBootstrap.cs.pp" target="content\wp8\Bootstrap\SqlitePluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
@@ -60,12 +71,14 @@
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Sqlite.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Plugins.Sqlite.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Sqlite.WindowsCommon.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Plugins.Sqlite.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.WindowsCommon" />
 		
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Sqlite.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Sqlite.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Sqlite.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Sqlite.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Sqlite.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Sqlite.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Sqlite.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Sqlite.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.Droid" />
         <file src="BootstrapContent\SqlitePluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\SqlitePluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -75,6 +88,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Sqlite.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Sqlite.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\Sqlite\Cirrious.MvvmCross.Plugins.Sqlite.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Sqlite.Touch" />
 		<file src="TouchBootstrapContent\SqlitePluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\SqlitePluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.Share.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Share.3.0.1.nuspec
@@ -15,7 +15,10 @@
 		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\Share\Cirrious.MvvmCross.Plugins.Share\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Share" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Share.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Share.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Share.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Share.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Share.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Share.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Share.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Share\Cirrious.MvvmCross.Plugins.Share.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Share.Wpf" />
         <file src="BootstrapContent\SharePluginBootstrap.cs.pp" target="content\net45\Bootstrap\SharePluginBootstrap.cs.pp" />
 	
 		<!-- store -->
@@ -32,6 +36,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Share.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Share.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Share.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Share.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Share.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Share\Cirrious.MvvmCross.Plugins.Share.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Share.WindowsStore" />
         <file src="BootstrapContent\SharePluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\SharePluginBootstrap.cs.pp" />
 		
 		<!-- phone -->
@@ -39,6 +44,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Share.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Share.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Share.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Share.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Share.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Share\Cirrious.MvvmCross.Plugins.Share.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Share.WindowsPhone" />
         <file src="BootstrapContent\SharePluginBootstrap.cs.pp" target="content\wp8\Bootstrap\SharePluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
@@ -47,6 +53,7 @@
         <file src="BootstrapContent\SharePluginBootstrap.cs.pp" target="content\win81\Bootstrap\SharePluginBootstrap.cs.pp" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Share.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Share.WindowsCommon.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Share.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Share\Cirrious.MvvmCross.Plugins.Share.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Share.WindowsCommon" />
         <file src="BootstrapContent\SharePluginBootstrap.cs.pp" target="content\wpa81\Bootstrap\SharePluginBootstrap.cs.pp" />
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Plugins.Share.dll" />
@@ -57,6 +64,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Share.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Share.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Share.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Share.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Share.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Share.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Share\Cirrious.MvvmCross.Plugins.Share.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Share.Droid" />
         <file src="BootstrapContent\SharePluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\SharePluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -66,6 +74,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Share.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Share.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\Share\Cirrious.MvvmCross.Plugins.Share.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Share.Touch" />
 		<file src="TouchBootstrapContent\SharePluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\SharePluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.SoundEffects.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.SoundEffects.3.0.1.nuspec
@@ -19,12 +19,14 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.SoundEffects.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.SoundEffects.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.SoundEffects.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.SoundEffects.pdb" />
+		<file src="..\Plugins\Cirrious\SoundEffects\Cirrious.MvvmCross.Plugins.SoundEffects\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.SoundEffects" />
 	
 		<!-- phone -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.SoundEffects.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.SoundEffects.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.SoundEffects.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.SoundEffects.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.SoundEffects.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.SoundEffects.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.SoundEffects.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.SoundEffects.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\SoundEffects\Cirrious.MvvmCross.Plugins.SoundEffects.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.SoundEffects.WindowsPhone" />
         <file src="BootstrapContent\SoundEffectsPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\SoundEffectsPluginBootstrap.cs.pp" />
 	
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.ThreadUtils.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.ThreadUtils.3.0.1.nuspec
@@ -16,6 +16,9 @@
 		</dependencies>
 	</metadata>
 	<files>		
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\ThreadUtils\Cirrious.MvvmCross.Plugins.ThreadUtils\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ThreadUtils" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ThreadUtils.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.ThreadUtils.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.ThreadUtils.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.ThreadUtils.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.ThreadUtils.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.ThreadUtils.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\ThreadUtils\Cirrious.MvvmCross.Plugins.ThreadUtils.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ThreadUtils.Wpf" />
         <file src="BootstrapContent\ThreadUtilsPluginBootstrap.cs.pp" target="content\net45\Bootstrap\ThreadUtilsPluginBootstrap.cs.pp" />
 		
 		<!-- store -->
@@ -32,6 +36,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\ThreadUtils\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsStore" />
         <file src="BootstrapContent\ThreadUtilsPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\ThreadUtilsPluginBootstrap.cs.pp" />
 			
 		<!-- phone -->
@@ -39,6 +44,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\ThreadUtils\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsPhone" />
         <file src="BootstrapContent\ThreadUtilsPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\ThreadUtilsPluginBootstrap.cs.pp" />
 		
 		<!-- windows common -->
@@ -47,6 +53,7 @@
         <file src="BootstrapContent\ThreadUtilsPluginBootstrap.cs.pp" target="content\win81\Bootstrap\ThreadUtilsPluginBootstrap.cs.pp" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ThreadUtils.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.ThreadUtils.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsCommon.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\ThreadUtils\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ThreadUtils.WindowsCommon" />
         <file src="BootstrapContent\ThreadUtilsPluginBootstrap.cs.pp" target="content\wpa81\Bootstrap\ThreadUtilsPluginBootstrap.cs.pp" />
 
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ThreadUtils.dll" target="lib\portable-win81+wpa81\Cirrious.MvvmCross.Plugins.ThreadUtils.dll" />
@@ -57,6 +64,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ThreadUtils.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.ThreadUtils.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ThreadUtils.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.ThreadUtils.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.ThreadUtils.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\ThreadUtils\Cirrious.MvvmCross.Plugins.ThreadUtils.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ThreadUtils.Droid" />
         <file src="BootstrapContent\ThreadUtilsPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\ThreadUtilsPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -66,6 +74,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.ThreadUtils.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.ThreadUtils.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\ThreadUtils\Cirrious.MvvmCross.Plugins.ThreadUtils.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.ThreadUtils.Touch" />
 		<file src="TouchBootstrapContent\ThreadUtilsPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\ThreadUtilsPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.Visibility.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.Visibility.3.0.1.nuspec
@@ -15,7 +15,11 @@
 		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility" />
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility.Console\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility.Console" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Visibility.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.Visibility.pdb" />
@@ -25,6 +29,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Visibility.pdb" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Visibility.Wpf.dll" target="lib\net45\Cirrious.MvvmCross.Plugins.Visibility.Wpf.dll" />
 		<file src="..\bin\Release\Mvx\Wpf\Cirrious.MvvmCross.Plugins.Visibility.Wpf.pdb" target="lib\net45\Cirrious.MvvmCross.Plugins.Visibility.Wpf.pdb" />
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility.Wpf\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility.Wpf" />
         <file src="BootstrapContent\VisibilityPluginBootstrap.cs.pp" target="content\net45\Bootstrap\VisibilityPluginBootstrap.cs.pp" />
 		
 		<!-- store -->
@@ -32,6 +37,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Visibility.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Visibility.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Visibility.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.Visibility.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.Visibility.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility.WindowsStore" />
         <file src="BootstrapContent\VisibilityPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\VisibilityPluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -39,11 +45,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Visibility.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Visibility.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.Visibility.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.Visibility.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.Visibility.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility.WindowsPhone" />
         <file src="BootstrapContent\VisibilityPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\VisibilityPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.Visibility.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.Visibility.WindowsCommon.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.Visibility.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility.WindowsCommon" />
         <file src="BootstrapContent\VisibilityPluginBootstrap.cs.pp" target="content\win81\Bootstrap\VisibilityPluginBootstrap.cs.pp" />
 		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.Visibility.dll" />
@@ -58,6 +66,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.Visibility.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Visibility.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Visibility.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Visibility.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.Visibility.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.Visibility.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility.Droid" />
         <file src="BootstrapContent\VisibilityPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\VisibilityPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -67,6 +76,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.Visibility.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.Visibility.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\Visibility\Cirrious.MvvmCross.Plugins.Visibility.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Visibility.Touch" />
 		<file src="TouchBootstrapContent\VisibilityPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\VisibilityPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Plugin.WebBrowser.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Plugin.WebBrowser.3.0.1.nuspec
@@ -15,7 +15,10 @@
 		  <dependency id="MvvmCross.HotTuna.CrossCore" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\Plugins\Cirrious\WebBrowser\Cirrious.MvvmCross.Plugins.WebBrowser\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WebBrowser" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.WebBrowser.dll" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.WebBrowser.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" target="lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" />
@@ -25,6 +28,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsStore.dll" target="lib\netcore45\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsStore.dll" />
 		<file src="..\bin\Release\Mvx\WindowsStore\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsStore.pdb" target="lib\netcore45\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsStore.pdb" />
+		<file src="..\Plugins\Cirrious\WebBrowser\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsStore\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsStore" />
         <file src="BootstrapContent\WebBrowserPluginBootstrap.cs.pp" target="content\netcore45\Bootstrap\WebBrowserPluginBootstrap.cs.pp" />
         
 		<!-- phone -->
@@ -32,11 +36,13 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsPhone.dll" target="lib\wp8\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsPhone.dll" />
 		<file src="..\bin\Release\Mvx\WindowsPhone\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsPhone.pdb" target="lib\wp8\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsPhone.pdb" />
+		<file src="..\Plugins\Cirrious\WebBrowser\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsPhone\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsPhone" />
         <file src="BootstrapContent\WebBrowserPluginBootstrap.cs.pp" target="content\wp8\Bootstrap\WebBrowserPluginBootstrap.cs.pp" />
 	
 		<!-- windows common -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.WebBrowser.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.WebBrowser.dll" />
 		<file src="..\bin\Release\Mvx\WindowsCommon\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsCommon.dll" target="lib\win81\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsCommon.dll" />
+		<file src="..\Plugins\Cirrious\WebBrowser\Cirrious.MvvmCross.Plugins.WebBrowser.WindowsCommon\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.WindowsCommon" />
         <file src="BootstrapContent\WebBrowserPluginBootstrap.cs.pp" target="content\win81\Bootstrap\WebBrowserPluginBootstrap.cs.pp" />
 		
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.WebBrowser.dll" target="lib\wpa81\Cirrious.MvvmCross.Plugins.WebBrowser.dll" />
@@ -51,6 +57,7 @@
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.WebBrowser.pdb" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.WebBrowser.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.WebBrowser.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Plugins.WebBrowser.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Plugins.WebBrowser.Droid.pdb" />
+		<file src="..\Plugins\Cirrious\WebBrowser\Cirrious.MvvmCross.Plugins.WebBrowser.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Droid" />
         <file src="BootstrapContent\WebBrowserPluginBootstrap.cs.pp" target="content\MonoAndroid\Bootstrap\WebBrowserPluginBootstrap.cs.pp" />
 
 		<!-- touch -->
@@ -60,6 +67,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Plugins.WebBrowser.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Plugins.WebBrowser.Touch.pdb" />
         -->
+		<file src="..\Plugins\Cirrious\WebBrowser\Cirrious.MvvmCross.Plugins.WebBrowser.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Plugins.Touch" />
 		<file src="TouchBootstrapContent\WebBrowserPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\WebBrowserPluginBootstrap.cs.pp" />
 		
 	</files>

--- a/nuspec/MvvmCross.HotTuna.Touch.AutoViews.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Touch.AutoViews.3.0.1.nuspec
@@ -24,6 +24,7 @@
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\CrossUI.Touch.pdb" target="lib\Xamarin.iOS10\CrossUI.Touch.pdb" />
 		-->
+		<file src="..\Cirrious\Cirrious.MvvmCross.AutoView.Touch\**\*.cs" target="src\Cirrious.MvvmCross.AutoView.Touch" />
 		
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.Touch.Dialog.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Touch.Dialog.3.0.1.nuspec
@@ -17,14 +17,16 @@
 		<!-- touch -->
 		<file src="..\bin\Release\Mvx\Touch\CrossUI.Core.dll" target="lib\Xamarin.iOS10\CrossUI.Core.dll" />
 		<file src="..\bin\Release\Mvx\Touch\CrossUI.Core.pdb" target="lib\Xamarin.iOS10\CrossUI.Core.pdb" />
+		<file src="..\CrossUI\CrossUI.Core\**\*.cs" target="CrossUI.Core" />
 		<file src="..\bin\Release\Mvx\Touch\CrossUI.Touch.dll" target="lib\Xamarin.iOS10\CrossUI.Touch.dll" />
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\CrossUI.Touch.pdb" target="lib\Xamarin.iOS10\CrossUI.Touch.pdb" />
 		-->
+		<file src="..\CrossUI\CrossUI.Touch\**\*.cs" target="CrossUI.Touch" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Dialog.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Dialog.Touch.dll" />
 		<!-- vs doesn't seem to generate symbols for Touch
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Dialog.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Dialog.Touch.pdb" />
 		-->
-		
+		<file src="..\Cirrious\Cirrious.MvvmCross.Dialog.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Dialog.Touch" />
 	</files>
 </package>

--- a/nuspec/MvvmCross.HotTuna.XamMac.CrossCore.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.XamMac.CrossCore.3.0.1.nuspec
@@ -12,7 +12,12 @@
 		  <dependency id="MvvmCross.Mac.PortableSupport" version="3.5.0" />
 		</dependencies>
 	</metadata>
-	<files>		
+	<files>
+		<!-- Common -->
+		<file src="..\CrossCore\Cirrious.CrossCore\**\*.cs" target="src\Cirrious.CrossCore" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Localization\**\*.cs" target="src\Cirrious.MvvmCross.Localization" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding\**\*.cs" target="src\Cirrious.MvvmCross.Binding" />
+		
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.CrossCore.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.pdb" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.CrossCore.pdb" />
@@ -22,8 +27,10 @@
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.CrossCore.Droid.dll" target="lib\MonoAndroid\Cirrious.CrossCore.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.CrossCore.Droid.pdb" target="lib\MonoAndroid\Cirrious.CrossCore.Droid.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.Droid\**\*.cs" target="src\Cirrious.CrossCore.Droid" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Binding.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Binding.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Binding.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Binding.Droid.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Binding.Droid" />
 
 		<!-- droid - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\MonoAndroid\Cirrious.CrossCore.dll" />
@@ -36,8 +43,10 @@
 		<!-- touch -->
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.CrossCore.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.CrossCore.Touch.dll" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.CrossCore.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.CrossCore.Touch.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.Touch\**\*.cs" target="src\Cirrious.CrossCore.Touch" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Binding.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Binding.Touch.dll" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Binding.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Binding.Touch.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Binding.Touch" />
 
 		<!-- touch - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\Xamarin.iOS10\Cirrious.CrossCore.dll" />
@@ -50,8 +59,10 @@
 		<!-- mac -->
 		<file src="..\bin\Release\Mvx\XamMac\Cirrious.CrossCore.XamMac.dll" target="lib\net45\Cirrious.CrossCore.XamMac.dll" />
 		<file src="..\bin\Release\Mvx\XamMac\Cirrious.CrossCore.XamMac.pdb" target="lib\net45\Cirrious.CrossCore.XamMac.pdb" />
+		<file src="..\CrossCore\Cirrious.CrossCore.XamMac\**\*.cs" target="src\Cirrious.CrossCore.XamMac" />
 		<file src="..\bin\Release\Mvx\XamMac\Cirrious.MvvmCross.Binding.XamMac.dll" target="lib\net45\Cirrious.MvvmCross.Binding.XamMac.dll" />
 		<file src="..\bin\Release\Mvx\XamMac\Cirrious.MvvmCross.Binding.XamMac.pdb" target="lib\net45\Cirrious.MvvmCross.Binding.XamMac.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Binding.XamMac\**\*.cs" target="src\Cirrious.MvvmCross.Binding.XamMac" />
 
 		<!-- mac - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.CrossCore.dll" target="lib\net45\Cirrious.CrossCore.dll" />

--- a/nuspec/MvvmCross.HotTuna.XamMac.MvvmCrossLibraries.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.XamMac.MvvmCrossLibraries.3.0.1.nuspec
@@ -16,10 +16,12 @@
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.MvvmCross.dll" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.pdb" target="lib\portable-win+net45+sl50+wp8+MonoAndroid+Xamarin.iOS10\Cirrious.MvvmCross.pdb" />
-
+		<file src="..\Cirrious\Cirrious.MvvmCross\**\*.cs" target="src\Cirrious.MvvmCross" />
+		
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.dll" />
 		<file src="..\bin\Release\Mvx\Droid\Cirrious.MvvmCross.Droid.pdb" target="lib\MonoAndroid\Cirrious.MvvmCross.Droid.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Droid\**\*.cs" target="src\Cirrious.MvvmCross.Droid" />
 
 		<!-- droid - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\MonoAndroid\Cirrious.MvvmCross.dll" />
@@ -28,6 +30,7 @@
 		<!-- touch -->
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Touch.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Touch.dll" />
 		<file src="..\bin\Release\Mvx\Touch\Cirrious.MvvmCross.Touch.pdb" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.Touch.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.Touch\**\*.cs" target="src\Cirrious.MvvmCross.Touch" />
 
 		<!-- touch - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\Xamarin.iOS10\Cirrious.MvvmCross.dll" />
@@ -36,6 +39,7 @@
 		<!-- mac -->
 		<file src="..\bin\Release\Mvx\XamMac\Cirrious.MvvmCross.XamMac.dll" target="lib\net45\Cirrious.MvvmCross.XamMac.dll" />
 		<file src="..\bin\Release\Mvx\XamMac\Cirrious.MvvmCross.XamMac.pdb" target="lib\net45\Cirrious.MvvmCross.XamMac.pdb" />
+		<file src="..\Cirrious\Cirrious.MvvmCross.XamMac\**\*.cs" target="src\Cirrious.MvvmCross.XamMac" />
 
 		<!-- mac - PCL -->
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\net45\Cirrious.MvvmCross.dll" />


### PR DESCRIPTION
This should add all of the sources to the symbol packages so that people who use the nuget packages can step through the source.

That's the theory anyway, I can't build iOS or windows phone/store apps so I can't test those.

See http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-symbol-package