### PR TITLE
Accidently deleting all files in DownloadCache

### DIFF
--- a/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/MvxFileDownloadCache.cs
+++ b/Plugins/Cirrious/DownloadCache/Cirrious.MvvmCross.Plugins.DownloadCache/MvxFileDownloadCache.cs
@@ -110,7 +110,22 @@ namespace Cirrious.MvvmCross.Plugins.DownloadCache
         private void QueueUnindexedFilesForDelete()
         {
             var store = MvxFileStoreHelper.SafeGetFileStore();
-            var files = store.GetFilesIn(_cacheFolder);
+            var files = new List<string>();
+
+            // Transform absolute file paths into relative ones
+            foreach (var file in store.GetFilesIn(_cacheFolder))
+            {
+                var pos = file.IndexOf(_cacheFolder, StringComparison.Ordinal);
+                if (pos != -1)
+                {
+                    var relativeFile = file.Substring(pos);
+                    files.Add(relativeFile);
+                }
+                else
+                {
+                    files.Add(file);
+                }
+            }
 
             // we don't use Linq because of AOT/JIT problem on MonoTouch :/
             //var cachedFiles = _entriesByHttpUrl.ToDictionary(x => x.Value.DownloadedPath);


### PR DESCRIPTION
I just came across an issue in my touch app. The DownloadCache plugin is removing all files from the file cache during the app start, rendering the cache totally useless in an offline situation. The pull request adds a commit, transforming an absolute file path into a relative file path. After that it is comparable to the stored DownloadedPath and the file cache is not fully wiped.

I've tested on iOS only. The cache is not cleaned on app restart after applying the patch.