### PR TITLE
Improved ViewModelLoader and ViewModelLocator with viewmodel reloading

### DIFF
--- a/Cirrious/Cirrious.MvvmCross/ViewModels/IMvxViewModelLoader.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/IMvxViewModelLoader.cs
@@ -10,5 +10,6 @@ namespace Cirrious.MvvmCross.ViewModels
     public interface IMvxViewModelLoader
     {
         IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState);
+        IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState);
     }
 }

--- a/Cirrious/Cirrious.MvvmCross/ViewModels/IMvxViewModelLocator.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/IMvxViewModelLocator.cs
@@ -12,5 +12,6 @@ namespace Cirrious.MvvmCross.ViewModels
     public interface IMvxViewModelLocator
     {
         IMvxViewModel Load(Type viewModelType, IMvxBundle parameterValues, IMvxBundle savedState);
+        IMvxViewModel Reload(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState);
     }
 }

--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -15,6 +15,28 @@ namespace Cirrious.MvvmCross.ViewModels
     public class MvxDefaultViewModelLocator
         : IMvxViewModelLocator
     {
+
+        public virtual IMvxViewModel Reload(IMvxViewModel viewModel,
+                                   IMvxBundle parameterValues,
+                                   IMvxBundle savedState)
+        {
+            try
+            {
+                CallCustomInitMethods(viewModel, parameterValues);
+                if (savedState != null)
+                {
+                    CallReloadStateMethods(viewModel, savedState);
+                }
+                viewModel.Start();
+            }
+            catch (Exception exception)
+            {
+                throw exception.MvxWrap("Problem initialising viewModel of type {0}", viewModel.GetType().Name);
+            }
+
+            return viewModel;
+        }
+
         public virtual IMvxViewModel Load(Type viewModelType,
                                     IMvxBundle parameterValues,
                                     IMvxBundle savedState)

--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -20,19 +20,7 @@ namespace Cirrious.MvvmCross.ViewModels
                                    IMvxBundle parameterValues,
                                    IMvxBundle savedState)
         {
-            try
-            {
-                CallCustomInitMethods(viewModel, parameterValues);
-                if (savedState != null)
-                {
-                    CallReloadStateMethods(viewModel, savedState);
-                }
-                viewModel.Start();
-            }
-            catch (Exception exception)
-            {
-                throw exception.MvxWrap("Problem initialising viewModel of type {0}", viewModel.GetType().Name);
-            }
+            RunViewModelLifecycle(viewModel, parameterValues, savedState);
 
             return viewModel;
         }
@@ -51,19 +39,7 @@ namespace Cirrious.MvvmCross.ViewModels
                 throw exception.MvxWrap("Problem creating viewModel of type {0}", viewModelType.Name);
             }
 
-            try
-            {
-                CallCustomInitMethods(viewModel, parameterValues);
-                if (savedState != null)
-                {
-                    CallReloadStateMethods(viewModel, savedState);
-                }
-                viewModel.Start();
-            }
-            catch (Exception exception)
-            {
-                throw exception.MvxWrap("Problem initialising viewModel of type {0}", viewModelType.Name);
-            }
+            RunViewModelLifecycle(viewModel, parameterValues, savedState);
 
             return viewModel;
         }
@@ -76,6 +52,23 @@ namespace Cirrious.MvvmCross.ViewModels
         protected virtual void CallReloadStateMethods(IMvxViewModel viewModel, IMvxBundle savedState)
         {
             viewModel.CallBundleMethods("ReloadState", savedState);
+        }
+
+        protected void RunViewModelLifecycle(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState)
+        {
+            try
+            {
+                CallCustomInitMethods(viewModel, parameterValues);
+                if (savedState != null)
+                {
+                    CallReloadStateMethods(viewModel, savedState);
+                }
+                viewModel.Start();
+            }
+            catch (Exception exception)
+            {
+                throw exception.MvxWrap("Problem running viewModel lifecycle of type {0}", viewModel.GetType().Name);
+            }
         }
     }
 }

--- a/Cirrious/Cirrious.MvvmCross/ViewModels/MvxViewModelLoader.cs
+++ b/Cirrious/Cirrious.MvvmCross/ViewModels/MvxViewModelLoader.cs
@@ -25,6 +25,36 @@ namespace Cirrious.MvvmCross.ViewModels
             }
         }
 
+        // Reload should be used to re-run cached ViewModels lifecycle if required. 
+        public IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState)
+        {
+            var viewModelLocator = FindViewModelLocator(request);
+            return ReloadViewModel(viewModel, request, savedState, viewModelLocator);
+        }
+
+        private IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState,
+                                    IMvxViewModelLocator viewModelLocator)
+        {
+            if (viewModelLocator == null)
+            {
+                throw new MvxException("Received view model is null, view model reload failed. ", request.ViewModelType);
+            }
+
+            var parameterValues = new MvxBundle(request.ParameterValues);
+            try
+            {
+                viewModel = viewModelLocator.Reload(viewModel, parameterValues, savedState);
+            }
+            catch (Exception exception)
+            {
+                throw exception.MvxWrap(
+                    "Failed to reload a previously created created ViewModel for type {0} from locator {1} - check InnerException for more information",
+                    request.ViewModelType, viewModelLocator.GetType().Name);
+            }
+            viewModel.RequestedBy = request.RequestedBy;
+            return viewModel;
+        }
+
         public IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState)
         {
             if (request.ViewModelType == typeof(MvxNullViewModel))


### PR DESCRIPTION
This should enable cached viewmodels to go through the lifecycle again if they are being showed multiple times with different parameters. My current usecase was to properly support fragment caching in AndroidSupport.