### PR TITLE
4.0 android search view custom binding

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Cirrious.MvvmCross.Binding.Droid.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Target\MvxAutoCompleteTextViewPartialTextTargetBinding.cs" />
     <Compile Include="Target\MvxAutoCompleteTextViewSelectedObjectTargetBinding.cs" />
     <Compile Include="Target\MvxRadioGroupSelectedItemBinding.cs" />
+    <Compile Include="Target\MvxSearchViewQueryTextTargetBinding.cs" />
     <Compile Include="Target\MvxTextViewFocusTargetBinding.cs" />
     <Compile Include="Target\MvxTextViewTextFormattedTargetBinding.cs" />
     <Compile Include="Target\MvxTextViewTextTargetBinding.cs" />

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/MvxAndroidBindingBuilder.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/MvxAndroidBindingBuilder.cs
@@ -131,6 +131,10 @@ namespace Cirrious.MvvmCross.Binding.Droid
             registry.RegisterCustomBindingFactory<MvxRadioGroup>("SelectedItem",
                 radioGroup => new MvxRadioGroupSelectedItemBinding(radioGroup));
 			registry.RegisterCustomBindingFactory("TextFocus", (EditText view) => new MvxTextViewFocusTargetBinding(view));
+            registry.RegisterCustomBindingFactory<SearchView>(
+                "Query",
+                search => new MvxSearchViewQueryTextTargetBinding(search)
+                );
         }
 
         protected override void FillDefaultBindingNames(IMvxBindingNameRegistry registry)
@@ -139,7 +143,6 @@ namespace Cirrious.MvvmCross.Binding.Droid
 
             registry.AddOrOverwrite(typeof(Button), "Click");
             registry.AddOrOverwrite(typeof(CheckBox), "Checked");
-
             registry.AddOrOverwrite(typeof(TextView), "Text");
             registry.AddOrOverwrite(typeof(MvxListView), "ItemsSource");
             registry.AddOrOverwrite(typeof(MvxLinearLayout), "ItemsSource");
@@ -154,6 +157,7 @@ namespace Cirrious.MvvmCross.Binding.Droid
             registry.AddOrOverwrite(typeof(CompoundButton), "Checked");
             registry.AddOrOverwrite(typeof(SeekBar), "Progress");
             registry.AddOrOverwrite(typeof(IMvxImageHelper<Bitmap>), "ImageUrl");
+            registry.AddOrOverwrite(typeof(SearchView), "Query");
         }
 
         protected override void RegisterPlatformSpecificComponents()

--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
@@ -1,0 +1,64 @@
+using System;
+using Android.Widget;
+
+namespace Cirrious.MvvmCross.Binding.Droid.Target
+{
+    public class MvxSearchViewQueryTextTargetBinding : MvxAndroidTargetBinding
+    {
+        public MvxSearchViewQueryTextTargetBinding(object target)
+            : base(target)
+        {
+        }
+
+        public override Type TargetType
+        {
+            get { return typeof(string); }
+        }
+
+        public override MvxBindingMode DefaultMode
+        {
+            get { return MvxBindingMode.OneWayToSource; }
+        }
+
+        protected SearchView SearchView
+        {
+            get { return (SearchView)Target; }
+        }
+
+        public override void SubscribeToEvents()
+        {
+            SearchView.QueryTextChange += HandleQueryTextChanged;
+        }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                var target = Target as SearchView;
+                if (target != null)
+                {
+                    target.QueryTextChange -= HandleQueryTextChanged;
+                }
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        private void HandleQueryTextChanged(object sender, SearchView.QueryTextChangeEventArgs e)
+        {
+            var target = Target as SearchView;
+
+            if (target == null)
+            {
+                return;
+            }
+
+            var value = target.Query;
+            FireValueChanged(value);
+        }
+    }
+}


### PR DESCRIPTION
Add custom binding for android SearchView, so that a SearchView's query-text can be bound to a string in the viewmodel