### PR TITLE
Missing mono-related jni constructors

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAdapter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAdapter.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using Android;
 using Android.Content;
+using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Cirrious.CrossCore;
@@ -62,6 +63,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             SimpleViewLayoutId = Resource.Layout.SimpleListItem1;
             SimpleDropDownViewLayoutId = Resource.Layout.SimpleSpinnerDropDownItem;
         }
+
+		protected MvxAdapter(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         protected Context Context
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAdapterWithChangedEvent.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAdapterWithChangedEvent.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Specialized;
 using Android.Content;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Binding.Droid.Views
 {
@@ -19,6 +20,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             : base(context)
         {
         }
+
+		protected MvxAdapterWithChangedEvent(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public event EventHandler<NotifyCollectionChangedEventArgs> DataSetChanged;
 

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAutoCompleteTextView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxAutoCompleteTextView.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -34,6 +35,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             Adapter = adapter;
             this.ItemClick += OnItemClick;
         }
+
+		protected MvxAutoCompleteTextView(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         private void OnItemClick(object sender, AdapterView.ItemClickEventArgs itemClickEventArgs)
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxBaseListItemView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxBaseListItemView.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Android.Content;
+using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.BindingContext;
@@ -26,6 +27,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
         {
             _bindingContext = new MvxAndroidBindingContext(context, layoutInflater, dataContext);
         }
+
+		protected MvxBaseListItemView(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         /*
         protected override ViewGroup.LayoutParams GenerateDefaultLayoutParams()

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxDatePicker.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxDatePicker.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.CrossCore.Droid.Platform;
@@ -28,6 +29,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             : base(context, attrs)
         {
         }
+
+		protected MvxDatePicker(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public DateTime Value
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxExpandableListAdapter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxExpandableListAdapter.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Linq;
 using Android.Content;
+using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Cirrious.CrossCore;
@@ -16,6 +17,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
 
         public MvxExpandableListAdapter(Context context)
             : base(context) { }
+
+		protected MvxExpandableListAdapter(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         private int _groupTemplateId;
 

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxExpandableListView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxExpandableListView.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections;
 using System.Windows.Input;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -26,6 +28,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             adapter.GroupTemplateId = groupTemplateId;
             adapter.ItemTemplateId = itemTemplateId;
         }
+
+		protected MvxExpandableListView(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         // An expandableListView has ExpandableListAdapter as propertyname, but Adapter still exists but is always null.
         protected MvxExpandableListAdapter ThisAdapter

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxFilteringAdapter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxFilteringAdapter.cs
@@ -9,6 +9,7 @@ using System;
 using System.Threading;
 using Android.App;
 using Android.Content;
+using Android.Runtime;
 using Android.Widget;
 using Cirrious.CrossCore.Droid;
 using Cirrious.CrossCore.Platform;
@@ -114,6 +115,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             ReturnSingleObjectFromGetItem = true;
             Filter = new MyFilter(this);
         }
+
+		protected MvxFilteringAdapter(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public bool ReturnSingleObjectFromGetItem { get; set; }
 

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxFrameLayout.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxFrameLayout.cs
@@ -5,9 +5,11 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -35,6 +37,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             }
             this.ChildViewRemoved += OnChildViewRemoved;
         }
+
+		protected MvxFrameLayout(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public void AdapterOnDataSetChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxGridView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxGridView.cs
@@ -5,9 +5,11 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections;
 using System.Windows.Input;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -34,6 +36,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             adapter.ItemTemplateId = itemTemplateId;
             Adapter = adapter;
         }
+
+		protected MvxGridView(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public new IMvxAdapter Adapter
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxImageView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxImageView.cs
@@ -66,6 +66,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             }
         }
 
+		protected MvxImageView(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
+
         public string ImageUrl
         {
             get

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxLinearLayout.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxLinearLayout.cs
@@ -5,9 +5,11 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -35,6 +37,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             }
             this.ChildViewRemoved += OnChildViewRemoved;
         }
+
+		protected MvxLinearLayout(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public void AdapterOnDataSetChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxListItemView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxListItemView.cs
@@ -5,7 +5,9 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using Android.Content;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Binding.Droid.Views
 {
@@ -24,6 +26,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             _templateId = templateId;
             AndroidBindingContext.BindingInflate(templateId, this);
         }
+
+		protected MvxListItemView(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public int TemplateId
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxListView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxListView.cs
@@ -5,9 +5,11 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections;
 using System.Windows.Input;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -34,6 +36,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             adapter.ItemTemplateId = itemTemplateId;
             Adapter = adapter;
         }
+
+		protected MvxListView(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public new IMvxAdapter Adapter
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxRadioGroup.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxRadioGroup.cs
@@ -5,7 +5,9 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding;
@@ -39,6 +41,10 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             this.ChildViewRemoved += OnChildViewRemoved;
         }
 
+		protected MvxRadioGroup(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public void AdapterOnDataSetChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxRelativeLayout.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxRelativeLayout.cs
@@ -5,9 +5,11 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -35,6 +37,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             }
             this.ChildViewRemoved += OnChildViewRemoved;
         }
+
+		protected MvxRelativeLayout(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public void AdapterOnDataSetChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxSpinner.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxSpinner.cs
@@ -5,9 +5,11 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections;
 using System.Windows.Input;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -36,6 +38,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             Adapter = adapter;
             SetupHandleItemSelected();
         }
+
+		protected MvxSpinner(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public new IMvxAdapter Adapter
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxTableLayout.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxTableLayout.cs
@@ -5,9 +5,11 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using Cirrious.MvvmCross.Binding.Attributes;
@@ -35,6 +37,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             }
             this.ChildViewRemoved += OnChildViewRemoved;
         }
+
+		protected MvxTableLayout(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public void AdapterOnDataSetChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
         {

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxTimePicker.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxTimePicker.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Android.Content;
+using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 
@@ -30,6 +31,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             : base(context, attrs)
         {
         }
+
+		protected MvxTimePicker(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+	    {
+	    }
 
         public TimeSpan Value
         {


### PR DESCRIPTION
Hello this is my first PR for MvvmX, trying to fix issue https://github.com/MvvmCross/MvvmCross/issues/928

Our MvvmX based app was crashing on freshly updated Android Lollipop with this exception: http://stackoverflow.com/questions/26573627/no-constructor-found-for-system-intptr-android-runtime-jnihandleownership, so this is my attempt to fix those. I have previously done it on some other non-MvvmX controls and I can confirm that the crashes stopped appearing on those controls. To be able to add jni constructors on other our classes derived from MvvmX I need MvvmX defines those. Thank you, Jan