### PR TITLE
Pass the java handle down to the base constructor to avoid a potentia…

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxActivity.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxActivity.cs
@@ -22,6 +22,7 @@ namespace Cirrious.MvvmCross.Droid.Views
     {
 
         protected MvxActivity(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
         {
             BindingContext = new MvxAndroidBindingContext(this, this);
             this.AddEventListeners();

--- a/CrossCore/Cirrious.CrossCore.Droid/Views/MvxEventSourceActivity.cs
+++ b/CrossCore/Cirrious.CrossCore.Droid/Views/MvxEventSourceActivity.cs
@@ -24,7 +24,8 @@ namespace Cirrious.CrossCore.Droid.Views
 
         }
 
-        protected MvxEventSourceActivity(IntPtr javaReference, JniHandleOwnership transfer) { }
+        protected MvxEventSourceActivity(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer) { }
 
         protected override void OnCreate(Bundle bundle)
         {


### PR DESCRIPTION
…lly nasty leak

I haven't seen this in the wild but it should prevent a disconnect between the java and c#
if instantiating the activity from java. I don't *think* we'd hit this unless starting an activity
from an intent on the java side of things and we happened to override a virtual method called
from one of the constructors.

See http://developer.xamarin.com/guides/android/under_the_hood/architecture/#Java_Activation