### PR TITLE
Allows binding to EditTextPreference.Text and TwoStatePreference.Chec…

### DIFF
--- a/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
+++ b/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
@@ -81,7 +81,9 @@
     <Compile Include="ResourceHelpers\MvxAndroidBindingResource.cs" />
     <Compile Include="ResourceHelpers\MvxAppResourceTypeFinder.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
+    <Compile Include="Target\MvxEditTextPreferenceTextTargetBinding.cs" />
     <Compile Include="Target\MvxExpandableListViewSelectedItemTargetBinding.cs" />
+    <Compile Include="Target\MvxPreferenceValueTargetBinding.cs" />
     <Compile Include="Target\MvxRatingBarRatingTargetBinding.cs" />
     <Compile Include="Target\MvxBaseStreamImageViewTargetBinding.cs" />
     <Compile Include="Target\MvxBaseViewVisibleBinding.cs" />
@@ -100,6 +102,7 @@
     <Compile Include="Target\MvxTextViewTextTargetBinding.cs" />
     <Compile Include="Target\MvxSeekBarProgressTargetBinding.cs" />
     <Compile Include="Target\MvxSpinnerSelectedItemBinding.cs" />
+    <Compile Include="Target\MvxTwoStatePreferenceCheckedTargetBinding.cs" />
     <Compile Include="Target\MvxViewClickBinding.cs" />
     <Compile Include="Target\MvxViewHiddenBinding.cs" />
     <Compile Include="Target\MvxViewVisibleBinding.cs" />

--- a/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
@@ -5,6 +5,8 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using Android.Preferences;
+
 namespace MvvmCross.Binding.Droid
 {
     using Android.Graphics;
@@ -134,8 +136,16 @@ namespace MvvmCross.Binding.Droid
             registry.RegisterCustomBindingFactory("TextFocus", (EditText view) => new MvxTextViewFocusTargetBinding(view));
             registry.RegisterCustomBindingFactory<SearchView>(
                 "Query",
-                search => new MvxSearchViewQueryTextTargetBinding(search)
-                );
+                search => new MvxSearchViewQueryTextTargetBinding(search));
+            registry.RegisterCustomBindingFactory<Preference>(
+                "Value",
+                preference => new MvxPreferenceValueTargetBinding(preference));
+            registry.RegisterCustomBindingFactory<EditTextPreference>(
+                "Text",
+                preference => new MvxEditTextPreferenceTextTargetBinding(preference));
+            registry.RegisterCustomBindingFactory<TwoStatePreference>(
+                "Checked",
+                preference => new MvxTwoStatePreferenceCheckedTargetBinding(preference));
         }
 
         protected override void FillDefaultBindingNames(IMvxBindingNameRegistry registry)

--- a/MvvmCross/Binding/Droid/Target/MvxEditTextPreferenceTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxEditTextPreferenceTextTargetBinding.cs
@@ -1,0 +1,19 @@
+﻿using Android.Preferences;
+
+namespace MvvmCross.Binding.Droid.Target
+{
+    public class MvxEditTextPreferenceTextTargetBinding : MvxPreferenceValueTargetBinding
+    {
+        public MvxEditTextPreferenceTextTargetBinding(EditTextPreference preference)
+            : base(preference) { }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            var t = target as EditTextPreference;
+            if (t != null)
+            {
+                t.Text = (string)value;
+            }
+        }
+    }
+}

--- a/MvvmCross/Binding/Droid/Target/MvxPreferenceValueTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxPreferenceValueTargetBinding.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Android.Preferences;
+using MvvmCross.Platform;
+
+namespace MvvmCross.Binding.Droid.Target
+{
+    public class MvxPreferenceValueTargetBinding : MvxAndroidTargetBinding
+    {
+        public MvxPreferenceValueTargetBinding(Preference preference)
+            : base(preference)
+        { }
+
+        public Preference Preference => Target as Preference;
+
+        public override Type TargetType => typeof(Preference);
+
+        public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
+
+        public override void SubscribeToEvents()
+        {
+            Preference.PreferenceChange += HandlePreferenceChange;
+        }
+
+        protected void HandlePreferenceChange(object sender, Preference.PreferenceChangeEventArgs e)
+        {
+            if (e.Preference == Preference)
+            {
+                this.FireValueChanged(e.NewValue);
+                e.Handled = true;
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                if (Preference != null)
+                {
+                    Preference.PreferenceChange -= this.HandlePreferenceChange;
+                }
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            Mvx.Warning("SetValueImpl called on generic Preference target");
+        }
+    }
+}

--- a/MvvmCross/Binding/Droid/Target/MvxTwoStatePreferenceCheckedTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTwoStatePreferenceCheckedTargetBinding.cs
@@ -1,0 +1,19 @@
+using Android.Preferences;
+
+namespace MvvmCross.Binding.Droid.Target
+{
+    public class MvxTwoStatePreferenceCheckedTargetBinding : MvxPreferenceValueTargetBinding
+    {
+        public MvxTwoStatePreferenceCheckedTargetBinding(TwoStatePreference preference)
+            : base(preference) { }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            var t = target as TwoStatePreference;
+            if (t != null)
+            {
+                t.Checked = (bool)value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ked as

well as one-way binding to any other Preference subclass using the generic
"Value" binding.

```
public class SettingsViewFragment : MvxPreferenceFragment<SettingsViewModel>
{
    public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
    {
        // Since the view is created in PreferenceFragment's OnCreateView
        // we don't use BindingInflate like a typical MvxFragment.
        var view = base.OnCreateView(inflater, container, savedInstanceState);

        var serverPreference = (EditTextPreference)this.FindPreference("pref_eugs_server");

        var bindingSet = this.CreateBindingSet<SettingsViewFragment, SettingsViewModel>();
        bindingSet.Bind(serverPreference)
            .For(v => v.Text)
            .To(vm => vm.EugsServerAddress);
        bindingSet.Apply();

        return view;
    }

    public override void OnCreatePreferences(Bundle savedInstanceState, string rootKey)
    {
        this.AddPreferencesFromResource(Resource.Xml.preferences);
    }
}
```