### PR TITLE
Added swipe-gesture-recognizer

### DIFF
--- a/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
+++ b/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ValueConverters\MvxUnifiedTypesValueConverter.cs" />
     <Compile Include="Views\Gestures\MvxBehaviourExtensions.cs" />
     <Compile Include="Views\Gestures\MvxGestureRecognizerBehavior.cs" />
+    <Compile Include="Views\Gestures\MvxSwipeGestureRecognizerBehaviour.cs" />
     <Compile Include="Views\Gestures\MvxTapGestureRecognizerBehaviour.cs" />
     <Compile Include="Views\MvxImageView.cs" />
     <Compile Include="Views\MvxImageViewWrapper.cs" />

--- a/MvvmCross/Binding/iOS/Views/Gestures/MvxBehaviourExtensions.cs
+++ b/MvvmCross/Binding/iOS/Views/Gestures/MvxBehaviourExtensions.cs
@@ -17,5 +17,12 @@ namespace MvvmCross.Binding.iOS.Views.Gestures
             var toReturn = new MvxTapGestureRecognizerBehaviour(view, numberOfTapsRequired, numberOfTouchesRequired);
             return toReturn;
         }
+
+        public static MvxSwipeGestureRecognizerBehaviour Swipe(this UIView view, UISwipeGestureRecognizerDirection direction,
+            uint numberOfTouchesRequired = 1)
+        {
+            var toReturn = new MvxSwipeGestureRecognizerBehaviour(view, direction, numberOfTouchesRequired);
+            return toReturn;
+        }
     }
 }

--- a/MvvmCross/Binding/iOS/Views/Gestures/MvxGestureRecognizerBehavior.cs
+++ b/MvvmCross/Binding/iOS/Views/Gestures/MvxGestureRecognizerBehavior.cs
@@ -40,16 +40,6 @@ namespace MvvmCross.Binding.iOS.Views.Gestures
 
     /*
      * these commented out as no use has been found for any of them yet
-    public class MvxSwipeGestureRecognizerBehaviour
-        : MvxGestureRecognizerBehavior<UISwipeGestureRecognizer>
-    {
-        public void Apply(UIView view, UISwipeGestureRecognizerDirection direction = UISwipeGestureRecognizerDirection.Right)
-        {
-            var tap = new UISwipeGestureRecognizer(FireCommandWithNull) {Direction = direction};
-            view.AddGestureRecognizer(tap);
-        }
-    }
-
     public class MvxPinchGestureRecognizerBehaviour
         : MvxGestureRecognizerBehavior
     {

--- a/MvvmCross/Binding/iOS/Views/Gestures/MvxSwipeGestureRecognizerBehaviour.cs
+++ b/MvvmCross/Binding/iOS/Views/Gestures/MvxSwipeGestureRecognizerBehaviour.cs
@@ -1,0 +1,32 @@
+﻿// MvxSwipeGestureRecognizerBehaviour.cs
+
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+namespace MvvmCross.Binding.iOS.Views.Gestures
+{
+    using UIKit;
+
+    public class MvxSwipeGestureRecognizerBehaviour
+        : MvxGestureRecognizerBehavior<UISwipeGestureRecognizer>
+    {
+        protected override void HandleGesture(UISwipeGestureRecognizer gesture)
+        {
+            this.FireCommand();
+        }
+
+        public MvxSwipeGestureRecognizerBehaviour(UIView target, UISwipeGestureRecognizerDirection direction,
+                                                uint numberOfTouchesRequired = 1)
+        {
+            var swipe = new UISwipeGestureRecognizer(this.HandleGesture)
+            {
+                Direction = direction,
+                NumberOfTouchesRequired = numberOfTouchesRequired
+            };
+
+            this.AddGestureRecognizer(target, swipe);
+        }
+    }
+}


### PR DESCRIPTION
I've added the swipe gesture recognizer. One of the comments said, that there weren't a use-case, but I see a use-case for it. I didn't want to set a default-swipe-direction so the developer has to think about it. If he get's a default, he may get the intention, that this captures all directions.

Here's an example how you can use it. You can also apply multiple directions to one view.

    set.Bind(MyView.Swipe(UISwipeGestureRecognizerDirection.Right)).For(v => v.Command).To(vm => vm.SwipedRightCommand);
    set.Bind(MyView.Swipe(UISwipeGestureRecognizerDirection.Left)).For(v => v.Command).To(vm => vm.SwipedLeftCommand);