### PR TITLE
Use reflection instead of Expression.Compile()

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding/ExpressionParse/MvxPropertyExpressionParser.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding/ExpressionParse/MvxPropertyExpressionParser.cs
@@ -82,22 +82,21 @@ namespace Cirrious.MvvmCross.Binding.ExpressionParse
 
             try
             {
-                var constExpr = memberExpr.Expression as ConstantExpression;
-                if (constExpr != null)
-                {
-                    var property = memberExpr.Member as PropertyInfo;
-                    if (property != null)
-                    {
-                        var constant = property.GetValue(constExpr.Value);
-                        return Expression.Constant(constant);
-                    }
+                var constExpr = ConvertMemberAccessToConstant(memberExpr.Expression) as ConstantExpression;
+                object value = constExpr != null ? constExpr.Value : null;
 
-                    var field = memberExpr.Member as FieldInfo;
-                    if (field != null)
-                    {
-                        var constant = field.GetValue(constExpr.Value);
-                        return Expression.Constant(constant);
-                    }
+                var property = memberExpr.Member as PropertyInfo;
+                if (property != null)
+                {
+                    var constant = property.GetValue(value);
+                    return Expression.Constant(constant);
+                }
+
+                var field = memberExpr.Member as FieldInfo;
+                if (field != null)
+                {
+                    var constant = field.GetValue(value);
+                    return Expression.Constant(constant);
                 }
             }
             catch

--- a/Cirrious/Test/Cirrious.MvvmCross.Binding.Test/ExpressionParse/MvxExpressionBindingTest.cs
+++ b/Cirrious/Test/Cirrious.MvvmCross.Binding.Test/ExpressionParse/MvxExpressionBindingTest.cs
@@ -310,6 +310,51 @@ namespace Cirrious.MvvmCross.Binding.Test.ExpressionParse
             DoTest(test, expectedDesc);
         }
 
+        private static readonly int Zero = 0;
+
+        [Test]
+        public void TestNumberStaticVariableIndexedExpression()
+        {
+            var expectedDesc = new MvxBindingDescription
+            {
+                Source = new MvxPathSourceStepDescription()
+                {
+                    SourcePropertyPath = "MyCollection.MyList[0].Value",
+                },
+                TargetName = "Text"
+            };
+            Action<MockBindingContext> test = mock =>
+                mock
+                .CreateBinding(mock.Target)
+                .For(te => te.Text)
+                .To<TestDataContext>(source => source.MyCollection.MyList[Zero].Value)
+                .Apply();
+
+            DoTest(test, expectedDesc);
+        }
+
+        [Test]
+        public void TestNumberPropertyIndexedExpression()
+        {
+            var expectedDesc = new MvxBindingDescription
+            {
+                Source = new MvxPathSourceStepDescription()
+                {
+                    SourcePropertyPath = "MyCollection.MyList[0].Value",
+                },
+                TargetName = "Text"
+            };
+            var obj = new { Index = 0 };
+            Action<MockBindingContext> test = mock =>
+                mock
+                .CreateBinding(mock.Target)
+                .For(te => te.Text)
+                .To<TestDataContext>(source => source.MyCollection.MyList[obj.Index].Value)
+                .Apply();
+
+            DoTest(test, expectedDesc);
+        }
+
         [Test]
         public void TestStringVariableIndexedExpression()
         {


### PR DESCRIPTION
in MvxPropertyExpressionParser.

Expression.Compile() depends on Mono.Dynamic.Interpreter on iOS, which
adds about 1MB per architecture to iOS apps.