### PR TITLE
Add bitmap existance check in Droid's MvxImageView

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxImageView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxImageView.cs
@@ -139,6 +139,11 @@ namespace MvvmCross.Binding.Droid.Views
         {
             if (Handle != IntPtr.Zero)
             {
+                if (bm != null && (bm.Handle == IntPtr.Zero || bm.IsRecycled))
+                {
+                    // Don't try to update disposed or recycled bitmap
+                    return;
+                }
                 base.SetImageBitmap (bm);
             }
         }


### PR DESCRIPTION
Partial fix of https://github.com/MvvmCross/MvvmCross-Plugins/issues/41
Avoids crashes when Bitmap already disposed.
