### PR TITLE
Add override to determine if the requested fragment

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/MvxCachingFragmentActivity.cs
@@ -196,8 +196,9 @@ namespace Cirrious.MvvmCross.Droid.Fragging
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);
 
-            // Only do something if we are not currently showing the tag at the contentId
-            if (IsFragmentCurrentlyShowing(contentId, tag)) return;
+            var shouldReplaceCurrentFragment = ShouldReplaceCurrentFragment(contentId, tag);
+            if (!shouldReplaceCurrentFragment)
+                return;
 
             var ft = SupportFragmentManager.BeginTransaction();
             OnBeforeFragmentChanging(tag, ft);
@@ -208,7 +209,7 @@ namespace Cirrious.MvvmCross.Droid.Fragging
 
             fragInfo.ContentId = contentId;
             // if we haven't already created a Fragment, do it now
-            if (fragInfo.CachedFragment == null)
+            if (fragInfo.CachedFragment == null || shouldReplaceCurrentFragment)
             {
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
@@ -225,12 +226,16 @@ namespace Cirrious.MvvmCross.Droid.Fragging
             SupportFragmentManager.ExecutePendingTransactions();
         }
 
-        protected virtual IsFragmentCurrentlyShowing(int contentId, string tag)
+        private bool ShouldReplaceCurrentFragment(int contentId, string tag)
         {
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);
 
-            return currentFragment == tag;
+            return ShouldReplaceFragment(contentId, currentFragment, tag);
+        }
+
+        protected virtual bool ShouldReplaceFragment(int contentId, string currentTag, string replacementTag)  {
+            return currentTag != replacementTag;
         }
 
         private void RemoveFragmentIfShowing(FragmentTransaction ft, int contentId)

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/MvxCachingFragmentActivity.cs
@@ -197,7 +197,7 @@ namespace Cirrious.MvvmCross.Droid.Fragging
             _currentFragments.TryGetValue(contentId, out currentFragment);
 
             // Only do something if we are not currently showing the tag at the contentId
-            if (IsContentIdCurrentyShowingFragmentWithTag(contentId, tag)) return;
+            if (IsFragmentCurrentlyShowing(contentId, tag)) return;
 
             var ft = SupportFragmentManager.BeginTransaction();
             OnBeforeFragmentChanging(tag, ft);
@@ -225,7 +225,7 @@ namespace Cirrious.MvvmCross.Droid.Fragging
             SupportFragmentManager.ExecutePendingTransactions();
         }
 
-        private bool IsContentIdCurrentyShowingFragmentWithTag(int contentId, string tag)
+        protected virtual IsFragmentCurrentlyShowing(int contentId, string tag)
         {
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxCachingFragmentActivity.cs
@@ -199,7 +199,7 @@ namespace Cirrious.MvvmCross.Droid.FullFragging
             _currentFragments.TryGetValue(contentId, out currentFragment);
 
             // Only do something if we are not currently showing the tag at the contentId
-            if (IsContentIdCurrentyShowingFragmentWithTag(contentId, tag)) return;
+            if (IsFragmentCurrentlyShowing(contentId, tag)) return;
 
             var ft = FragmentManager.BeginTransaction();
             OnBeforeFragmentChanging(tag, ft);
@@ -227,7 +227,7 @@ namespace Cirrious.MvvmCross.Droid.FullFragging
             FragmentManager.ExecutePendingTransactions();
         }
 
-        private bool IsContentIdCurrentyShowingFragmentWithTag(int contentId, string tag)
+        protected override bool IsFragmentCurrentlyShowing(int contentId, string tag)
         {
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxCachingFragmentActivity.cs
@@ -227,7 +227,7 @@ namespace Cirrious.MvvmCross.Droid.FullFragging
             FragmentManager.ExecutePendingTransactions();
         }
 
-        protected override bool IsFragmentCurrentlyShowing(int contentId, string tag)
+        protected virtual bool IsFragmentCurrentlyShowing(int contentId, string tag)
         {
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);


### PR DESCRIPTION
is currently showing so that you can force the fragment to be reloaded in situations where the same fragment is requested again but with different parameters

resolve #966 