### PR TITLE
EnsureFolderExists support nested folders on Windows

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonBlockingFileStore.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Windows.Storage;
 using Cirrious.CrossCore;
 using Cirrious.CrossCore.Exceptions;
@@ -222,18 +223,20 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsCommon
 
         public void EnsureFolderExists(string folderPath)
         {
-            // contributed by @AlexMortola via Stackoverflow creative commons
-            // http://stackoverflow.com/questions/19890756/mvvmcross-notimplementedexception-calling-ensurefolderexists-method-of-imvxfile
-            if (FolderExists(folderPath))
-                return;
+          if (FolderExists(folderPath))
+            return;
 
-            // note that this does not work recursively
-            if (folderPath.Contains("\\") || folderPath.Contains("/"))
-                Mvx.Warning("WindowsStore EnsureFolderExists implementation can't yet cope with nested paths");
+          var rootFolder = ToFullPath(string.Empty);
+          var storageFolder = StorageFolder.GetFolderFromPathAsync(rootFolder).Await();
+          CreateFolderAsync(storageFolder, folderPath).GetAwaiter().GetResult();
+        }
 
-            var rootFolder = ToFullPath(string.Empty);
-            var storageFolder = StorageFolder.GetFolderFromPathAsync(rootFolder).Await();
-            storageFolder.CreateFolderAsync(folderPath).Await();
+        private static async Task<StorageFolder> CreateFolderAsync(StorageFolder rootFolder, string folderPath)
+        {
+          if (string.IsNullOrEmpty(folderPath))
+            return rootFolder;
+          var currentFolder = await CreateFolderAsync(rootFolder, Path.GetDirectoryName(folderPath)).ConfigureAwait(false);
+          return await currentFolder.CreateFolderAsync(Path.GetFileName(folderPath), CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
         }
 
         public IEnumerable<string> GetFilesIn(string folderPath)

--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreBlockingFileStore.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Cirrious.CrossCore;
 using Cirrious.CrossCore.Exceptions;
 using Cirrious.CrossCore.Platform;
@@ -222,18 +223,20 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
 
         public void EnsureFolderExists(string folderPath)
         {
-            // contributed by @AlexMortola via Stackoverflow creative commons
-            // http://stackoverflow.com/questions/19890756/mvvmcross-notimplementedexception-calling-ensurefolderexists-method-of-imvxfile
-            if (FolderExists(folderPath))
-                return;
+          if (FolderExists(folderPath))
+            return;
 
-            // note that this does not work recursively
-            if (folderPath.Contains("\\") || folderPath.Contains("/"))
-                Mvx.Warning("WindowsStore EnsureFolderExists implementation can't yet cope with nested paths");
+          var rootFolder = ToFullPath(string.Empty);
+          var storageFolder = StorageFolder.GetFolderFromPathAsync(rootFolder).Await();
+          CreateFolderAsync(storageFolder, folderPath).GetAwaiter().GetResult();
+        }
 
-            var rootFolder = ToFullPath(string.Empty);
-            var storageFolder = StorageFolder.GetFolderFromPathAsync(rootFolder).Await();
-            storageFolder.CreateFolderAsync(folderPath).Await();
+        private static async Task<StorageFolder> CreateFolderAsync(StorageFolder rootFolder, string folderPath)
+        {
+          if (string.IsNullOrEmpty(folderPath))
+            return rootFolder;
+          var currentFolder = await CreateFolderAsync(rootFolder, Path.GetDirectoryName(folderPath)).ConfigureAwait(false);
+          return await currentFolder.CreateFolderAsync(Path.GetFileName(folderPath), CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
         }
 
         public IEnumerable<string> GetFilesIn(string folderPath)


### PR DESCRIPTION
Adds method that tries to create parents folder recursively before creating sub folder.