### PR TITLE
Fix for https://github.com/MvvmCross/MvvmCross/issues/1050. 

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/HackFileShare/MvxIoFileStoreBase.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File/HackFileShare/MvxIoFileStoreBase.cs
@@ -10,9 +10,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Cirrious.CrossCore.Exceptions;
 using Cirrious.CrossCore.Platform;
-using System.Threading.Tasks;
 
 namespace Cirrious.MvvmCross.Plugins.File
 {
@@ -29,7 +29,7 @@ namespace Cirrious.MvvmCross.Plugins.File
                 return null;
             }
 
-            return System.IO.File.OpenRead(fullPath);
+			return System.IO.File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         }
 
         public override Stream OpenWrite(string path)
@@ -150,7 +150,7 @@ namespace Cirrious.MvvmCross.Plugins.File
                 return false;
             }
 
-            using (var fileStream = System.IO.File.OpenRead(fullPath))
+			using (var fileStream = System.IO.File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 return streamAction(fileStream);
             }
@@ -179,7 +179,7 @@ namespace Cirrious.MvvmCross.Plugins.File
 				return false;
 			}
 
-			using (var fileStream = System.IO.File.OpenRead(fullPath))
+			using (var fileStream = System.IO.File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
 			{
 				return await streamAction(fileStream).ConfigureAwait(false);
 			}


### PR DESCRIPTION
Hello, this solved my particular problem but am not sure about all possible consequences of FileShare.ReadWrite so please review carefully. Notice that typical System.IO.File implementation uses the combination of FileMode.Open, FileAccess.Read, FileShare.Read and this modification uses the combination of FileMode.Open, FileAccess.Read, FileShare.ReadWrite - file access is still Read-only but the sharing changes...

I was bit surprised that TryReadFileCommon() method calls the same (copy&pasted) System.IO.File operation. If it called overridable MvxIoFileStoreBase.OpenRead() method instead then maybe only MvxWpfFileStore could override OpenRead() method with FileShare.ReadWrite and not directly MvxIoFileStoreBase. I did not want to do this refac right-away to make the review process as simple as possible but I can do it upon request.

As said about I do not feel to be expert in understanding FileShare parameter. It solved my practical problem when I wanted to READ (only to read) the file that was opened for reading and writing by another process. This approach is still read-only for the current thread so it feels to be safe for my understanding.

Best
Jan