### PR TITLE
Unsubscribe events

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxAdapter.cs
@@ -31,9 +31,7 @@ namespace MvvmCross.Binding.Droid.Views
         : BaseAdapter
         , IMvxAdapter
     {
-        private readonly IMvxAndroidBindingContext _bindingContext;
-        private readonly Context _context;
-        private int _itemTemplateId;
+	    private int _itemTemplateId;
         private int _dropDownItemTemplateId;
         private IEnumerable _itemsSource;
         private IDisposable _subscription;
@@ -56,15 +54,15 @@ namespace MvvmCross.Binding.Droid.Views
 
         public MvxAdapter(Context context, IMvxAndroidBindingContext bindingContext)
         {
-            this._context = context;
-            this._bindingContext = bindingContext;
-            if (this._bindingContext == null)
+            Context = context;
+            BindingContext = bindingContext;
+            if (BindingContext == null)
             {
                 throw new MvxException(
                     "bindingContext is null during MvxAdapter creation - Adapter's should only be created when a specific binding context has been placed on the stack");
             }
-            this.SimpleViewLayoutId = Android.Resource.Layout.SimpleListItem1;
-            this.SimpleDropDownViewLayoutId = Android.Resource.Layout.SimpleSpinnerDropDownItem;
+            SimpleViewLayoutId = Android.Resource.Layout.SimpleListItem1;
+            SimpleDropDownViewLayoutId = Android.Resource.Layout.SimpleSpinnerDropDownItem;
         }
 
         protected MvxAdapter(IntPtr javaReference, JniHandleOwnership transfer)
@@ -72,11 +70,11 @@ namespace MvvmCross.Binding.Droid.Views
         {
         }
 
-        protected Context Context => this._context;
+        protected Context Context { get; }
 
-        protected IMvxAndroidBindingContext BindingContext => this._bindingContext;
+	    protected IMvxAndroidBindingContext BindingContext { get; }
 
-        public int SimpleViewLayoutId { get; set; }
+	    public int SimpleViewLayoutId { get; set; }
 
         public int SimpleDropDownViewLayoutId { get; set; }
 
@@ -85,81 +83,81 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public virtual IEnumerable ItemsSource
         {
-            get { return this._itemsSource; }
-            set { this.SetItemsSource(value); }
+            get { return _itemsSource; }
+            set { SetItemsSource(value); }
         }
 
         public virtual int ItemTemplateId
         {
-            get { return this._itemTemplateId; }
+            get { return _itemTemplateId; }
             set
             {
-                if (this._itemTemplateId == value)
+                if (_itemTemplateId == value)
                     return;
-                this._itemTemplateId = value;
+                _itemTemplateId = value;
 
                 // since the template has changed then let's force the list to redisplay by firing NotifyDataSetChanged()
-                if (this._itemsSource != null)
-                    this.NotifyDataSetChanged();
+                if (_itemsSource != null)
+                    NotifyDataSetChanged();
             }
         }
 
         public virtual int DropDownItemTemplateId
         {
-            get { return this._dropDownItemTemplateId; }
+            get { return _dropDownItemTemplateId; }
             set
             {
-                if (this._dropDownItemTemplateId == value)
+                if (_dropDownItemTemplateId == value)
                     return;
-                this._dropDownItemTemplateId = value;
+                _dropDownItemTemplateId = value;
 
                 // since the template has changed then let's force the list to redisplay by firing NotifyDataSetChanged()
-                if (this._itemsSource != null)
-                    this.NotifyDataSetChanged();
+                if (_itemsSource != null)
+                    NotifyDataSetChanged();
             }
         }
 
-        public override int Count => this._itemsSource.Count();
+        public override int Count => _itemsSource.Count();
 
         protected virtual void SetItemsSource(IEnumerable value)
         {
-            if (Object.ReferenceEquals(this._itemsSource, value)
-                && !this.ReloadOnAllItemsSourceSets)
+            if (ReferenceEquals(_itemsSource, value)
+                && !ReloadOnAllItemsSourceSets)
                 return;
 
-            if (this._subscription != null)
+            if (_subscription != null)
             {
-                this._subscription.Dispose();
-                this._subscription = null;
+                _subscription.Dispose();
+                _subscription = null;
             }
 
-            this._itemsSource = value;
+            _itemsSource = value;
 
-            if (this._itemsSource != null && !(this._itemsSource is IList))
+            if (_itemsSource != null && !(_itemsSource is IList))
                 MvxBindingTrace.Trace(MvxTraceLevel.Warning,
                                       "You are currently binding to IEnumerable - this can be inefficient, especially for large collections. Binding to IList is more efficient.");
 
-            var newObservable = this._itemsSource as INotifyCollectionChanged;
+            var newObservable = _itemsSource as INotifyCollectionChanged;
             if (newObservable != null)
             {
-                this._subscription = newObservable.WeakSubscribe(OnItemsSourceCollectionChanged);
+                _subscription = newObservable.WeakSubscribe(OnItemsSourceCollectionChanged);
             }
-            this.NotifyDataSetChanged();
+            NotifyDataSetChanged();
         }
 
         protected virtual void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            this.NotifyDataSetChanged(e);
+            NotifyDataSetChanged(e);
         }
 
         public virtual void NotifyDataSetChanged(NotifyCollectionChangedEventArgs e)
         {
-            this.RealNotifyDataSetChanged();
+            RealNotifyDataSetChanged();
         }
 
         public override void NotifyDataSetChanged()
         {
-            this.RealNotifyDataSetChanged();
+            RealNotifyDataSetChanged();
         }
 
         protected virtual void RealNotifyDataSetChanged()
@@ -178,12 +176,12 @@ namespace MvvmCross.Binding.Droid.Views
 
         public virtual int GetPosition(object item)
         {
-            return this._itemsSource.GetPosition(item);
+            return _itemsSource.GetPosition(item);
         }
 
-        public virtual System.Object GetRawItem(int position)
+        public virtual object GetRawItem(int position)
         {
-            return this._itemsSource.ElementAt(position);
+            return _itemsSource.ElementAt(position);
         }
 
         public override Object GetItem(int position)
@@ -201,44 +199,44 @@ namespace MvvmCross.Binding.Droid.Views
 
         public override View GetDropDownView(int position, View convertView, ViewGroup parent)
         {
-            this._currentSimpleId = this.SimpleDropDownViewLayoutId;
-            this._currentParent = parent;
-            var toReturn = this.GetView(position, convertView, parent, this.DropDownItemTemplateId);
-            this._currentParent = null;
+            _currentSimpleId = SimpleDropDownViewLayoutId;
+            _currentParent = parent;
+            var toReturn = GetView(position, convertView, parent, DropDownItemTemplateId);
+            _currentParent = null;
             return toReturn;
         }
 
         public override View GetView(int position, View convertView, ViewGroup parent)
         {
-            this._currentSimpleId = this.SimpleViewLayoutId;
-            this._currentParent = parent;
-            var toReturn = this.GetView(position, convertView, parent, this.ItemTemplateId);
-            this._currentParent = null;
+            _currentSimpleId = SimpleViewLayoutId;
+            _currentParent = parent;
+            var toReturn = GetView(position, convertView, parent, ItemTemplateId);
+            _currentParent = null;
             return toReturn;
         }
 
         protected virtual View GetView(int position, View convertView, ViewGroup parent, int templateId)
         {
-            if (this._itemsSource == null)
+            if (_itemsSource == null)
             {
                 MvxBindingTrace.Trace(MvxTraceLevel.Error, "GetView called when ItemsSource is null");
                 return null;
             }
 
-            var source = this.GetRawItem(position);
+            var source = GetRawItem(position);
 
-            return this.GetBindableView(convertView, source, templateId);
+            return GetBindableView(convertView, source, templateId);
         }
 
         protected virtual View GetSimpleView(View convertView, object dataContext)
         {
             if (convertView == null)
             {
-                convertView = this.CreateSimpleView(dataContext);
+                convertView = CreateSimpleView(dataContext);
             }
             else
             {
-                this.BindSimpleView(convertView, dataContext);
+                BindSimpleView(convertView, dataContext);
             }
 
             return convertView;
@@ -258,14 +256,14 @@ namespace MvvmCross.Binding.Droid.Views
             // note - this could technically be a non-binding inflate - but the overhead is minimal
             // note - it's important to use `false` for the attachToRoot argument here
             //    see discussion in https://github.com/MvvmCross/MvvmCross/issues/507
-            var view = this._bindingContext.BindingInflate(this._currentSimpleId, this._currentParent, false);
-            this.BindSimpleView(view, dataContext);
+            var view = BindingContext.BindingInflate(_currentSimpleId, _currentParent, false);
+            BindSimpleView(view, dataContext);
             return view;
         }
 
         protected virtual View GetBindableView(View convertView, object dataContext)
         {
-            return this.GetBindableView(convertView, dataContext, this.ItemTemplateId);
+            return GetBindableView(convertView, dataContext, ItemTemplateId);
         }
 
         protected virtual View GetBindableView(View convertView, object dataContext, int templateId)
@@ -273,7 +271,7 @@ namespace MvvmCross.Binding.Droid.Views
             if (templateId == 0)
             {
                 // no template seen - so use a standard string view from Android and use ToString()
-                return this.GetSimpleView(convertView, dataContext);
+                return GetSimpleView(convertView, dataContext);
             }
 
             // we have a templateid so lets use bind and inflate on it :)
@@ -288,11 +286,11 @@ namespace MvvmCross.Binding.Droid.Views
 
             if (viewToUse == null)
             {
-                viewToUse = this.CreateBindableView(dataContext, templateId);
+                viewToUse = CreateBindableView(dataContext, templateId);
             }
             else
             {
-                this.BindBindableView(dataContext, viewToUse);
+                BindBindableView(dataContext, viewToUse);
             }
 
             return viewToUse as View;
@@ -305,11 +303,11 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected virtual IMvxListItemView CreateBindableView(object dataContext, int templateId)
         {
-            return new MvxListItemView(this._context, this._bindingContext.LayoutInflaterHolder, dataContext, templateId);
+            return new MvxListItemView(Context, BindingContext.LayoutInflaterHolder, dataContext, templateId);
         }
     }
 
-	public class MvxAdapter<TItem> : MvxAdapter, IMvxAdapter where TItem : class
+	public class MvxAdapter<TItem> : MvxAdapter where TItem : class
 	{
 		public MvxAdapter(Context context) : base(context, MvxAndroidBindingContextHelpers.Current())
 		{
@@ -323,7 +321,8 @@ namespace MvvmCross.Binding.Droid.Views
 		{
 		}
 
-		public new IEnumerable<TItem> ItemsSource
+        [MvxSetToNullAfterBinding]
+        public new IEnumerable<TItem> ItemsSource
 		{
 			get
 			{

--- a/MvvmCross/Binding/Droid/Views/MvxAutoCompleteTextView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxAutoCompleteTextView.cs
@@ -25,8 +25,8 @@ namespace MvvmCross.Binding.Droid.Views
             : this(context, attrs, new MvxFilteringAdapter(context))
         {
             // note - we shouldn't realy need both of these... but we do
-            this.ItemClick += this.OnItemClick;
-            this.ItemSelected += this.OnItemSelected;
+            ItemClick += OnItemClick;
+            ItemSelected += OnItemSelected;
         }
 
         public MvxAutoCompleteTextView(Context context, IAttributeSet attrs,
@@ -35,8 +35,8 @@ namespace MvvmCross.Binding.Droid.Views
         {
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             adapter.ItemTemplateId = itemTemplateId;
-            this.Adapter = adapter;
-            this.ItemClick += this.OnItemClick;
+            Adapter = adapter;
+            ItemClick += OnItemClick;
         }
 
         protected MvxAutoCompleteTextView(IntPtr javaReference, JniHandleOwnership transfer)
@@ -46,24 +46,24 @@ namespace MvvmCross.Binding.Droid.Views
 
         private void OnItemClick(object sender, AdapterView.ItemClickEventArgs itemClickEventArgs)
         {
-            this.OnItemClick(itemClickEventArgs.Position);
+            OnItemClick(itemClickEventArgs.Position);
         }
 
         private void OnItemSelected(object sender, AdapterView.ItemSelectedEventArgs itemSelectedEventArgs)
         {
-            this.OnItemSelected(itemSelectedEventArgs.Position);
+            OnItemSelected(itemSelectedEventArgs.Position);
         }
 
         protected virtual void OnItemClick(int position)
         {
-            var selectedObject = this.Adapter.GetRawItem(position);
-            this.SelectedObject = selectedObject;
+            var selectedObject = Adapter.GetRawItem(position);
+            SelectedObject = selectedObject;
         }
 
         protected virtual void OnItemSelected(int position)
         {
-            var selectedObject = this.Adapter.GetRawItem(position);
-            this.SelectedObject = selectedObject;
+            var selectedObject = Adapter.GetRawItem(position);
+            SelectedObject = selectedObject;
         }
 
         public new MvxFilteringAdapter Adapter
@@ -71,12 +71,12 @@ namespace MvvmCross.Binding.Droid.Views
             get { return base.Adapter as MvxFilteringAdapter; }
             set
             {
-                var existing = this.Adapter;
+                var existing = Adapter;
                 if (existing == value)
                     return;
 
                 if (existing != null)
-                    existing.PartialTextChanged -= this.AdapterOnPartialTextChanged;
+                    existing.PartialTextChanged -= AdapterOnPartialTextChanged;
 
                 if (existing != null && value != null)
                 {
@@ -85,7 +85,7 @@ namespace MvvmCross.Binding.Droid.Views
                 }
 
                 if (value != null)
-                    value.PartialTextChanged += this.AdapterOnPartialTextChanged;
+                    value.PartialTextChanged += AdapterOnPartialTextChanged;
 
                 base.Adapter = value;
             }
@@ -93,36 +93,36 @@ namespace MvvmCross.Binding.Droid.Views
 
         private void AdapterOnPartialTextChanged(object sender, EventArgs eventArgs)
         {
-            this.FireChanged(this.PartialTextChanged);
+            FireChanged(PartialTextChanged);
         }
 
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
         }
 
-        public string PartialText => this.Adapter.PartialText;
+        public string PartialText => Adapter.PartialText;
 
         private object _selectedObject;
 
         public object SelectedObject
         {
-            get { return this._selectedObject; }
+            get { return _selectedObject; }
             private set
             {
-                if (this._selectedObject == value)
+                if (_selectedObject == value)
                     return;
 
-                this._selectedObject = value;
-                this.FireChanged(this.SelectedObjectChanged);
+                _selectedObject = value;
+                FireChanged(SelectedObjectChanged);
             }
         }
 
@@ -134,6 +134,22 @@ namespace MvvmCross.Binding.Droid.Views
         {
             var handler = eventHandler;
             handler?.Invoke(this, EventArgs.Empty);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                ItemClick -= OnItemClick;
+                ItemSelected -= OnItemSelected;
+
+                if (Adapter != null)
+                {
+                    Adapter.PartialTextChanged -= AdapterOnPartialTextChanged;
+                }
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxExpandableListView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxExpandableListView.cs
@@ -14,6 +14,15 @@ namespace MvvmCross.Binding.Droid.Views
     [Register("mvvmcross.binding.droid.views.MvxExpandableListView")]
     public class MvxExpandableListView : ExpandableListView
     {
+        private bool _groupClickOverloaded;
+        private bool _itemClickOverloaded;
+        private bool _itemLongClickOverloaded;
+
+        private ICommand _itemClick;
+        private ICommand _itemLongClick;
+        private ICommand _groupClick;
+        private ICommand _groupLongClick;
+
         public MvxExpandableListView(Context context, IAttributeSet attrs)
             : this(context, attrs, new MvxExpandableListAdapter(context))
         { }
@@ -27,7 +36,7 @@ namespace MvvmCross.Binding.Droid.Views
             var groupTemplateId = MvxAttributeHelpers.ReadGroupItemTemplateId(context, attrs);
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
 
-            this.SetAdapter(adapter);
+            SetAdapter(adapter);
 
             adapter.GroupTemplateId = groupTemplateId;
             adapter.ItemTemplateId = itemTemplateId;
@@ -39,122 +48,118 @@ namespace MvvmCross.Binding.Droid.Views
         }
 
         // An expandableListView has ExpandableListAdapter as propertyname, but Adapter still exists but is always null.
-        protected MvxExpandableListAdapter ThisAdapter => this.ExpandableListAdapter as MvxExpandableListAdapter;
+        protected MvxExpandableListAdapter ThisAdapter => ExpandableListAdapter as MvxExpandableListAdapter;
 
         [MvxSetToNullAfterBinding]
         public virtual IEnumerable ItemsSource
         {
-            get { return this.ThisAdapter.ItemsSource; }
-            set { this.ThisAdapter.ItemsSource = value; }
+            get { return ThisAdapter.ItemsSource; }
+            set { ThisAdapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.ThisAdapter.ItemTemplateId; }
-            set { this.ThisAdapter.ItemTemplateId = value; }
+            get { return ThisAdapter.ItemTemplateId; }
+            set { ThisAdapter.ItemTemplateId = value; }
         }
 
         public int GroupTemplateId
         {
-            get { return this.ThisAdapter.GroupTemplateId; }
-            set { this.ThisAdapter.GroupTemplateId = value; }
+            get { return ThisAdapter.GroupTemplateId; }
+            set { ThisAdapter.GroupTemplateId = value; }
         }
-
-        private ICommand _itemClick;
 
         public new ICommand ItemClick
         {
-            get { return this._itemClick; }
+            get { return _itemClick; }
             set
             {
-                this._itemClick = value;
-                if (this._itemClick != null) this.EnsureItemClickOverloaded();
+                _itemClick = value;
+                if (_itemClick != null) EnsureItemClickOverloaded();
             }
         }
-
-        private ICommand _itemLongClick;
 
         public new ICommand ItemLongClick
         {
-            get { return this._itemLongClick; }
+            get { return _itemLongClick; }
             set
             {
-                this._itemLongClick = value;
-                if (this._itemLongClick != null) this.EnsureItemLongClickOverloaded();
+                _itemLongClick = value;
+                if (_itemLongClick != null) EnsureItemLongClickOverloaded();
             }
         }
-
-        private ICommand _groupClick;
 
         public new ICommand GroupClick
         {
-            get { return this._groupClick; }
+            get { return _groupClick; }
             set
             {
-                this._groupClick = value;
-                if (this._groupClick != null) this.EnsureGroupClickOverloaded();
+                _groupClick = value;
+                if (_groupClick != null) EnsureGroupClickOverloaded();
             }
         }
 
-        private ICommand _groupLongClick;
-
-        public new ICommand GroupLongClick
+        public ICommand GroupLongClick
         {
-            get { return this._groupLongClick; }
+            get { return _groupLongClick; }
             set
             {
-                this._groupLongClick = value;
-                if (this._groupLongClick != null) this.EnsureItemLongClickOverloaded();
+                _groupLongClick = value;
+                if (_groupLongClick != null) EnsureItemLongClickOverloaded();
             }
         }
-
-        private bool _itemClickOverloaded = false;
 
         private void EnsureItemClickOverloaded()
         {
-            if (this._itemClickOverloaded)
+            if (_itemClickOverloaded)
                 return;
 
-            this._itemClickOverloaded = true;
-            base.ChildClick +=
-                (sender, args) => this.ExecuteCommandOnItem(this.ItemClick, args.GroupPosition, args.ChildPosition);
+            _itemClickOverloaded = true;
+            ChildClick += ChildOnClick;
         }
 
-        private bool _groupClickOverloaded = false;
+        private void ChildOnClick(object sender, ChildClickEventArgs e)
+        {
+            ExecuteCommandOnItem(ItemClick, e.GroupPosition, e.ChildPosition);
+        }
 
         private void EnsureGroupClickOverloaded()
         {
-            if (this._groupClickOverloaded)
+            if (_groupClickOverloaded)
                 return;
 
-            this._groupClickOverloaded = true;
-            base.GroupClick +=
-                (sender, args) => this.ExecuteCommandOnGroup(this.GroupClick, args.GroupPosition);
+            _groupClickOverloaded = true;
+            base.GroupClick += GroupOnClick;
         }
 
-        private bool _itemLongClickOverloaded;
+        private void GroupOnClick(object sender, GroupClickEventArgs e)
+        {
+           ExecuteCommandOnGroup(GroupClick, e.GroupPosition);
+        }
 
         private void EnsureItemLongClickOverloaded()
         {
-            if (this._itemLongClickOverloaded)
+            if (_itemLongClickOverloaded)
                 return;
-            this._itemLongClickOverloaded = true;
-            base.ItemLongClick += (sender, args) =>
-            {
-                var type = GetPackedPositionType(args.Id);
-                long packedPos = ((ExpandableListView)args.Parent).GetExpandableListPosition(args.Position);
-                int groupPosition = GetPackedPositionGroup(packedPos);
-                int childPosition = GetPackedPositionChild(packedPos);
+            _itemLongClickOverloaded = true;
+            base.ItemLongClick += ItemOnLongClick;
+        }
 
-                if (type == PackedPositionType.Child)
-                {
-                    this.ExecuteCommandOnItem(this.ItemLongClick, groupPosition, childPosition);
-                }
-                else if (type == PackedPositionType.Group)
-                {
-                    this.ExecuteCommandOnGroup(this.GroupLongClick, groupPosition);
-                }
-            };
+        private void ItemOnLongClick(object sender, ItemLongClickEventArgs e)
+        {
+            var type = GetPackedPositionType(e.Id);
+            long packedPos = ((ExpandableListView)e.Parent).GetExpandableListPosition(e.Position);
+            int groupPosition = GetPackedPositionGroup(packedPos);
+            int childPosition = GetPackedPositionChild(packedPos);
+
+            if (type == PackedPositionType.Child)
+            {
+                ExecuteCommandOnItem(ItemLongClick, groupPosition, childPosition);
+            }
+            else if (type == PackedPositionType.Group)
+            {
+                ExecuteCommandOnGroup(GroupLongClick, groupPosition);
+            }
         }
 
         protected virtual void ExecuteCommandOnItem(ICommand command, int groupPosition, int position)
@@ -162,7 +167,7 @@ namespace MvvmCross.Binding.Droid.Views
             if (command == null)
                 return;
 
-            var item = this.ThisAdapter.GetRawItem(groupPosition, position);
+            var item = ThisAdapter.GetRawItem(groupPosition, position);
             if (item == null)
                 return;
 
@@ -177,7 +182,7 @@ namespace MvvmCross.Binding.Droid.Views
             if (command == null)
                 return;
 
-            var item = this.ThisAdapter.GetRawGroup(groupPosition);
+            var item = ThisAdapter.GetRawGroup(groupPosition);
             if (item == null)
                 return;
 
@@ -185,6 +190,18 @@ namespace MvvmCross.Binding.Droid.Views
                 return;
 
             command.Execute(item);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                base.GroupClick -= GroupOnClick;
+                ChildClick -= ChildOnClick;
+                base.ItemLongClick -= ItemOnLongClick;
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
@@ -115,7 +115,7 @@ namespace MvvmCross.Binding.Droid.Views
             if (disposing)
             {
                 if (_adapter != null)
-                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
+                    _adapter.DataSetChanged -= AdapterOnDataSetChanged;
 
                 ChildViewRemoved -= OnChildViewRemoved;
             }

--- a/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
@@ -35,10 +35,10 @@ namespace MvvmCross.Binding.Droid.Views
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             if (adapter != null)
             {
-                this.Adapter = adapter;
-                this.Adapter.ItemTemplateId = itemTemplateId;
+                Adapter = adapter;
+                Adapter.ItemTemplateId = itemTemplateId;
             }
-            this.ChildViewRemoved += this.OnChildViewRemoved;
+            ChildViewRemoved += OnChildViewRemoved;
         }
 
         protected MvxFrameLayout(IntPtr javaReference, JniHandleOwnership transfer)
@@ -61,10 +61,10 @@ namespace MvvmCross.Binding.Droid.Views
 
         public IMvxAdapterWithChangedEvent Adapter
         {
-            get { return this._adapter; }
+            get { return _adapter; }
             protected set
             {
-                var existing = this._adapter;
+                var existing = _adapter;
                 if (existing == value)
                 {
                     return;
@@ -72,7 +72,7 @@ namespace MvvmCross.Binding.Droid.Views
 
                 if (existing != null)
                 {
-                    existing.DataSetChanged -= this.AdapterOnDataSetChanged;
+                    existing.DataSetChanged -= AdapterOnDataSetChanged;
                     if (value != null)
                     {
                         value.ItemsSource = existing.ItemsSource;
@@ -80,14 +80,14 @@ namespace MvvmCross.Binding.Droid.Views
                     }
                 }
 
-                this._adapter = value;
+                _adapter = value;
 
-                if (this._adapter != null)
+                if (_adapter != null)
                 {
-                    this._adapter.DataSetChanged += this.AdapterOnDataSetChanged;
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
 
-                if (this._adapter == null)
+                if (_adapter == null)
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you amy lose ItemsSource binding when doing this");
@@ -98,14 +98,27 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (_adapter != null)
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
+
+                ChildViewRemoved -= OnChildViewRemoved;
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxGridView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxGridView.cs
@@ -22,6 +22,12 @@ namespace MvvmCross.Binding.Droid.Views
     public class MvxGridView
         : GridView
     {
+        private ICommand _itemClick;
+        private ICommand _itemLongClick;
+
+        private bool _itemClickOverloaded;
+        private bool _itemLongClickOverloaded;
+
         public MvxGridView(Context context, IAttributeSet attrs)
             : this(context, attrs, new MvxAdapter(context))
         {
@@ -37,7 +43,7 @@ namespace MvvmCross.Binding.Droid.Views
 
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             adapter.ItemTemplateId = itemTemplateId;
-            this.Adapter = adapter;
+            Adapter = adapter;
         }
 
         protected MvxGridView(IntPtr javaReference, JniHandleOwnership transfer)
@@ -50,7 +56,7 @@ namespace MvvmCross.Binding.Droid.Views
             get { return base.Adapter as IMvxAdapter; }
             set
             {
-                var existing = this.Adapter;
+                var existing = Adapter;
                 if (existing == value)
                     return;
 
@@ -71,52 +77,64 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
         }
-
-        private ICommand _itemClick;
 
         public new ICommand ItemClick
         {
-            get { return this._itemClick; }
-            set { this._itemClick = value; if (this._itemClick != null) this.EnsureItemClickOverloaded(); }
+            get { return _itemClick; }
+            set
+            {
+                _itemClick = value;
+                if (_itemClick != null)
+                    EnsureItemClickOverloaded();
+            }
         }
-
-        private bool _itemClickOverloaded = false;
 
         private void EnsureItemClickOverloaded()
         {
-            if (this._itemClickOverloaded)
+            if (_itemClickOverloaded)
                 return;
 
-            this._itemClickOverloaded = true;
-            base.ItemClick += (sender, args) => this.ExecuteCommandOnItem(this.ItemClick, args.Position);
+            _itemClickOverloaded = true;
+            base.ItemClick += ItemOnClick;
         }
 
-        private ICommand _itemLongClick;
+        private void ItemOnClick(object sender, ItemClickEventArgs e)
+        {
+            ExecuteCommandOnItem(ItemClick, e.Position);
+        }
 
         public new ICommand ItemLongClick
         {
-            get { return this._itemLongClick; }
-            set { this._itemLongClick = value; if (this._itemLongClick != null) this.EnsureItemLongClickOverloaded(); }
+            get { return _itemLongClick; }
+            set
+            {
+                _itemLongClick = value;
+                if (_itemLongClick != null)
+                    EnsureItemLongClickOverloaded(); 
+            }
         }
-
-        private bool _itemLongClickOverloaded = false;
 
         private void EnsureItemLongClickOverloaded()
         {
-            if (this._itemLongClickOverloaded)
+            if (_itemLongClickOverloaded)
                 return;
 
-            this._itemLongClickOverloaded = true;
-            base.ItemLongClick += (sender, args) => this.ExecuteCommandOnItem(this.ItemLongClick, args.Position);
+            _itemLongClickOverloaded = true;
+            base.ItemLongClick += ItemOnLongClick;
+        }
+
+        private void ItemOnLongClick(object sender, ItemLongClickEventArgs e)
+        {
+            ExecuteCommandOnItem(ItemLongClick, e.Position);
         }
 
         protected virtual void ExecuteCommandOnItem(ICommand command, int position)
@@ -124,7 +142,7 @@ namespace MvvmCross.Binding.Droid.Views
             if (command == null)
                 return;
 
-            var item = this.Adapter.GetRawItem(position);
+            var item = Adapter.GetRawItem(position);
             if (item == null)
                 return;
 
@@ -132,6 +150,17 @@ namespace MvvmCross.Binding.Droid.Views
                 return;
 
             command.Execute(item);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                base.ItemClick -= ItemOnClick;
+                base.ItemLongClick -= ItemOnLongClick;
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxImageView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxImageView.cs
@@ -31,40 +31,40 @@ namespace MvvmCross.Binding.Droid.Views
         {
             get
             {
-                return this.ImageHelper?.ImageUrl;
+                return ImageHelper?.ImageUrl;
             }
             set
             {
-                if (this.ImageHelper == null)
+                if (ImageHelper == null)
                     return;
-                this.ImageHelper.ImageUrl = value;
+                ImageHelper.ImageUrl = value;
             }
         }
 
         public string DefaultImagePath
         {
-            get { return this.ImageHelper.DefaultImagePath; }
-            set { this.ImageHelper.DefaultImagePath = value; }
+            get { return ImageHelper.DefaultImagePath; }
+            set { ImageHelper.DefaultImagePath = value; }
         }
 
         public string ErrorImagePath
         {
-            get { return this.ImageHelper.ErrorImagePath; }
-            set { this.ImageHelper.ErrorImagePath = value; }
+            get { return ImageHelper.ErrorImagePath; }
+            set { ImageHelper.ErrorImagePath = value; }
         }
 
         public override void SetMaxHeight(int maxHeight)
         {
-            if (this.ImageHelper != null)
-                this.ImageHelper.MaxHeight = maxHeight;
+            if (ImageHelper != null)
+                ImageHelper.MaxHeight = maxHeight;
 
             base.SetMaxHeight(maxHeight);
         }
 
         public override void SetMaxWidth(int maxWidth)
         {
-            if (this.ImageHelper != null)
-                this.ImageHelper.MaxWidth = maxWidth;
+            if (ImageHelper != null)
+                ImageHelper.MaxWidth = maxWidth;
 
             base.SetMaxWidth(maxWidth);
         }
@@ -73,19 +73,19 @@ namespace MvvmCross.Binding.Droid.Views
         {
             get
             {
-                if (this._imageHelper == null)
+                if (_imageHelper == null)
                 {
-                    if (!Mvx.TryResolve(out this._imageHelper))
+                    if (!Mvx.TryResolve(out _imageHelper))
                     {
                         MvxTrace.Error(
                             "No IMvxImageHelper registered - you must provide an image helper before you can use a MvxImageView");
                     }
                     else
                     {
-                        this._imageHelper.ImageChanged += this.ImageHelperOnImageChanged;
+                        _imageHelper.ImageChanged += ImageHelperOnImageChanged;
                     }
                 }
-                return this._imageHelper;
+                return _imageHelper;
             }
         }
 
@@ -111,7 +111,11 @@ namespace MvvmCross.Binding.Droid.Views
         {
             if (disposing)
             {
-                this._imageHelper?.Dispose();
+                if (_imageHelper != null)
+                {
+                    _imageHelper.ImageChanged -= ImageHelperOnImageChanged;
+                    _imageHelper?.Dispose();
+                }
             }
 
             base.Dispose(disposing);
@@ -122,7 +126,7 @@ namespace MvvmCross.Binding.Droid.Views
             using (var h = new Handler(Looper.MainLooper))
                 h.Post(() =>
                 {
-                    this.SetImageBitmap(mvxValueEventArgs.Value);
+                    SetImageBitmap(mvxValueEventArgs.Value);
                 });
         }
 
@@ -136,7 +140,7 @@ namespace MvvmCross.Binding.Droid.Views
                 int attributeId = typedArray.GetIndex(i);
                 if (attributeId == MvxAndroidBindingResource.Instance.SourceBindId)
                 {
-                    this.ImageUrl = typedArray.GetString(attributeId);
+                    ImageUrl = typedArray.GetString(attributeId);
                 }
             }
             typedArray.Recycle();

--- a/MvvmCross/Binding/Droid/Views/MvxLinearLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxLinearLayout.cs
@@ -35,10 +35,10 @@ namespace MvvmCross.Binding.Droid.Views
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             if (adapter != null)
             {
-                this.Adapter = adapter;
-                this.Adapter.ItemTemplateId = itemTemplateId;
+                Adapter = adapter;
+                Adapter.ItemTemplateId = itemTemplateId;
             }
-            this.ChildViewRemoved += this.OnChildViewRemoved;
+            ChildViewRemoved += OnChildViewRemoved;
         }
 
         protected MvxLinearLayout(IntPtr javaReference, JniHandleOwnership transfer)
@@ -61,10 +61,10 @@ namespace MvvmCross.Binding.Droid.Views
 
         public IMvxAdapterWithChangedEvent Adapter
         {
-            get { return this._adapter; }
+            get { return _adapter; }
             protected set
             {
-                var existing = this._adapter;
+                var existing = _adapter;
                 if (existing == value)
                 {
                     return;
@@ -72,7 +72,7 @@ namespace MvvmCross.Binding.Droid.Views
 
                 if (existing != null)
                 {
-                    existing.DataSetChanged -= this.AdapterOnDataSetChanged;
+                    existing.DataSetChanged -= AdapterOnDataSetChanged;
                     if (value != null)
                     {
                         value.ItemsSource = existing.ItemsSource;
@@ -80,14 +80,14 @@ namespace MvvmCross.Binding.Droid.Views
                     }
                 }
 
-                this._adapter = value;
+                _adapter = value;
 
-                if (this._adapter != null)
+                if (_adapter != null)
                 {
-                    this._adapter.DataSetChanged += this.AdapterOnDataSetChanged;
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
 
-                if (this._adapter == null)
+                if (_adapter == null)
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
@@ -98,14 +98,27 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (_adapter != null)
+                    _adapter.DataSetChanged -= AdapterOnDataSetChanged;
+
+                ChildViewRemoved -= OnChildViewRemoved;
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxListItemView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxListItemView.cs
@@ -17,16 +17,14 @@ namespace MvvmCross.Binding.Droid.Views
         : MvxBaseListItemView
           , IMvxListItemView
     {
-        private readonly int _templateId;
-
         public MvxListItemView(Context context,
                                IMvxLayoutInflaterHolder layoutInflaterHolder,
                                object dataContext,
                                int templateId)
             : base(context, layoutInflaterHolder, dataContext)
         {
-            this._templateId = templateId;
-            this.AndroidBindingContext.BindingInflate(templateId, this);
+            TemplateId = templateId;
+            AndroidBindingContext.BindingInflate(templateId, this);
         }
 
         protected MvxListItemView(IntPtr javaReference, JniHandleOwnership transfer)
@@ -34,6 +32,6 @@ namespace MvvmCross.Binding.Droid.Views
         {
         }
 
-        public int TemplateId => this._templateId;
+        public int TemplateId { get; }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxListView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxListView.cs
@@ -22,6 +22,12 @@ namespace MvvmCross.Binding.Droid.Views
     public class MvxListView
         : ListView
     {
+        private bool _itemClickOverloaded;
+        private bool _itemLongClickOverloaded;
+
+        private ICommand _itemClick;
+        private ICommand _itemLongClick;
+
         public MvxListView(Context context, IAttributeSet attrs)
             : this(context, attrs, new MvxAdapter(context))
         {
@@ -37,7 +43,7 @@ namespace MvvmCross.Binding.Droid.Views
 
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             adapter.ItemTemplateId = itemTemplateId;
-            this.Adapter = adapter;
+            Adapter = adapter;
         }
 
         protected MvxListView(IntPtr javaReference, JniHandleOwnership transfer)
@@ -50,7 +56,7 @@ namespace MvvmCross.Binding.Droid.Views
             get { return base.Adapter as IMvxAdapter; }
             set
             {
-                var existing = this.Adapter;
+                var existing = Adapter;
                 if (existing == value)
                     return;
 
@@ -71,52 +77,54 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
         }
-
-        private ICommand _itemClick;
 
         public new ICommand ItemClick
         {
-            get { return this._itemClick; }
-            set { this._itemClick = value; if (this._itemClick != null) this.EnsureItemClickOverloaded(); }
+            get { return _itemClick; }
+            set
+            {
+                _itemClick = value;
+                if (_itemClick != null)
+                    EnsureItemClickOverloaded(); 
+            }
         }
-
-        private bool _itemClickOverloaded = false;
 
         private void EnsureItemClickOverloaded()
         {
-            if (this._itemClickOverloaded)
+            if (_itemClickOverloaded)
                 return;
 
-            this._itemClickOverloaded = true;
-            base.ItemClick += (sender, args) => this.ExecuteCommandOnItem(this.ItemClick, args.Position);
+            _itemClickOverloaded = true;
+            base.ItemClick += OnItemClick;
         }
-
-        private ICommand _itemLongClick;
 
         public new ICommand ItemLongClick
         {
-            get { return this._itemLongClick; }
-            set { this._itemLongClick = value; if (this._itemLongClick != null) this.EnsureItemLongClickOverloaded(); }
+            get { return _itemLongClick; }
+            set
+            {
+                _itemLongClick = value;
+                if (_itemLongClick != null)
+                    EnsureItemLongClickOverloaded();
+            }
         }
-
-        private bool _itemLongClickOverloaded = false;
 
         private void EnsureItemLongClickOverloaded()
         {
-            if (this._itemLongClickOverloaded)
+            if (_itemLongClickOverloaded)
                 return;
 
-            this._itemLongClickOverloaded = true;
-            base.ItemLongClick += (sender, args) => this.ExecuteCommandOnItem(this.ItemLongClick, args.Position);
+            _itemLongClickOverloaded = true;
+            base.ItemLongClick += OnItemLongClick;
         }
 
         protected virtual void ExecuteCommandOnItem(ICommand command, int position)
@@ -124,7 +132,7 @@ namespace MvvmCross.Binding.Droid.Views
             if (command == null)
                 return;
 
-            var item = this.Adapter.GetRawItem(position);
+            var item = Adapter.GetRawItem(position);
             if (item == null)
                 return;
 
@@ -132,6 +140,27 @@ namespace MvvmCross.Binding.Droid.Views
                 return;
 
             command.Execute(item);
+        }
+
+        private void OnItemClick(object sender, ItemClickEventArgs e)
+        {
+            ExecuteCommandOnItem(ItemClick, e.Position);
+        }
+
+        private void OnItemLongClick(object sender, ItemLongClickEventArgs e)
+        {
+            ExecuteCommandOnItem(ItemLongClick, e.Position);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                base.ItemLongClick -= OnItemLongClick;
+                base.ItemClick -= OnItemClick;
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxRadioGroup.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxRadioGroup.cs
@@ -34,12 +34,12 @@ namespace MvvmCross.Binding.Droid.Views
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             if (adapter != null)
             {
-                this.Adapter = adapter;
-                this.Adapter.ItemTemplateId = itemTemplateId;
+                Adapter = adapter;
+                Adapter.ItemTemplateId = itemTemplateId;
             }
 
-            this.ChildViewAdded += this.OnChildViewAdded;
-            this.ChildViewRemoved += this.OnChildViewRemoved;
+            ChildViewAdded += OnChildViewAdded;
+            ChildViewRemoved += OnChildViewRemoved;
         }
 
         protected MvxRadioGroup(IntPtr javaReference, JniHandleOwnership transfer)
@@ -52,18 +52,18 @@ namespace MvvmCross.Binding.Droid.Views
             this.UpdateDataSetFromChange(sender, eventArgs);
         }
 
-        private void OnChildViewAdded(object sender, Android.Views.ViewGroup.ChildViewAddedEventArgs args)
+        private void OnChildViewAdded(object sender, ChildViewAddedEventArgs args)
         {
             var li = (args.Child as MvxListItemView);
             var radioButton = li?.GetChildAt(0) as RadioButton;
             if (radioButton != null)
             {
                 // radio buttons require an id so that they get un-checked correctly
-                if (radioButton.Id == Android.Views.View.NoId)
+                if (radioButton.Id == NoId)
                 {
                     radioButton.Id = GenerateViewId();
                 }
-                radioButton.CheckedChange += this.OnRadioButtonCheckedChange;
+                radioButton.CheckedChange += OnRadioButtonCheckedChange;
             }
         }
 
@@ -72,7 +72,7 @@ namespace MvvmCross.Binding.Droid.Views
             var radionButton = (sender as RadioButton);
             if (radionButton != null)
             {
-                this.Check(radionButton.Id);
+                Check(radionButton.Id);
             }
         }
 
@@ -86,10 +86,10 @@ namespace MvvmCross.Binding.Droid.Views
 
         public IMvxAdapterWithChangedEvent Adapter
         {
-            get { return this._adapter; }
+            get { return _adapter; }
             protected set
             {
-                var existing = this._adapter;
+                var existing = _adapter;
                 if (existing == value)
                 {
                     return;
@@ -97,7 +97,7 @@ namespace MvvmCross.Binding.Droid.Views
 
                 if (existing != null)
                 {
-                    existing.DataSetChanged -= this.AdapterOnDataSetChanged;
+                    existing.DataSetChanged -= AdapterOnDataSetChanged;
                     if (value != null)
                     {
                         value.ItemsSource = existing.ItemsSource;
@@ -105,14 +105,14 @@ namespace MvvmCross.Binding.Droid.Views
                     }
                 }
 
-                this._adapter = value;
+                _adapter = value;
 
-                if (this._adapter != null)
+                if (_adapter != null)
                 {
-                    this._adapter.DataSetChanged += this.AdapterOnDataSetChanged;
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
 
-                if (this._adapter == null)
+                if (_adapter == null)
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
@@ -123,14 +123,14 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
         }
 
         private static long _nextGeneratedViewId = 1;
@@ -152,6 +152,28 @@ namespace MvvmCross.Binding.Droid.Views
                 if (Interlocked.CompareExchange(ref _nextGeneratedViewId, newValue, result) == result)
                 {
                     return result;
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (_adapter != null)
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
+
+                ChildViewAdded -= OnChildViewAdded;
+                ChildViewRemoved -= OnChildViewRemoved;
+
+                var childCount = ChildCount;
+                for (var i = 0; i < childCount; i++)
+                {
+                    var child = GetChildAt(i) as RadioButton;
+                    if (child != null)
+                        child.CheckedChange -= OnRadioButtonCheckedChange;
                 }
             }
         }

--- a/MvvmCross/Binding/Droid/Views/MvxRelativeLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxRelativeLayout.cs
@@ -35,10 +35,10 @@ namespace MvvmCross.Binding.Droid.Views
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             if (adapter != null)
             {
-                this.Adapter = adapter;
-                this.Adapter.ItemTemplateId = itemTemplateId;
+                Adapter = adapter;
+                Adapter.ItemTemplateId = itemTemplateId;
             }
-            this.ChildViewRemoved += this.OnChildViewRemoved;
+            ChildViewRemoved += OnChildViewRemoved;
         }
 
         protected MvxRelativeLayout(IntPtr javaReference, JniHandleOwnership transfer)
@@ -61,10 +61,10 @@ namespace MvvmCross.Binding.Droid.Views
 
         public IMvxAdapterWithChangedEvent Adapter
         {
-            get { return this._adapter; }
+            get { return _adapter; }
             protected set
             {
-                var existing = this._adapter;
+                var existing = _adapter;
                 if (existing == value)
                 {
                     return;
@@ -72,7 +72,7 @@ namespace MvvmCross.Binding.Droid.Views
 
                 if (existing != null)
                 {
-                    existing.DataSetChanged -= this.AdapterOnDataSetChanged;
+                    existing.DataSetChanged -= AdapterOnDataSetChanged;
                     if (value != null)
                     {
                         value.ItemsSource = existing.ItemsSource;
@@ -80,14 +80,14 @@ namespace MvvmCross.Binding.Droid.Views
                     }
                 }
 
-                this._adapter = value;
+                _adapter = value;
 
-                if (this._adapter != null)
+                if (_adapter != null)
                 {
-                    this._adapter.DataSetChanged += this.AdapterOnDataSetChanged;
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
 
-                if (this._adapter == null)
+                if (_adapter == null)
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you amy lose ItemsSource binding when doing this");
@@ -98,14 +98,27 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                ChildViewRemoved -= OnChildViewRemoved;
+
+                if (_adapter != null)
+                    _adapter.DataSetChanged -= AdapterOnDataSetChanged;
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
@@ -114,7 +114,7 @@ namespace MvvmCross.Binding.Droid.Views
 
             if (disposing)
             {
-                ItemSelected += OnItemSelected;
+                ItemSelected -= OnItemSelected;
             }
         }
     }

--- a/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
@@ -38,8 +38,8 @@ namespace MvvmCross.Binding.Droid.Views
             var dropDownItemTemplateId = MvxAttributeHelpers.ReadDropDownListItemTemplateId(context, attrs);
             adapter.ItemTemplateId = itemTemplateId;
             adapter.DropDownItemTemplateId = dropDownItemTemplateId;
-            this.Adapter = adapter;
-            this.SetupHandleItemSelected();
+            Adapter = adapter;
+            ItemSelected += OnItemSelected;
         }
 
         protected MvxSpinner(IntPtr javaReference, JniHandleOwnership transfer)
@@ -52,7 +52,7 @@ namespace MvvmCross.Binding.Droid.Views
             get { return base.Adapter as IMvxAdapter; }
             set
             {
-                var existing = this.Adapter;
+                var existing = Adapter;
                 if (existing == value)
                     return;
 
@@ -73,42 +73,49 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
         }
 
         public int DropDownItemTemplateId
         {
-            get { return this.Adapter.DropDownItemTemplateId; }
-            set { this.Adapter.DropDownItemTemplateId = value; }
+            get { return Adapter.DropDownItemTemplateId; }
+            set { Adapter.DropDownItemTemplateId = value; }
         }
 
         public ICommand HandleItemSelected { get; set; }
 
-        private void SetupHandleItemSelected()
+        private void OnItemSelected(object sender, ItemSelectedEventArgs e)
         {
-            base.ItemSelected += (sender, args) =>
-                {
-                    var position = args.Position;
-                    this.HandleSelected(position);
-                };
+            var position = e.Position;
+            HandleSelected(position);
         }
 
         protected virtual void HandleSelected(int position)
         {
-            var item = this.Adapter.GetRawItem(position);
-            if (this.HandleItemSelected == null
+            var item = Adapter.GetRawItem(position);
+            if (HandleItemSelected == null
                 || item == null
-                || !this.HandleItemSelected.CanExecute(item))
+                || !HandleItemSelected.CanExecute(item))
                 return;
 
-            this.HandleItemSelected.Execute(item);
+            HandleItemSelected.Execute(item);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                ItemSelected += OnItemSelected;
+            }
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
@@ -115,9 +115,9 @@ namespace MvvmCross.Binding.Droid.Views
             if (disposing)
             {
                 if (_adapter != null)
-                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
+                    _adapter.DataSetChanged -= AdapterOnDataSetChanged;
 
-                ChildViewRemoved += OnChildViewRemoved;
+                ChildViewRemoved -= OnChildViewRemoved;
             }
         }
     }

--- a/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
@@ -35,10 +35,10 @@ namespace MvvmCross.Binding.Droid.Views
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             if (adapter != null)
             {
-                this.Adapter = adapter;
-                this.Adapter.ItemTemplateId = itemTemplateId;
+                Adapter = adapter;
+                Adapter.ItemTemplateId = itemTemplateId;
             }
-            this.ChildViewRemoved += this.OnChildViewRemoved;
+            ChildViewRemoved += OnChildViewRemoved;
         }
 
         protected MvxTableLayout(IntPtr javaReference, JniHandleOwnership transfer)
@@ -61,10 +61,10 @@ namespace MvvmCross.Binding.Droid.Views
 
         public IMvxAdapterWithChangedEvent Adapter
         {
-            get { return this._adapter; }
+            get { return _adapter; }
             protected set
             {
-                var existing = this._adapter;
+                var existing = _adapter;
                 if (existing == value)
                 {
                     return;
@@ -72,7 +72,7 @@ namespace MvvmCross.Binding.Droid.Views
 
                 if (existing != null)
                 {
-                    existing.DataSetChanged -= this.AdapterOnDataSetChanged;
+                    existing.DataSetChanged -= AdapterOnDataSetChanged;
                     if (value != null)
                     {
                         value.ItemsSource = existing.ItemsSource;
@@ -80,14 +80,14 @@ namespace MvvmCross.Binding.Droid.Views
                     }
                 }
 
-                this._adapter = value;
+                _adapter = value;
 
-                if (this._adapter != null)
+                if (_adapter != null)
                 {
-                    this._adapter.DataSetChanged += this.AdapterOnDataSetChanged;
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
 
-                if (this._adapter == null)
+                if (_adapter == null)
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you amy lose ItemsSource binding when doing this");
@@ -98,14 +98,27 @@ namespace MvvmCross.Binding.Droid.Views
         [MvxSetToNullAfterBinding]
         public IEnumerable ItemsSource
         {
-            get { return this.Adapter.ItemsSource; }
-            set { this.Adapter.ItemsSource = value; }
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
         }
 
         public int ItemTemplateId
         {
-            get { return this.Adapter.ItemTemplateId; }
-            set { this.Adapter.ItemTemplateId = value; }
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (_adapter != null)
+                    _adapter.DataSetChanged += AdapterOnDataSetChanged;
+
+                ChildViewRemoved += OnChildViewRemoved;
+            }
         }
     }
 }

--- a/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
@@ -5,6 +5,8 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
+
 namespace MvvmCross.Droid.Views
 {
     using System.Collections.Generic;
@@ -17,6 +19,7 @@ namespace MvvmCross.Droid.Views
     using MvvmCross.Core.ViewModels;
     using MvvmCross.Platform.Droid.Views;
 
+    [Obsolete("TabActivity is obsolete. Use ViewPager + Indicator or any other Activity with Toolbar support.")]
     public abstract class MvxTabActivity
         : MvxEventSourceTabActivity
           , IMvxAndroidView
@@ -71,6 +74,7 @@ namespace MvvmCross.Droid.Views
         }
     }
 
+    [Obsolete("TabActivity is obsolete. Use ViewPager + Indicator or any other Activity with Toolbar support.")]
     public class MvxTabActivity<TViewModel>
         : MvxTabActivity
         , IMvxAndroidView<TViewModel> where TViewModel : class, IMvxViewModel

--- a/MvvmCross/Platform/Droid/Views/MvxEventSourceTabActivity.cs
+++ b/MvvmCross/Platform/Droid/Views/MvxEventSourceTabActivity.cs
@@ -15,6 +15,7 @@ namespace MvvmCross.Platform.Droid.Views
 
     using MvvmCross.Platform.Core;
 
+    [Obsolete("TabActivity is obsolete. Use ViewPager + Indicator or any other Activity with Toolbar support.")]
     public abstract class MvxEventSourceTabActivity
         : TabActivity
           , IMvxEventSourceActivity

--- a/MvvmCross/Platform/Platform/Parse/MvxParser.cs
+++ b/MvvmCross/Platform/Platform/Parse/MvxParser.cs
@@ -206,8 +206,9 @@ namespace MvvmCross.Platform.Parse
 
         protected void SkipWhitespaceAndCharacters(IEnumerable<char> toSkip)
         {
+            var skipChars = toSkip.ToArray();
             while (!this.IsComplete
-                   && IsWhiteSpaceOrCharacter(this.CurrentChar, toSkip))
+                   && IsWhiteSpaceOrCharacter(this.CurrentChar, skipChars))
             {
                 this.MoveNext();
             }


### PR DESCRIPTION
Loads of views were subscribing events without unsubscribing. Let's be better citizens and actually do that to help minimizing memory issues.

This also marks TabActivity obsolete, as it has been obsolete in many API versions of Android.