### PR TITLE
Made MvvmCross.StarterPack pull in MvvmCross, not the other way around.

### DIFF
--- a/nuspec/MvvmCross.StarterPack.nuspec
+++ b/nuspec/MvvmCross.StarterPack.nuspec
@@ -12,50 +12,40 @@
 		<description>
 		MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.
 
-This package contains the 'Getting Started' libraries for MvvmCross
+This package contains the 'Getting Started' libraries for MvvmCross and installs sample files. This package can be removed after installation so the sample files don't get recreated on each update.
 		</description>
 		<tags>mvvm mvvmcross cross xamarin android ios forms monodroid monotouch xamarin.android xamarin.ios xamarin.forms wpf windows8 winrt net net45 netcore wp wpdev windowsphone windowsstore uwp</tags>
 		<iconUrl>http://i.imgur.com/BvdAtgT.png</iconUrl>
 		<dependencies>
 			<group targetFramework="net">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="win">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="wp">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="wpa">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="MonoAndroid">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="Xamarin.iOS10">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="Xamarin.Mac20">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="portable-net45+win+wpa81+wp80">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="uap">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="dotnet">
-				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
-				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+				<dependency id="MvvmCross" version="4.0.0-beta8" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/nuspec/MvvmCross.nuspec
+++ b/nuspec/MvvmCross.nuspec
@@ -17,34 +17,44 @@ This package contains the 'Getting Started' libraries for MvvmCross.
 		<iconUrl>http://i.imgur.com/BvdAtgT.png</iconUrl>
 		<dependencies>
 			<group targetFramework="net">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="win">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="wp">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="wpa">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="MonoAndroid">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="Xamarin.iOS10">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
-			</group>
-			<group targetFramework="portable-net45+win+wpa81+wp80">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
-			</group>
-			<group targetFramework="uap">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
-			</group>
-			<group targetFramework="dotnet">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
 			</group>
 			<group targetFramework="Xamarin.Mac20">
-				<dependency id="MvvmCross.StarterPack" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+			</group>
+			<group targetFramework="portable-net45+win+wpa81+wp80">
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+			</group>
+			<group targetFramework="uap">
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
+			</group>
+			<group targetFramework="dotnet">
+				<dependency id="MvvmCross.Core" version="4.0.0-beta8" />
+				<dependency id="MvvmCross.Binding" version="4.0.0-beta8" />
 			</group>
 		</dependencies>
 	</metadata>


### PR DESCRIPTION
If you want example files, install StarterPack (and uninstall it right away).
If you don't want the samples, install MvvmCross.