### PR TITLE
Fix design time error

### DIFF
--- a/CrossCore/Cirrious.CrossCore/Mvx.cs
+++ b/CrossCore/Cirrious.CrossCore/Mvx.cs
@@ -42,12 +42,22 @@ namespace Cirrious.CrossCore
         public static bool TryResolve<TService>(out TService service) where TService : class
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            if (ioc == null)
+            {
+                service = null;
+                return false;
+            }
             return ioc.TryResolve(out service);
         }
 
         public static bool TryResolve(Type serviceType, out object service)
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            if (ioc == null)
+            {
+                service = null;
+                return false;
+            }
             return ioc.TryResolve(serviceType, out service);
         }
 


### PR DESCRIPTION
The binding for mvxcommand cause designer error because in mvxcommandbase it use Mvx.TryResolve but the IMvxIoCProvider is not initialized.
One solution is to add the check if ioc is null in TryResolve method.