### PR TITLE
Add javaReference/transfer constructors to fragments

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -12,6 +12,7 @@ using Android.Views;
 using Cirrious.CrossCore.Core;
 
 using DialogFragment = Android.Support.V4.App.DialogFragment;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
@@ -33,6 +34,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 
         public event EventHandler DisposeCalled;
         public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        protected MvxEventSourceDialogFragment() { }
+
+        protected MvxEventSourceDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        { }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
@@ -12,6 +12,7 @@ using Android.Views;
 using Cirrious.CrossCore.Core;
 
 using Fragment = Android.Support.V4.App.Fragment;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
@@ -33,6 +34,17 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 
         public event EventHandler DisposeCalled;
         public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        public MvxEventSourceFragment()
+        {
+
+        }
+
+        public MvxEventSourceFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+            this.AddEventListeners();
+        }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceFragment.cs
@@ -43,7 +43,7 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
         public MvxEventSourceFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
         {
-            this.AddEventListeners();
+
         }
 
         public override void OnAttach(Activity activity)

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -12,6 +12,7 @@ using Android.Views;
 using Cirrious.CrossCore.Core;
 
 using ListFragment = Android.Support.V4.App.ListFragment;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 {
@@ -33,6 +34,10 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource
 
         public event EventHandler DisposeCalled;
         public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        protected MvxEventSourceListFragment() { }
+
+        protected MvxEventSourceListFragment(IntPtr javaReference, JniHandleOwnership transfer) { }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxDialogFragment.cs
@@ -6,9 +6,11 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.OS;
+using Android.Runtime;
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource;
 using Cirrious.MvvmCross.ViewModels;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
 {
@@ -17,6 +19,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
         , IMvxFragmentView
     {
         protected MvxDialogFragment()
+        {
+            this.AddEventListeners();
+        }
+
+        protected MvxDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
         {
             this.AddEventListeners();
         }

--- a/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.Fragging/Fragments/MvxFragment.cs
@@ -6,9 +6,11 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.OS;
+using Android.Runtime;
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Droid.Fragging.Fragments.EventSource;
 using Cirrious.MvvmCross.ViewModels;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
 {
@@ -31,6 +33,12 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
         }
 
         protected MvxFragment()
+        {
+            this.AddEventListeners();
+        }
+
+        public MvxFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
         {
             this.AddEventListeners();
         }
@@ -69,6 +77,15 @@ namespace Cirrious.MvvmCross.Droid.Fragging.Fragments
         : MvxFragment
         , IMvxFragmentView<TViewModel> where TViewModel : class, IMvxViewModel
     {
+
+        public MvxFragment()
+        {
+
+        }
+
+        public MvxFragment(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
+
+
         public new TViewModel ViewModel
         {
             get { return (TViewModel)base.ViewModel; }

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -10,6 +10,7 @@ using Android.App;
 using Android.OS;
 using Android.Views;
 using Cirrious.CrossCore.Core;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
 {
@@ -31,6 +32,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
 
         public event EventHandler DisposeCalled;
         public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        protected MvxEventSourceDialogFragment() { }
+
+        protected MvxEventSourceDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        { }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceFragment.cs
@@ -10,6 +10,7 @@ using Android.App;
 using Android.OS;
 using Android.Views;
 using Cirrious.CrossCore.Core;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
 {
@@ -31,6 +32,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
 
         public event EventHandler DisposeCalled;
         public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        protected MvxEventSourceFragment() { }
+
+        protected MvxEventSourceFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        { }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -10,6 +10,7 @@ using Android.App;
 using Android.OS;
 using Android.Views;
 using Cirrious.CrossCore.Core;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
 {
@@ -31,6 +32,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource
 
         public event EventHandler DisposeCalled;
         public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        protected MvxEventSourceListFragment() { }
+
+        protected MvxEventSourceListFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        { }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxDialogFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxDialogFragment.cs
@@ -6,9 +6,11 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.OS;
+using Android.Runtime;
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource;
 using Cirrious.MvvmCross.ViewModels;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments
 {
@@ -16,6 +18,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments
         : MvxEventSourceDialogFragment
           , IMvxFragmentView
     {
+        protected MvxDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+            this.AddEventListeners();
+        }
+
         protected MvxDialogFragment()
         {
             this.AddEventListeners();

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxFragment.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Fragments/MvxFragment.cs
@@ -6,9 +6,11 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.OS;
+using Android.Runtime;
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Droid.FullFragging.Fragments.EventSource;
 using Cirrious.MvvmCross.ViewModels;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments
 {
@@ -28,6 +30,12 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Fragments
             var fragment = new MvxFragment { Arguments = bundle };
 
             return fragment;
+        }
+
+        protected MvxFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+            this.AddEventListeners();
         }
 
         protected MvxFragment()

--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Views/MvxActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Views/MvxActivity.cs
@@ -14,6 +14,7 @@ using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Binding.Droid.BindingContext;
 using Cirrious.MvvmCross.Droid.Views;
 using Cirrious.MvvmCross.ViewModels;
+using Android.Runtime;
 
 namespace Cirrious.MvvmCross.Droid.FullFragging.Views
 {
@@ -21,6 +22,14 @@ namespace Cirrious.MvvmCross.Droid.FullFragging.Views
         : MvxEventSourceActivity
         , IMvxAndroidView
     {
+
+        protected MvxActivity(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+            BindingContext = new MvxAndroidBindingContext(this, this);
+            this.AddEventListeners();
+        }
+
         protected MvxActivity()
         {
             BindingContext = new MvxAndroidBindingContext(this, this);

--- a/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxActivity.cs
@@ -6,10 +6,12 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.Content;
+using Android.Runtime;
 using Cirrious.CrossCore.Droid.Views;
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Binding.Droid.BindingContext;
 using Cirrious.MvvmCross.ViewModels;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.Views
 {
@@ -17,6 +19,13 @@ namespace Cirrious.MvvmCross.Droid.Views
         : MvxEventSourceActivity
         , IMvxAndroidView
     {
+
+        protected MvxActivity(IntPtr javaReference, JniHandleOwnership transfer)
+        {
+            BindingContext = new MvxAndroidBindingContext(this, this);
+            this.AddEventListeners();
+        }
+
         protected MvxActivity()
         {
             BindingContext = new MvxAndroidBindingContext(this, this);

--- a/CrossCore/Cirrious.CrossCore.Droid/Views/MvxEventSourceActivity.cs
+++ b/CrossCore/Cirrious.CrossCore.Droid/Views/MvxEventSourceActivity.cs
@@ -10,6 +10,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using Cirrious.CrossCore.Core;
+using Android.Runtime;
 
 namespace Cirrious.CrossCore.Droid.Views
 {
@@ -17,6 +18,14 @@ namespace Cirrious.CrossCore.Droid.Views
         : Activity
           , IMvxEventSourceActivity
     {
+
+        protected MvxEventSourceActivity()
+        {
+
+        }
+
+        protected MvxEventSourceActivity(IntPtr javaReference, JniHandleOwnership transfer) { }
+
         protected override void OnCreate(Bundle bundle)
         {
             CreateWillBeCalled.Raise(this, bundle);


### PR DESCRIPTION
Android sometimes crashes if it cannot find this constructor. Note that ideally we need to warn people to add this constructor to their own fragments as well although I'm not sure what causes Xamarin.Android to call this constructor