### PR TITLE
Unified enum-compatible segmented control with default binding

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/MvxTouchBindingBuilder.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/MvxTouchBindingBuilder.cs
@@ -133,6 +133,7 @@ namespace Cirrious.MvvmCross.Binding.Touch
             registry.AddOrOverwrite(typeof (UIProgressView), "Progress");
             registry.AddOrOverwrite(typeof (IMvxImageHelper<UIImage>), "ImageUrl");
             registry.AddOrOverwrite(typeof (MvxImageViewLoader), "ImageUrl");
+            registry.AddOrOverwrite(typeof (UISegmentedControl), "SelectedSegment");
 
             if (_fillBindingNamesAction != null)
                 _fillBindingNamesAction(registry);

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Target/MvxUISegmentedControlSelectedSegmentTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Target/MvxUISegmentedControlSelectedSegmentTargetBinding.cs
@@ -19,7 +19,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Target
             var view = View;
             if (view == null)
                 return;
-            FireValueChanged(view.SelectedSegment);
+            FireValueChanged((int)view.SelectedSegment);
         }
 
         public override MvxBindingMode DefaultMode


### PR DESCRIPTION
Trying to bind UISegmentedControl to an enum previously resulted in failing to convert an nint to that enum (in MakeSafeValueCore) and throwing an exception.
Also I thought a default binding for SelectedSegment might be nice.

Possibly MakeSafeValueCore could be made more Unified-friendly, but this was the easy/safe fix...