### PR TITLE
Add javaReference/transfer constructors to fragments

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
@@ -12,6 +12,7 @@ using Android.Views;
 using Cirrious.CrossCore.Core;
 
 using Fragment = Android.Support.V4.App.Fragment;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
@@ -33,6 +34,17 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 
         public event EventHandler DisposeCalled;
         public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        public MvxEventSourceFragment()
+        {
+
+        }
+
+        public MvxEventSourceFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+            this.AddEventListeners();
+        }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxFragment.cs
@@ -6,9 +6,11 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.OS;
+using Android.Runtime;
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource;
 using Cirrious.MvvmCross.ViewModels;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
 {
@@ -31,6 +33,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
         }
 
         protected MvxFragment()
+        {
+            this.AddEventListeners();
+        }
+
+        public MvxFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
         {
             this.AddEventListeners();
         }
@@ -69,6 +77,15 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
         : MvxFragment
         , IMvxFragmentView<TViewModel> where TViewModel : class, IMvxViewModel
     {
+
+        public MvxFragment()
+        {
+
+        }
+
+        public MvxFragment(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
+
+
         public new TViewModel ViewModel
         {
             get { return (TViewModel)base.ViewModel; }


### PR DESCRIPTION
Android sometimes crashes if it cannot find this constructor.  Note that ideally we need to warn people to add this constructor to their own fragments as well although I'm not sure what causes Xamarin.Android to call this constructor