### PR TITLE
Fixed unified value types conversion when binding to a nfloat, nint or uint from a managed equivalent value type.

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/Cirrious.MvvmCross.Binding.Touch.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/Cirrious.MvvmCross.Binding.Touch.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Target\MvxUIViewTapTargetBinding.cs" />
     <Compile Include="Target\MvxUIViewVisibilityTargetBinding.cs" />
     <Compile Include="Target\MvxUIViewVisibleTargetBinding.cs" />
+    <Compile Include="ValueConverters\MvxUnifiedTypesValueConverter.cs" />
     <Compile Include="Views\Gestures\MvxBehaviourExtensions.cs" />
     <Compile Include="Views\Gestures\MvxGestureRecognizerBehavior.cs" />
     <Compile Include="Views\Gestures\MvxTapGestureRecognizerBehaviour.cs" />

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/MvxTouchBindingBuilder.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/MvxTouchBindingBuilder.cs
@@ -6,11 +6,15 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using System.Collections.Generic;
+
 using Cirrious.CrossCore.Converters;
 using Cirrious.CrossCore.Platform;
+using Cirrious.MvvmCross.Binding.Binders;
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Binding.Bindings.Target.Construction;
 using Cirrious.MvvmCross.Binding.Touch.Target;
+using Cirrious.MvvmCross.Binding.Touch.ValueConverters;
 using Cirrious.MvvmCross.Binding.Touch.Views;
 using UIKit;
 
@@ -21,15 +25,21 @@ namespace Cirrious.MvvmCross.Binding.Touch
     {
         private readonly Action<IMvxTargetBindingFactoryRegistry> _fillRegistryAction;
         private readonly Action<IMvxValueConverterRegistry> _fillValueConvertersAction;
+        private readonly Action<IMvxAutoValueConverters> _fillAutoValueConvertersAction;
         private readonly Action<IMvxBindingNameRegistry> _fillBindingNamesAction;
+        private readonly MvxUnifiedTypesValueConverter _unifiedValueTypesConverter;
 
         public MvxTouchBindingBuilder(Action<IMvxTargetBindingFactoryRegistry> fillRegistryAction = null,
                                       Action<IMvxValueConverterRegistry> fillValueConvertersAction = null,
+                                      Action<IMvxAutoValueConverters> fillAutoValueConvertersAction = null,
                                       Action<IMvxBindingNameRegistry> fillBindingNamesAction = null)
         {
             _fillRegistryAction = fillRegistryAction;
             _fillValueConvertersAction = fillValueConvertersAction;
+            _fillAutoValueConvertersAction = fillAutoValueConvertersAction;
             _fillBindingNamesAction = fillBindingNamesAction;
+
+            _unifiedValueTypesConverter = new MvxUnifiedTypesValueConverter();
         }
 
         protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
@@ -54,8 +64,8 @@ namespace Cirrious.MvvmCross.Binding.Touch
             registry.RegisterPropertyInfoBindingFactory(typeof(MvxUISegmentedControlSelectedSegmentTargetBinding),
                                                         typeof(UISegmentedControl),
                                                         "SelectedSegment");
-            registry.RegisterPropertyInfoBindingFactory(typeof (MvxUIDatePickerDateTargetBinding),
-                                                        typeof (UIDatePicker),
+            registry.RegisterPropertyInfoBindingFactory(typeof(MvxUIDatePickerDateTargetBinding),
+                                                        typeof(UIDatePicker),
                                                         "Date");
             registry.RegisterCustomBindingFactory<UITextField>("ShouldReturn",
                                                                textField => new MvxUITextFieldShouldReturnTargetBinding(textField));
@@ -70,8 +80,8 @@ namespace Cirrious.MvvmCross.Binding.Touch
                                                               view => new MvxUITextViewTextTargetBinding(view));
             registry.RegisterCustomBindingFactory<UIView>("LayerBorderWidth",
                                                           view => new MvxUIViewLayerBorderWidthTargetBinding(view));
-            registry.RegisterPropertyInfoBindingFactory(typeof (MvxUISwitchOnTargetBinding),
-                                                        typeof (UISwitch),
+            registry.RegisterPropertyInfoBindingFactory(typeof(MvxUISwitchOnTargetBinding),
+                                                        typeof(UISwitch),
                                                         "On");
             registry.RegisterPropertyInfoBindingFactory(typeof(MvxUISearchBarTextTargetBinding),
                                                         typeof(UISearchBar),
@@ -91,8 +101,8 @@ namespace Cirrious.MvvmCross.Binding.Touch
                                                           view => new MvxUIViewTapTargetBinding(view, 2, 1));
             registry.RegisterCustomBindingFactory<UIView>("TwoFingerTap",
                                                           view => new MvxUIViewTapTargetBinding(view, 1, 2));
-			registry.RegisterCustomBindingFactory<UITextField>("TextFocus", (UITextField textField) => new MvxUITextFieldTextFocusTargetBinding(textField));
-														  
+            registry.RegisterCustomBindingFactory<UITextField>("TextFocus", (UITextField textField) => new MvxUITextFieldTextFocusTargetBinding(textField));
+
             /*
             registry.RegisterCustomBindingFactory<UIView>("TwoFingerDoubleTap",
                                                           view => new MvxUIViewTapTargetBinding(view, 2, 2));
@@ -114,28 +124,40 @@ namespace Cirrious.MvvmCross.Binding.Touch
                 _fillValueConvertersAction(registry);
         }
 
+        protected override void FillAutoValueConverters(IMvxAutoValueConverters autoValueConverters)
+        {
+            base.FillAutoValueConverters(autoValueConverters);
+
+            //register converter for xamarin unified types
+            foreach (var kvp in MvxUnifiedTypesValueConverter.UnifiedTypeConversions)
+                autoValueConverters.Register(kvp.Key, kvp.Value, _unifiedValueTypesConverter);
+
+            if (_fillAutoValueConvertersAction != null)
+                _fillAutoValueConvertersAction(autoValueConverters);
+        }
+
         protected override void FillDefaultBindingNames(IMvxBindingNameRegistry registry)
         {
             base.FillDefaultBindingNames(registry);
 
-            registry.AddOrOverwrite(typeof (UIButton), "TouchUpInside");
-            registry.AddOrOverwrite(typeof (UIBarButtonItem), "Clicked");
+            registry.AddOrOverwrite(typeof(UIButton), "TouchUpInside");
+            registry.AddOrOverwrite(typeof(UIBarButtonItem), "Clicked");
 
-            registry.AddOrOverwrite(typeof (UISearchBar), "Text");
-            registry.AddOrOverwrite(typeof (UITextField), "Text");
-            registry.AddOrOverwrite(typeof (UITextView), "Text");
-            registry.AddOrOverwrite(typeof (UILabel), "Text");
-            registry.AddOrOverwrite(typeof (MvxCollectionViewSource), "ItemsSource");
-            registry.AddOrOverwrite(typeof (MvxTableViewSource), "ItemsSource");
-            registry.AddOrOverwrite(typeof (MvxImageView), "ImageUrl");
-            registry.AddOrOverwrite(typeof (UIImageView), "Image");
-            registry.AddOrOverwrite(typeof (UIDatePicker), "Date");
-            registry.AddOrOverwrite(typeof (UISlider), "Value");
-            registry.AddOrOverwrite(typeof (UISwitch), "On");
-            registry.AddOrOverwrite(typeof (UIProgressView), "Progress");
-            registry.AddOrOverwrite(typeof (IMvxImageHelper<UIImage>), "ImageUrl");
-            registry.AddOrOverwrite(typeof (MvxImageViewLoader), "ImageUrl");
-            registry.AddOrOverwrite(typeof (UISegmentedControl), "SelectedSegment");
+            registry.AddOrOverwrite(typeof(UISearchBar), "Text");
+            registry.AddOrOverwrite(typeof(UITextField), "Text");
+            registry.AddOrOverwrite(typeof(UITextView), "Text");
+            registry.AddOrOverwrite(typeof(UILabel), "Text");
+            registry.AddOrOverwrite(typeof(MvxCollectionViewSource), "ItemsSource");
+            registry.AddOrOverwrite(typeof(MvxTableViewSource), "ItemsSource");
+            registry.AddOrOverwrite(typeof(MvxImageView), "ImageUrl");
+            registry.AddOrOverwrite(typeof(UIImageView), "Image");
+            registry.AddOrOverwrite(typeof(UIDatePicker), "Date");
+            registry.AddOrOverwrite(typeof(UISlider), "Value");
+            registry.AddOrOverwrite(typeof(UISwitch), "On");
+            registry.AddOrOverwrite(typeof(UIProgressView), "Progress");
+            registry.AddOrOverwrite(typeof(IMvxImageHelper<UIImage>), "ImageUrl");
+            registry.AddOrOverwrite(typeof(MvxImageViewLoader), "ImageUrl");
+            registry.AddOrOverwrite(typeof(UISegmentedControl), "SelectedSegment");
 
             if (_fillBindingNamesAction != null)
                 _fillBindingNamesAction(registry);

--- a/Cirrious/Cirrious.MvvmCross.Binding.Touch/ValueConverters/MvxUnifiedTypesValueConverter.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Touch/ValueConverters/MvxUnifiedTypesValueConverter.cs
@@ -1,0 +1,63 @@
+// MvxBindingBuilder.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+using Cirrious.CrossCore.Converters;
+using Cirrious.CrossCore.IoC;
+
+namespace Cirrious.MvvmCross.Binding.Touch.ValueConverters
+{
+    class MvxUnifiedTypesValueConverter
+        : MvxValueConverter
+    {
+        //dictionary of supported unified type conversions
+        internal static readonly IReadOnlyDictionary<Type, Type> UnifiedTypeConversions;
+
+        static MvxUnifiedTypesValueConverter()
+        {
+            var initDictionary = new Dictionary<Type, Type>()
+                {
+                    {typeof (float), typeof (nfloat)},
+                    {typeof (int), typeof (nint)},
+                    {typeof (uint), typeof (nuint)}
+                };
+
+            UnifiedTypeConversions = new ReadOnlyDictionary<Type, Type>(initDictionary);
+        }
+
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            //actually value cannot be null if converter is being used by auto converter registry and was
+            //registered with proper source/target types for unified (value types which are non nullable)
+            //but keep it for sanity in case converter is used outside of auto converters scope
+            if (value == null)
+                return targetType.CreateDefault();
+
+            //return original value if converter not used to convert to unified value type from proper managed value type
+            var valueType = value.GetType();
+            if (!UnifiedTypeConversions.ContainsKey(valueType))
+                return value;
+
+            var nativeType = UnifiedTypeConversions[valueType];
+            var nativeValue = Activator.CreateInstance(nativeType, value);
+
+            return nativeValue;
+        }
+
+        public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            //unified types already implement proper conversion with IConvertible interface support
+            return System.Convert.ChangeType(value, targetType, culture);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #878 

Test project used for this fix available at https://github.com/ggirard-distech/MvvmCross_Issue878_TestProject.git