### PR TITLE
MvxAndroidViewFactory: Remove error message

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/MvxAndroidViewFactory.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Binders/MvxAndroidViewFactory.cs
@@ -39,7 +39,7 @@ namespace Cirrious.MvvmCross.Binding.Droid.Binders
 
             if (viewType == null)
             {
-                MvxBindingTrace.Trace(MvxTraceLevel.Error, "View type not found - {0}", name);
+                //MvxBindingTrace.Trace(MvxTraceLevel.Error, "View type not found - {0}", name);
                 return null;
             }
 


### PR DESCRIPTION
Now that MvxLayoutInflater is in charge of inflating all views MvxAndroidViewFactory.CreateView gets called for android internal views including bits and pieces of the action bar etc.  Comment out the error message for now.