### PR TITLE
Set image resource directly on the ImageView instead of decoding it first

### DIFF
--- a/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableNameTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableNameTargetBinding.cs
@@ -9,7 +9,6 @@ namespace MvvmCross.Binding.Droid.Target
 {
     using System;
 
-    using Android.Graphics;
     using Android.Widget;
 
     using MvvmCross.Platform.Platform;
@@ -17,20 +16,25 @@ namespace MvvmCross.Binding.Droid.Target
     public class MvxImageViewDrawableNameTargetBinding
         : MvxImageViewDrawableTargetBinding
     {
-        public MvxImageViewDrawableNameTargetBinding(ImageView imageView) : base(imageView)
+        public MvxImageViewDrawableNameTargetBinding(ImageView imageView)
+            : base(imageView)
         {
         }
 
+        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
+
         public override Type TargetType => typeof(string);
 
-        protected override bool GetBitmap(object value, out Bitmap bitmap)
+        protected override void SetValueImpl(object target, object value)
         {
+            var imageView = (ImageView)target;
+
             if (!(value is string))
             {
                 MvxBindingTrace.Trace(MvxTraceLevel.Warning,
-                                      "Value '{0}' could not be parsed as a valid string identifier", value);
-                bitmap = null;
-                return false;
+                    "Value '{0}' could not be parsed as a valid string identifier", value);
+                imageView.SetImageDrawable(null);
+                return;
             }
 
             var resources = this.AndroidGlobals.ApplicationContext.Resources;
@@ -38,12 +42,12 @@ namespace MvvmCross.Binding.Droid.Target
             if (id == 0)
             {
                 MvxBindingTrace.Trace(MvxTraceLevel.Warning,
-                                      "Value '{0}' was not a known drawable name", value);
-                bitmap = null;
-                return false;
+                    "Value '{0}' was not a known drawable name", value);
+                imageView.SetImageDrawable(null);
+                return;
             }
 
-            return base.GetBitmap(id, out bitmap);
+            base.SetValueImpl(target, id);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
@@ -9,42 +9,44 @@ namespace MvvmCross.Binding.Droid.Target
 {
     using System;
 
-    using Android.Graphics;
     using Android.Widget;
 
     using MvvmCross.Platform.Platform;
 
     public class MvxImageViewDrawableTargetBinding
-        : MvxBaseImageViewTargetBinding
+        : MvxAndroidTargetBinding
     {
+        protected ImageView ImageView => (ImageView)Target;
+
         public MvxImageViewDrawableTargetBinding(ImageView imageView)
             : base(imageView)
         {
         }
 
+        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
+
         public override Type TargetType => typeof(int);
 
-        protected override bool GetBitmap(object value, out Bitmap bitmap)
+        protected override void SetValueImpl(object target, object value)
         {
+            var imageView = (ImageView)target;
+
             if (!(value is int))
             {
                 MvxBindingTrace.Trace(MvxTraceLevel.Warning,
                     "Value was not a valid Drawable");
-                bitmap = null;
-                return false;
+                imageView.SetImageDrawable(null);
+                return;
             }
 
             var intValue = (int)value;
 
             if (intValue == 0)
-                bitmap = null;
+                imageView.SetImageDrawable(null);
             else
             {
-                var resources = this.AndroidGlobals.ApplicationContext.Resources;
-                bitmap = BitmapFactory.DecodeResource(resources, intValue, new BitmapFactory.Options() { InPurgeable = true });
+                imageView.SetImageResource(intValue);
             }
-
-            return true;
         }
     }
 }


### PR DESCRIPTION
The current DrawableName binding has a few bad side effects:
* When decoding a large image on a low resolution device, the quality will be bad. I don't know why yet, but it doesn't happen when letting Android decode the image.
* Current implementation decodes the Bitmap => Mono runtime has a reference to the Bitmap => Java GC won't be able to clean up the bitmap unless Mono has already collected this reference => possible memory leak
* There is no automatic reuse of drawables. When setting the same drawable on multiple ImageViews, Android will detect this and decode the drawable only once. When the bitmap is explicitly decoded, we lose this advantage.