### PR TITLE
Fix Android crash when Bitmap updated after MvxImageView destroyed

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxImageView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxImageView.cs
@@ -134,5 +134,13 @@ namespace MvvmCross.Binding.Droid.Views
                     this.SetImageBitmap(mvxValueEventArgs.Value);
                 });
         }
+
+        public override void SetImageBitmap (Bitmap bm)
+        {
+            if (Handle != IntPtr.Zero)
+            {
+                base.SetImageBitmap (bm);
+            }
+        }
     }
 }


### PR DESCRIPTION
ImageHelperOnImageChanged method propogates bitmap update on the UI thread,
which leads to crash in case MvxImageView object has been disposed by Android runtime.
This simple fix avoids the crash.