### PR TITLE
[Analyzer/CodeFix] RaiseCanExecuteChanged never called when needed

### DIFF
--- a/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
@@ -43,7 +43,7 @@ namespace CoreApp
     }
 }";
 
-        private const string Test = @"
+        private const string TestWithLazyLoading = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -225,6 +225,24 @@ namespace CoreApp
             };
 
             VerifyCSharpDiagnostic(TestWithPropertyCreatedWithCs6, expectedDiagnostic);
+        }
+
+        [Test]
+        public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerWithLazyLoadingShouldShowOneDiagnostic()
+        {
+            var expectedDiagnostic = new DiagnosticResult
+            {
+                Id = DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId,
+                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.CanExecuteChanged' from your code",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 22, 77)
+                    }
+            };
+
+            VerifyCSharpDiagnostic(TestWithLazyLoading, expectedDiagnostic);
         }
 
         //[Test]

--- a/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
@@ -154,6 +154,37 @@ namespace CoreApp
     }
 }";
 
+        private const string TestWithPropertyCreatedWithCs6 = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Windows.Input;
+using MvvmCross.Core.ViewModels;
+
+namespace CoreApp
+{
+    public class FirstViewModel : MvxViewModel
+    {
+        public bool ShouldSubmit { get; set; }
+
+        public MvxCommand SubmitCommand => new MvxCommand(DoSubmit, CanDoSubmit);
+
+        public FirstViewModel()
+        {
+        }
+
+        private void DoSubmit() { }
+
+        private bool CanDoSubmit()
+        {
+            return ShouldSubmit;
+        }
+    }
+}";
+
         [Test]
         public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldShowOneDiagnostic()
         {
@@ -176,6 +207,24 @@ namespace CoreApp
         public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldNotShowAnyDiagnostic()
         {
             VerifyCSharpDiagnostic(TestWithPropertyButCalling);
+        }
+
+        [Test]
+        public void CommandWithCanExecuteWithCs6WithoutCanExecuteChangedAnalyzerShouldShowOneDiagnostic()
+        {
+            var expectedDiagnostic = new DiagnosticResult
+            {
+                Id = DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId,
+                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.CanExecuteChanged' from your code",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 17, 69)
+                    }
+            };
+
+            VerifyCSharpDiagnostic(TestWithPropertyCreatedWithCs6, expectedDiagnostic);
         }
 
         //[Test]

--- a/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.CodeAnalysis;
 using MvvmCross.CodeAnalysis.Analyzers;
+using MvvmCross.CodeAnalysis.CodeFixes;
 using MvvmCross.CodeAnalysis.Core;
 using NUnit.Framework;
 
 namespace MvvmCross.CodeAnalysis.Test
 {
     [TestFixture]
-    public class CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests : DiagnosticVerifier<CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer>//, CommandWithCanExecuteWithoutCanExecuteChangedCodeFix>
+    public class CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests : CodeFixVerifier<CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer, CommandWithCanExecuteWithoutCanExecuteChangedCodeFix>
     {
         private const string Expected = @"
 using System;
@@ -291,10 +292,10 @@ namespace CoreApp
             VerifyCSharpDiagnostic(TestWithLazyLoading, expectedDiagnostic);
         }
 
-        //[Test]
-        //public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldFixTheCode()
-        //{
-        //    VerifyCSharpFix(Test, Expected);
-        //}
+        [Test]
+        public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldFixTheCode()
+        {
+            VerifyCSharpFix(TestWithLazyLoading, Expected);
+        }
     }
 }

--- a/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
@@ -1,0 +1,187 @@
+﻿using Microsoft.CodeAnalysis;
+using MvvmCross.CodeAnalysis.Analyzers;
+using MvvmCross.CodeAnalysis.Core;
+using NUnit.Framework;
+
+namespace MvvmCross.CodeAnalysis.Test
+{
+    [TestFixture]
+    public class CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests : DiagnosticVerifier<CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer>//, CommandWithCanExecuteWithoutCanExecuteChangedCodeFix>
+    {
+        private const string Expected = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Windows.Input;
+using MvvmCross.Core.ViewModels;
+
+namespace CoreApp
+{
+    public class FirstViewModel : MvxViewModel
+    {
+        public bool ShouldSubmit { get; set; }
+
+        private MvxCommand _submitCommand;
+        public MvxCommand SubmitCommand
+        {
+            get
+            {
+                _submitCommand = _submitCommand ?? new MvxCommand(DoSubmit);
+                return _submitCommand;
+            }
+        }
+
+        private void DoSubmit() { }
+
+        private bool CanDoSubmit()
+        {
+            return ShouldSubmit;
+        }
+    }
+}";
+
+        private const string Test = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Windows.Input;
+using MvvmCross.Core.ViewModels;
+
+namespace CoreApp
+{
+    public class FirstViewModel : MvxViewModel
+    {
+        public bool ShouldSubmit { get; set; }
+
+        private MvxCommand _submitCommand;
+        public MvxCommand SubmitCommand
+        {
+            get
+            {
+                _submitCommand = _submitCommand ?? new MvxCommand(DoSubmit, CanDoSubmit);
+                return _submitCommand;
+            }
+        }
+
+        private void DoSubmit() { }
+
+        private bool CanDoSubmit()
+        {
+            return ShouldSubmit;
+        }
+    }
+}";
+
+        private const string TestWithProperty = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Windows.Input;
+using MvvmCross.Core.ViewModels;
+
+namespace CoreApp
+{
+    public class FirstViewModel : MvxViewModel
+    {
+        public bool ShouldSubmit { get; set; }
+
+        public MvxCommand SubmitCommand { get; set; }
+        
+        public FirstViewModel()
+        {
+            SubmitCommand = new MvxCommand(DoSubmit, CanDoSubmit);
+        }
+        
+        private void DoSubmit() { }
+
+        private bool CanDoSubmit()
+        {
+            return ShouldSubmit;
+        }
+    }
+}";
+
+        private const string TestWithPropertyButCalling = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Windows.Input;
+using MvvmCross.Core.ViewModels;
+
+namespace CoreApp
+{
+    public class FirstViewModel : MvxViewModel
+    {
+        private bool _shouldSubmit;
+        public bool ShouldSubmit
+        {
+            get
+            {
+                return _shouldSubmit;
+            }
+            set
+            {
+                _shouldSubmit = value;
+                SubmitCommand.RaiseCanExecuteChanged()
+            }
+        }
+
+        public MvxCommand SubmitCommand { get; set; }
+        
+        public FirstViewModel()
+        {
+            SubmitCommand = new MvxCommand(DoSubmit, CanDoSubmit);
+        }
+        
+        private void DoSubmit() { }
+
+        private bool CanDoSubmit()
+        {
+            return ShouldSubmit;
+        }
+    }
+}";
+
+        [Test]
+        public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldShowOneDiagnostic()
+        {
+            var expectedDiagnostic = new DiagnosticResult
+            {
+                Id = DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId,
+                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.CanExecuteChanged' from your code",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 21, 54)
+                    }
+            };
+
+            VerifyCSharpDiagnostic(TestWithProperty, expectedDiagnostic);
+        }
+
+        [Test]
+        public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldNotShowAnyDiagnostic()
+        {
+            VerifyCSharpDiagnostic(TestWithPropertyButCalling);
+        }
+
+        //[Test]
+        //public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldFixTheCode()
+        //{
+        //    VerifyCSharpFix(Test, Expected);
+        //}
+    }
+}

--- a/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis.Test/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs
@@ -154,6 +154,50 @@ namespace CoreApp
     }
 }";
 
+        private const string TestWithPropertyButCallingWithElvis = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Windows.Input;
+using MvvmCross.Core.ViewModels;
+
+namespace CoreApp
+{
+    public class FirstViewModel : MvxViewModel
+    {
+        private bool _shouldSubmit;
+        public bool ShouldSubmit
+        {
+            get
+            {
+                return _shouldSubmit;
+            }
+            set
+            {
+                _shouldSubmit = value;
+                SubmitCommand?.RaiseCanExecuteChanged()
+            }
+        }
+
+        public MvxCommand SubmitCommand { get; set; }
+        
+        public FirstViewModel()
+        {
+            SubmitCommand = new MvxCommand(DoSubmit, CanDoSubmit);
+        }
+        
+        private void DoSubmit() { }
+
+        private bool CanDoSubmit()
+        {
+            return ShouldSubmit;
+        }
+    }
+}";
+
         private const string TestWithPropertyCreatedWithCs6 = @"
 using System;
 using System.Collections.Generic;
@@ -191,7 +235,7 @@ namespace CoreApp
             var expectedDiagnostic = new DiagnosticResult
             {
                 Id = DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId,
-                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.CanExecuteChanged' from your code",
+                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.RaiseCanExecuteChanged' from your code",
                 Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[]
@@ -203,10 +247,12 @@ namespace CoreApp
             VerifyCSharpDiagnostic(TestWithProperty, expectedDiagnostic);
         }
 
+        [TestCase(TestWithPropertyButCalling)]
+        [TestCase(TestWithPropertyButCallingWithElvis)]
         [Test]
-        public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldNotShowAnyDiagnostic()
+        public void CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerShouldNotShowAnyDiagnostic(string testCase)
         {
-            VerifyCSharpDiagnostic(TestWithPropertyButCalling);
+            VerifyCSharpDiagnostic(testCase);
         }
 
         [Test]
@@ -215,7 +261,7 @@ namespace CoreApp
             var expectedDiagnostic = new DiagnosticResult
             {
                 Id = DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId,
-                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.CanExecuteChanged' from your code",
+                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.RaiseCanExecuteChanged' from your code",
                 Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[]
@@ -233,7 +279,7 @@ namespace CoreApp
             var expectedDiagnostic = new DiagnosticResult
             {
                 Id = DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId,
-                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.CanExecuteChanged' from your code",
+                Message = "Remove 'CanDoSubmit' from the constructor or call 'SubmitCommand.RaiseCanExecuteChanged' from your code",
                 Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[]

--- a/CodeAnalysis/MvvmCross.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -25,6 +26,21 @@ namespace MvvmCross.CodeAnalysis.Test
         private static readonly MetadataReference _mvvmCrossCoreReference = MetadataReference.CreateFromFile(typeof(MvxViewPresenter).Assembly.Location);
         private static readonly MetadataReference _mvvmCrossDroidReference = MetadataReference.CreateFromFile(typeof(MvxActivity).Assembly.Location);
         private static readonly MetadataReference _componentModelReference = MetadataReference.CreateFromFile(typeof(INotifyPropertyChanged).Assembly.Location);
+        private static readonly MetadataReference _objectModelReference = MetadataReference.CreateFromFile(GetCorrectObjectModelPath());
+
+        private static string GetCorrectObjectModelPath()
+        {
+            var winDir = Environment.GetEnvironmentVariable("windir");
+
+            if (winDir != null)
+            {
+                var gacObjectModelPath = Path.Combine(winDir, @"Microsoft.NET\assembly\GAC_MSIL\System.ObjectModel");
+                var finalPath = Directory.GetDirectories(gacObjectModelPath).First();
+
+                return Directory.GetFiles(finalPath).First();
+            }
+            throw new ArgumentException("You don't have ObjectModel inside your GAC! Fix your environment.");
+        }
 
         internal static string DefaultFilePathPrefix = "Test";
         internal static string CSharpDefaultFileExt = "cs";
@@ -153,7 +169,8 @@ namespace MvvmCross.CodeAnalysis.Test
                 .AddMetadataReference(projectId, _codeAnalysisReference)
                 .AddMetadataReference(projectId, _mvvmCrossCoreReference)
                 .AddMetadataReference(projectId, _mvvmCrossDroidReference)
-                .AddMetadataReference(projectId, _componentModelReference);
+                .AddMetadataReference(projectId, _componentModelReference)
+                .AddMetadataReference(projectId, _objectModelReference);
 
             int count = 0;
             foreach (var source in sources)

--- a/CodeAnalysis/MvvmCross.CodeAnalysis.Test/MvvmCross.CodeAnalysis.Test.csproj
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis.Test/MvvmCross.CodeAnalysis.Test.csproj
@@ -91,6 +91,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandWithCanExecuteWithoutCanExecuteChangedAnalyzerTests.cs" />
     <Compile Include="ConsiderUsingGenericBaseViewAnalyzerTests.cs" />
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />
     <Compile Include="Helpers\DiagnosticResult.cs" />

--- a/CodeAnalysis/MvvmCross.CodeAnalysis/Analyzers/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis/Analyzers/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs
@@ -15,8 +15,8 @@ namespace MvvmCross.CodeAnalysis.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer : DiagnosticAnalyzer
     {
-        internal static readonly LocalizableString Title = "Commands with CanExecute should have the CanExecuteChanged method called at least once";
-        internal static readonly LocalizableString MessageFormat = "Remove '{0}' from the constructor or call '{1}.CanExecuteChanged' from your code";
+        internal static readonly LocalizableString Title = "Commands with CanExecute should have the RaiseCanExecuteChanged method called at least once";
+        internal static readonly LocalizableString MessageFormat = "Remove '{0}' from the constructor or call '{1}.RaiseCanExecuteChanged' from your code";
         internal const string Category = Categories.Usage;
 
         internal static readonly DiagnosticDescriptor Rule =
@@ -119,8 +119,10 @@ namespace MvvmCross.CodeAnalysis.Analyzers
         {
             return classDeclaration.DescendantNodes()
                 .OfType<InvocationExpressionSyntax>()
-                .Any(i => ((i.Expression as MemberAccessExpressionSyntax)?.Name as IdentifierNameSyntax)
-                ?.Identifier.Value.Equals("RaiseCanExecuteChanged") ?? false);
+                .Any(i =>
+                    (((i.Expression as MemberAccessExpressionSyntax)?.Name
+                      ?? (i.Expression as MemberBindingExpressionSyntax)?.Name
+                        ) as IdentifierNameSyntax)?.Identifier.Value.Equals("RaiseCanExecuteChanged") ?? false);
         }
 
         private static bool IsViewModelType(SyntaxNodeAnalysisContext context, ITypeSymbol symbol)

--- a/CodeAnalysis/MvvmCross.CodeAnalysis/Analyzers/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis/Analyzers/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs
@@ -1,0 +1,111 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using MvvmCross.CodeAnalysis.Core;
+using MvvmCross.CodeAnalysis.Extensions;
+using MvvmCross.Core.ViewModels;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Windows.Input;
+
+namespace MvvmCross.CodeAnalysis.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer : DiagnosticAnalyzer
+    {
+        internal static readonly LocalizableString Title = "Commands with CanExecute should have the CanExecuteChanged method called at least once";
+        internal static readonly LocalizableString MessageFormat = "Remove '{0}' from the constructor or call '{1}.CanExecuteChanged' from your code";
+        internal const string Category = Categories.Usage;
+
+        internal static readonly DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyzer, SyntaxKind.PropertyDeclaration);
+        }
+
+        private static void Analyzer(SyntaxNodeAnalysisContext context)
+        {
+            var propertyDeclarationSyntax = context.Node as PropertyDeclarationSyntax;
+            if (propertyDeclarationSyntax != null)
+            {
+                var propertySymbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclarationSyntax);
+
+                var iCommandType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(ICommand).FullName);
+
+                if (propertySymbol != null &&
+                    (propertySymbol.Type.Equals(iCommandType) || propertySymbol.Type.ImplementsSymbol(iCommandType)) &&
+                    propertySymbol.DeclaredAccessibility == Accessibility.Public &&
+                    propertySymbol.GetMethod != null &&
+                    propertySymbol.GetMethod.DeclaredAccessibility == Accessibility.Public &&
+                    propertySymbol.ContainingType != null)
+                {
+                    var viewModelType = propertySymbol.ContainingType;
+
+                    if (!IsViewModelType(context, viewModelType))
+                        return;
+
+                    var classDeclaration = context.Node.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+                    if (classDeclaration != null)
+                    {
+                        var containingAssignments = classDeclaration.DescendantNodes()
+                            .OfType<AssignmentExpressionSyntax>()
+                            .Where(a => context.SemanticModel.GetSymbolInfo(a.Left).Symbol.Equals(propertySymbol));
+
+                        var mvxCommandType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(MvxCommand).FullName);
+
+                        foreach (var assignment in containingAssignments)
+                        {
+                            var objectCreationExpressionSyntax = assignment.Right as ObjectCreationExpressionSyntax;
+                            if (objectCreationExpressionSyntax != null)
+                            {
+                                var objectCreationSymbol = context.SemanticModel.GetSymbolInfo(objectCreationExpressionSyntax.Type).Symbol;
+                                if (objectCreationSymbol != null && objectCreationSymbol.Equals(mvxCommandType))
+                                {
+                                    if (objectCreationExpressionSyntax.ArgumentList.Arguments.Count == 2)
+                                    {
+                                        // Is using CanExecute
+                                        if (CallingCanExecuteChanged(context, classDeclaration) == false)
+                                        {
+                                            var canExecute = objectCreationExpressionSyntax.ArgumentList.Arguments[1];
+
+                                            context.ReportDiagnostic(
+                                                Diagnostic.Create(
+                                                    Rule
+                                                    , canExecute.GetLocation()
+                                                    , canExecute.ToString()
+                                                    , propertySymbol.Name)
+                                                );
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool CallingCanExecuteChanged(SyntaxNodeAnalysisContext context, ClassDeclarationSyntax classDeclaration)
+        {
+            return classDeclaration.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Any(i => ((i.Expression as MemberAccessExpressionSyntax)?.Name as IdentifierNameSyntax)?.Identifier.Value.Equals("RaiseCanExecuteChanged") ?? false);
+        }
+
+        private static bool IsViewModelType(SyntaxNodeAnalysisContext context, ITypeSymbol symbol)
+        {
+            var iMvxViewModelType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(IMvxViewModel).FullName);
+            var iNotifyPropertyChangedType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(System.ComponentModel.INotifyPropertyChanged).FullName);
+
+            return symbol.ImplementsSymbol(iMvxViewModelType) ||
+                   symbol.ImplementsSymbol(iNotifyPropertyChangedType);
+        }
+    }
+}

--- a/CodeAnalysis/MvvmCross.CodeAnalysis/Analyzers/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis/Analyzers/CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs
@@ -70,10 +70,13 @@ namespace MvvmCross.CodeAnalysis.Analyzers
                                     {
                                         var canExecute = objectCreation.ArgumentList.Arguments[1];
 
+                                        var properties = new Dictionary<string, string> { { nameof(canExecute), canExecute.ToString() } }.ToImmutableDictionary();
+
                                         context.ReportDiagnostic(
                                             Diagnostic.Create(
                                                 Rule
                                                 , canExecute.GetLocation()
+                                                , properties
                                                 , canExecute.ToString()
                                                 , propertySymbol.Name)
                                             );

--- a/CodeAnalysis/MvvmCross.CodeAnalysis/CodeFixes/CommandWithCanExecuteWithoutCanExecuteChangedCodeFix.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis/CodeFixes/CommandWithCanExecuteWithoutCanExecuteChangedCodeFix.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using MvvmCross.CodeAnalysis.Core;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace MvvmCross.CodeAnalysis.CodeFixes
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CommandWithCanExecuteWithoutCanExecuteChangedCodeFix)), Shared]
+    public class CommandWithCanExecuteWithoutCanExecuteChangedCodeFix : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticIds.CommandWithCanExecuteWithoutCanExecuteChangedRuleId);
+
+        public sealed override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public static readonly string MessageFormat = "Remove method invocation: {0}.";
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    string.Format(MessageFormat, GetCanExecute(diagnostic)),
+                    cancelToken =>
+                        ApplyFix(
+                            context.Document,
+                            context.Span, cancelToken),
+                    nameof(CommandWithCanExecuteWithoutCanExecuteChangedCodeFix))
+                , diagnostic);
+
+            return Task.FromResult(0);
+        }
+
+        private static string GetCanExecute(Diagnostic diagnostic)
+        {
+            return diagnostic.Properties["canExecute"];
+        }
+
+        private static async Task<Document> ApplyFix(Document document, TextSpan span, CancellationToken cancellationToken)
+        {
+            var root = await document
+                .GetSyntaxRootAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var argumentListSyntax = root.FindNode(span)
+                .FirstAncestorOrSelf<ArgumentListSyntax>();
+
+            var newArgumentListSyntax = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+            {
+                argumentListSyntax.Arguments[0]
+            }));
+
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken);
+            editor.ReplaceNode(argumentListSyntax, newArgumentListSyntax);
+            return editor.GetChangedDocument();
+        }
+    }
+}

--- a/CodeAnalysis/MvvmCross.CodeAnalysis/Core/DiagnosticIds.cs
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis/Core/DiagnosticIds.cs
@@ -3,5 +3,6 @@
     public static class DiagnosticIds
     {
         public const string UseGenericBaseClassRuleId = "MVX1001";
+        public const string CommandWithCanExecuteWithoutCanExecuteChangedRuleId = "MVX1002";
     }
 }

--- a/CodeAnalysis/MvvmCross.CodeAnalysis/MvvmCrossCodeAnalysis.csproj
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis/MvvmCrossCodeAnalysis.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Analyzers\CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs" />
+    <Compile Include="CodeFixes\CommandWithCanExecuteWithoutCanExecuteChangedCodeFix.cs" />
     <Compile Include="CodeFixes\ConsiderUsingGenericBaseViewCodeFix.cs" />
     <Compile Include="Analyzers\ConsiderUsingGenericBaseViewAnalyzer.cs" />
     <Compile Include="Core\Categories.cs" />

--- a/CodeAnalysis/MvvmCross.CodeAnalysis/MvvmCrossCodeAnalysis.csproj
+++ b/CodeAnalysis/MvvmCross.CodeAnalysis/MvvmCrossCodeAnalysis.csproj
@@ -35,6 +35,7 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Analyzers\CommandWithCanExecuteWithoutCanExecuteChangedAnalyzer.cs" />
     <Compile Include="CodeFixes\ConsiderUsingGenericBaseViewCodeFix.cs" />
     <Compile Include="Analyzers\ConsiderUsingGenericBaseViewAnalyzer.cs" />
     <Compile Include="Core\Categories.cs" />


### PR DESCRIPTION
This is covering most cases, like C# 6 Arrow property creation, lazy loading and direct property set, all using MvxCommand's two parameters constructor.
The code fix can't do much, so all it does is remove the call to the CanExecute at the constructor.