### PR TITLE
Avoid loading resource when resourceId == 0 in MvxImageViewDrawableTargetBinding.

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxImageViewDrawableTargetBinding.cs
@@ -36,8 +36,16 @@ namespace Cirrious.MvvmCross.Binding.Droid.Target
                 return false;
             }
 
-            var resources = AndroidGlobals.ApplicationContext.Resources;
-            bitmap = BitmapFactory.DecodeResource(resources, (int)value, new BitmapFactory.Options() { InPurgeable = true});
+            var intValue = (int)value;
+
+            if (intValue == 0)
+                bitmap = null;
+            else
+            {
+                var resources = AndroidGlobals.ApplicationContext.Resources;
+                bitmap = BitmapFactory.DecodeResource(resources, intValue, new BitmapFactory.Options() { InPurgeable = true});
+            }
+
             return true;
         }
     }


### PR DESCRIPTION
In MvxImageViewDrawableTargetBinding.GetBitmap, do not attempt to load bitmap resource if resourceId == 0. Instead, set the returned bitmap to null and signal success.