### PR TITLE
[Wip] Example of parent binding code - works for Droid collection views currently

### DIFF
--- a/MvvmCross/Binding/Droid/BindingContext/MvxAndroidBindingContext.cs
+++ b/MvvmCross/Binding/Droid/BindingContext/MvxAndroidBindingContext.cs
@@ -21,8 +21,8 @@ namespace MvvmCross.Binding.Droid.BindingContext
         private readonly Context _droidContext;
         private IMvxLayoutInflaterHolder _layoutInflaterHolder;
 
-        public MvxAndroidBindingContext(Context droidContext, IMvxLayoutInflaterHolder layoutInflaterHolder, object source = null)
-            : base(source)
+        public MvxAndroidBindingContext(Context droidContext, IMvxLayoutInflaterHolder layoutInflaterHolder, object source = null, object parentSource = null)
+            : base(source, parentSource)
         {
             this._droidContext = droidContext;
             this._layoutInflaterHolder = layoutInflaterHolder;

--- a/MvvmCross/Binding/Droid/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxLayoutInflater.cs
@@ -114,7 +114,7 @@ namespace MvvmCross.Binding.Droid.Views
                 var currentBindingContext = MvxAndroidBindingContextHelpers.Current();
                 if (currentBindingContext != null)
                 {
-                    factory = this.FactoryFactory.Create(currentBindingContext.DataContext);
+                    factory = this.FactoryFactory.Create(currentBindingContext.EnhancedDataContext);
 
                     // Set the current factory used to generate bindings
                     if (factory != null)

--- a/MvvmCross/Binding/Droid/Views/MvxListItemView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxListItemView.cs
@@ -23,7 +23,16 @@ namespace MvvmCross.Binding.Droid.Views
                                IMvxLayoutInflaterHolder layoutInflaterHolder,
                                object dataContext,
                                int templateId)
-            : base(context, layoutInflaterHolder, dataContext)
+            : this(context, layoutInflaterHolder, dataContext, null, templateId)
+        {
+        }
+
+        public MvxListItemView(Context context,
+                               IMvxLayoutInflaterHolder layoutInflaterHolder,
+                               object dataContext,
+                               object parentDataContext,
+                               int templateId)
+            : base(context, layoutInflaterHolder, dataContext, parentDataContext)
         {
             this._templateId = templateId;
             this.AndroidBindingContext.BindingInflate(templateId, this);

--- a/MvvmCross/Binding/Test/Bindings/MvxFullBindingConstructionTest.cs
+++ b/MvvmCross/Binding/Test/Bindings/MvxFullBindingConstructionTest.cs
@@ -124,12 +124,14 @@ namespace MvvmCross.Binding.Test.Bindings
 
             var toTest = new MvxFullBinding(request);
 
+#warning TODO - why are these commented out? Do they need removing or is there something needs fixing?
             //var sourceBindingTimes = expectSourceBinding ? Times.Once() : Times.Never();
             //mockSourceBinding.Verify(x => x.Changed += It.IsAny<EventHandler<MvxSourcePropertyBindingEventArgs>>(), sourceBindingTimes);
             mockSourceBindingFactory
                 .Verify(x => x.CreateBinding(It.Is<object>(s => s == source), It.Is<string>(s => s == sourceText)),
                         Times.Once());
 
+#warning // TODO - why are these commented out? Do they need removing or is there something needs fixing?
             //var targetBindingTimes = expectSourceBinding ? Times.Once() : Times.Never();
             //mockTargetBinding.Verify(x => x.ValueChanged += It.IsAny<EventHandler<MvxTargetChangedEventArgs>>(), targetBindingTimes);
             mockTargetBindingFactory

--- a/MvvmCross/Binding/Test/Parse/PropertyPath/MvxSourcePropertyPathParserTest.cs
+++ b/MvvmCross/Binding/Test/Parse/PropertyPath/MvxSourcePropertyPathParserTest.cs
@@ -71,6 +71,57 @@ namespace MvvmCross.Binding.Test.Parse.PropertyPath
         }
 
         [Test]
+        public void TestTokeniser_OnChainedSimplePropertyWithParent()
+        {
+            var text = "$parent.Hello.World.Good.Morning.Foo.Bar";
+            var split = text.Split('.');
+
+            var result = this.Tokenise(text);
+            Assert.AreEqual(7, result.Count);
+            Assert.IsTrue(result[0] is MvxParentPropertyToken);
+            for (var i = 1; i < split.Length; i++)
+            {
+                AssertIsSimplePropertyToken(result[i], split[i]);
+            }
+
+            var result2 = this.Tokenise(this.AddWhitespace(text));
+            Assert.AreEqual(7, result2.Count);
+            Assert.IsTrue(result2[0] is MvxParentPropertyToken);
+            for (var i = 1; i < split.Length; i++)
+            {
+                AssertIsSimplePropertyToken(result2[i], split[i]);
+            }
+        }
+
+        [Test]
+        public void TestTokeniser_MultipleParent()
+        {
+            var text = "$parent.$parent.$parent.Foo";
+            var split = text.Split('.');
+
+            var result = this.Tokenise(text);
+            Assert.AreEqual(4, result.Count);
+            Assert.IsTrue(result[0] is MvxParentPropertyToken);
+            Assert.IsTrue(result[1] is MvxParentPropertyToken);
+            Assert.IsTrue(result[2] is MvxParentPropertyToken);
+            for (var i = 3; i < split.Length; i++)
+            {
+                AssertIsSimplePropertyToken(result[i], split[i]);
+            }
+
+            var result2 = this.Tokenise(this.AddWhitespace(text));
+            Assert.AreEqual(4, result2.Count);
+            Assert.IsTrue(result2[0] is MvxParentPropertyToken);
+            Assert.IsTrue(result2[1] is MvxParentPropertyToken);
+            Assert.IsTrue(result2[2] is MvxParentPropertyToken);
+            for (var i = 3; i < split.Length; i++)
+            {
+                AssertIsSimplePropertyToken(result2[i], split[i]);
+            }
+        }
+
+
+        [Test]
         public void TestTokeniser_OnIntegerPropertyIndexer()
         {
             var toTest = new[] { 0, 1, 123, int.MaxValue };

--- a/MvvmCross/Core/Binding/BindingContext/IMvxBindingContext.cs
+++ b/MvvmCross/Core/Binding/BindingContext/IMvxBindingContext.cs
@@ -11,10 +11,9 @@ namespace MvvmCross.Binding.BindingContext
     using System.Collections.Generic;
 
     using MvvmCross.Binding.Bindings;
-    using MvvmCross.Platform.Core;
 
     public interface IMvxBindingContext
-        : IMvxDataConsumer
+        : IMvxEnhancedDataConsumer
     {
         event EventHandler DataContextChanged;
 

--- a/MvvmCross/Core/Binding/BindingContext/IMvxEnhancedDataConsumer.cs
+++ b/MvvmCross/Core/Binding/BindingContext/IMvxEnhancedDataConsumer.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Binding.Bindings.Source.Construction;
+using MvvmCross.Platform.Core;
+
+namespace MvvmCross.Binding.BindingContext
+{
+#warning TODO - this is in the wrong namespace (blame R#)
+    public interface IMvxEnhancedDataConsumer
+        : IMvxDataConsumer
+    {
+        IMvxEnhancedDataContext EnhancedDataContext { get; set; }
+    }
+}

--- a/MvvmCross/Core/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
@@ -193,7 +193,7 @@ namespace MvvmCross.Binding.BindingContext
             return targetPropertyName;
         }
 
-        protected static string SourcePropertyPath<TSource>(Expression<Func<TSource, object>> sourceProperty)
+        protected static string SourcePropertyPath<T>(Expression<Func<T, object>> sourceProperty)
         {
             var parser = MvxBindingSingletonCache.Instance.PropertyExpressionParser;
             var sourcePropertyPath = parser.Parse(sourceProperty).Print();

--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -75,6 +75,22 @@ namespace MvvmCross.Binding.BindingContext
             return this;
         }
 
+        //Don't let this happen?
+        //[Obsolete("Should this method be added?")]
+        //public MvxFluentBindingDescription<TTarget, TSource> ToParent(string sourcePropertyPath)
+        //{
+        //    // TODO - not sure about this string addition ... it kind of battles the free text...
+        //    this.SetFreeTextPropertyPath("$parent." + sourcePropertyPath);
+        //    return this;
+        //}
+
+        public MvxFluentBindingDescription<TTarget, TSource> To<TParent>(Expression<Func<TParent, object>> parentSourceProperty)
+        {
+            var sourcePropertyPath = SourcePropertyPath(parentSourceProperty);
+            this.SetKnownTextPropertyPath(sourcePropertyPath);
+            return this;
+        }
+
         public MvxFluentBindingDescription<TTarget, TSource> CommandParameter(object parameter)
         {
             return this.WithConversion(new MvxCommandParameterValueConverter(), parameter);

--- a/MvvmCross/Core/Binding/Bindings/IMvxEnhancedDataContextAwareBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/IMvxEnhancedDataContextAwareBinding.cs
@@ -1,0 +1,8 @@
+namespace MvvmCross.Binding.Bindings
+{
+#warning TODO - this is in the wrong namespace (blame R#)
+
+    public interface IMvxEnhancedDataContextAwareBinding
+    {
+    }
+}

--- a/MvvmCross/Core/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/MvxFullBinding.cs
@@ -19,7 +19,8 @@ namespace MvvmCross.Binding.Bindings
 
     public class MvxFullBinding
         : MvxBinding
-          , IMvxUpdateableBinding
+        , IMvxUpdateableBinding
+        , IMvxEnhancedDataContextAwareBinding
     {
         private IMvxSourceStepFactory SourceStepFactory => MvxBindingSingletonCache.Instance.SourceStepFactory;
 
@@ -233,6 +234,7 @@ namespace MvvmCross.Binding.Bindings
                 this.ClearTargetBinding();
                 this.ClearSourceBinding();
             }
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/MvvmCross/Core/Binding/Bindings/Source/Construction/IMvxEnhancedDataContext.cs
+++ b/MvvmCross/Core/Binding/Bindings/Source/Construction/IMvxEnhancedDataContext.cs
@@ -1,0 +1,9 @@
+namespace MvvmCross.Binding.Bindings.Source.Construction
+{
+#warning TODO - this is in the wrong namespace (blame R#)
+    public interface IMvxEnhancedDataContext
+    {
+        object Core { get;  }
+        object Parent { get; }
+    }
+}

--- a/MvvmCross/Core/Binding/Bindings/Source/Construction/MvxSimpleEnhancedDataContext.cs
+++ b/MvvmCross/Core/Binding/Bindings/Source/Construction/MvxSimpleEnhancedDataContext.cs
@@ -1,0 +1,35 @@
+namespace MvvmCross.Binding.Bindings.Source.Construction
+{
+#warning TODO - this is in the wrong namespace (blame R#)
+#warning TODO - should this be a struct... it's asking for problems...
+    public class MvxSimpleEnhancedDataContext
+        : IMvxEnhancedDataContext
+    {
+        public object Core { get; private set; }
+        public object Parent { get; private set; }
+
+        private MvxSimpleEnhancedDataContext()
+        {
+            
+        }
+
+        public static IMvxEnhancedDataContext CreateEmpty()
+        {
+            return new MvxSimpleEnhancedDataContext();
+        }
+
+        public static IMvxEnhancedDataContext Clone(IMvxEnhancedDataContext value)
+        {
+            return FromCoreAndParent(value?.Core, value?.Parent);
+        }
+
+        public static IMvxEnhancedDataContext FromCoreAndParent(object core, object parent)
+        {
+            return new MvxSimpleEnhancedDataContext()
+            {
+                Core = core,
+                Parent = parent
+            };
+        }
+    }
+}

--- a/MvvmCross/Core/Binding/MvvmCross.Binding.csproj
+++ b/MvvmCross/Core/Binding/MvvmCross.Binding.csproj
@@ -43,6 +43,8 @@
     <Compile Include="Binders\MvxNamedInstanceRegistryFiller.cs" />
     <Compile Include="Binders\MvxValueConverterRegistryFiller.cs" />
     <Compile Include="Binders\MvxRegistryFillerExtensions.cs" />
+    <Compile Include="BindingContext\IMvxEnhancedDataConsumer.cs" />
+    <Compile Include="Bindings\IMvxEnhancedDataContextAwareBinding.cs" />
     <Compile Include="Bindings\SourceSteps\IMvxSourceStep.cs" />
     <Compile Include="Bindings\SourceSteps\IMvxSourceStepFactory.cs" />
     <Compile Include="Bindings\SourceSteps\IMvxSourceStepFactoryRegistry.cs" />
@@ -55,8 +57,10 @@
     <Compile Include="Bindings\SourceSteps\MvxPathSourceStep.cs" />
     <Compile Include="Bindings\SourceSteps\MvxPathSourceStepDescription.cs" />
     <Compile Include="Bindings\SourceSteps\MvxPathSourceStepFactory.cs" />
+    <Compile Include="Bindings\Source\Construction\IMvxEnhancedDataContext.cs" />
     <Compile Include="Bindings\Source\Construction\IMvxSourceBindingFactoryExtension.cs" />
     <Compile Include="Bindings\Source\Construction\IMvxSourceBindingFactoryExtensionHost.cs" />
+    <Compile Include="Bindings\Source\Construction\MvxSimpleEnhancedDataContext.cs" />
     <Compile Include="Bindings\Source\MvxMissingSourceBinding.cs" />
     <Compile Include="Bindings\Source\Construction\MvxPropertySourceBindingFactoryExtension.cs" />
     <Compile Include="Bindings\Target\MvxConvertingTargetBinding.cs" />
@@ -97,6 +101,7 @@
     <Compile Include="Combiners\MvxValueConverterValueCombiner.cs" />
     <Compile Include="ExtensionMethods\IMvxEditableTextView.cs" />
     <Compile Include="Parse\Binding\Tibet\MvxTibetBindingParser.cs" />
+    <Compile Include="Parse\PropertyPath\PropertyTokens\MvxParentPropertyToken.cs" />
     <Compile Include="ValueConverters\MvxCommandParameterValueConverter.cs" />
     <Compile Include="BindingContext\MvxInlineBindingTarget.cs" />
     <Compile Include="BindingContext\MvxFluentBindingDescription.cs" />

--- a/MvvmCross/Core/Binding/Parse/PropertyPath/MvxSourcePropertyPathParser.cs
+++ b/MvvmCross/Core/Binding/Parse/PropertyPath/MvxSourcePropertyPathParser.cs
@@ -71,6 +71,10 @@ namespace MvvmCross.Binding.Parse.PropertyPath
             {
                 this.ParsePropertyName();
             }
+            else if (currentChar == '$')
+            {
+                this.ParseSpecialProperty();
+            }
             else
             {
                 throw new MvxException("Unexpected character {0} at position {1} in targetProperty text {2}",
@@ -93,6 +97,26 @@ namespace MvvmCross.Binding.Parse.PropertyPath
 
             var text = propertyText.ToString();
             this.CurrentTokens.Add(new MvxPropertyNamePropertyToken(text));
+        }
+
+        private void ParseSpecialProperty()
+        {
+            var propertyText = new StringBuilder();
+            while (!this.IsComplete)
+            {
+                var currentChar = this.CurrentChar;
+                if (!char.IsLetterOrDigit(currentChar) && currentChar != '_' && currentChar != '$')
+                    break;
+                propertyText.Append(currentChar);
+                this.MoveNext();
+            }
+
+            var text = propertyText.ToString();
+            if (text.ToLowerInvariant() != "$parent")
+            {
+                throw new MvxException("Unknown special property {0}", text);
+            }
+            this.CurrentTokens.Add(new MvxParentPropertyToken());
         }
 
         private void ParseIndexer()

--- a/MvvmCross/Core/Binding/Parse/PropertyPath/PropertyTokens/MvxParentPropertyToken.cs
+++ b/MvvmCross/Core/Binding/Parse/PropertyPath/PropertyTokens/MvxParentPropertyToken.cs
@@ -1,0 +1,10 @@
+namespace MvvmCross.Binding.Parse.PropertyPath.PropertyTokens
+{
+    public class MvxParentPropertyToken : MvxPropertyToken
+    {
+        public override string ToString()
+        {
+            return "$Parent";
+        }
+    }
+}


### PR DESCRIPTION
#35 seems to have been open quite a long time...

This code uses `$parent` to allow a parent data context to be accessed for any view that knows what it's parent is - this is currently is only Droid `MvxListItemView`s hosted inside `MvxAdapter`s, but it could be extended to other views such as fragments (see code in `MvxBaseListItemView` and `MvxAdapter` which provides the additional parent linking...)

There's a sample of this binding working in https://github.com/MvvmCross/MvvmCross-Samples/blob/parent-binding-experiment/ApiExamples/ApiExamples.Droid/Resources/Layout/Item_Parented.axml

```
    <TextView
        android:layout_width="fill_parent"
        android:layout_height="wrap_content"
        local:MvxBind="Text  'From Item:' + . + ' From ParentVM:' + $parent.DebugOutput" />
    <Button
        android:layout_width="fill_parent"
        android:layout_height="wrap_content"
        android:text="Tap Me"
        local:MvxBind="Click $parent.Hello" />
```

The code's not perfect... as it has to abuse some `object` to `MvxEnhancedDataContext` casting - but doing anything else would have required making breaking changes to the binding object interfaces (and are plenty enough breaking changes already so I didn't fancy adding more!)

This is really just at a hack level right now.... To complete this pull request....
- [x] prototype code should be written
- [ ] need to decide if this is wanted.... and if `$parent` is the right approach... (`$parent` is the only thing I've ever really heard people asking for....)
- [ ] code needs to be tidied up, refactored, written properly, etc (there's just something a bit too "hacky-go-lucky" about the code in https://github.com/MvvmCross/MvvmCross/commit/68e556098360216d144c8bea6b67039c111c90e8#diff-2a644c81f6260239ebb50b8f9fe1059dR33 right now :8ball: )
- [ ] Droid code for other controls could be written (is this just fragments? Or others too? Maybe Mvx frame controls would be needed)
- [ ] iOS code needs to be written - should be possible to get something working for tableviewsource and collectionviewsource - beyond that maybe would need to look at how other `MvxView` type controls could support parent access...
- [ ] unit tests should be added (I added a couple of parser ones, but no binding ones)
- [ ] android, ios, winphone, etc would need testing.... what has this hacking broken?
- [ ] field binding, command binding, reactive binding and any other extensions that have been written should be tested...
- [ ] somehow would need to check there are no leaks here.... I think there aren't but I've thought that before :)
- [ ] somehow would need to check there are no gaps in the assumption that parent can't be changed without the control getting a notification. I'm pretty confident this assumption is good for Droid list views... but is it safe for other view types?
- [ ] docs updated
- [ ] resharper code stasi would need to be applied

No hurry on any of this.... #35 is not exactly new ;) Don't know how much time I'll get on any of it... so very happy for others to work on the pull...
