### PR TITLE
Fixed passing of some tests on systems with non-english culture

### DIFF
--- a/Cirrious/Test/Cirrious.MvvmCross.Binding.Test/Binders/MvxSourceStepTests.cs
+++ b/Cirrious/Test/Cirrious.MvvmCross.Binding.Test/Binders/MvxSourceStepTests.cs
@@ -141,6 +141,12 @@ namespace Cirrious.MvvmCross.Binding.Test.Binders
             }
         }
 
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
+        {
+            SetInvariantCulture();
+        }
+
         [Test]
         public void TestSimpleStringBinding()
         {

--- a/Cirrious/Test/Cirrious.MvvmCross.Test.Core/MvxIoCSupportingTest.cs
+++ b/Cirrious/Test/Cirrious.MvvmCross.Test.Core/MvxIoCSupportingTest.cs
@@ -9,6 +9,8 @@ using Cirrious.CrossCore.Core;
 using Cirrious.CrossCore.IoC;
 using Cirrious.CrossCore.Platform;
 using Cirrious.MvvmCross.Platform;
+using System.Globalization;
+using System.Threading;
 
 namespace Cirrious.MvvmCross.Test.Core
 {
@@ -57,6 +59,16 @@ namespace Cirrious.MvvmCross.Test.Core
         protected virtual void AdditionalSetup()
         {
             // nothing here..
+        }
+
+
+        protected void SetInvariantCulture()
+        {
+            var invariantCulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentCulture = invariantCulture;
+            Thread.CurrentThread.CurrentUICulture = invariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = invariantCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = invariantCulture;
         }
     }
 }

--- a/Cirrious/Test/Cirrious.MvvmCross.Test/Platform/MvxStringToTypeParserTest.cs
+++ b/Cirrious/Test/Cirrious.MvvmCross.Test/Platform/MvxStringToTypeParserTest.cs
@@ -15,6 +15,12 @@ namespace Cirrious.MvvmCross.Test.Platform
     [TestFixture]
     public class MvxStringToTypeParserTest : MvxIoCSupportingTest
     {
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
+        {
+            SetInvariantCulture();
+        }
+
         [Test]
         public void Test_AllTypesAreSupported()
         {


### PR DESCRIPTION
Some tests can be failed on systems with non-english culture due to unexpected formatting of numbers. Setting of InvariantCulture to the test thread solves this issue.