### PR TITLE
Fix SelectionChangedCommand CanExecute not being called

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseCollectionViewSource.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseCollectionViewSource.cs
@@ -71,7 +71,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
             var item = GetItemAt(indexPath);
 
             var command = SelectionChangedCommand;
-            if (command != null)
+            if (command != null && command.CanExecute(item))
                 command.Execute(item);
 
             SelectedItem = item;

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Views/MvxBaseTableViewSource.cs
@@ -78,7 +78,7 @@ namespace Cirrious.MvvmCross.Binding.Touch.Views
             var item = GetItemAt(indexPath);
 
             var command = SelectionChangedCommand;
-            if (command != null)
+            if (command != null && command.CanExecute(item))
                 command.Execute(item);
 
             SelectedItem = item;


### PR DESCRIPTION
SelectionChangedCommand for MvxBaseTableViewSource and MvxBaseCollectionViewSource checks if command can be executed (CanExecute). This enforces the same behavior as in android.