### PR TITLE
Network Plugin: fixed disposing response stream after finishing successAction

### DIFF
--- a/Plugins/Cirrious/Network/Cirrious.MvvmCross.Plugins.Network/Rest/MvxRestClient.cs
+++ b/Plugins/Cirrious/Network/Cirrious.MvvmCross.Plugins.Network/Rest/MvxRestClient.cs
@@ -220,24 +220,21 @@ namespace Cirrious.MvvmCross.Plugins.Network.Rest
         {
             httpRequest.BeginGetResponse(result =>
                                          TryCatch(() =>
-                                             {
-                                                 var response = (HttpWebResponse) httpRequest.EndGetResponse(result);
+                    {
+                        var response = (HttpWebResponse)httpRequest.EndGetResponse(result);
 
-                                                 var code = response.StatusCode;
-
-                                                 using (var responseStream = response.GetResponseStream())
-                                                 {
-                                                     var restResponse = new MvxStreamRestResponse
-                                                         {
-                                                             CookieCollection = response.Cookies,
-                                                             Stream = responseStream,
-                                                             Tag = restRequest.Tag,
-                                                             StatusCode = code
-                                                         };
-                                                     successAction(restResponse);
-                                                 }
-                                             }, errorAction)
-                                         , null);
+                        var code = response.StatusCode;
+                        var responseStream = response.GetResponseStream();
+                        var restResponse = new MvxStreamRestResponse
+                        {
+                            CookieCollection = response.Cookies,
+                            Stream = responseStream,
+                            Tag = restRequest.Tag,
+                            StatusCode = code
+                        };
+                        successAction(restResponse);
+                    }, errorAction)
+                , null);
         }
 
         protected virtual void ProcessRequestThen(


### PR DESCRIPTION
Fixed the issue when responce stream gets disposed after leaving from successAction.

It's important because with current implementation we can't save the stream to fields. And we also can't wrap this plugin into async Task implementation.

Now in our we project we have to save responce stream into the MemoryStream for further usage. And it looks smth like this:
```C#
        void OnSuccess(MvxStreamRestResponse responce)
        {
            var memoryStream = new MemoryStream();
            responce.Stream.CopyTo(memoryStream);
            responce.Stream.Dispose();
            memoryStream.Position = 0;
            _fieldStream = memoryStream;
        }
```

Doesn't look good enough, does it?