### PR TITLE
Return full paths from MvxWindowsCommonBlockingFileStore.GetFilesIn(...)

### DIFF
--- a/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreFileStore.cs
+++ b/Plugins/Cirrious/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreFileStore.cs
@@ -169,7 +169,7 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
         {
             var folder = StorageFolder.GetFolderFromPathAsync(ToFullPath(folderPath)).Await();
             var files = folder.GetFilesAsync().Await();
-            return files.Select(x => x.Name);
+            return files.Select(x => x.Path);
         }
 
         public override IEnumerable<string> GetFoldersIn(string folderPath)


### PR DESCRIPTION
Fix Issue: https://github.com/MvvmCross/MvvmCross/issues/1086
Tests to demonstrate the issue on this branch: https://github.com/tekkies/MvvmCross/tree/plugin-platform-tests