### PR TITLE
Ignore transparent proxies on Mono, #1308.

### DIFF
--- a/MvvmCross/Platform/Platform/ReflectionExtensions.cs
+++ b/MvvmCross/Platform/Platform/ReflectionExtensions.cs
@@ -39,7 +39,12 @@ namespace MvvmCross.Platform
 
         public static bool IsInstanceOfType(this Type type, object obj)
         {
-            return type.IsAssignableFrom(obj.GetType());
+            return type.IsAssignableFrom(obj.GetType()) || obj.IsMarshalByRefObject();
+        }
+
+        private static bool IsMarshalByRefObject(this object obj)
+        {
+            return obj != null && obj.GetType().FullName == "System.MarshalByRefObject";
         }
 
         public static MethodInfo GetAddMethod(this EventInfo eventInfo, bool nonPublic = false)


### PR DESCRIPTION
On Mono, there is no easy way to check if a transparent proxy supports a given type.
So I just ignore transparent proxies (they are hardly ever used nowadays anyway).