### PR TITLE
Convert full paths to relative in EnsureFolderExists(...) (Issue 1104)

### DIFF
--- a/Plugins/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreFileStore.cs
+++ b/Plugins/File/Cirrious.MvvmCross.Plugins.File.WindowsStore/MvxWindowsStoreFileStore.cs
@@ -151,10 +151,20 @@ namespace Cirrious.MvvmCross.Plugins.File.WindowsStore
         {
           if (FolderExists(folderPath))
             return;
-
           var rootFolder = ToFullPath(string.Empty);
-          var storageFolder = StorageFolder.GetFolderFromPathAsync(rootFolder).Await();
-          CreateFolderAsync(storageFolder, folderPath).GetAwaiter().GetResult();
+          var rootStorageFolder = StorageFolder.GetFolderFromPathAsync(rootFolder).Await();
+          var relativeFolderPath = GetRelativePathToSubFolder(rootStorageFolder.Path, folderPath);
+          CreateFolderAsync(rootStorageFolder, relativeFolderPath).GetAwaiter().GetResult();
+        }
+
+        private string GetRelativePathToSubFolder(string rootPath, string subFolderPath)
+        {
+            string relativePath = subFolderPath;
+            if (subFolderPath.ToLower().Contains(rootPath.ToLower()))
+            {
+                relativePath = subFolderPath.Substring(rootPath.Length+1);
+            }
+            return relativePath;
         }
 
         private static async Task<StorageFolder> CreateFolderAsync(StorageFolder rootFolder, string folderPath)


### PR DESCRIPTION
Issue: https://github.com/MvvmCross/MvvmCross/issues/1104
Fix: If absolute path is a subfolder of the app root, then convert the path to relative.

Tests to demonstrate the issue: https://github.com/tekkies/MvvmCross/tree/plugin-platform-tests

#risk3 #plugin #plugin-file #windows-store