### PR TITLE
Fixed crash if same picture is added twice

### DIFF
--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
@@ -53,7 +53,10 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache
                     _fileDownloadCache.RequestLocalFilePath(url, 
                         async s => {
                             var image = await Parse(s).ConfigureAwait(false);
-                            _entriesByHttpUrl.Add(url, new Entry(url, image));
+							if(!_entriesByHttpUrl.ContainsKey(url)) {
+                            	_entriesByHttpUrl.Add(url, new Entry(url, image));
+							}
+
                             tcs.TrySetResult(image.RawImage);
                         },
                         exception => {


### PR DESCRIPTION
A check if key exists already - Crashed when same picture was reloaded the second time.