### PR TITLE
Fix crash caused by the MvvmCross environment not being initialized yet ...

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxBindingFragmentAdapter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxBindingFragmentAdapter.cs
@@ -36,6 +36,8 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
 
         protected override void HandleCreateCalled(object sender, MvxValueEventArgs<Bundle> bundleArgs)
         {
+            FragmentView.EnsureSetupInitialized();
+
             Bundle bundle = null;
             MvxViewModelRequest request = null;
             if (bundleArgs != null && bundleArgs.Value != null)

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxFragmentExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxFragmentExtensions.cs
@@ -9,9 +9,11 @@ using Android.OS;
 using Android.Support.V4.App;
 using Android.Views;
 using Cirrious.CrossCore;
+using Cirrious.CrossCore.Exceptions;
 using Cirrious.CrossCore.Platform;
 using Cirrious.MvvmCross.Binding.Droid.BindingContext;
 using Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource;
+using Cirrious.MvvmCross.Droid.Platform;
 using Cirrious.MvvmCross.Droid.Views;
 using Cirrious.MvvmCross.ViewModels;
 using Cirrious.MvvmCross.Views;
@@ -44,6 +46,14 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
             var cached = cache.GetAndClear(viewModelType);
 
             view.OnViewCreate(() => cached ?? LoadViewModel(fragmentView, bundle, request));
+        }
+
+        public static Fragment ToFragment(this IMvxFragmentView fragmentView)
+        {
+            var activity = fragmentView as Fragment;
+            if (activity == null)
+                throw new MvxException("ToFragment called on an IMvxFragmentView which is not an Android Fragment: {0}", fragmentView);
+            return activity;
         }
 
         private static IMvxViewModel LoadViewModel(this IMvxFragmentView fragmentView, IMvxBundle savedState,
@@ -104,6 +114,13 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
                 if (androidContext != null)
                     androidContext.LayoutInflater = new MvxSimpleLayoutInflater(actualFragment.Activity.LayoutInflater);
             }
+        }
+
+        public static void EnsureSetupInitialized(this IMvxFragmentView fragmentView)
+        {
+            var fragment = fragmentView.ToFragment();
+            var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(fragment.Activity.ApplicationContext);
+            setupSingleton.EnsureInitialized();
         }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxBindingFragmentAdapter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxBindingFragmentAdapter.cs
@@ -36,6 +36,8 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments
 
         protected override void HandleCreateCalled(object sender, MvxValueEventArgs<Bundle> bundleArgs)
         {
+            FragmentView.EnsureSetupInitialized();
+
             Bundle bundle = null;
             MvxViewModelRequest request = null;
             if (bundleArgs != null && bundleArgs.Value != null)

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxFragmentExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxFragmentExtensions.cs
@@ -9,9 +9,11 @@ using Android.App;
 using Android.OS;
 using Android.Views;
 using Cirrious.CrossCore;
+using Cirrious.CrossCore.Exceptions;
 using Cirrious.CrossCore.Platform;
 using Cirrious.MvvmCross.Binding.Droid.BindingContext;
 using Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource;
+using Cirrious.MvvmCross.Droid.Platform;
 using Cirrious.MvvmCross.Droid.Views;
 using Cirrious.MvvmCross.ViewModels;
 using Cirrious.MvvmCross.Views;
@@ -44,6 +46,14 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments
             var cached = cache.GetAndClear(viewModelType);
 
             view.OnViewCreate(() => cached ?? LoadViewModel(fragmentView, bundle, request));
+        }
+
+        public static Fragment ToFragment(this IMvxFragmentView fragmentView)
+        {
+            var activity = fragmentView as Fragment;
+            if (activity == null)
+                throw new MvxException("ToFragment called on an IMvxFragmentView which is not an Android Fragment: {0}", fragmentView);
+            return activity;
         }
 
         private static IMvxViewModel LoadViewModel(this IMvxFragmentView fragmentView, IMvxBundle savedState,
@@ -104,6 +114,13 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments
                 if (androidContext != null)
                     androidContext.LayoutInflater = new MvxSimpleLayoutInflater(actualFragment.Activity.LayoutInflater);
             }
+        }
+
+        public static void EnsureSetupInitialized(this IMvxFragmentView fragmentView)
+        {
+            var fragment = fragmentView.ToFragment();
+            var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(fragment.Activity.ApplicationContext);
+            setupSingleton.EnsureInitialized();
         }
     }
 }


### PR DESCRIPTION
...when tombstoned MvxFragments are restored after application termination (they restore before their host Activity).

This is a critical bug that will crash any application that includes fragments.

This mirrors the code in MvxActivityViewExtensions.OnViewCreate and needs to be done for the same reason.

Until this is merged/released, you can work around this crash by overriding OnCreate for each of your fragments and placing the following *before* calling `base.OnCreate()`:
```
var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(fragment.Activity.ApplicationContext);
setupSingleton.EnsureInitialized();
```

The easiest way to repro is to run Cheesebaron's MvxFragmentsAndHamburger project:
1) Turn on Always Finish Activities in dev settings
2) Run app.
3) Task switch away
4) Kill process
5) Task switch back to app. 

Before, this would crash when it tried to call Mvx.TryResolve() in https://github.com/MvvmCross/MvvmCross/blob/3.5/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxBindingFragmentAdapter.cs#L70 because MvxSingleton<IMvxIoCProvider>.Instance was null.

In the below stack trace, MainView indirectly extends an activity, GroupsView indirectly extends a fragment.
```
02-11 14:24:44.060: I/MonoDroid(1690): UNHANDLED EXCEPTION:
02-11 14:24:44.080: I/MonoDroid(1690): System.NullReferenceException: Object reference not set to an instance of an object
02-11 14:24:44.080: I/MonoDroid(1690):   at Cirrious.CrossCore.Mvx.TryResolve[IMvxSavedStateConverter] (IMvxSavedStateConverter& service) [0x00000] in <filename unknown>:0 
02-11 14:24:44.092: I/MonoDroid(1690):   at Cirrious.MvvmCross.Droid.Fragging.Fragments.MvxBindingFragmentAdapter.HandleCreateCalled (System.Object sender, Cirrious.CrossCore.Core.MvxValueEventArgs`1 bundleArgs) [0x00000] in <filename unknown>:0 
02-11 14:24:44.092: I/MonoDroid(1690):   at Cirrious.CrossCore.Core.MvxDelegateExtensionMethods.Raise[Bundle] (System.EventHandler`1 eventHandler, System.Object sender, Android.OS.Bundle value) [0x00000] in <filename unknown>:0 
02-11 14:24:44.092: I/MonoDroid(1690):   at Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource.MvxEventSourceFragment.OnCreate (Android.OS.Bundle savedInstanceState) [0x00000] in <filename unknown>:0 
02-11 14:24:44.092: I/MonoDroid(1690):   at Faithlife.Groups.Mobile.Android.Views.RefreshableWebViewFragmentBase`1[Faithlife.Groups.Mobile.Core.ViewModels.FaithlifeWebViewModelBase].OnCreate (Android.OS.Bundle savedInstanceState) [0x00000] in <filename unknown>:0 
02-11 14:24:44.092: I/MonoDroid(1690):   at Faithlife.Groups.Mobile.Android.Views.GroupsView.OnCreate (Android.OS.Bundle savedInstanceState) [0x00000] in <filename unknown>:0 
02-11 14:24:44.096: I/MonoDroid(1690):   at Android.Support.V4.App.Fragment.n_OnCreate_Landroid_os_Bundle_ (IntPtr jnienv, IntPtr native__this, IntPtr native_savedInstanceState) [0x00000] in <filename unknown>:0 
02-11 14:24:44.096: I/MonoDroid(1690):   at (wrapper dynamic-method) object:94896613-5f66-4fcb-9573-310befe41681 (intptr,intptr,intptr)
02-11 14:24:44.096: W/dalvikvm(1690): JNI WARNING: JNI method called with exception pending
02-11 14:24:44.096: W/dalvikvm(1690):              in Lfaithlife/groups/mobile/android/views/GroupsView;.n_onCreate:(Landroid/os/Bundle;)V (NewString)
02-11 14:24:44.100: W/dalvikvm(1690): Pending exception is:
02-11 14:24:44.100: I/dalvikvm(1690): android.runtime.JavaProxyThrowable: System.NullReferenceException: Object reference not set to an instance of an object
02-11 14:24:44.100: I/dalvikvm(1690): at Cirrious.CrossCore.Mvx.TryResolve<Cirrious.MvvmCross.Droid.Platform.IMvxSavedStateConverter> (Cirrious.MvvmCross.Droid.Platform.IMvxSavedStateConverter&) <0x00043>
02-11 14:24:44.100: I/dalvikvm(1690): at Cirrious.MvvmCross.Droid.Fragging.Fragments.MvxBindingFragmentAdapter.HandleCreateCalled (object,Cirrious.CrossCore.Core.MvxValueEventArgs`1<Android.OS.Bundle>) <0x0021f>
02-11 14:24:44.100: I/dalvikvm(1690): at Cirrious.CrossCore.Core.MvxDelegateExtensionMethods.Raise<Android.OS.Bundle> (System.EventHandler`1<Cirrious.CrossCore.Core.MvxValueEventArgs`1<Android.OS.Bundle>>,object,Android.OS.Bundle) <0x00054>
02-11 14:24:44.100: I/dalvikvm(1690): at Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource.MvxEventSourceFragment.OnCreate (Android.OS.Bundle) <0x00047>
02-11 14:24:44.100: I/dalvikvm(1690): at Faithlife.Groups.Mobile.Android.Views.RefreshableWebViewFragmentBase`1<Faithlife.Groups.Mobile.Core.ViewModels.FaithlifeWebViewModelBase>.OnCreate (Android.OS.Bundle) <0x00017>
02-11 14:24:44.100: I/dalvikvm(1690): at Faithlife.Groups.Mobile.Android.Views.GroupsView.OnCrea
02-11 14:24:44.100: I/dalvikvm(1690): 	at faithlife.groups.mobile.android.views.GroupsView.n_onCreate(Native Method)
02-11 14:24:44.100: I/dalvikvm(1690): 	at faithlife.groups.mobile.android.views.GroupsView.onCreate(GroupsView.java:28)
02-11 14:24:44.104: I/dalvikvm(1690): 	at android.support.v4.app.Fragment.performCreate(Fragment.java:1763)
02-11 14:24:44.104: I/dalvikvm(1690): 	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:913)
02-11 14:24:44.104: I/dalvikvm(1690): 	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1126)
02-11 14:24:44.104: I/dalvikvm(1690): 	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1108)
02-11 14:24:44.104: I/dalvikvm(1690): 	at android.support.v4.app.FragmentManagerImpl.dispatchCreate(FragmentManager.java:1912)
02-11 14:24:44.108: I/dalvikvm(1690): 	at android.support.v4.app.FragmentActivity.onCreate(FragmentActivity.java:266)
02-11 14:24:44.108: I/dalvikvm(1690): 	at android.support.v7.app.ActionBarActivity.onCreate(ActionBarActivity.java:122)
02-11 14:24:44.108: I/dalvikvm(1690): 	at faithlife.groups.mobile.android.views.MainView.n_onCreate(Native Method)
02-11 14:24:44.108: I/dalvikvm(1690): 	at faithlife.groups.mobile.android.views.MainView.onCreate(MainView.java:30)
02-11 14:24:44.112: I/dalvikvm(1690): 	at android.app.Activity.performCreate(Activity.java:5133)
02-11 14:24:44.112: I/dalvikvm(1690): 	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1087)
02-11 14:24:44.116: I/dalvikvm(1690): 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2175)
02-11 14:24:44.120: I/dalvikvm(1690): 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2261)
02-11 14:24:44.124: I/dalvikvm(1690): 	at android.app.ActivityThread.access$600(ActivityThread.java:141)
02-11 14:24:44.128: I/dalvikvm(1690): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1256)
02-11 14:24:44.128: I/dalvikvm(1690): 	at android.os.Handler.dispatchMessage(Handler.java:99)
02-11 14:24:44.132: I/dalvikvm(1690): 	at android.os.Looper.loop(Looper.java:137)
02-11 14:24:44.132: I/dalvikvm(1690): 	at android.app.ActivityThread.main(ActivityThread.java:5103)
02-11 14:24:44.132: I/dalvikvm(1690): 	at java.lang.reflect.Method.invokeNative(Native Method)
02-11 14:24:44.132: I/dalvikvm(1690): 	at java.lang.reflect.Method.invoke(Method.java:525)
02-11 14:24:44.132: I/dalvikvm(1690): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:737)
02-11 14:24:44.132: I/dalvikvm(1690): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
02-11 14:24:44.132: I/dalvikvm(1690): 	at dalvik.system.NativeStart.main(Native Method)
```