### PR TITLE
Load local images asynchronously and scale them down (android)

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxImageView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxImageView.cs
@@ -22,21 +22,11 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
     public class MvxImageView
         : ImageView
     {
-        private readonly IMvxImageHelper<Bitmap> _imageHelper;
+        private IMvxImageHelper<Bitmap> _imageHelper;
 
         public MvxImageView(Context context, IAttributeSet attrs)
             : base(context, attrs)
         {
-            if (!Mvx.TryResolve(out _imageHelper))
-            {
-                MvxTrace.Error(
-                    "No IMvxImageHelper registered - you must provide an image helper before you can use a MvxImageView");
-            }
-            else
-            {
-                _imageHelper.ImageChanged += ImageHelperOnImageChanged;
-            }
-
             var typedArray = context.ObtainStyledAttributes(attrs,
                                                             MvxAndroidBindingResource.Instance
                                                                                      .ImageViewStylableGroupId);
@@ -56,15 +46,6 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
         public MvxImageView(Context context)
             : base(context)
         {
-            if (!Mvx.TryResolve(out _imageHelper))
-            {
-                MvxTrace.Error(
-                    "No IMvxImageHelper registered - you must provide an image helper before you can use a MvxImageView");
-            }
-            else
-            {
-                _imageHelper.ImageChanged += ImageHelperOnImageChanged;
-            }
         }
 
 		protected MvxImageView(IntPtr javaReference, JniHandleOwnership transfer)
@@ -76,28 +57,28 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
         {
             get
             {
-                if (_imageHelper == null)
+                if (ImageHelper == null)
                     return null;
-                return _imageHelper.ImageUrl;
+                return ImageHelper.ImageUrl;
             }
             set
             {
-                if (_imageHelper == null)
+                if (ImageHelper == null)
                     return;
-                _imageHelper.ImageUrl = value;
+                ImageHelper.ImageUrl = value;
             }
         }
 
         public string DefaultImagePath
         {
-            get { return _imageHelper.DefaultImagePath; }
-            set { _imageHelper.DefaultImagePath = value; }
+            get { return ImageHelper.DefaultImagePath; }
+            set { ImageHelper.DefaultImagePath = value; }
         }
 
         public string ErrorImagePath
         {
-            get { return _imageHelper.ErrorImagePath; }
-            set { _imageHelper.ErrorImagePath = value; }
+            get { return ImageHelper.ErrorImagePath; }
+            set { ImageHelper.ErrorImagePath = value; }
         }
 
         [Obsolete("Use ImageUrl instead")]
@@ -106,12 +87,30 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             get { return ImageUrl; }
             set { ImageUrl = value; }
         }
+
+        protected IMvxImageHelper<Bitmap> ImageHelper
+        {
+            get
+            {
+                if (!Mvx.TryResolve(out _imageHelper))
+                {
+                    MvxTrace.Error(
+                        "No IMvxImageHelper registered - you must provide an image helper before you can use a MvxImageView");
+                }
+                else
+                {
+                    ImageHelper.ImageChanged += ImageHelperOnImageChanged;
+                }
+                return _imageHelper;
+            }
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                if (_imageHelper != null)
-                    _imageHelper.Dispose();
+                if (ImageHelper != null)
+                    ImageHelper.Dispose();
             }
 
             base.Dispose(disposing);

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxImageView.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxImageView.cs
@@ -81,6 +81,22 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             set { ImageHelper.ErrorImagePath = value; }
         }
 
+        public override void SetMaxHeight(int maxHeight)
+        {
+            if (ImageHelper != null)
+                ImageHelper.MaxHeight = maxHeight;
+
+            base.SetMaxHeight(maxHeight);
+        }
+
+        public override void SetMaxWidth(int maxWidth)
+        {
+            if (ImageHelper != null)
+                ImageHelper.MaxWidth = maxWidth;
+
+            base.SetMaxWidth(maxWidth);
+        }
+
         [Obsolete("Use ImageUrl instead")]
         public string HttpImageUrl
         {
@@ -92,14 +108,17 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
         {
             get
             {
-                if (!Mvx.TryResolve(out _imageHelper))
+                if (_imageHelper == null)
                 {
-                    MvxTrace.Error(
-                        "No IMvxImageHelper registered - you must provide an image helper before you can use a MvxImageView");
-                }
-                else
-                {
-                    ImageHelper.ImageChanged += ImageHelperOnImageChanged;
+                    if (!Mvx.TryResolve(out _imageHelper))
+                    {
+                        MvxTrace.Error(
+                            "No IMvxImageHelper registered - you must provide an image helper before you can use a MvxImageView");
+                    }
+                    else
+                    {
+                        _imageHelper.ImageChanged += ImageHelperOnImageChanged;
+                    }
                 }
                 return _imageHelper;
             }
@@ -109,8 +128,8 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
         {
             if (disposing)
             {
-                if (ImageHelper != null)
-                    ImageHelper.Dispose();
+                if (_imageHelper != null)
+                    _imageHelper.Dispose();
             }
 
             base.Dispose(disposing);

--- a/Cirrious/Test/Cirrious.MvvmCross.Binding.Test/Cirrious.MvvmCross.Binding.Test.csproj
+++ b/Cirrious/Test/Cirrious.MvvmCross.Binding.Test/Cirrious.MvvmCross.Binding.Test.csproj
@@ -82,7 +82,9 @@
       <Name>Cirrious.MvvmCross.Test.Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -92,4 +94,3 @@
   </Target>
   -->
 </Project>
-

--- a/Cirrious/Test/Cirrious.MvvmCross.Test/Cirrious.MvvmCross.Test.csproj
+++ b/Cirrious/Test/Cirrious.MvvmCross.Test/Cirrious.MvvmCross.Test.csproj
@@ -98,6 +98,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -107,4 +110,3 @@
   </Target>
   -->
 </Project>
-

--- a/CrossCore/Cirrious.CrossCore/Platform/IMvxImageHelper.cs
+++ b/CrossCore/Cirrious.CrossCore/Platform/IMvxImageHelper.cs
@@ -21,5 +21,9 @@ namespace Cirrious.CrossCore.Platform
         string ImageUrl { get; set; }
 
         event EventHandler<MvxValueEventArgs<T>> ImageChanged;
+
+        int MaxWidth { get; set; }
+
+        int MaxHeight { get; set; }
     }
 }

--- a/CrossCore/Test/Cirrious.CrossCore.Test/Cirrious.CrossCore.Test.csproj
+++ b/CrossCore/Test/Cirrious.CrossCore.Test/Cirrious.CrossCore.Test.csproj
@@ -66,6 +66,9 @@
       <Name>Cirrious.CrossCore</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -75,4 +78,3 @@
   </Target>
   -->
 </Project>
-

--- a/Plugins/Cirrious/Color/Cirrious.MvvmCross.Plugins.Color.Test/Cirrious.MvvmCross.Plugins.Color.Test.csproj
+++ b/Plugins/Cirrious/Color/Cirrious.MvvmCross.Plugins.Color.Test/Cirrious.MvvmCross.Plugins.Color.Test.csproj
@@ -66,6 +66,9 @@
       <Name>Cirrious.MvvmCross.Plugins.Color</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -75,4 +78,3 @@
   </Target>
   -->
 </Project>
-

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
@@ -5,44 +5,34 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
+using System.Threading.Tasks;
 using Android.Graphics;
 using Cirrious.CrossCore;
+using Cirrious.CrossCore.Core;
 using Cirrious.CrossCore.Droid;
 using Cirrious.CrossCore.Platform;
 using Cirrious.MvvmCross.Binding;
 using Cirrious.MvvmCross.Plugins.File;
-using System.Collections.Generic;
-using System;
 
 namespace Cirrious.MvvmCross.Plugins.DownloadCache.Droid
 {
     public class MvxAndroidLocalFileImageLoader
-        : IMvxLocalFileImageLoader<Bitmap>          
+        : IMvxLocalFileImageLoader<Bitmap>
     {
         private const string ResourcePrefix = "res:";
-        private readonly IDictionary<string, WeakReference<Bitmap>> _memCache = new Dictionary<string, WeakReference<Bitmap>>();
 
-        public MvxImage<Bitmap> Load(string localPath, bool shouldCache)
+        public MvxImage<Bitmap> Load(string localPath, bool shouldCache /* ignored here */, int maxWidth, int maxHeight)
         {
             Bitmap bitmap;
-            var shouldAddToCache = shouldCache;
-            if (shouldCache && TryGetCachedBitmap (localPath, out bitmap))
-            {
-                shouldAddToCache = false;
-            }
-            else if (localPath.StartsWith(ResourcePrefix))
+            if (localPath.StartsWith(ResourcePrefix))
             {
                 var resourcePath = localPath.Substring(ResourcePrefix.Length);
                 bitmap = LoadResourceBitmap(resourcePath);
             }
             else
             {
-                bitmap = LoadBitmap(localPath);
-            }
-
-            if (shouldAddToCache)
-            {
-                AddToCache (localPath, bitmap);
+                bitmap = LoadBitmap(localPath, maxWidth, maxHeight);
             }
 
             return new MvxAndroidImage(bitmap);
@@ -56,6 +46,18 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache.Droid
                 if (_androidGlobals == null)
                     _androidGlobals = Mvx.Resolve<IMvxAndroidGlobals>();
                 return _androidGlobals;
+            }
+        }
+
+        private IMvxMainThreadDispatcher _dispatcher;
+
+        public IMvxMainThreadDispatcher Dispatcher
+        {
+            get
+            {
+                if (_dispatcher == null)
+                    _dispatcher = Mvx.Resolve<IMvxMainThreadDispatcher>();
+                return _dispatcher;
             }
         }
 
@@ -73,46 +75,83 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache.Droid
             return BitmapFactory.DecodeResource(resources, id, new BitmapFactory.Options { InPurgeable = true });
         }
 
-        private Bitmap LoadBitmap(string localPath)
-        {
-            var fileStore = Mvx.Resolve<IMvxFileStore>();
-            byte[] contents;
-            if (!fileStore.TryReadBinaryFile(localPath, out contents))
-                return null;
 
-			// the InPurgeable option is very important for Droid memory management.
-			// see http://slodge.blogspot.co.uk/2013/02/huge-android-memory-bug-and-bug-hunting.html
-			var options = new BitmapFactory.Options { InPurgeable = true };
-            var image = BitmapFactory.DecodeByteArray(contents, 0, contents.Length, options);
-            return image;
+        private Bitmap LoadBitmap(string localPath, int maxWidth, int maxHeight)
+        {
+            if (maxWidth > 0 || maxHeight > 0)
+            {
+                // load thumbnail - see: http://developer.android.com/training/displaying-bitmaps/load-bitmap.html
+                var options = new BitmapFactory.Options();
+                options.InJustDecodeBounds = true;
+                BitmapFactory.DecodeFile(localPath, options);
+
+                // Calculate inSampleSize
+                options.InSampleSize = CalculateInSampleSize(options, maxWidth, maxHeight);
+                // see http://slodge.blogspot.co.uk/2013/02/huge-android-memory-bug-and-bug-hunting.html
+                options.InPurgeable = true;
+
+                // Decode bitmap with inSampleSize set
+                options.InJustDecodeBounds = false;
+                return BitmapFactory.DecodeFile(localPath, options);
+            }
+            else
+            {
+
+                var fileStore = Mvx.Resolve<IMvxFileStore>();
+                byte[] contents;
+                if (!fileStore.TryReadBinaryFile(localPath, out contents))
+                    return null;
+
+                // the InPurgeable option is very important for Droid memory management.
+                // see http://slodge.blogspot.co.uk/2013/02/huge-android-memory-bug-and-bug-hunting.html
+                var options = new BitmapFactory.Options { InPurgeable = true };
+                var image = BitmapFactory.DecodeByteArray(contents, 0, contents.Length, options);
+                return image;
+            }
+
         }
 
-        private bool TryGetCachedBitmap(string key, out Bitmap bitmap)
+        public static int CalculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight)
         {
-            WeakReference<Bitmap> reference;
-            if (_memCache.TryGetValue(key, out reference))
+            // Raw height and width of image
+            int height = options.OutHeight;
+            int width = options.OutWidth;
+            int inSampleSize = 1;
+
+            if (height > reqHeight || width > reqWidth)
             {
-                Bitmap target;
-                if (reference.TryGetTarget(out target) && target != null && target.Handle != IntPtr.Zero && !target.IsRecycled)
+
+                int halfHeight = height / 2;
+                int halfWidth = width / 2;
+
+                // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+                // height and width larger than the requested height and width.
+                while ((halfHeight / inSampleSize) > reqHeight
+                        && (halfWidth / inSampleSize) > reqWidth)
                 {
-                    bitmap = target;
-                    return true;
-                }
-                else
-                {
-                    _memCache.Remove(key);
+                    inSampleSize *= 2;
                 }
             }
-            bitmap = null;
-            return false;
+
+            return inSampleSize;
         }
 
-        private void AddToCache(string key, Bitmap bitmap)
+
+        public void Load(string localPath, bool shouldCache, int maxWidth, int maxHeight, Action<MvxImage<Bitmap>> success, Action<Exception> error)
         {
-            if (bitmap != null)
+            Task.Run(() =>
             {
-                _memCache[key] = new WeakReference<Bitmap>(bitmap);
-            }
+                try
+                {
+                    var bitmap = Load(localPath, shouldCache, maxWidth, maxHeight);
+
+                    success(bitmap);
+                }
+                catch (Exception x)
+                {
+                    error(x);
+                }
+            });
         }
     }
 }

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Touch/MvxTouchLocalFileImageLoader.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Touch/MvxTouchLocalFileImageLoader.cs
@@ -12,15 +12,15 @@ using UIKit;
 
 namespace Cirrious.MvvmCross.Plugins.DownloadCache.Touch
 {
-    public class MvxTouchLocalFileImageLoader
-        : IMvxLocalFileImageLoader<UIImage>    
-    {
+	public class MvxTouchLocalFileImageLoader
+        : IMvxLocalFileImageLoader<UIImage>
+	{
 		private const string ResourcePrefix = "res:";
 
-        public MvxImage<UIImage> Load(string localPath, bool shouldCache)
-        {
+		private MvxImage<UIImage> Load(string localPath, bool shouldCache)
+		{
 			UIImage uiImage;
-            if (localPath.StartsWith(ResourcePrefix))
+			if (localPath.StartsWith(ResourcePrefix))
 			{
 				var resourcePath = localPath.Substring(ResourcePrefix.Length);
 				uiImage = LoadResourceImage(resourcePath, shouldCache);
@@ -29,19 +29,37 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache.Touch
 			{
 				uiImage = LoadUIImage(localPath);
 			}
-            return new MvxTouchImage(uiImage);
-        }
 
-        private UIImage LoadUIImage(string localPath)
-        {
-            var file = Mvx.Resolve<IMvxFileStore>();
-            var nativePath = file.NativePath(localPath);
-            return UIImage.FromFile(nativePath);
-        }
+			return new MvxTouchImage(uiImage);
+		}
+
+		private UIImage LoadUIImage(string localPath)
+		{
+			var file = Mvx.Resolve<IMvxFileStore>();
+			var nativePath = file.NativePath(localPath);
+			return UIImage.FromFile(nativePath);
+		}
 
 		private UIImage LoadResourceImage(string resourcePath, bool shouldCache)
 		{
 			return UIImage.FromBundle(resourcePath);
 		}
+
+        public void Load(string localPath, bool shouldCache, int maxWidth, int maxHeight, Action<MvxImage<Bitmap>> success, Action<Exception> error)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    var bitmap = Load(localPath, shouldCache, maxWidth, maxHeight);
+
+                    success(bitmap);
+                }
+                catch (Exception x)
+                {
+                    error(x);
+                }
+            });
+        }
     }
 }

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Touch/MvxTouchLocalFileImageLoader.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.Touch/MvxTouchLocalFileImageLoader.cs
@@ -5,6 +5,7 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System.Threading.Tasks;
 using Cirrious.CrossCore;
 using Cirrious.MvvmCross.Plugins.File;
 using Foundation;
@@ -17,20 +18,23 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache.Touch
 	{
 		private const string ResourcePrefix = "res:";
 
-		private MvxImage<UIImage> Load(string localPath, bool shouldCache)
+		public Task<MvxImage<UIImage>> Load(string localPath, bool shouldCache, int width, int height)
 		{
-			UIImage uiImage;
-			if (localPath.StartsWith(ResourcePrefix))
-			{
-				var resourcePath = localPath.Substring(ResourcePrefix.Length);
-				uiImage = LoadResourceImage(resourcePath, shouldCache);
-			}
-			else
-			{
-				uiImage = LoadUIImage(localPath);
-			}
+		    return Task.Run(() =>
+		    {
+                UIImage uiImage;
+                if (localPath.StartsWith(ResourcePrefix))
+                {
+                    var resourcePath = localPath.Substring(ResourcePrefix.Length);
+                    uiImage = LoadResourceImage(resourcePath, shouldCache);
+                }
+                else
+                {
+                    uiImage = LoadUIImage(localPath);
+                }
 
-			return new MvxTouchImage(uiImage);
+                return (MvxImage<UIImage>)new MvxTouchImage(uiImage);
+		    });
 		}
 
 		private UIImage LoadUIImage(string localPath)
@@ -44,22 +48,5 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache.Touch
 		{
 			return UIImage.FromBundle(resourcePath);
 		}
-
-        public void Load(string localPath, bool shouldCache, int maxWidth, int maxHeight, Action<MvxImage<Bitmap>> success, Action<Exception> error)
-        {
-            Task.Run(() =>
-            {
-                try
-                {
-                    var bitmap = Load(localPath, shouldCache, maxWidth, maxHeight);
-
-                    success(bitmap);
-                }
-                catch (Exception x)
-                {
-                    error(x);
-                }
-            });
-        }
     }
 }

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.csproj
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache.csproj
@@ -31,6 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
@@ -68,7 +74,15 @@
       <Name>Cirrious.MvvmCross.Plugins.File</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/IMvxLocalFileImageLoader.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/IMvxLocalFileImageLoader.cs
@@ -5,10 +5,12 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
+
 namespace Cirrious.MvvmCross.Plugins.DownloadCache
 {
     public interface IMvxLocalFileImageLoader<T>
     {
-        MvxImage<T> Load(string localPath, bool shouldCache);
+        void Load(string localPath, bool shouldCache, int width, int height, Action<MvxImage<T>> success, Action<Exception> error);
     }
 }

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/IMvxLocalFileImageLoader.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/IMvxLocalFileImageLoader.cs
@@ -6,11 +6,12 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using System.Threading.Tasks;
 
 namespace Cirrious.MvvmCross.Plugins.DownloadCache
 {
     public interface IMvxLocalFileImageLoader<T>
     {
-        void Load(string localPath, bool shouldCache, int width, int height, Action<MvxImage<T>> success, Action<Exception> error);
+        Task<MvxImage<T>> Load(string localPath, bool shouldCache, int width, int height);
     }
 }

--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/packages.config
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+</packages>

--- a/Plugins/Cirrious/Messenger/Cirrious.MvvmCross.Plugins.Messenger.Test/Cirrious.MvvmCross.Plugins.Messenger.Test.csproj
+++ b/Plugins/Cirrious/Messenger/Cirrious.MvvmCross.Plugins.Messenger.Test/Cirrious.MvvmCross.Plugins.Messenger.Test.csproj
@@ -56,6 +56,9 @@
       <Name>Cirrious.MvvmCross.Plugins.Messenger</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -65,4 +68,3 @@
   </Target>
   -->
 </Project>
-

--- a/Plugins/Cirrious/Network/Cirrious.MvvmCross.Plugins.Network.Test/Cirrious.MvvmCross.Plugins.Network.Test.csproj
+++ b/Plugins/Cirrious/Network/Cirrious.MvvmCross.Plugins.Network.Test/Cirrious.MvvmCross.Plugins.Network.Test.csproj
@@ -81,6 +81,9 @@
       <Name>Cirrious.MvvmCross.Plugins.Network</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -90,4 +93,3 @@
   </Target>
   -->
 </Project>
-


### PR DESCRIPTION
Load local images asynchronously and scale them down (android)

== Problem ==
Loading local images on the UI Thread on Android is a serious bottleneck.
In our production application we've got a ListView that displays all images a user has taken with the devices camera. These can be up to 8 or even more megapixels.
As loading is done on the UI thread the UI freezes as the user scrolls through the ListView.

== This change brings two benefits: ==
a) It changes (sorry for that) the interface of the IMvxLocalFileImageLoader<T> to be asynchronous as the others. The LocalImageLoaders of iOS and Android kick off a task (Task.Run()) to load the actual images.
This already improves scolling performance.

b) As Android supports loading a scaled down version of a Bitmap, the IMvxImageHelper<T> got two properties "MaxWidth" and "MaxHeight"
These are set by the MvxImageView, if its "maxWidth" and "maxHeight" properties are set.
So given you specify a maxWidth- and maxHeight on MvxImageView, it loads the scaled-down version.
This speeds up loading but brings a tremendous memory benefit! 


== Note ==

a) Please note that I do not have a license for Xamarin.IOS - so I made the iOS Plugin change in Notepad ++. (I triple checked it, but I'll take the blame :-))

b) I also have to admit that I have very little knowledge of Xamarin.iOS license. I tried to find an approach to load a scaled-down UIImage but could not find anything. Maybe I am blind. That said - if anybody could point me to the right direction or just implement this feature in my branch, that would be pretty awesome.
