### PR TITLE
Location plugin provides event to track permission now

### DIFF
--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidGeoLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidGeoLocationWatcher.cs
@@ -155,7 +155,7 @@ namespace Cirrious.MvvmCross.Plugins.Location.Droid
 
         public void OnProviderDisabled(string provider)
         {
-            SendError(MvxLocationErrorCode.PositionUnavailable);
+            SendError(MvxLocationErrorCode.ServiceUnavailable);
         }
 
         public void OnProviderEnabled(string provider)
@@ -170,6 +170,8 @@ namespace Cirrious.MvvmCross.Plugins.Location.Droid
                 case Availability.Available:
                     break;
                 case Availability.OutOfService:
+                    SendError(MvxLocationErrorCode.ServiceUnavailable);
+                    break;
                 case Availability.TemporarilyUnavailable:
                     SendError(MvxLocationErrorCode.PositionUnavailable);
                     break;

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidLocationWatcher.cs
@@ -167,7 +167,7 @@ namespace Cirrious.MvvmCross.Plugins.Location.Droid
         public void OnProviderDisabled(string provider)
         {
 			Permission = MvxLocationPermission.Denied;
-            SendError(MvxLocationErrorCode.PositionUnavailable);
+            SendError(MvxLocationErrorCode.ServiceUnavailable);
         }
 
         public void OnProviderEnabled(string provider)
@@ -182,6 +182,8 @@ namespace Cirrious.MvvmCross.Plugins.Location.Droid
                 case Availability.Available:
                     break;
                 case Availability.OutOfService:
+                    SendError(MvxLocationErrorCode.ServiceUnavailable);
+                    break;
                 case Availability.TemporarilyUnavailable:
                     SendError(MvxLocationErrorCode.PositionUnavailable);
                     break;

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidLocationWatcher.cs
@@ -166,12 +166,13 @@ namespace Cirrious.MvvmCross.Plugins.Location.Droid
 
         public void OnProviderDisabled(string provider)
         {
+			Permission = MvxLocationPermission.Denied;
             SendError(MvxLocationErrorCode.PositionUnavailable);
         }
 
         public void OnProviderEnabled(string provider)
         {
-            // nothing to do 
+			Permission = MvxLocationPermission.Granted;
         }
 
         public void OnStatusChanged(string provider, Availability status, Bundle extras)

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Droid/MvxAndroidLocationWatcher.cs
@@ -74,6 +74,10 @@ namespace Cirrious.MvvmCross.Plugins.Location.Droid
                 (long)options.TimeBetweenUpdates.TotalMilliseconds,
                 options.MovementThresholdInM, 
                 _locationListener);
+
+			Permission = _locationManager.IsProviderEnabled (_bestProvider)
+				? MvxLocationPermission.Granted
+				: MvxLocationPermission.Denied;
         }
 
         protected override void PlatformSpecificStop()

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Touch/MvxTouchLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Touch/MvxTouchLocationWatcher.cs
@@ -196,6 +196,25 @@ namespace Cirrious.MvvmCross.Plugins.Location.Touch
             {
                 // ignored for now
             }
+
+			public override void AuthorizationChanged (CLLocationManager manager, CLAuthorizationStatus status)
+			{
+				switch (status) {
+				case CLAuthorizationStatus.NotDetermined:
+					_owner.Permission = MvxLocationPermission.Unknown;
+					break;
+				case CLAuthorizationStatus.Restricted:
+				case CLAuthorizationStatus.Denied:
+					_owner.Permission = MvxLocationPermission.Denied;
+					break;
+				case CLAuthorizationStatus.AuthorizedAlways:
+				case CLAuthorizationStatus.AuthorizedWhenInUse:
+					_owner.Permission = MvxLocationPermission.Granted;
+					break;
+				default:
+					throw new ArgumentOutOfRangeException ();
+				}
+			}
         }
 
         #endregion

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.WindowsCommon/MvxWCommonLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.WindowsCommon/MvxWCommonLocationWatcher.cs
@@ -80,22 +80,18 @@ namespace Cirrious.MvvmCross.Plugins.Location.WindowsCommon
             switch (args.Status)
             {
                 case PositionStatus.Ready:
-                    break;
                 case PositionStatus.Initializing:
+					Permission = MvxLocationPermission.Granted;
                     break;
                 case PositionStatus.NoData:
+					// TODO Permission = Unknown? Denied?
                     // TODO - trace could be useful here?
                     SendError(MvxLocationErrorCode.PositionUnavailable);
                     break;
                 case PositionStatus.Disabled:
-                    // TODO - trace could be useful here?
-                    SendError(MvxLocationErrorCode.ServiceUnavailable);
-                    break;
                 case PositionStatus.NotInitialized:
-                    // TODO - trace could be useful here?
-                    SendError(MvxLocationErrorCode.ServiceUnavailable);
-                    break;
                 case PositionStatus.NotAvailable:
+					Permission = MvxLocationPermission.Denied;
                     // TODO - trace could be useful here?
                     SendError(MvxLocationErrorCode.ServiceUnavailable);
                     break;

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.WindowsPhone/MvxWindowsPhoneLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.WindowsPhone/MvxWindowsPhoneLocationWatcher.cs
@@ -85,6 +85,7 @@ namespace Cirrious.MvvmCross.Plugins.Location.WindowsPhone
             {
                 case GeoPositionStatus.NoData:
                 case GeoPositionStatus.Disabled:
+					Permission = MvxLocationPermission.Denied;
                     var errorCode = _geoWatcher.Permission == GeoPositionPermission.Denied
                                         ? MvxLocationErrorCode.PermissionDenied
                                         : MvxLocationErrorCode.PositionUnavailable;
@@ -92,10 +93,12 @@ namespace Cirrious.MvvmCross.Plugins.Location.WindowsPhone
                     break;
                 case GeoPositionStatus.Initializing:
                 case GeoPositionStatus.Ready:
+					Permission = MvxLocationPermission.Granted;
                     // not an error - so ignored
                     break;
                 default:
                     // other codes ignored
+					// TODO do other codes affect Permission?
                     break;
             }
         }

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.WindowsStore/MvxStoreLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.WindowsStore/MvxStoreLocationWatcher.cs
@@ -80,22 +80,17 @@ namespace Cirrious.MvvmCross.Plugins.Location.WindowsStore
             switch (args.Status)
             {
                 case PositionStatus.Ready:
-                    break;
                 case PositionStatus.Initializing:
+					Permission = MvxLocationPermission.Granted;
                     break;
                 case PositionStatus.NoData:
                     // TODO - trace could be useful here?
                     SendError(MvxLocationErrorCode.PositionUnavailable);
                     break;
                 case PositionStatus.Disabled:
-                    // TODO - trace could be useful here?
-                    SendError(MvxLocationErrorCode.ServiceUnavailable);
-                    break;
                 case PositionStatus.NotInitialized:
-                    // TODO - trace could be useful here?
-                    SendError(MvxLocationErrorCode.ServiceUnavailable);
-                    break;
                 case PositionStatus.NotAvailable:
+					Permission = MvxLocationPermission.Denied;
                     // TODO - trace could be useful here?
                     SendError(MvxLocationErrorCode.ServiceUnavailable);
                     break;

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Wpf/MvxWpfLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location.Wpf/MvxWpfLocationWatcher.cs
@@ -89,14 +89,15 @@ namespace Cirrious.MvvmCross.Plugins.Location.Wpf
             switch (args.Status)
             {
                 case GeoPositionStatus.Ready:
-                    break;
                 case GeoPositionStatus.Initializing:
+					Permission = MvxLocationPermission.Granted;
                     break;
                 case GeoPositionStatus.NoData:
                     // TODO - trace could be useful here?
                     SendError(MvxLocationErrorCode.PositionUnavailable);
                     break;
                 case GeoPositionStatus.Disabled:
+					Permission = MvxLocationPermission.Denied;
                     // TODO - trace could be useful here?
                     SendError(MvxLocationErrorCode.ServiceUnavailable);
                     break;

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/Cirrious.MvvmCross.Plugins.Location.csproj
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/Cirrious.MvvmCross.Plugins.Location.csproj
@@ -52,6 +52,7 @@
     <Compile Include="PluginLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MvxLocationTrackingMode.cs" />
+    <Compile Include="MvxLocationStatus.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\CrossCore\Cirrious.CrossCore\Cirrious.CrossCore.csproj">

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/IMvxLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/IMvxLocationWatcher.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using Cirrious.CrossCore.Core;
 
 namespace Cirrious.MvvmCross.Plugins.Location
 {
@@ -19,6 +20,6 @@ namespace Cirrious.MvvmCross.Plugins.Location
         bool Started { get; }
         MvxGeoLocation CurrentLocation { get; }
         MvxGeoLocation LastSeenLocation { get; }
-		event Action<MvxLocationPermission> OnPermissionChanged;
+		event EventHandler<MvxValueEventArgs<MvxLocationPermission>> OnPermissionChanged;
     }
 }

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/IMvxLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/IMvxLocationWatcher.cs
@@ -19,5 +19,6 @@ namespace Cirrious.MvvmCross.Plugins.Location
         bool Started { get; }
         MvxGeoLocation CurrentLocation { get; }
         MvxGeoLocation LastSeenLocation { get; }
+		event Action<MvxLocationPermission> OnPermissionChanged;
     }
 }

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationStatus.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationStatus.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Cirrious.MvvmCross.Plugins.Location
+{
+	public enum MvxLocationPermission
+	{
+		Unknown,
+		Denied,
+		Granted,
+	}
+}
+

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationWatcher.cs
@@ -15,6 +15,22 @@ namespace Cirrious.MvvmCross.Plugins.Location
         private Action<MvxGeoLocation> _locationCallback;
         private Action<MvxLocationError> _errorCallback;
 
+		public event Action<MvxLocationPermission> OnPermissionChanged = delegate {};
+
+		private MvxLocationPermission _permission = MvxLocationPermission.Unknown;
+		protected MvxLocationPermission Permission 
+		{
+			get { return _permission; }
+			set 
+			{ 
+				if (_permission != value)
+				{
+					_permission = value;
+					OnPermissionChanged (value);
+				}
+			}
+		}
+
         public void Start(MvxLocationOptions options, Action<MvxGeoLocation> success, Action<MvxLocationError> error)
         {
             lock (this)

--- a/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationWatcher.cs
+++ b/Plugins/Cirrious/Location/Cirrious.MvvmCross.Plugins.Location/MvxLocationWatcher.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using Cirrious.CrossCore.Core;
 
 namespace Cirrious.MvvmCross.Plugins.Location
 {
@@ -15,7 +16,7 @@ namespace Cirrious.MvvmCross.Plugins.Location
         private Action<MvxGeoLocation> _locationCallback;
         private Action<MvxLocationError> _errorCallback;
 
-		public event Action<MvxLocationPermission> OnPermissionChanged = delegate {};
+		public event EventHandler<MvxValueEventArgs<MvxLocationPermission>> OnPermissionChanged = delegate {};
 
 		private MvxLocationPermission _permission = MvxLocationPermission.Unknown;
 		protected MvxLocationPermission Permission 
@@ -26,7 +27,7 @@ namespace Cirrious.MvvmCross.Plugins.Location
 				if (_permission != value)
 				{
 					_permission = value;
-					OnPermissionChanged (value);
+					OnPermissionChanged (this, new MvxValueEventArgs<MvxLocationPermission> (value));
 				}
 			}
 		}


### PR DESCRIPTION
IMvxLocationWatcher has an event OnPermissionChanged now.

New enum introduced:
```csharp
public enum MvxLocationPermission {
	Unknown,
	Denied,
	Granted
}
```

iOS and Android plugins tested for sure. See https://github.com/SeeD-Seifer/MvvmCross-Playground
Win plugins are not tested (and even not complied). But according to documentation they should compile and work well (I hope).

Basic usage example:
```csharp
locationWatcher.OnPermissionChanged += (object sender, MvxValueEventArgs<MvxLocationPermission> args) => {
	var newPermission = args.Value;
}
```

**The reason of new feature**:
One of our iOS app has a flow on startup with few UIAlerts.
Each alert should wait for dismiss before the next one appears.
One of such alerts is Location Request.
The new OnPermissionChanged event allows to handle the case when user has pressed a button on the Alert, and so that the flow could be continued smoothly.