### PR TITLE
Added WCF DataContract attribute to allow MvxNotifyPropertyChanged-de…

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
@@ -9,10 +9,12 @@ using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using Cirrious.CrossCore.Core;
 
 namespace Cirrious.MvvmCross.ViewModels
 {
+    [DataContract]
     public abstract class MvxNotifyPropertyChanged
         : MvxMainThreadDispatchingObject
         , IMvxNotifyPropertyChanged

--- a/CrossCore/Cirrious.CrossCore/Core/MvxMainThreadDispatchingObject.cs
+++ b/CrossCore/Cirrious.CrossCore/Core/MvxMainThreadDispatchingObject.cs
@@ -6,9 +6,11 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Cirrious.CrossCore.Core
 {
+    [DataContract]
     public abstract class MvxMainThreadDispatchingObject
     {
         protected IMvxMainThreadDispatcher Dispatcher


### PR DESCRIPTION
I was using this in an application I am developing.  App consists of a WCF service backend which a variety of clients can communicate with (WPF, Android, etc).

For simplicity, developed a PCL base-library that contained the necessary data objects, view models, etc.  Those data objects, derived from MvxNotifyPropertyChanged to make data binding easier, were throwing errors when the WCF layer attempted to serialize them.  All base types needed to have the [DataContract] attribute on them for the serializer to be able to handle them.