### PR TITLE
Adding Cirrious.MvvmCross.WindowsUWP.rd.xml in nuspec.

### DIFF
--- a/nuspec/MvvmCross.HotTuna.MvvmCrossLibraries.nuspec
+++ b/nuspec/MvvmCross.HotTuna.MvvmCrossLibraries.nuspec
@@ -99,6 +99,7 @@
 
 		<!-- uap -->
 		<file src="..\bin\Release\Mvx\WindowsUWP\Cirrious.MvvmCross.WindowsUWP.*" target="lib\uap" />
+		<file src="..\bin\Release\Mvx\WindowsUWP\Cirrious.MvvmCross.WindowsUWP\Properties\Cirrious.MvvmCross.WindowsUWP.rd.xml" target="lib\uap\Cirrious.MvvmCross.WindowsUWP\Properties" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.dll" target="lib\uap" />
 		<file src="..\bin\Release\Mvx\Portable\Cirrious.MvvmCross.pdb" target="lib\uap" />
 		


### PR DESCRIPTION
The UWP package requires the file "Cirrious.MvvmCross.WindowsUWP.rd.xml" be distributed with it in order for projects using it to build properly. When the project is open in Visual Studio, this file is found under the Properties node of Cirrious.MvvmCross.WIndowsUWP. It's copied to the output folder during Release builds.