### PR TITLE
Updates to fix MvxExpandableListAdapter when creating adapter in code

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxExpandableListAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxExpandableListAdapter.cs
@@ -16,6 +16,10 @@ namespace MvvmCross.Binding.Droid.Views
         public MvxExpandableListAdapter(Context context)
             : base(context)
         { }
+        
+        public MvxExpandableListAdapter(Context context, IMvxAndroidBindingContext bindingContext)
+            : base(context, bindingContext)
+        { }
 
         protected MvxExpandableListAdapter(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)

--- a/MvvmCross/Binding/Droid/Views/MvxExpandableListAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxExpandableListAdapter.cs
@@ -43,7 +43,7 @@ namespace MvvmCross.Binding.Droid.Views
             }
         }
 
-        public int GroupCount => base.Count;
+        public int GroupCount => this.Count;
 
         public void OnGroupExpanded(int groupPosition)
         {
@@ -63,7 +63,7 @@ namespace MvvmCross.Binding.Droid.Views
         public View GetGroupView(int groupPosition, bool isExpanded, View convertView, ViewGroup parent)
         {
             var item = this.GetRawGroup(groupPosition);
-            return base.GetBindableView(convertView, item, this.GroupTemplateId);
+            return this.GetBindableView(convertView, item, this.GroupTemplateId);
         }
 
         public long GetGroupId(int groupPosition)
@@ -103,7 +103,7 @@ namespace MvvmCross.Binding.Droid.Views
 
         public object GetRawGroup(int groupPosition)
         {
-            return base.GetRawItem(groupPosition);
+            return this.GetRawItem(groupPosition);
         }
 
         public View GetChildView(int groupPosition, int childPosition, bool isLastChild, View convertView,
@@ -111,7 +111,7 @@ namespace MvvmCross.Binding.Droid.Views
         {
             var item = this.GetRawItem(groupPosition, childPosition);
 
-            return base.GetBindableView(convertView, item, this.ItemTemplateId);
+            return this.GetBindableView(convertView, item, this.ItemTemplateId);
         }
 
         public int GetChildrenCount(int groupPosition)


### PR DESCRIPTION
Additional constructor is to pass context to parent constructor when creating adapter from code.

Calls to `this` instead of `base` enable us to override the methods with our own custom method implementations.