### PR TITLE
DeselectRow support in base UITableViewSource

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
@@ -35,7 +35,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
             get { return _tableView; }
         }
 
-        public virtual bool DeselectAutomatically { get { return false; } }
+        public bool DeselectAutomatically { get; set; }
 
         public ICommand SelectionChangedCommand { get; set; }
 

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
@@ -35,12 +35,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
             get { return _tableView; }
         }
 
-        /// <summary>
-        /// Gets a value indicating whether this
-        /// <see cref="Cirrious.MvvmCross.Binding.Touch.Views.MvxBaseTableViewSource"/> should deselect row automatically after selection.
-        /// </summary>
-        /// <value><c>true</c> if deselect automatically; otherwise, <c>false</c>.</value>
-        protected virtual bool DeselectAutomatically { get { return true; } }
+        public virtual bool DeselectAutomatically { get { return false; } }
 
         public ICommand SelectionChangedCommand { get; set; }
 

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
@@ -35,6 +35,13 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
             get { return _tableView; }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this
+        /// <see cref="Cirrious.MvvmCross.Binding.Touch.Views.MvxBaseTableViewSource"/> should deselect row automatically after selection.
+        /// </summary>
+        /// <value><c>true</c> if deselect automatically; otherwise, <c>false</c>.</value>
+        protected virtual bool DeselectAutomatically { get { return true; } }
+
         public ICommand SelectionChangedCommand { get; set; }
 
         public ICommand AccessoryTappedCommand { get; set; }
@@ -68,6 +75,11 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
 
         public override void RowSelected(UITableView tableView, NSIndexPath indexPath)
         {
+            if (DeselectAutomatically)
+            {
+                tableView.DeselectRow(indexPath, true);
+            }
+            
             var item = GetItemAt(indexPath);
 
             var command = SelectionChangedCommand;


### PR DESCRIPTION
@slodge what about adding "DeselectRow" to base MvxTableViewSource class so no one need to write this code in the app ever. From our experience, it's only small amount of apps don't remove selection in row after it's been done. 