### PR TITLE
Save the original IMvxLayoutInflaterHolderFactory when inflating views and restore at the end

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxAndroidBindingContext.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/BindingContext/MvxAndroidBindingContext.cs
@@ -56,12 +56,13 @@ namespace Cirrious.MvvmCross.Binding.Droid.BindingContext
         {
             using (new MvxBindingContextStackRegistration<IMvxAndroidBindingContext>(this))
             {
-                var layoutInflater = this._layoutInflaterHolder.LayoutInflater.CloneInContext(_droidContext);
-                
-                // This is most likely a MvxLayoutInflater but it doesn't have to be.
-                // It handles setting the bindings and interacts with this instance of
-                // MvxAndroidBindingContext through the use of MvxAndroidBindingContextHelpers.Current().
-                return layoutInflater.Inflate(resourceId, viewGroup, attachToRoot);
+                using (var layoutInflater = this._layoutInflaterHolder.LayoutInflater.CloneInContext(_droidContext))
+                {
+                    // This is most likely a MvxLayoutInflater but it doesn't have to be.
+                    // It handles setting the bindings and interacts with this instance of
+                    // MvxAndroidBindingContext through the use of MvxAndroidBindingContextHelpers.Current().
+                    return layoutInflater.Inflate(resourceId, viewGroup, attachToRoot);
+                }
             }
         }
     }

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxLayoutInflater.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Views/MvxLayoutInflater.cs
@@ -98,6 +98,9 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             // uses a private factory.
             this.SetPrivateFactoryInternal();
 
+            // Save the old factory in case we are recursing because of an MvxAdapter etc.
+            IMvxLayoutInflaterHolderFactory originalFactory = this._bindingVisitor.Factory;
+
             try
             {
                 IMvxLayoutInflaterHolderFactory factory = null;
@@ -128,7 +131,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
             }
             finally
             {
-                this._bindingVisitor.Factory = null;
+                this._bindingVisitor.Factory = originalFactory;
             }
         }
 
@@ -141,9 +144,10 @@ namespace Cirrious.MvvmCross.Binding.Droid.Views
         protected override View OnCreateView(string name, IAttributeSet attrs)
         {
             View view = this.AndroidViewFactory.CreateView(null, name, this.Context, attrs) ??
-                            (this.PhoneLayoutInflaterOnCreateView(name, attrs) ?? base.OnCreateView(name, attrs));
+                            this.PhoneLayoutInflaterOnCreateView(name, attrs) ??
+                            base.OnCreateView(name, attrs);
 
-            return this._bindingVisitor.OnViewCreated(view, view.Context, attrs);
+            return this._bindingVisitor.OnViewCreated(view, this.Context, attrs);
         }
 
         // Mimic PhoneLayoutInflater's OnCreateView.


### PR DESCRIPTION
Fixes #1045 