### PR TITLE
I made changes to MvxTouchSetup and MvxTouchDialogSetup to take a new in...

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Dialog.Touch/MvxTouchDialogSetup.cs
+++ b/Cirrious/Cirrious.MvvmCross.Dialog.Touch/MvxTouchDialogSetup.cs
@@ -17,13 +17,13 @@ namespace Cirrious.MvvmCross.Dialog.Touch
     public abstract class MvxTouchDialogSetup
         : MvxTouchSetup
     {
-        protected MvxTouchDialogSetup(MvxApplicationDelegate applicationDelegate,
+        protected MvxTouchDialogSetup(IMvxApplicationDelegate applicationDelegate,
                                       IMvxTouchViewPresenter presenter)
             : base(applicationDelegate, presenter)
         {
         }
 
-        protected MvxTouchDialogSetup(MvxApplicationDelegate applicationDelegate, UIWindow window)
+        protected MvxTouchDialogSetup(IMvxApplicationDelegate applicationDelegate, UIWindow window)
             : base(applicationDelegate, window)
         {
         }

--- a/Cirrious/Cirrious.MvvmCross.Touch/Cirrious.MvvmCross.Touch.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Touch/Cirrious.MvvmCross.Touch.csproj
@@ -44,6 +44,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Platform\IMvxApplicationDelegate.cs" />
     <Compile Include="Views\IMvxCanCreateTouchView.cs" />
     <Compile Include="Views\IMvxCurrentRequest.cs" />
     <Compile Include="Platform\IMvxTouchPlatformProperties.cs" />

--- a/Cirrious/Cirrious.MvvmCross.Touch/Platform/IMvxApplicationDelegate.cs
+++ b/Cirrious/Cirrious.MvvmCross.Touch/Platform/IMvxApplicationDelegate.cs
@@ -1,0 +1,16 @@
+// IMvxTouchApplicationDelegate.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using Cirrious.MvvmCross.Platform;
+using UIKit;
+
+namespace Cirrious.MvvmCross.Touch.Platform
+{
+    public interface IMvxApplicationDelegate : IUIApplicationDelegate, IMvxLifetime
+    {
+    }
+}

--- a/Cirrious/Cirrious.MvvmCross.Touch/Platform/MvxApplicationDelegate.cs
+++ b/Cirrious/Cirrious.MvvmCross.Touch/Platform/MvxApplicationDelegate.cs
@@ -12,7 +12,7 @@ using UIKit;
 namespace Cirrious.MvvmCross.Touch.Platform
 {
     public class MvxApplicationDelegate : UIApplicationDelegate
-                                          , IMvxLifetime
+                                          , IMvxApplicationDelegate
     {
         public override void WillEnterForeground(UIApplication application)
         {

--- a/Cirrious/Cirrious.MvvmCross.Touch/Platform/MvxTouchSetup.cs
+++ b/Cirrious/Cirrious.MvvmCross.Touch/Platform/MvxTouchSetup.cs
@@ -31,18 +31,18 @@ namespace Cirrious.MvvmCross.Touch.Platform
 	public abstract class MvxTouchSetup
 		: MvxSetup
 	{
-		private readonly MvxApplicationDelegate _applicationDelegate;
+		private readonly IMvxApplicationDelegate _applicationDelegate;
         private readonly UIWindow _window;
 
         private IMvxTouchViewPresenter _presenter;
 
-        protected MvxTouchSetup(MvxApplicationDelegate applicationDelegate, UIWindow window)
+        protected MvxTouchSetup(IMvxApplicationDelegate applicationDelegate, UIWindow window)
         {
             _window = window;
             _applicationDelegate = applicationDelegate;
         }
 
-        protected MvxTouchSetup(MvxApplicationDelegate applicationDelegate, IMvxTouchViewPresenter presenter)
+        protected MvxTouchSetup(IMvxApplicationDelegate applicationDelegate, IMvxTouchViewPresenter presenter)
 		{
 			_presenter = presenter;
 			_applicationDelegate = applicationDelegate;
@@ -53,7 +53,7 @@ namespace Cirrious.MvvmCross.Touch.Platform
             get { return _window; }
         }
 
-        protected MvxApplicationDelegate ApplicationDelegate
+        protected IMvxApplicationDelegate ApplicationDelegate
         {
             get { return _applicationDelegate; }
         }

--- a/Cirrious/Cirrious.MvvmCross.Touch/Views/Presenters/MvxTouchViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Touch/Views/Presenters/MvxTouchViewPresenter.cs
@@ -16,7 +16,7 @@ namespace Cirrious.MvvmCross.Touch.Views.Presenters
     public class MvxTouchViewPresenter
         : MvxBaseTouchViewPresenter
     {
-        private readonly UIApplicationDelegate _applicationDelegate;
+        private readonly IUIApplicationDelegate _applicationDelegate;
         private readonly UIWindow _window;
 
         public virtual UINavigationController MasterNavigationController
@@ -24,7 +24,7 @@ namespace Cirrious.MvvmCross.Touch.Views.Presenters
             get; protected set;
         }
 
-        protected virtual UIApplicationDelegate ApplicationDelegate
+        protected virtual IUIApplicationDelegate ApplicationDelegate
         {
             get { return _applicationDelegate; }
         }
@@ -34,7 +34,7 @@ namespace Cirrious.MvvmCross.Touch.Views.Presenters
             get { return _window; }
         }
 
-        public MvxTouchViewPresenter(UIApplicationDelegate applicationDelegate, UIWindow window)
+        public MvxTouchViewPresenter(IUIApplicationDelegate applicationDelegate, UIWindow window)
         {
             _applicationDelegate = applicationDelegate;
             _window = window;


### PR DESCRIPTION
...terface, IMvxApplicationDelegate instead of the concrete MvxApplicationDelegate class.  This allows Mvx to be used with other frameworks that have their own ApplicationDelegate that must be used such as Xamarin Forms 1.3.X+.  Users of Mvx and Xamarin Forms can now create their own application delegate that inherits from FormsApplicationDelegate and pass it to MvxTouchSetup as long as their custom application delegate also implements the IMvxApplicationDelegate interface.