### PR TITLE
Use drawable instead of resource, which is not UI thread bound

### DIFF
--- a/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
@@ -46,12 +46,12 @@ namespace MvvmCross.Binding.Droid.Target
                 imageView.SetImageDrawable(null);
             else
             {
-				var appContext = AndroidGlobals.ApplicationContext;
+                var context = imageView.Context;
 				Drawable drawable;
 				if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
-					drawable = appContext.Resources.GetDrawable(intValue, appContext.Theme);
+					drawable = context.Resources.GetDrawable(intValue, context.Theme);
 				else
-					drawable = appContext.Resources.GetDrawable(intValue);
+					drawable = context.Resources.GetDrawable(intValue);
 
 				if (drawable != null)
 					imageView.SetImageDrawable(drawable);

--- a/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
@@ -49,9 +49,9 @@ namespace MvvmCross.Binding.Droid.Target
                 var context = imageView.Context;
 				Drawable drawable;
 				if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
-					drawable = context.Resources.GetDrawable(intValue, context.Theme);
+					drawable = context?.Resources?.GetDrawable(intValue, context.Theme);
 				else
-					drawable = context.Resources.GetDrawable(intValue);
+					drawable = context?.Resources?.GetDrawable(intValue);
 
 				if (drawable != null)
 					imageView.SetImageDrawable(drawable);

--- a/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
@@ -48,7 +48,7 @@ namespace MvvmCross.Binding.Droid.Target
             {
 				var appContext = AndroidGlobals.ApplicationContext;
 				Drawable drawable;
-				if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
+				if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
 					drawable = appContext.Resources.GetDrawable(intValue, appContext.Theme);
 				else
 					drawable = appContext.Resources.GetDrawable(intValue);

--- a/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
@@ -7,13 +7,14 @@
 
 namespace MvvmCross.Binding.Droid.Target
 {
-    using System;
+	using System;
+	using Android.Graphics.Drawables;
+	using Android.Widget;
+	using Android.OS;
 
-    using Android.Widget;
+	using MvvmCross.Platform.Platform;
 
-    using MvvmCross.Platform.Platform;
-
-    public class MvxImageViewDrawableTargetBinding
+	public class MvxImageViewDrawableTargetBinding
         : MvxAndroidTargetBinding
     {
         protected ImageView ImageView => (ImageView)Target;
@@ -45,7 +46,15 @@ namespace MvvmCross.Binding.Droid.Target
                 imageView.SetImageDrawable(null);
             else
             {
-                imageView.SetImageResource(intValue);
+				var appContext = AndroidGlobals.ApplicationContext;
+				Drawable drawable;
+				if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
+					drawable = appContext.Resources.GetDrawable(intValue, appContext.Theme);
+				else
+					drawable = appContext.Resources.GetDrawable(intValue);
+
+				if (drawable != null)
+					imageView.SetImageDrawable(drawable);
             }
         }
     }


### PR DESCRIPTION
Improves #1307 not forcing images to be set on UI thread.