### PR TITLE
Added missing JNI interop constructors in MvxLayoutInflaterCompat

### DIFF
--- a/MvvmCross/Binding/Droid/Binders/MvxLayoutInflaterCompat.cs
+++ b/MvvmCross/Binding/Droid/Binders/MvxLayoutInflaterCompat.cs
@@ -20,6 +20,12 @@ namespace MvvmCross.Binding.Droid.Binders
         {
             protected readonly IMvxLayoutInflaterFactory DelegateFactory;
 
+            public FactoryWrapper(System.IntPtr handle, Android.Runtime.JniHandleOwnership ownership) : base(handle, ownership)
+            {
+                
+            }
+
+
             public FactoryWrapper(IMvxLayoutInflaterFactory delegateFactory)
             {
                 this.DelegateFactory = delegateFactory;
@@ -33,6 +39,11 @@ namespace MvvmCross.Binding.Droid.Binders
 
         internal class FactoryWrapper2 : FactoryWrapper, LayoutInflater.IFactory2
         {
+            public FactoryWrapper2(System.IntPtr handle, Android.Runtime.JniHandleOwnership ownership) : base(handle, ownership)
+            {
+
+            }
+
             public FactoryWrapper2(IMvxLayoutInflaterFactory delegateFactory)
                 : base(delegateFactory)
             { }


### PR DESCRIPTION
When Fragment/Activity is destroyed, it looks like managed peer instance of MvxLayoutInflaterCompat is sometimes disposed. JNI could not recreate instance of inflater because of missing IntPtr, JniHandleOwnership constructor - therefore application crash with UnsupportedOperationException.

Fixes issue #1260