### PR TITLE
SeekBar binding to use event subscription instead of on change listener

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxSeekBarProgressTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxSeekBarProgressTargetBinding.cs
@@ -38,33 +38,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Target
             seekbar.Progress = (int) value;
         }
 
-        public class SeekBarChangeListener :
-            Java.Lang.Object
-            , SeekBar.IOnSeekBarChangeListener
-        {
-			private readonly MvxSeekBarProgressTargetBinding _parent;
-
-			public SeekBarChangeListener(MvxSeekBarProgressTargetBinding parent)
-            {
-                _parent = parent;
-            }
-
-            public void OnProgressChanged(SeekBar seekBar, int progress, bool fromUser)
-            {
-                if (fromUser)
-                    _parent.FireValueChanged(progress);
-            }
-
-            public void OnStartTrackingTouch(SeekBar seekBar)
-            {
-                // ignore
-            }
-
-            public void OnStopTrackingTouch(SeekBar seekBar)
-            {
-                // ignore
-            }
-        }
+		private void SeekBarProgressChanged(object sender, SeekBar.ProgressChangedEventArgs e)
+		{
+			if (e.FromUser)
+				FireValueChanged(e.Progress);
+		}
 
         public override MvxBindingMode DefaultMode
         {
@@ -80,7 +58,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Target
                 return;
             }
 
-            seekBar.SetOnSeekBarChangeListener(new SeekBarChangeListener(this));
+			seekBar.ProgressChanged += SeekBarProgressChanged;
             _subscribed = true;
         }
 
@@ -91,7 +69,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Target
                 var view = View;
                 if (view != null && _subscribed)
                 {
-                    view.SetOnSeekBarChangeListener(null);
+					view.ProgressChanged -= SeekBarProgressChanged;
                     _subscribed = false;
                 }
             }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxSeekBarProgressTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxSeekBarProgressTargetBinding.cs
@@ -38,11 +38,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Target
             seekbar.Progress = (int) value;
         }
 
-		private void SeekBarProgressChanged(object sender, SeekBar.ProgressChangedEventArgs e)
-		{
-			if (e.FromUser)
-				FireValueChanged(e.Progress);
-		}
+        private void SeekBarProgressChanged(object sender, SeekBar.ProgressChangedEventArgs e)
+        {
+            if (e.FromUser)
+                FireValueChanged(e.Progress);
+        }
 
         public override MvxBindingMode DefaultMode
         {
@@ -58,7 +58,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Target
                 return;
             }
 
-			seekBar.ProgressChanged += SeekBarProgressChanged;
+            seekBar.ProgressChanged += SeekBarProgressChanged;
             _subscribed = true;
         }
 
@@ -69,7 +69,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Target
                 var view = View;
                 if (view != null && _subscribed)
                 {
-					view.ProgressChanged -= SeekBarProgressChanged;
+                    view.ProgressChanged -= SeekBarProgressChanged;
                     _subscribed = false;
                 }
             }


### PR DESCRIPTION
Issue #884

Allows user to apply additional event handlers without breaking the mvx
binding.