### PR TITLE
Adding Close Hint support for MvxConsole

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Console/Views/MvxConsoleContainer.cs
+++ b/Cirrious/Cirrious.MvvmCross.Console/Views/MvxConsoleContainer.cs
@@ -40,7 +40,32 @@ namespace Cirrious.MvvmCross.Console.Views
 
         public override void ChangePresentation(MvxPresentationHint hint)
         {
+            if (hint is MvxClosePresentationHint)
+            {
+                Close((hint as MvxClosePresentationHint).ViewModelToClose);
+                return;
+            }
+
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
+        }
+
+        public void Close(IMvxViewModel viewModel)
+        {
+            var currentView = Mvx.Resolve<IMvxConsoleCurrentView>().CurrentView;
+
+            if (currentView == null)
+            {
+                Mvx.Warning("Ignoring close for viewmodel - rootframe has no current page");
+                return;
+            }
+
+            if (currentView.ViewModel != viewModel)
+            {
+                Mvx.Warning("Ignoring close for viewmodel - rootframe's current page is not the view for the requested viewmodel");
+                return;
+            }
+
+            this.GoBack();
         }
 
         public override void GoBack()


### PR DESCRIPTION
For MVX Console projects, Close hint is not implemented in the console presenter.