### PR TITLE
Add a way to interact on Content with MvxFrameControl

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxFrameControl.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFrameControl.cs
@@ -100,7 +100,19 @@ namespace MvvmCross.Binding.Droid.Views
             this._isAttachedToWindow = false;
         }
 
-        protected View Content { get; set; }
+        private View _content;
+
+        protected View Content
+        {
+            get { return _content; }
+            set
+            {
+                _content = value;
+                OnContentSet();
+            }
+        }
+
+        protected virtual void OnContentSet() { }
 
         [MvxSetToNullAfterBinding]
         public object DataContext


### PR DESCRIPTION
For now, if you create your custom control based on `MvxFrameControl` on Android, you don't have (or let me know how :) ) any way to write custom code when Content is inflated (except by copy / pasting all the class).

Thanks to this PR, the developper can simply override the `OnContentSet` method and do whatever (s)he wants.