### PR TITLE
Lambda is replaced by action call

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxNotifyPropertyChangedExtensions.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxNotifyPropertyChangedExtensions.cs
@@ -1,22 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Cirrious.MvvmCross.ViewModels
 {
     public static class MvxNotifyPropertyChangedExtensions
     {
-        private static TReturn RaiseAndSetIfChanged<T, TReturn>(T source, ref TReturn backingField, TReturn newValue, Action raiseAction)
+        private static TReturn RaiseAndSetIfChanged<T, TReturn, TActionParameter>(
+            T source, ref TReturn backingField, TReturn newValue, Action<TActionParameter> raiseAction, TActionParameter raiseActionParameter)
             where T : IMvxNotifyPropertyChanged
         {
             if (EqualityComparer<TReturn>.Default.Equals(backingField, newValue) == false)
             {
                 backingField = newValue;
-
-                raiseAction();
+                raiseAction(raiseActionParameter);
             }
 
             return newValue;
@@ -25,19 +23,19 @@ namespace Cirrious.MvvmCross.ViewModels
         public static TReturn RaiseAndSetIfChanged<T, TReturn>(this T source, ref TReturn backingField, TReturn newValue, Expression<Func<TReturn>> propertySelector)
             where T : IMvxNotifyPropertyChanged
         {
-            return RaiseAndSetIfChanged(source, ref backingField, newValue, () => source.RaisePropertyChanged(propertySelector));
+            return RaiseAndSetIfChanged(source, ref backingField, newValue, source.RaisePropertyChanged, propertySelector);
         }
 
         public static TReturn RaiseAndSetIfChanged<T, TReturn>(this T source, ref TReturn backingField, TReturn newValue, string propertyName)
             where T : IMvxNotifyPropertyChanged
         {
-            return RaiseAndSetIfChanged(source, ref backingField, newValue, () => source.RaisePropertyChanged(propertyName));
+            return RaiseAndSetIfChanged(source, ref backingField, newValue, source.RaisePropertyChanged, propertyName);
         }
 
         public static TReturn RaiseAndSetIfChanged<T, TReturn>(this T source, ref TReturn backingField, TReturn newValue, PropertyChangedEventArgs args)
             where T : IMvxNotifyPropertyChanged
         {
-            return RaiseAndSetIfChanged(source, ref backingField, newValue, () => source.RaisePropertyChanged(args));
+            return RaiseAndSetIfChanged(source, ref backingField, newValue, source.RaisePropertyChanged, args);
         }
     }
 }


### PR DESCRIPTION
Creating of a new lambda expression object is replaced by a call of passed action with passed argument. This should decrease memory allocation while using of `MvxNotifyPropertyChangedExtensions` methods.