### PR TITLE
Use LayoutInflaterCompat and ILayoutInflaterFactory to install the custo...

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/IMvxAndroidViewFactory.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/IMvxAndroidViewFactory.cs
@@ -13,6 +13,6 @@ namespace Cirrious.MvvmCross.Binding.Droid.Binders
 {
     public interface IMvxAndroidViewFactory
     {
-        View CreateView(string name, Context context, IAttributeSet attrs);
+        View CreateView(View parent, string name, Context context, IAttributeSet attrs);
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/IMvxLayoutInfactorFactory.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/IMvxLayoutInfactorFactory.cs
@@ -6,13 +6,14 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System.Collections.Generic;
+using Android.Support.V4.View;
 using Android.Views;
 using Cirrious.MvvmCross.Binding.Bindings;
 
 namespace Cirrious.MvvmCross.Binding.Droid.Binders
 {
     public interface IMvxLayoutInfactorFactory
-        : LayoutInflater.IFactory
+        : ILayoutInflaterFactory
     {
         IList<KeyValuePair<object, IMvxUpdateableBinding>> CreatedBindings { get; }
     }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/MvxAndroidViewFactory.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/MvxAndroidViewFactory.cs
@@ -32,7 +32,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Binders
             }
         }
 
-        public virtual View CreateView(string name, Context context, IAttributeSet attrs)
+        public virtual View CreateView(View parent, string name, Context context, IAttributeSet attrs)
         {
             // resolve the tag name to a type
             var viewType = ViewTypeResolver.Resolve(name);

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/MvxBindingLayoutInflatorFactory.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/MvxBindingLayoutInflatorFactory.cs
@@ -54,7 +54,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Binders
             get { return Binder.CreatedBindings; }
         }
 
-        public View OnCreateView(string name, Context context, IAttributeSet attrs)
+        public View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
         {
             if (name == "fragment")
             {
@@ -62,7 +62,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Binders
                 return null;
             }
 
-            View view = AndroidViewFactory.CreateView(name, context, attrs);
+            View view = AndroidViewFactory.CreateView(parent, name, context, attrs);
             if (view != null)
             {
                 Binder.BindView(view, context, attrs);

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxAndroidBindingContext.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxAndroidBindingContext.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Android.Content;
+using Android.Support.V4.View;
 using Android.Views;
 using Cirrious.CrossCore;
 using Cirrious.MvvmCross.Binding.BindingContext;
@@ -80,7 +81,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.BindingContext
                     {
                         if (factory != null)
                         {
-                            clone.Factory = factory;
+                            LayoutInflaterCompat.SetFactory(clone, factory);
                         }
                         var toReturn = clone.Inflate(resourceId, viewGroup, attachToRoot);
                         if (factory != null)

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
@@ -167,13 +167,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
@@ -13,7 +13,10 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidSupportedAbis>armeabi</AndroidSupportedAbis>
     <MandroidI18n />
-    <TargetFrameworkVersion>v3.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0.3</TargetFrameworkVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -44,6 +47,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
+    <Reference Include="Xamarin.Android.Support.v4, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xamarin.Android.Support.v4.22.1.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Binders\IMvxAndroidViewBinder.cs" />
@@ -156,8 +163,17 @@
       <SubType>Designer</SubType>
     </CodeAnalysisDictionary>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/packages.config
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Android.Support.v4" version="22.1.1.1" targetFramework="MonoAndroid403" />
+</packages>


### PR DESCRIPTION
...m layout inflater

I was a little nervous about making this change since it essentially adds a dependency on the
V4 support library for every Android app that uses MvvmCross.  That said almost every
application or library in existence uses the support libraries anyway.

Alternatively we could probably use LayoutInflater.IFactory2 on devices that support it but I
couldn't quite get that dance working correctly.

Allows us to use material design with appcompat v7 22.1+.