### PR TITLE
Use XIB and auto layouts for iOS Starter Pack example

### DIFF
--- a/nuspec/MvvmCross.HotTuna.Mac.StarterPack.nuspec
+++ b/nuspec/MvvmCross.HotTuna.Mac.StarterPack.nuspec
@@ -73,6 +73,8 @@ This package contains the Mac 'Getting Started' libraries for MvvmCross
 		<file src="TouchContent\AppDelegate.cs.txt.pp" target="content\Xamarin.iOS10\AppDelegate.cs.txt.pp" />
 		<file src="TouchContent\DebugTrace.cs.pp" target="content\Xamarin.iOS10\DebugTrace.cs.pp" />
 		<file src="TouchContent\FirstView.cs.pp" target="content\Xamarin.iOS10\Views\FirstView.cs.pp" />
+		<file src="TouchContent\FirstView.designer.cs.pp" target="content\Xamarin.iOS10\Views\FirstView.designer.cs.pp" />
+		<file src="TouchContent\FirstView.xib" target="content\Xamarin.iOS10\Views\FirstView.xib" />
 		<file src="TouchContent\LinkerPleaseInclude.cs.pp" target="content\Xamarin.iOS10\LinkerPleaseInclude.cs.pp" />
 
 		<!-- mac - Content -->

--- a/nuspec/MvvmCross.HotTuna.StarterPack.nuspec
+++ b/nuspec/MvvmCross.HotTuna.StarterPack.nuspec
@@ -117,6 +117,7 @@ This package contains the 'Getting Started' libraries for MvvmCross
 		<file src="TouchContent\AppDelegate.cs.txt.pp" target="content\Xamarin.iOS10\AppDelegate.cs.txt.pp" />
 		<file src="TouchContent\DebugTrace.cs.pp" target="content\Xamarin.iOS10\DebugTrace.cs.pp" />
 		<file src="TouchContent\FirstView.cs.pp" target="content\Xamarin.iOS10\Views\FirstView.cs.pp" />
+		<file src="TouchContent\FirstView.designer.cs.pp" target="content\Xamarin.iOS10\Views\FirstView.designer.cs.pp" />
 		<file src="TouchContent\FirstView.xib" target="content\Xamarin.iOS10\Views\FirstView.xib" />
 		<file src="TouchContent\LinkerPleaseInclude.cs.pp" target="content\Xamarin.iOS10\LinkerPleaseInclude.cs.pp" />
 

--- a/nuspec/MvvmCross.HotTuna.StarterPack.nuspec
+++ b/nuspec/MvvmCross.HotTuna.StarterPack.nuspec
@@ -117,6 +117,7 @@ This package contains the 'Getting Started' libraries for MvvmCross
 		<file src="TouchContent\AppDelegate.cs.txt.pp" target="content\Xamarin.iOS10\AppDelegate.cs.txt.pp" />
 		<file src="TouchContent\DebugTrace.cs.pp" target="content\Xamarin.iOS10\DebugTrace.cs.pp" />
 		<file src="TouchContent\FirstView.cs.pp" target="content\Xamarin.iOS10\Views\FirstView.cs.pp" />
+		<file src="TouchContent\FirstView.xib" target="content\Xamarin.iOS10\Views\FirstView.xib" />
 		<file src="TouchContent\LinkerPleaseInclude.cs.pp" target="content\Xamarin.iOS10\LinkerPleaseInclude.cs.pp" />
 
 		<!-- mac - Content -->

--- a/nuspec/TouchContent/AppDelegate.cs.txt.pp
+++ b/nuspec/TouchContent/AppDelegate.cs.txt.pp
@@ -6,24 +6,28 @@ using UIKit;
 
 namespace $rootnamespace$
 {
-	[Register("AppDelegate")]
-	public partial class AppDelegate : MvxApplicationDelegate
-	{
-		UIWindow _window;
+    [Register("AppDelegate")]
+    public partial class AppDelegate : MvxApplicationDelegate
+    {
+        public override UIWindow Window
+        {
+            get;
+            set;
+        }
 
-		public override bool FinishedLaunching(UIApplication app, NSDictionary options)
-		{
-			_window = new UIWindow(UIScreen.MainScreen.Bounds);
+        public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+        {
+            Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
-			var setup = new Setup(this, _window);
-			setup.Initialize();
+            var setup = new Setup(this, Window);
+            setup.Initialize();
 
-			var startup = Mvx.Resolve<IMvxAppStart>();
-			startup.Start();
+            var startup = Mvx.Resolve<IMvxAppStart>();
+            startup.Start();
 
-			_window.MakeKeyAndVisible();
-			
-			return true;
-		}
-	}
+            Window.MakeKeyAndVisible();
+
+            return true;
+        }
+    }
 }

--- a/nuspec/TouchContent/FirstView.cs.pp
+++ b/nuspec/TouchContent/FirstView.cs.pp
@@ -1,34 +1,22 @@
 using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Touch.Views;
-using CoreGraphics;
-using Foundation;
-using ObjCRuntime;
-using UIKit;
 
 namespace $rootnamespace$.Views
 {
     [Register("FirstView")]
-    public class FirstView : MvxViewController
+    public partial class FirstView : MvxViewController
     {
+        public FirstView() : base("FirstView", null)
+        {
+        }
+
         public override void ViewDidLoad()
         {
-            View = new UIView { BackgroundColor = UIColor.White };
             base.ViewDidLoad();
 
-			// ios7 layout
-            if (RespondsToSelector(new Selector("edgesForExtendedLayout")))
-            {
-               EdgesForExtendedLayout = UIRectEdge.None;
-            }
-			   
-            var label = new UILabel(new CGRect(10, 10, 300, 40));
-            Add(label);
-            var textField = new UITextField(new CGRect(10, 50, 300, 40));
-            Add(textField);
-
             var set = this.CreateBindingSet<FirstView, Core.ViewModels.FirstViewModel>();
-            set.Bind(label).To(vm => vm.Hello);
-            set.Bind(textField).To(vm => vm.Hello);
+            set.Bind(Label).To(vm => vm.Hello);
+            set.Bind(TextField).To(vm => vm.Hello);
             set.Apply();
         }
     }

--- a/nuspec/TouchContent/FirstView.cs.pp
+++ b/nuspec/TouchContent/FirstView.cs.pp
@@ -3,7 +3,6 @@ using Cirrious.MvvmCross.Touch.Views;
 
 namespace $rootnamespace$.Views
 {
-    [Register("FirstView")]
     public partial class FirstView : MvxViewController
     {
         public FirstView() : base("FirstView", null)

--- a/nuspec/TouchContent/FirstView.designer.cs.pp
+++ b/nuspec/TouchContent/FirstView.designer.cs.pp
@@ -1,0 +1,37 @@
+// WARNING
+//
+// This file has been generated automatically by Xamarin Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
+//
+using Foundation;
+using System;
+using System.CodeDom.Compiler;
+using UIKit;
+
+namespace $rootnamespace$.Views
+{
+	[Register ("FirstView")]
+	partial class FirstView
+	{
+		[Outlet]
+		[GeneratedCode ("iOS Designer", "1.0")]
+		UILabel Label { get; set; }
+
+		[Outlet]
+		[GeneratedCode ("iOS Designer", "1.0")]
+		UITextField TextField { get; set; }
+
+		void ReleaseDesignerOutlets ()
+		{
+			if (Label != null) {
+				Label.Dispose ();
+				Label = null;
+			}
+			if (TextField != null) {
+				TextField.Dispose ();
+				TextField = null;
+			}
+		}
+	}
+}

--- a/nuspec/TouchContent/FirstView.xib
+++ b/nuspec/TouchContent/FirstView.xib
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FirstView">
+            <connections>
+                <outlet property="view" destination="2" id="RRd-Eg-VrN"/>
+                <outlet property="Label" destination="5" id="name-outlet-5"/>
+                <outlet property="TextField" destination="10" id="name-outlet-10"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="2">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label" lineBreakMode="tailTruncation" minimumFontSize="10" id="5" translatesAutoresizingMaskIntoConstraints="NO">
+                    <rect key="frame" x="10" y="72" width="580" height="21"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                    <constraints>
+                        <constraint id="9" firstItem="5" firstAttribute="height" constant="21" placeholder="YES"/>
+                    </constraints>
+                </label>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Text" borderStyle="roundedRect" minimumFontSize="17" id="10" translatesAutoresizingMaskIntoConstraints="NO">
+                    <rect key="frame" x="10" y="103" width="580" height="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                    <constraints>
+                        <constraint id="14" firstItem="10" firstAttribute="height" constant="30" placeholder="YES"/>
+                    </constraints>
+                </textField>
+            </subviews>
+            <constraints>
+                <constraint id="6" firstItem="5" firstAttribute="top" secondItem="2" secondAttribute="top" constant="72"/>
+                <constraint id="7" firstItem="5" firstAttribute="centerX" secondItem="2" secondAttribute="centerX"/>
+                <constraint id="8" firstItem="5" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="10"/>
+                <constraint id="11" firstItem="10" firstAttribute="top" secondItem="5" secondAttribute="bottom" constant="10"/>
+                <constraint id="12" firstItem="10" firstAttribute="centerX" secondItem="2" secondAttribute="centerX"/>
+                <constraint id="13" firstItem="10" firstAttribute="width" secondItem="5" secondAttribute="width"/>
+            </constraints>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
Now that there is a visual XIB file editor in both Visual Studio and Xamarin Studio I think the example provided in the Starter Pack should not use a hand-coded UI with absolute coordinates (from the times of 3.5" iPhones). Having an editor should scare away less people who are migrating to MvvmCross from a Windows background.

My changes have not been tested. How can I test this? I'm not sure where to declare how the XIB file is to be included in the csproj. It should show up as

    <InterfaceDefinition Include="Views\FirstView.xib" />

in the csproj. Also, the designer file should show up as a nested file

    <Compile Include="Views\FirstView.designer.cs">
      <DependentUpon>FirstView.cs</DependentUpon>
    </Compile>

Has anyone done this before?