### PR TITLE
Added Android specific MvxPropertyChangedListener

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid/Cirrious.MvvmCross.Droid.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Cirrious.MvvmCross.Droid.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ViewModels\MvxAndroidPropertyChangedListener.cs" />
     <Compile Include="Views\IMvxAndroidViewModelLoader.cs" />
     <Compile Include="Views\IMvxAndroidViewsContainer.cs" />
     <Compile Include="Views\IMvxMultipleViewModelCache.cs" />

--- a/Cirrious/Cirrious.MvvmCross.Droid/ViewModels/MvxAndroidPropertyChangedListener.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/ViewModels/MvxAndroidPropertyChangedListener.cs
@@ -1,0 +1,36 @@
+using System;
+using System.ComponentModel;
+using Android.Runtime;
+using Cirrious.MvvmCross.ViewModels;
+
+namespace Cirrious.MvvmCross.Droid.ViewModels {
+    /// <summary>
+    ///     Just like <see cref="MvxPropertyChangedListener"/> but
+    ///     won't call handlers if the target (being an activity, fragment,
+    ///     view or other object that belongs to the Java VM) is in "mono
+    ///     limbo" (where the object still exists in the mono VM, but not
+    ///     in the Java VM).
+    /// </summary>
+    public class MvxAndroidPropertyChangedListener : MvxPropertyChangedListener
+    {
+        private readonly WeakReference<IJavaObject> _target;
+
+        public MvxAndroidPropertyChangedListener(INotifyPropertyChanged source, IJavaObject target) : base(source)
+        {
+            if (target == null)
+                throw new ArgumentNullException(nameof(target));
+
+            _target = new WeakReference<IJavaObject>(target);
+        }
+
+        public override void NotificationObjectOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            IJavaObject target;
+
+            if (!_target.TryGetTarget(out target) || target.Handle == IntPtr.Zero)
+                return;
+
+            base.NotificationObjectOnPropertyChanged(sender, e);
+        }
+    }
+}

--- a/Cirrious/Cirrious.MvvmCross.Droid/ViewModels/MvxAndroidPropertyChangedListener.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/ViewModels/MvxAndroidPropertyChangedListener.cs
@@ -3,7 +3,8 @@ using System.ComponentModel;
 using Android.Runtime;
 using Cirrious.MvvmCross.ViewModels;
 
-namespace Cirrious.MvvmCross.Droid.ViewModels {
+namespace Cirrious.MvvmCross.Droid.ViewModels
+{
     /// <summary>
     ///     Just like <see cref="MvxPropertyChangedListener"/> but
     ///     won't call handlers if the target (being an activity, fragment,

--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxPropertyChangedListener.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxPropertyChangedListener.cs
@@ -34,7 +34,7 @@ namespace Cirrious.MvvmCross.ViewModels
         }
 
         // Note - this is public because we use it in weak referenced situations
-        public void NotificationObjectOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
+        public virtual void NotificationObjectOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
         {
             var whichProperty = propertyChangedEventArgs.PropertyName;
 


### PR DESCRIPTION
In our Android app, we use `MvxPropertyChangedListener` in activities and fragments quite a bit. In the listeners we check if the object is still alive in the Java VM - `Handle != IntPtr.Zero`. When you miss the checks out, you'll occasionally get some errors that look like this:  `ArgumentException: 'jobject' must not be IntPtr.Zero`.

`MvxAndroidPropertyChangedListener` builds on this by adding the check in to the listener... and hopefully avoiding those pesky `IntPtr.Zero` exceptions :smile: