### PR TITLE
Renaming "GroupItemTemplate" android attribute to "MvxGroupItemTemplate"

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxTabsFragmentActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxTabsFragmentActivity.cs
@@ -97,7 +97,11 @@ namespace Cirrious.MvvmCross.Droid.FullFragging
 
         private void InitializeTabHost(Bundle args)
         {
-            _tabHost = (TabHost) FindViewById(Android.Resource.Id.TabHost);
+            var tabHostView = FindViewById(Android.Resource.Id.TabHost);
+            if (tabHostView == null)
+                throw new Exception("Unable to find a view with \"Android.Resource.Id.TabHost\" resource Id !")
+                
+            _tabHost = (TabHost)tabHostView;
             _tabHost.Setup();
 
             AddTabs(args);

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxTabsFragmentActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/MvxTabsFragmentActivity.cs
@@ -97,11 +97,7 @@ namespace Cirrious.MvvmCross.Droid.FullFragging
 
         private void InitializeTabHost(Bundle args)
         {
-            var tabHostView = FindViewById(Android.Resource.Id.TabHost);
-            if (tabHostView == null)
-                throw new Exception("Unable to find a view with \"Android.Resource.Id.TabHost\" resource Id !")
-                
-            _tabHost = (TabHost)tabHostView;
+            _tabHost = (TabHost) FindViewById(Android.Resource.Id.TabHost);
             _tabHost.Setup();
 
             AddTabs(args);


### PR DESCRIPTION
"GroupItemTemplate" android attribute has been renamed to "MvxGroupItemTemplate" to match the current naming convention that uses "Mvx" prefix for android attribute.