### PR TITLE
Main thread marshal

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxAdapter.cs
@@ -5,6 +5,8 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using Android.OS;
+
 namespace MvvmCross.Binding.Droid.Views
 {
     using System;
@@ -163,14 +165,8 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected virtual void RealNotifyDataSetChanged()
         {
-            try
-            {
-                base.NotifyDataSetChanged();
-            }
-            catch (Exception exception)
-            {
-                Mvx.Warning("Exception masked during Adapter RealNotifyDataSetChanged {0}", exception.ToLongString());
-            }
+            using (var handler = new Handler(Looper.MainLooper))
+                handler.Post(() => base.NotifyDataSetChanged());
         }
 
         public virtual int GetPosition(object item)


### PR DESCRIPTION
As described in #1217 NotififyDataSetChanged does not always happen on the UI thread, which will result in throwing an exception.

This has been changed and removed the masking of exceptions in NotifyDataSetChanged.