### PR TITLE
Add missing OnSaveInstanceState override in MvxEventSource[Dialog|List]Fragment

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -102,12 +102,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-		}
-
-		public override void OnSaveInstanceState(Bundle outState)
-		{
-			SaveInstanceStateCalled.Raise(this, outState);
-			base.OnSaveInstanceState(outState);
-		}
+        }
+        
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -102,6 +102,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-        }
+		}
+
+		public override void OnSaveInstanceState(Bundle outState)
+		{
+			SaveInstanceStateCalled.Raise(this, outState);
+			base.OnSaveInstanceState(outState);
+		}
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -102,12 +102,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-		}
-
-		public override void OnSaveInstanceState(Bundle outState)
-		{
-			SaveInstanceStateCalled.Raise(this, outState);
-			base.OnSaveInstanceState(outState);
-		}
+        }
+        
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -102,6 +102,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-        }
+		}
+
+		public override void OnSaveInstanceState(Bundle outState)
+		{
+			SaveInstanceStateCalled.Raise(this, outState);
+			base.OnSaveInstanceState(outState);
+		}
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -100,12 +100,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-		}
-
-		public override void OnSaveInstanceState(Bundle outState)
-		{
-			SaveInstanceStateCalled.Raise(this, outState);
-			base.OnSaveInstanceState(outState);
-		}
+        }
+        
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -100,6 +100,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-        }
+		}
+
+		public override void OnSaveInstanceState(Bundle outState)
+		{
+			SaveInstanceStateCalled.Raise(this, outState);
+			base.OnSaveInstanceState(outState);
+		}
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -100,12 +100,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-		}
-
-		public override void OnSaveInstanceState(Bundle outState)
-		{
-			SaveInstanceStateCalled.Raise(this, outState);
-			base.OnSaveInstanceState(outState);
-		}
+        }
+        
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -100,6 +100,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
                 DisposeCalled.Raise(this);
             }
             base.Dispose(disposing);
-        }
+		}
+
+		public override void OnSaveInstanceState(Bundle outState)
+		{
+			SaveInstanceStateCalled.Raise(this, outState);
+			base.OnSaveInstanceState(outState);
+		}
     }
 }


### PR DESCRIPTION
The MvxEventSource[Dialog|List]Fragment classes did contain the OnSaveInstanceState override which is present in MvxEventSourceFragment. Thus, the MvxViewModel's save state methods are not called for views which inherit MvxEventSource[Dialog|List]Fragment. This patch provides the missing override.