### PR TITLE
Null exception when not creating attatchments

### DIFF
--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -64,32 +64,34 @@ namespace Cirrious.MvvmCross.Plugins.Email.Droid
                 emailIntent.PutExtra(Intent.ExtraText, body);
             }
 
-            var attachmentList = attachments as IList<EmailAttachment> ?? attachments.ToList();
-            if (attachmentList.Any())
+            if (attachments != null)
             {
-                var uris = new List<IParcelable>();
-
-                DoOnActivity(activity =>
+                var attachmentList = attachments as IList<EmailAttachment> ?? attachments.ToList();
+                if (attachmentList.Any())
                 {
-                    foreach (var file in attachmentList)
+                    var uris = new List<IParcelable>();
+
+                    DoOnActivity(activity =>
                     {
-                        var fileWorking = file;
-                        File localfile;
-                        using (var localFileStream = activity.OpenFileOutput(
-                            fileWorking.FileName, FileCreationMode.WorldReadable))
+                        foreach (var file in attachmentList)
                         {
-                            localfile = activity.GetFileStreamPath(fileWorking.FileName);
-                            fileWorking.Content.CopyTo(localFileStream);
+                            var fileWorking = file;
+                            File localfile;
+                            using (var localFileStream = activity.OpenFileOutput(
+                                fileWorking.FileName, FileCreationMode.WorldReadable))
+                            {
+                                localfile = activity.GetFileStreamPath(fileWorking.FileName);
+                                fileWorking.Content.CopyTo(localFileStream);
+                            }
+                            localfile.SetReadable(true, false);
+                            uris.Add(Uri.FromFile(localfile));
+                            localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
                         }
-                        localfile.SetReadable(true, false);
-                        uris.Add(Uri.FromFile(localfile));
-                        localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
-                    }
-                });
+                    });
 
-                emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
+                    emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
+                }
             }
-
             // fix for GMail App 5.x (File not found / permission denied when using "StartActivity")
             StartActivityForResult(0, Intent.CreateChooser(emailIntent, string.Empty));
         }

--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -64,34 +64,32 @@ namespace Cirrious.MvvmCross.Plugins.Email.Droid
                 emailIntent.PutExtra(Intent.ExtraText, body);
             }
 
-            if (attachments != null)
+            var attachmentList = attachments as IList<EmailAttachment> ?? attachments.ToList();
+            if (attachmentList.Any())
             {
-                var attachmentList = attachments as IList<EmailAttachment> ?? attachments.ToList();
-                if (attachmentList.Any())
+                var uris = new List<IParcelable>();
+
+                DoOnActivity(activity =>
                 {
-                    var uris = new List<IParcelable>();
-
-                    DoOnActivity(activity =>
+                    foreach (var file in attachmentList)
                     {
-                        foreach (var file in attachmentList)
+                        var fileWorking = file;
+                        File localfile;
+                        using (var localFileStream = activity.OpenFileOutput(
+                            fileWorking.FileName, FileCreationMode.WorldReadable))
                         {
-                            var fileWorking = file;
-                            File localfile;
-                            using (var localFileStream = activity.OpenFileOutput(
-                                fileWorking.FileName, FileCreationMode.WorldReadable))
-                            {
-                                localfile = activity.GetFileStreamPath(fileWorking.FileName);
-                                fileWorking.Content.CopyTo(localFileStream);
-                            }
-                            localfile.SetReadable(true, false);
-                            uris.Add(Uri.FromFile(localfile));
-                            localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
+                            localfile = activity.GetFileStreamPath(fileWorking.FileName);
+                            fileWorking.Content.CopyTo(localFileStream);
                         }
-                    });
+                        localfile.SetReadable(true, false);
+                        uris.Add(Uri.FromFile(localfile));
+                        localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
+                    }
+                });
 
-                    emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
-                }
+                emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
             }
+
             // fix for GMail App 5.x (File not found / permission denied when using "StartActivity")
             StartActivityForResult(0, Intent.CreateChooser(emailIntent, string.Empty));
         }

--- a/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/Plugins/Cirrious/Email/Cirrious.MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -64,32 +64,33 @@ namespace Cirrious.MvvmCross.Plugins.Email.Droid
                 emailIntent.PutExtra(Intent.ExtraText, body);
             }
 
-            var attachmentList = attachments as IList<EmailAttachment> ?? attachments.ToList();
-            if (attachmentList.Any())
             {
-                var uris = new List<IParcelable>();
-
-                DoOnActivity(activity =>
+                var attachmentList = attachments as IList<EmailAttachment> ?? attachments.ToList();
+                if (attachmentList.Any())
                 {
-                    foreach (var file in attachmentList)
+                    var uris = new List<IParcelable>();
+
+                    DoOnActivity(activity =>
                     {
-                        var fileWorking = file;
-                        File localfile;
-                        using (var localFileStream = activity.OpenFileOutput(
-                            fileWorking.FileName, FileCreationMode.WorldReadable))
+                        foreach (var file in attachmentList)
                         {
-                            localfile = activity.GetFileStreamPath(fileWorking.FileName);
-                            fileWorking.Content.CopyTo(localFileStream);
+                            var fileWorking = file;
+                            File localfile;
+                            using (var localFileStream = activity.OpenFileOutput(
+                                fileWorking.FileName, FileCreationMode.WorldReadable))
+                            {
+                                localfile = activity.GetFileStreamPath(fileWorking.FileName);
+                                fileWorking.Content.CopyTo(localFileStream);
+                            }
+                            localfile.SetReadable(true, false);
+                            uris.Add(Uri.FromFile(localfile));
+                            localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
                         }
-                        localfile.SetReadable(true, false);
-                        uris.Add(Uri.FromFile(localfile));
-                        localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
-                    }
-                });
+                    });
 
-                emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
+                    emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
+                }
             }
-
             // fix for GMail App 5.x (File not found / permission denied when using "StartActivity")
             StartActivityForResult(0, Intent.CreateChooser(emailIntent, string.Empty));
         }


### PR DESCRIPTION
An exception is now thrown with 3.5.1 when calling the ComposeEmail method without any attachments. This simply adds a null check before it tries to call the ToList extension method on attachments.