### PR TITLE
MultipleViewModel cache was not prepared for multiple instances of ViewModel

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid/Views/IMvxMultipleViewModelCache.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Views/IMvxMultipleViewModelCache.cs
@@ -6,8 +6,8 @@ namespace Cirrious.MvvmCross.Droid.Views
 {
     public interface IMvxMultipleViewModelCache
     {
-        void Cache(IMvxViewModel toCache);
-        IMvxViewModel GetAndClear(Type viewModelType);
-        T GetAndClear<T>() where T : IMvxViewModel;
+        void Cache(IMvxViewModel toCache, string viewModelTag = "singleInstanceCache");
+        IMvxViewModel GetAndClear(Type viewModelType, string viewModelTag = "singleInstanceCache");
+        T GetAndClear<T>(string viewModelTag = "singleInstanceCache") where T : IMvxViewModel;
     }
 }

--- a/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxMultipleViewModelCache.cs
+++ b/Cirrious/Cirrious.MvvmCross.Droid/Views/MvxMultipleViewModelCache.cs
@@ -7,12 +7,14 @@ namespace Cirrious.MvvmCross.Droid.Views
     public class MvxMultipleViewModelCache
         : IMvxMultipleViewModelCache
     {
-        private ConcurrentDictionary<Type, IMvxViewModel> _currentViewModels;
+        private readonly Lazy<ConcurrentDictionary<Type, IMvxViewModel>> _lazyCurrentViewModels;
 
-        private ConcurrentDictionary<Type, IMvxViewModel> CurrentViewModels
+        public MvxMultipleViewModelCache()
         {
-            get { return _currentViewModels ?? (_currentViewModels = new ConcurrentDictionary<Type, IMvxViewModel>()); }
+            _lazyCurrentViewModels = new Lazy<ConcurrentDictionary<Type, IMvxViewModel>>(() => new ConcurrentDictionary<Type, IMvxViewModel>());
         }
+
+        private ConcurrentDictionary<Type, IMvxViewModel> CurrentViewModels => _lazyCurrentViewModels.Value;
 
         public void Cache(IMvxViewModel toCache)
         {


### PR DESCRIPTION
As in title.
It is required to fix multiple instances of same type fragment caching.