### PR TITLE
A nicer way to handle handling multiple presentation hints

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxAndroidViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxAndroidViewPresenter.cs
@@ -16,14 +16,14 @@ using Cirrious.MvvmCross.Views;
 namespace Cirrious.MvvmCross.Droid.Views
 {
     public class MvxAndroidViewPresenter
-        : IMvxAndroidViewPresenter
+        : MvxViewPresenter, IMvxAndroidViewPresenter
     {
         protected Activity Activity
         {
             get { return Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity; }
         }
 
-        public virtual void Show(MvxViewModelRequest request)
+        public override void Show(MvxViewModelRequest request)
         {
             var intent = CreateIntentForRequest(request);
             Show(intent);
@@ -47,13 +47,15 @@ namespace Cirrious.MvvmCross.Droid.Views
             return intent;
         }
 
-        public virtual void ChangePresentation(MvxPresentationHint hint)
+        public override void ChangePresentation(MvxPresentationHint hint)
         {
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
+
+            if (HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxAndroidViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxAndroidViewPresenter.cs
@@ -49,13 +49,13 @@ namespace Cirrious.MvvmCross.Droid.Views
 
         public override void ChangePresentation(MvxPresentationHint hint)
         {
+            if (HandlePresentationChange(hint)) return;
+
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
-
-            if (HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.Touch/Views/Presenters/MvxBaseTouchViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Touch/Views/Presenters/MvxBaseTouchViewPresenter.cs
@@ -7,19 +7,22 @@
 
 using Cirrious.CrossCore.Platform;
 using Cirrious.MvvmCross.ViewModels;
+using Cirrious.MvvmCross.Views;
 using UIKit;
 
 namespace Cirrious.MvvmCross.Touch.Views.Presenters
 {
     public class MvxBaseTouchViewPresenter
-        : IMvxTouchViewPresenter
+        : MvxViewPresenter, IMvxTouchViewPresenter
     {
-        public virtual void Show(MvxViewModelRequest request)
+        public override void Show(MvxViewModelRequest request)
         {
         }
 
-        public virtual void ChangePresentation(MvxPresentationHint hint)
+        public override void ChangePresentation(MvxPresentationHint hint)
         {
+            if (HandlePresentationChange(hint)) return;
+
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }
 

--- a/Cirrious/Cirrious.MvvmCross.Touch/Views/Presenters/MvxTouchViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Touch/Views/Presenters/MvxTouchViewPresenter.cs
@@ -53,13 +53,13 @@ namespace Cirrious.MvvmCross.Touch.Views.Presenters
 
         public override void ChangePresentation(MvxPresentationHint hint)
         {
+            base.ChangePresentation(hint);
+
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
-
-            base.ChangePresentation(hint);
         }
 
         public virtual void Show(IMvxTouchView view)

--- a/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsViewPresenter.cs
@@ -16,7 +16,7 @@ using Cirrious.MvvmCross.WindowsCommon.Platform;
 namespace Cirrious.MvvmCross.WindowsCommon.Views
 {
     public class MvxWindowsViewPresenter
-        : IMvxWindowsViewPresenter
+        : MvxViewPresenter, IMvxWindowsViewPresenter
     {
         private readonly IMvxWindowsFrame _rootFrame;
 
@@ -25,7 +25,7 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
             _rootFrame = rootFrame;
         }
 
-        public virtual void Show(MvxViewModelRequest request)
+        public override void Show(MvxViewModelRequest request)
         {
             try
             {
@@ -44,13 +44,15 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
             }
         }
 
-        public virtual void ChangePresentation(MvxPresentationHint hint)
+        public override void ChangePresentation(MvxPresentationHint hint)
         {
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
+
+            if (base.HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsCommon/Views/MvxWindowsViewPresenter.cs
@@ -46,13 +46,13 @@ namespace Cirrious.MvvmCross.WindowsCommon.Views
 
         public override void ChangePresentation(MvxPresentationHint hint)
         {
+            if (base.HandlePresentationChange(hint)) return;
+
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
-
-            if (base.HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.WindowsPhone/Views/MvxPhoneViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsPhone/Views/MvxPhoneViewPresenter.cs
@@ -17,7 +17,7 @@ using Microsoft.Phone.Controls;
 namespace Cirrious.MvvmCross.WindowsPhone.Views
 {
     public class MvxPhoneViewPresenter
-        : IMvxPhoneViewPresenter
+        : MvxViewPresenter, IMvxPhoneViewPresenter
     {
         private readonly PhoneApplicationFrame _rootFrame;
 
@@ -31,7 +31,7 @@ namespace Cirrious.MvvmCross.WindowsPhone.Views
             _rootFrame = rootFrame;
         }
 
-        public virtual void Show(MvxViewModelRequest request)
+        public override void Show(MvxViewModelRequest request)
         {
             try
             {
@@ -50,13 +50,15 @@ namespace Cirrious.MvvmCross.WindowsPhone.Views
             }
         }
 
-        public virtual void ChangePresentation(MvxPresentationHint hint)
+        public override void ChangePresentation(MvxPresentationHint hint)
         {
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
+
+            if (HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.WindowsPhone/Views/MvxPhoneViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsPhone/Views/MvxPhoneViewPresenter.cs
@@ -52,13 +52,13 @@ namespace Cirrious.MvvmCross.WindowsPhone.Views
 
         public override void ChangePresentation(MvxPresentationHint hint)
         {
+            if (HandlePresentationChange(hint)) return;
+
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
-
-            if (HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.WindowsStore/Views/MvxStoreViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsStore/Views/MvxStoreViewPresenter.cs
@@ -16,7 +16,7 @@ using Windows.UI.Xaml.Controls;
 namespace Cirrious.MvvmCross.WindowsStore.Views
 {
     public class MvxStoreViewPresenter
-        : IMvxStoreViewPresenter
+        : MvxViewPresenter, IMvxStoreViewPresenter
     {
         private readonly Frame _rootFrame;
 
@@ -25,7 +25,7 @@ namespace Cirrious.MvvmCross.WindowsStore.Views
             _rootFrame = rootFrame;
         }
 
-        public virtual void Show(MvxViewModelRequest request)
+        public override void Show(MvxViewModelRequest request)
         {
             try
             {
@@ -44,13 +44,15 @@ namespace Cirrious.MvvmCross.WindowsStore.Views
             }
         }
 
-        public virtual void ChangePresentation(MvxPresentationHint hint)
+        public override void ChangePresentation(MvxPresentationHint hint)
         {
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
+			
+            if (HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.WindowsStore/Views/MvxStoreViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.WindowsStore/Views/MvxStoreViewPresenter.cs
@@ -45,14 +45,14 @@ namespace Cirrious.MvvmCross.WindowsStore.Views
         }
 
         public override void ChangePresentation(MvxPresentationHint hint)
-        {
+        {			
+            if (HandlePresentationChange(hint)) return;
+			
             if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
                 return;
             }
-			
-            if (HandlePresentationChange(hint)) return;
 
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }

--- a/Cirrious/Cirrious.MvvmCross.Wpf/Views/MvxWpfViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Wpf/Views/MvxWpfViewPresenter.cs
@@ -11,13 +11,14 @@ using Cirrious.CrossCore.Exceptions;
 using Cirrious.CrossCore;
 using Cirrious.CrossCore.Platform;
 using Cirrious.MvvmCross.ViewModels;
+using Cirrious.MvvmCross.Views;
 
 namespace Cirrious.MvvmCross.Wpf.Views
 {
     public abstract class MvxWpfViewPresenter
-        : IMvxWpfViewPresenter
+        : MvxViewPresenter, IMvxWpfViewPresenter
     {
-        public virtual void Show(MvxViewModelRequest request)
+        public override void Show(MvxViewModelRequest request)
         {
             try
             {
@@ -34,8 +35,10 @@ namespace Cirrious.MvvmCross.Wpf.Views
 
         public abstract void Present(FrameworkElement frameworkElement);
 
-        public virtual void ChangePresentation(MvxPresentationHint hint)
+        public override void ChangePresentation(MvxPresentationHint hint)
         {
+			if (HandlePresentationChange(hint)) return;
+			
             MvxTrace.Warning("Hint ignored {0}", hint.GetType().Name);
         }
     }

--- a/Cirrious/Cirrious.MvvmCross/Cirrious.MvvmCross.csproj
+++ b/Cirrious/Cirrious.MvvmCross/Cirrious.MvvmCross.csproj
@@ -117,6 +117,7 @@
     <Compile Include="ViewModels\MvxAppStart.cs" />
     <Compile Include="ViewModels\MvxViewModel.cs" />
     <Compile Include="ViewModels\MvxViewModelRequest.cs" />
+    <Compile Include="Views\MvxViewPresenter.cs" />
     <Compile Include="Views\MvxViewsContainer.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/Cirrious/Cirrious.MvvmCross/Views/IMvxViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross/Views/IMvxViewPresenter.cs
@@ -5,6 +5,7 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using Cirrious.MvvmCross.ViewModels;
 
 namespace Cirrious.MvvmCross.Views
@@ -13,5 +14,7 @@ namespace Cirrious.MvvmCross.Views
     {
         void Show(MvxViewModelRequest request);
         void ChangePresentation(MvxPresentationHint hint);
+
+        void AddPresentationHintHandler<THint>(Func<THint, bool> action) where THint : MvxPresentationHint;
     }
 }

--- a/Cirrious/Cirrious.MvvmCross/Views/MvxViewPresenter.cs
+++ b/Cirrious/Cirrious.MvvmCross/Views/MvxViewPresenter.cs
@@ -1,0 +1,38 @@
+﻿// MvxViewPresenter.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using System.Collections.Generic;
+using Cirrious.MvvmCross.ViewModels;
+
+namespace Cirrious.MvvmCross.Views {
+    public abstract class MvxViewPresenter : IMvxViewPresenter
+    {
+        private readonly Dictionary<Type, Func<MvxPresentationHint, bool>> _presentationHintHandlers = new Dictionary<Type, Func<MvxPresentationHint, bool>>();
+
+        public void AddPresentationHintHandler<THint>(Func<THint, bool> action) where THint : MvxPresentationHint
+        {
+            _presentationHintHandlers[typeof(THint)] = hint => action((THint)hint);
+        }
+
+        public virtual bool HandlePresentationChange(MvxPresentationHint hint)
+        {
+            Func<MvxPresentationHint, bool> handler;
+
+            if (_presentationHintHandlers.TryGetValue(hint.GetType(), out handler))
+            {
+                if (handler(hint)) return true;
+            }
+
+            return false;
+        }
+
+        public abstract void Show(MvxViewModelRequest request);
+
+        public abstract void ChangePresentation(MvxPresentationHint hint);
+    }
+}


### PR DESCRIPTION
Rather than this in the `ChangePresentation` override:

```c#
if (hint is MyHintType)
{
    // do something
    return;
}

if (hint is MyOtherHintType)
{
    // do something
    return;
}
```

Or even worse, this:

```c#
var myHint = hint as MyHintType;
if (myHint != null)
{
    // do something
}
else {
    var myOtherHint = hint as MyOtherHintType;
    if (hint is MyOtherHintType)
    {
        // do something
    }
    else {
        // More nesting... goto anyone?
    }
}
```

We can do this anywhere you have access to the presenter (which may be the presenter's constructor):

```c#
AddPresentationHintHandler<MyHintType>(hint => {
    // do something
    return true; // To say it's been handled. Helpful when `MyHintType` inheirts `MvxClosePresentationHint` and you have conditional handling.
});
```

This means that in certain cases (say where a developer is only creating a presenter for hint handling), an additional class is not required - it can be done in `Setup.cs`.