### PR TITLE
Nuke dependency HotTuna.CrossCore -> PortableSupport

### DIFF
--- a/nuspec/MvvmCross.HotTuna.CrossCore.3.0.1.nuspec
+++ b/nuspec/MvvmCross.HotTuna.CrossCore.3.0.1.nuspec
@@ -9,7 +9,6 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>This package contains the 'Core' assemblies for MvvmCross v3 - Hot Tuna. This and other packages are currently under development...</description>
 		<dependencies>
-		  <dependency id="MvvmCross.PortableSupport" version="3.5.2-alpha2" />
 		</dependencies>
 		<iconUrl>http://i.imgur.com/ymzMpLX.png</iconUrl>
 	</metadata>


### PR DESCRIPTION
### This dependency was a legacy. ###

For some targets there used to aspects of the .Net Framework missing that required the assembly PortableSupport. As time progressed the missing aspects found their way into the core .Net Assemblies and duplicate coding in PortableSupport was replaced with Assembly Redirects to the Core .NET Assemblies. This tactic allowed projects that linked to PortableSupport to update NuSpec without having to relink.

Over time though all targets of CrossCore other than the PCL were either removed or commented out of the NuSpec. So in effect there was nothing to download and link to as a reference except for the PCL.

The PCL however at no stage had any content other than a single file named "-.-" put there presumably to stop NuGet complaining.

With Visual Studio 2015 there is a new NuGet that is not happy with this situation and complains about a being asked to download a package that has no content and then throws an exception.

So we decided to remove the dependency.

More information: [See the discussion.](https://github.com/MvvmCross/MvvmCross/issues/1053)