### PR TITLE
Use gitlink to inject source references in PDBs back to mvvmcross repo

### DIFF
--- a/nuspec/MvvmCross.AutoView.Droid.nuspec
+++ b/nuspec/MvvmCross.AutoView.Droid.nuspec
@@ -30,9 +30,7 @@ This package contains the 'AutoView' Android libraries for MvvmCross
 	<files>		
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\MvvmCross.AutoView.Droid.*" target="lib\MonoAndroid" />
-		<file src="..\MvvmCross\AutoView\Droid\**\*.cs" target="src\MvvmCross.AutoView.Droid" />
 		<file src="..\bin\Release\Mvx\Droid\CrossUI.Droid.*" target="lib\MonoAndroid" />
-		<file src="..\CrossUI\CrossUI.Droid\**\*.cs" target="src\CrossUI.Droid"/>
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.AutoView.iOS.nuspec
+++ b/nuspec/MvvmCross.AutoView.iOS.nuspec
@@ -32,9 +32,6 @@ This package contains the 'AutoView' iOS libraries for MvvmCross
 		<!-- iOS -->
 		<file src="..\bin\Release\Mvx\iOS\MvvmCross.AutoView.iOS.*" target="lib\Xamarin.iOS10" />
 		<file src="..\bin\Release\Mvx\iOS\CrossUI.iOS.*" target="lib\Xamarin.iOS10" />
-
-		<file src="..\MvvmCross\AutoView\iOS\**\*.cs" 
-			target="src\MvvmCross.AutoView.iOS" />		
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.AutoView.nuspec
+++ b/nuspec/MvvmCross.AutoView.nuspec
@@ -27,10 +27,6 @@ This package contains the 'AutoView' PCL assemblies for MvvmCross
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.AutoView.*" target="lib\dotnet" />
 		<file src="..\bin\Release\Mvx\Portable\CrossUI.Core.*" target="lib\dotnet" />
 		
-		<!-- src -->
-		<file src="..\MvvmCross\AutoView\**\*.cs" target="src\MvvmCross.AutoView" />
-		<file src="..\CrossUI\CrossUI.Core\**\*.cs" target="src\CrossUI.Core" />
-		
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.Binding.nuspec
+++ b/nuspec/MvvmCross.Binding.nuspec
@@ -96,12 +96,6 @@ This package contains the 'Core Binding' libraries for MvvmCross
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Binding.*" target="lib\net45" />
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Localization.*" target="lib\net45" />
 
-		<!-- src -->
-		<file src="..\MvvmCross\Core\Binding\**\*.cs" target="src\MvvmCross.Binding" />
-		<file src="..\MvvmCross\Binding\Droid\**\*.cs" target="src\MvvmCross.Binding.Droid" />
-		<file src="..\MvvmCross\Binding\iOS\**\*.cs" target="src\MvvmCross.Binding.iOS" />
-		<file src="..\MvvmCross\Core\Localization\**\*.cs" target="src\MvvmCross.Localization" />
-
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.BindingEx.nuspec
+++ b/nuspec/MvvmCross.BindingEx.nuspec
@@ -59,16 +59,7 @@ This package contains the 'binding extensions' for MvvmCross
 			</group>
 		</dependencies>
 	</metadata>
-	<files>		
-
-		<!-- common -->
-		<file src="..\MvvmCross\Binding\BindingEx.Wpf\**\*.cs" 
-			target="src\MvvmCross.BindingEx.Wpf" />
-		<file src="..\MvvmCross\Binding\BindingEx.WindowsStore\**\*.cs" 
-			target="src\MvvmCross.BindingEx.WindowsStore" />
-		<file src="..\MvvmCross\Binding\BindingEx.WindowsPhone\**\*.cs" 
-			target="src\MvvmCross.BindingEx.WindowsPhone" />
-
+	<files>
 		<!-- wpf -->
 		<file src="..\bin\Release\Mvx\Wpf\MvvmCross.BindingEx.Wpf.*" target="lib\net45" />
 

--- a/nuspec/MvvmCross.Core.nuspec
+++ b/nuspec/MvvmCross.Core.nuspec
@@ -49,26 +49,7 @@ This package contains the 'Core' libraries for MvvmCross
 			</group>
 		</dependencies>
 	</metadata>
-	<files>		
-		<!-- src -->
-		<file src="..\MvvmCross\Core\Core\**\*.cs" 
-			target="src\MvvmCross.Core" />
-		<file src="..\MvvmCross\Windows\Wpf\**\*.cs" 
-			target="src\MvvmCross.Wpf" />
-		<file src="..\MvvmCross\Windows\WindowsStore\**\*.cs" 
-			target="src\MvvmCross.WindowsStore" />
-		<file src="..\MvvmCross\Windows\WindowsPhone\**\*.cs" 
-			target="src\MvvmCross.WindowsPhone" />
-		<file src="..\MvvmCross\Windows\WindowsCommon\**\*.cs" 
-			target="src\MvvmCross.WindowsCommon" />
-		<file src="..\MvvmCross\Windows\WindowsUWP\**\*.cs" 
-			target="src\MvvmCross.WindowsUWP" />
-		<file src="..\MvvmCross\Droid\Droid\**\*.cs" 
-			target="src\MvvmCross.Droid" />
-		<file src="..\MvvmCross\iOS\iOS\**\*.cs" 
-			target="src\MvvmCross.iOS" />
-		<file src="..\MvvmCross\Mac\Mac\**\*.cs"
-			target="src\MvvmCross.Mac" />
+	<files>
 
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Core.dll" target="lib\portable-net45+win+wpa81+wp80" />

--- a/nuspec/MvvmCross.Dialog.Droid.nuspec
+++ b/nuspec/MvvmCross.Dialog.Droid.nuspec
@@ -29,15 +29,8 @@ This package contains the 'Android Dialog' libraries for MvvmCross
 
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Portable\CrossUI.Core.*" target="lib\MonoAndroid" />
-		<file src="..\CrossUI\CrossUI.Core\**\*.cs" target="src\CrossUI.Core" />
-
 		<file src="..\bin\Release\Mvx\Droid\CrossUI.Droid.*" target="lib\MonoAndroid" />
-
-		<file src="..\CrossUI\CrossUI.Droid\**\*.cs" target="src\CrossUI.Droid" />
-
 		<file src="..\bin\Release\Mvx\Droid\MvvmCross.Dialog.Droid.*" target="lib\MonoAndroid" />
-
-		<file src="..\MvvmCross\Dialog\Droid\**\*.cs" target="src\MvvmCross.Dialog.Droid" />
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.Dialog.iOS.nuspec
+++ b/nuspec/MvvmCross.Dialog.iOS.nuspec
@@ -29,10 +29,6 @@ This package contains the 'iOS Dialog' libraries for MvvmCross
 		<file src="..\bin\Release\Mvx\iOS\CrossUI.Core.*" target="lib\Xamarin.iOS10" />
 		<file src="..\bin\Release\Mvx\iOS\CrossUI.iOS.*" target="lib\Xamarin.iOS10" />
 		<file src="..\bin\Release\Mvx\iOS\MvvmCross.Dialog.iOS.*" target="lib\Xamarin.iOS10" />
-
-		<file src="..\CrossUI\CrossUI.Core\**\*.cs" target="src\CrossUI.Core" />
-		<file src="..\CrossUI\CrossUI.iOS\**\*.cs" target="src\CrossUI.iOS" />
-		<file src="..\MvvmCross\Dialog\iOS\**\*.cs" target="src\MvvmCross.Dialog.iOS" />
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.Droid.FullFragging.nuspec
+++ b/nuspec/MvvmCross.Droid.FullFragging.nuspec
@@ -30,7 +30,6 @@ This package contains the 'Android Fragment' assemblies for Android Honeycomb or
 	<files>		
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\MvvmCross.Droid.FullFragging.*" target="lib\MonoAndroid" />
-		<file src="..\MvvmCross\Droid\FullFragging\**\*.cs" target="src\MvvmCross.Droid.FullFragging" />
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.Droid.Shared.nuspec
+++ b/nuspec/MvvmCross.Droid.Shared.nuspec
@@ -32,7 +32,6 @@ This package contains the 'Android Shared' assemblies for Android Honeycomb or l
 	<files>		
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Droid\MvvmCross.Droid.Shared.*" target="lib\MonoAndroid" />
-		<file src="..\MvvmCross\Droid\Shared\**\*.cs" target="src\MvvmCross.Droid.Shared" />
 	</files>
 </package>
 

--- a/nuspec/MvvmCross.Platform.nuspec
+++ b/nuspec/MvvmCross.Platform.nuspec
@@ -18,24 +18,6 @@ This package contains the 'Platform' libraries for MvvmCross
 		<iconUrl>http://i.imgur.com/BvdAtgT.png</iconUrl>
 	</metadata>
 	<files>
-		<!-- src -->
-		<file src="..\MvvmCross\Platform\Platform\**\*.cs" 
-			target="src\MvvmCross.Platform" />
-		<file src="..\MvvmCross\Platform\Wpf\**\*.cs" 
-			target="src\MvvmCross.Platform.Wpf" />
-		<file src="..\MvvmCross\Platform\WindowsStore\**\*.cs" 
-			target="src\MvvmCross.Platform.WindowsStore" />
-		<file src="..\MvvmCross\Platform\WindowsPhone\**\*.cs" 
-			target="src\MvvmCross.Platform.WindowsPhone" />
-		<file src="..\MvvmCross\Platform\WindowsCommon\**\*.cs" 
-			target="src\MvvmCross.Platform.WindowsCommon" />
-		<file src="..\MvvmCross\Platform\Droid\**\*.cs" 
-			target="src\MvvmCross.Platform.Droid" />
-		<file src="..\MvvmCross\Platform\iOS\**\*.cs" 
-			target="src\MvvmCross.Platform.iOS" />
-		<file src="..\MvvmCross\Platform\Mac\**\*.cs" 
-			target="src\MvvmCross.Platform.Mac" />
-
 		<!-- PCL -->
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Platform.*" target="lib\portable-net45+win+wpa81+wp80" />
 

--- a/nuspec/MvvmCross.Tests.nuspec
+++ b/nuspec/MvvmCross.Tests.nuspec
@@ -52,8 +52,6 @@ This package contains the 'Test Helpers' for MvvmCross
 	<files>
 		<!-- full -->
 		<file src="..\bin\Release\Mvx\Console\MvvmCross.Test.Core.*" target="lib\net45" />
-		
-		<file src="..\MvvmCross\Test\Test.Core\**\*.cs" target="src\Test\MvvmCross.Test.Core" />
 	</files>
 </package>
 

--- a/nuspec/pack.ps1
+++ b/nuspec/pack.ps1
@@ -9,24 +9,33 @@ if (-Not(Test-Path ("nuget.exe")))
 Set-Alias nuget $targetNugetExe -Scope Global -Verbose
 
 del *.nupkg
-nuget pack MvvmCross.Binding.nuspec -Symbols
-nuget pack MvvmCross.Core.nuspec -Symbols
-nuget pack MvvmCross.Platform.nuspec -Symbols
-nuget pack MvvmCross.Console.Platform.nuspec -Symbols
-# note no -Symbols
+
+if (-Not(Get-Command "gitlink.exe" -ErrorAction SilentlyContinue))
+{
+    Write-Host "gitlink.exe is required to provide source information directly from the MvvmCross repositories on github." -ForegroundColor Yellow
+	Write-Host "See https://github.com/GitTools/GitLink for more information." -ForegroundColor Yellow
+    Write-Host "Please install gitlink via chocolatey" -ForegroundColor Red
+	return
+}
+
+$sourcePath = (Get-Item $PSScriptRoot).parent.FullName
+gitlink $sourcePath -u https://github.com/MvvmCross/MvvmCross
+
+nuget pack MvvmCross.Binding.nuspec
+nuget pack MvvmCross.Core.nuspec
+nuget pack MvvmCross.Platform.nuspec
+nuget pack MvvmCross.Console.Platform.nuspec
 nuget pack MvvmCross.StarterPack.nuspec
-# note no -Symbols
 nuget pack MvvmCross.CodeAnalysis.nuspec
-nuget pack MvvmCross.Tests.nuspec -Symbols
-# note no -Symbols
+nuget pack MvvmCross.Tests.nuspec
 nuget pack MvvmCross.nuspec
-nuget pack MvvmCross.Dialog.iOS.nuspec -Symbols
-nuget pack MvvmCross.Dialog.Droid.nuspec -Symbols
-nuget pack MvvmCross.BindingEx.nuspec -Symbols
-nuget pack MvvmCross.AutoView.nuspec -Symbols
-nuget pack MvvmCross.AutoView.iOS.nuspec -Symbols
-nuget pack MvvmCross.AutoView.Droid.nuspec -Symbols
-nuget pack MvvmCross.Droid.FullFragging.nuspec -Symbols
-nuget pack MvvmCross.Droid.Shared.nuspec -Symbols
+nuget pack MvvmCross.Dialog.iOS.nuspec
+nuget pack MvvmCross.Dialog.Droid.nuspec
+nuget pack MvvmCross.BindingEx.nuspec
+nuget pack MvvmCross.AutoView.nuspec
+nuget pack MvvmCross.AutoView.iOS.nuspec
+nuget pack MvvmCross.AutoView.Droid.nuspec
+nuget pack MvvmCross.Droid.FullFragging.nuspec
+nuget pack MvvmCross.Droid.Shared.nuspec
 
 pause


### PR DESCRIPTION
This requires the user to have `gitlink.exe` in their `PATH` which is typically installed via `chocolatey`.  See https://github.com/GitTools/GitLink/

Fixes #1314 
