### PR TITLE
Support open generic types in MvxBindingNameRegistry

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding/BindingContext/MvxBindingNameRegistry.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding/BindingContext/MvxBindingNameRegistry.cs
@@ -37,6 +37,13 @@ namespace Cirrious.MvvmCross.Binding.BindingContext
             if (_lookup.TryGetValue(type, out toReturn))
                 return true;
 
+            if (type.IsConstructedGenericType)
+            {
+                var openType = type.GetGenericTypeDefinition();
+                if (openType != null && _lookup.TryGetValue(openType, out toReturn))
+                    return true;
+            }
+
             if (type.GetTypeInfo().IsInterface)
                 return false;
 


### PR DESCRIPTION
Currently, adding a binding name only works with a closed generic type. For example, this will work for any MyView\<int, string\>:

    registry.AddOrOverwrite(typeof(MyView<int, string>), "ItemsSource");

however, this will not work for any MyView\<T1, T2\>, i.e. using the open generic type:

    registry.AddOrOverwrite(typeof(MyView<,>), "ItemsSource");

This commit adds support for checking the open generic type if the closed type is not found. This allows a default for a given open generic type, and an override for a specific closed type.