### PR TITLE
Fixes Casting for SelectedElement on UISegmentedControl

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Target/MvxUISegmentedControlSelectedSegmentTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Target/MvxUISegmentedControlSelectedSegmentTargetBinding.cs
@@ -2,6 +2,7 @@
 using Cirrious.CrossCore.Platform;
 using UIKit;
 using System.Reflection;
+using System;
 
 namespace Cirrious.MvvmCross.Binding.Touch.Target
 {
@@ -46,7 +47,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Target
             if (view == null)
                 return;
 
-            view.SelectedSegment = (int)value;
+            view.SelectedSegment = (nint)value;
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
I saw an exception during development time when trying to bind a segmented control.

	2015-06-13 11:58:35.824 MyApp[96723:5480589] MvxBind:Error: 12.37 Problem seen during binding execution for binding SelectedSegment for Fieldname - problem InvalidCastException: Unable to cast object of type 'System.nint' to type 'System.Int32'.
		  at Cirrious.MvvmCross.Binding.Touch.Target.MvxUISegmentedControlSelectedSegmentTargetBinding.SetValueImpl (System.Object target, System.Object value) [0x00015] in <filename unknown>:0 
	  at Cirrious.MvvmCross.Binding.Bindings.Target.MvxConvertingTargetBinding.SetValue (System.Object value) [0x00089] in <filename unknown>:0 
	  at Cirrious.MvvmCross.Binding.Bindings.MvxFullBinding.UpdateTargetFromSource (System.Object value) [0x00023] in <filename unknown>:0 
	MvxBind:Error: 12.37 Problem seen during binding execution for binding SelectedSegment for Anrede - problem InvalidCastException: Unable to cast object of type 'System.nint' to type 'System.Int32'.

This change provides a fix (with the correct casting on nint instead of int).