### PR TITLE
MultiRegionViewPresenter - Support frame search failure.

### DIFF
--- a/MvvmCross/Windows/WindowsUWP/Views/MvxWindowsMultiRegionViewPresenter.cs
+++ b/MvvmCross/Windows/WindowsUWP/Views/MvxWindowsMultiRegionViewPresenter.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.WindowsUWP.Views
     using MvvmCross.Core.Views;
     using MvvmCross.Platform;
     using MvvmCross.Platform.Exceptions;
-
+    using System.Collections.Generic;
     public class MvxWindowsMultiRegionViewPresenter
         : MvxWindowsViewPresenter
     {
@@ -64,6 +64,7 @@ namespace MvvmCross.WindowsUWP.Views
             if (reference == null) return null;
 
             var foundChild = default(T);
+            var nextPhase = new List<DependencyObject>();
 
             var childrenCount = VisualTreeHelper.GetChildrenCount(reference);
             for (var index = 0; index < childrenCount; index++)
@@ -90,12 +91,31 @@ namespace MvvmCross.WindowsUWP.Views
                         foundChild = (T)child;
                         break;
                     }
+                    else
+                    {
+                        // keep for searching inside this frame
+                        nextPhase.Add(child);
+                    }
                 }
                 else
                 {
                     // child element found.
                     foundChild = (T)child;
                     break;
+                }
+            }
+
+            // if failed to find the child, search inside the frames we found
+            if (foundChild == null)
+            {
+                foreach (var item in nextPhase)
+                {
+                    // recursively drill down the tree
+                    foundChild = FindChild<T>(item, childName);
+
+                    // If the child is found, break so we do not overwrite the found child. 
+                    if (foundChild != null) break;
+
                 }
             }
 

--- a/MvvmCross/Windows/WindowsUWP/Views/MvxWindowsMultiRegionViewPresenter.cs
+++ b/MvvmCross/Windows/WindowsUWP/Views/MvxWindowsMultiRegionViewPresenter.cs
@@ -40,15 +40,14 @@ namespace MvvmCross.WindowsUWP.Views
 
                 var containerView = FindChild<Frame>(this._rootFrame.UnderlyingControl, viewType.GetRegionName());
 
-                if (containerView == null)
-                    throw new MvxException($"Region '{viewType.GetRegionName()}' not found in view '{viewType}'");
+                if (containerView != null)
+                {
+                    containerView.Navigate(viewType, requestText);
+                    return;
+                }
+            }
 
-                containerView.Navigate(viewType, requestText);
-            }
-            else
-            {
-                base.Show(request);
-            }
+            base.Show(request);
         }
 
         private static Type GetViewType(MvxViewModelRequest request)


### PR DESCRIPTION
Upon search failure (no matching frame found), use the default frame.

It allows flexability in building a responsive app that navigates to a frame on big screens and navigates inside the main frame if the screen is small.