### PR TITLE
Fixed it (properly) for 'Release' mode. Should work if Release\Any CPU

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.WindowsUWP/Cirrious.MvvmCross.WindowsUWP.csproj
+++ b/Cirrious/Cirrious.MvvmCross.WindowsUWP/Cirrious.MvvmCross.WindowsUWP.csproj
@@ -110,6 +110,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->


### PR DESCRIPTION
Sorry - this would be the right fix. The previous PR was for 'Debug' only.

The nuspec seems to reference the file ..\bin\Release\Mvx\WindowsUWP\Cirrious.MvvmCross.WindowsUWP\Properties\Cirrious.MvvmCross.WindowsUWP.rd.xml