### PR TITLE
Generate lib layout to fix broken rd.xml reference in nupkg for UWP

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.WindowsUWP/Cirrious.MvvmCross.WindowsUWP.csproj
+++ b/Cirrious/Cirrious.MvvmCross.WindowsUWP/Cirrious.MvvmCross.WindowsUWP.csproj
@@ -97,6 +97,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>

--- a/MvvmCross_Windows.sln
+++ b/MvvmCross_Windows.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MvvmCross", "MvvmCross", "{91B3E1F2-BE90-4928-98D1-AF2748CBCB0A}"
 EndProject
@@ -313,6 +313,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E2863B
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WindowsUWP", "WindowsUWP", "{20A88CA7-E69C-4873-B2F1-77E2C57DCE21}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cirrious.MvvmCross.WindowsUWP", "Cirrious\Cirrious.MvvmCross.WindowsUWP\Cirrious.MvvmCross.WindowsUWP.csproj", "{C7E12CDD-6370-426A-8907-0ED6AF353F79}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2482,6 +2486,34 @@ Global
 		{E484087C-CB2B-453E-A696-2B4407A100F8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{E484087C-CB2B-453E-A696-2B4407A100F8}.Release|x64.ActiveCfg = Release|Any CPU
 		{E484087C-CB2B-453E-A696-2B4407A100F8}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|ARM.ActiveCfg = Debug|ARM
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|ARM.Build.0 = Debug|ARM
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|x64.ActiveCfg = Debug|x64
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|x64.Build.0 = Debug|x64
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|x86.ActiveCfg = Debug|x86
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Debug|x86.Build.0 = Debug|x86
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|ARM.ActiveCfg = Release|ARM
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|ARM.Build.0 = Release|ARM
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|iPhone.Build.0 = Release|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|Mixed Platforms.Build.0 = Release|x86
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|x64.ActiveCfg = Release|x64
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|x64.Build.0 = Release|x64
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|x86.ActiveCfg = Release|x86
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2635,9 +2667,10 @@ Global
 		{FBC07387-3560-471C-B0DF-E519F3ABFA07} = {E02CB35C-E0A9-4DF1-ACA8-8ECE80343225}
 		{81C8EA56-1280-4B79-AF02-FAB36A155359} = {82E80963-C12D-4366-98B9-5A60CF1FD0C5}
 		{E484087C-CB2B-453E-A696-2B4407A100F8} = {AEF83F49-67CB-4EF2-8E9D-ABF263BA06C0}
+		{20A88CA7-E69C-4873-B2F1-77E2C57DCE21} = {91B3E1F2-BE90-4928-98D1-AF2748CBCB0A}
+		{C7E12CDD-6370-426A-8907-0ED6AF353F79} = {20A88CA7-E69C-4873-B2F1-77E2C57DCE21}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Cirrious\Cirrious.MvvmCross.Droid.Maps\Cirrious.MvvmCross.Droid.Maps.csproj
 	EndGlobalSection
 EndGlobal
-


### PR DESCRIPTION
Hey guys, 

I've just tried the 4.0.0 beta 2 package on a new Windows UWP app.
My app fails to build complaining about a missing xml file from MVVMCross.

On investigating, it looks like it is indeed missing the Cirrious.MvvmCross.WindowsUWP.rd.xml in the nupkg - and it turns out that is because an option called 'Generate library layout' needs to be set to true for the file to be copies across to the output path.

I'm not entirely sure what this rd.xml does - but the solution is to set that option in the UWP project - so when it builds the rd.xml file is copied correctly.

This PR fixes that.
Hope this helps.

reference: https://social.msdn.microsoft.com/Forums/windowsapps/en-US/af9274cf-fb12-45df-aced-656509fed48d/rdxml-file-not-found?forum=wpdevelop

