### PR TITLE
Update Droid MvxComposeEmailTask (GMail-App 5, Multiple File Attachments)

### DIFF
--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -5,13 +5,14 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-using System;
-using System.Linq;
 using Android.Content;
+using Android.Net;
+using Android.OS;
 using Android.Text;
 using Cirrious.CrossCore.Droid.Platform;
+using Cirrious.MvvmCross.Plugins.Email;
 using System.Collections.Generic;
-using Cirrious.CrossCore.Exceptions;
+using System.Linq;
 
 namespace Cirrious.MvvmCross.Plugins.Email.Droid
 {
@@ -33,57 +34,62 @@ namespace Cirrious.MvvmCross.Plugins.Email.Droid
         }
 
         public void ComposeEmail(
-            IEnumerable<string> to, IEnumerable<string> cc, string subject, 
-            string body, bool isHtml, 
+            IEnumerable<string> to, IEnumerable<string> cc, string subject,
+            string body, bool isHtml,
             IEnumerable<EmailAttachment> attachments)
         {
-            var emailIntent = new Intent(Intent.ActionSendto);
+            // http://stackoverflow.com/questions/2264622/android-multiple-email-attachments-using-intent
+            var emailIntent = new Intent(Intent.ActionSendMultiple);
 
             if (to != null)
-                emailIntent.PutExtra(Intent.ExtraEmail, to.ToArray() );
+            {
+                emailIntent.PutExtra(Intent.ExtraEmail, to.ToArray());
+            }
             if (cc != null)
+            {
                 emailIntent.PutExtra(Intent.ExtraCc, cc.ToArray());
-
+            }
             emailIntent.PutExtra(Intent.ExtraSubject, subject ?? string.Empty);
 
             body = body ?? string.Empty;
 
-            if (isHtml) 
+            if (isHtml)
             {
                 emailIntent.SetType("text/html");
                 emailIntent.PutExtra(Intent.ExtraText, Html.FromHtml(body));
-            } 
+            }
             else
             {
                 emailIntent.SetType("text/plain");
                 emailIntent.PutExtra(Intent.ExtraText, body);
             }
 
-            if (attachments != null)
+            var attachmentList = attachments as IList<EmailAttachment> ?? attachments.ToList();
+            if (attachmentList.Any())
             {
-                var list = attachments.ToList();
-                if (list.Count > 1)
-                    throw new MvxException("Email Plugin for Droid cannot send more than 1 attachment.");
-                var attachment = list.FirstOrDefault();
+                var uris = new List<IParcelable>();
 
-                if (attachment != null)
+                foreach (var file in attachmentList)
                 {
+                    var fileWorking = file;
                     DoOnActivity(activity =>
-                        {
-                            var localFileStream = activity.OpenFileOutput(attachment.FileName, FileCreationMode.WorldReadable);
-                            var localfile = activity.GetFileStreamPath(attachment.FileName);
-                            attachment.Content.CopyTo(localFileStream);
-                            localFileStream.Close();
-                            var uri = Android.Net.Uri.FromFile(localfile);
-                            emailIntent.PutExtra(Intent.ExtraStream, uri);
-
-                            localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
-                        });
+                    {
+                        var localFileStream = activity.OpenFileOutput(fileWorking.FileName, FileCreationMode.WorldReadable | FileCreationMode.WorldWriteable);
+                        var localfile = activity.GetFileStreamPath(fileWorking.FileName);
+                        fileWorking.Content.CopyTo(localFileStream);
+                        localFileStream.Close();
+                        localfile.SetReadable(true,false);
+                        localfile.SetWritable(true, false);
+                        uris.Add(Uri.FromFile(localfile));
+                        localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
+                    });
                 }
+
+                emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
             }
 
-            emailIntent.SetData(Android.Net.Uri.Parse("mailto:"));
-            StartActivity(Intent.CreateChooser(emailIntent, string.Empty));
+            // fix for GMail App 5.x (File not found / permission denied when using "StartActivity")
+            StartActivityForResult(0, Intent.CreateChooser(emailIntent, string.Empty));
         }
 
         public bool CanSendEmail

--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -69,21 +69,20 @@ namespace Cirrious.MvvmCross.Plugins.Email.Droid
             {
                 var uris = new List<IParcelable>();
 
-                foreach (var file in attachmentList)
+                DoOnActivity(activity =>
                 {
-                    var fileWorking = file;
-                    DoOnActivity(activity =>
+                    foreach (var file in attachmentList)
                     {
-                        var localFileStream = activity.OpenFileOutput(fileWorking.FileName, FileCreationMode.WorldReadable | FileCreationMode.WorldWriteable);
+                        var fileWorking = file;
+                        var localFileStream = activity.OpenFileOutput(fileWorking.FileName, FileCreationMode.WorldReadable);
                         var localfile = activity.GetFileStreamPath(fileWorking.FileName);
                         fileWorking.Content.CopyTo(localFileStream);
                         localFileStream.Close();
-                        localfile.SetReadable(true,false);
-                        localfile.SetWritable(true, false);
+                        localfile.SetReadable(true, false);
                         uris.Add(Uri.FromFile(localfile));
                         localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
-                    });
-                }
+                    }
+                });
 
                 emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
             }


### PR DESCRIPTION
Modified MvxComposeEmailTask to support:

a) GMail 5.x App:
Using "StartActivityForResult(0, Intent.CreateChooser(emailIntent, string.Empty));" fixes the "Permission denied" bug when trying to attach a file under Android Lollipop and GMail-App 5.x

b) Support for multiple file attachments:
Generating E-Mail Intent from "Intent.ActionSendMultiple" to allow to upload a List of URIs.
Pushing the URI-List to the Intent "emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);"