### PR TITLE
Dispose of the base after cleaning up the derived instance

### DIFF
--- a/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewPartialTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewPartialTextTargetBinding.cs
@@ -49,7 +49,6 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 var autoComplete = View;
@@ -59,6 +58,8 @@ namespace MvvmCross.Binding.Droid.Target
                     this._subscribed = false;
                 }
             }
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewSelectedObjectTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewSelectedObjectTargetBinding.cs
@@ -50,7 +50,6 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 var autoComplete = View;
@@ -60,6 +59,8 @@ namespace MvvmCross.Binding.Droid.Target
                     this._subscribed = false;
                 }
             }
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Target/MvxCompoundButtonCheckedTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxCompoundButtonCheckedTargetBinding.cs
@@ -47,7 +47,6 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 var compoundButton = View;
@@ -57,6 +56,8 @@ namespace MvvmCross.Binding.Droid.Target
                     this._subscribed = false;
                 }
             }
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewFocusTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewFocusTargetBinding.cs
@@ -54,14 +54,15 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
-            if (!isDisposing) return;
-
-            if (this.TextField != null && this._subscribed)
+            if (isDisposing)
             {
-                this.TextField.FocusChange -= this.HandleLostFocus;
-                this._subscribed = false;
+                if (this.TextField != null && this._subscribed)
+                {
+                    this.TextField.FocusChange -= this.HandleLostFocus;
+                    this._subscribed = false;
+                }
             }
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewTextFormattedTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewTextFormattedTargetBinding.cs
@@ -70,7 +70,6 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 if (this._isEditTextBinding)
@@ -83,6 +82,7 @@ namespace MvvmCross.Binding.Droid.Target
                     }
                 }
             }
+            base.Dispose(isDisposing);
         }
 
         public string CurrentText

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewTextTargetBinding.cs
@@ -70,7 +70,6 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 if (this._isEditTextBinding)
@@ -83,6 +82,7 @@ namespace MvvmCross.Binding.Droid.Target
                     }
                 }
             }
+            base.Dispose(isDisposing);
         }
 
         public string CurrentText

--- a/MvvmCross/Binding/Droid/Views/MvxAutoCompleteTextView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxAutoCompleteTextView.cs
@@ -138,8 +138,6 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 ItemClick -= OnItemClick;
@@ -150,6 +148,7 @@ namespace MvvmCross.Binding.Droid.Views
                     Adapter.PartialTextChanged -= AdapterOnPartialTextChanged;
                 }
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxExpandableListView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxExpandableListView.cs
@@ -194,14 +194,13 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 base.GroupClick -= GroupOnClick;
                 ChildClick -= ChildOnClick;
                 base.ItemLongClick -= ItemOnLongClick;
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
@@ -110,8 +110,6 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 if (_adapter != null)
@@ -119,6 +117,8 @@ namespace MvvmCross.Binding.Droid.Views
 
                 ChildViewRemoved -= OnChildViewRemoved;
             }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxGridView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxGridView.cs
@@ -154,13 +154,13 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 base.ItemClick -= ItemOnClick;
                 base.ItemLongClick -= ItemOnLongClick;
             }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxLinearLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxLinearLayout.cs
@@ -110,8 +110,6 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 if (_adapter != null)
@@ -119,6 +117,8 @@ namespace MvvmCross.Binding.Droid.Views
 
                 ChildViewRemoved -= OnChildViewRemoved;
             }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxListView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxListView.cs
@@ -154,13 +154,12 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 base.ItemLongClick -= OnItemLongClick;
                 base.ItemClick -= OnItemClick;
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxRadioGroup.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxRadioGroup.cs
@@ -158,8 +158,6 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 if (_adapter != null)
@@ -176,6 +174,8 @@ namespace MvvmCross.Binding.Droid.Views
                         child.CheckedChange -= OnRadioButtonCheckedChange;
                 }
             }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxRelativeLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxRelativeLayout.cs
@@ -110,8 +110,6 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 ChildViewRemoved -= OnChildViewRemoved;
@@ -119,6 +117,7 @@ namespace MvvmCross.Binding.Droid.Views
                 if (_adapter != null)
                     _adapter.DataSetChanged -= AdapterOnDataSetChanged;
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
@@ -110,12 +110,11 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 ItemSelected -= OnItemSelected;
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
@@ -110,8 +110,6 @@ namespace MvvmCross.Binding.Droid.Views
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 if (_adapter != null)
@@ -119,6 +117,7 @@ namespace MvvmCross.Binding.Droid.Views
 
                 ChildViewRemoved -= OnChildViewRemoved;
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxEventHandlerEventInfoTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxEventHandlerEventInfoTargetBinding.cs
@@ -44,7 +44,6 @@ namespace MvvmCross.Binding.Bindings.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 var target = this.Target;
@@ -54,6 +53,8 @@ namespace MvvmCross.Binding.Bindings.Target
                     removeMethod.Invoke(target, new[] { this._eventHandler });
                 }
             }
+
+            base.Dispose(isDisposing);
         }
 
         private void HandleEvent(object sender, EventArgs args)

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxEventInfoTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxEventInfoTargetBinding.cs
@@ -39,7 +39,6 @@ namespace MvvmCross.Binding.Bindings.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 var target = this.Target;
@@ -48,6 +47,8 @@ namespace MvvmCross.Binding.Bindings.Target
                     this._targetEventInfo.GetRemoveMethod().Invoke(target, new object[] { new EventHandler<T>(this.HandleEvent) });
                 }
             }
+
+            base.Dispose(isDisposing);
         }
 
         private void HandleEvent(object sender, T args)

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxWithEventPropertyInfoTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxWithEventPropertyInfoTargetBinding.cs
@@ -77,7 +77,6 @@ namespace MvvmCross.Binding.Bindings.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 if (this._subscription != null)
@@ -86,6 +85,8 @@ namespace MvvmCross.Binding.Bindings.Target
                     this._subscription = null;
                 }
             }
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/MvvmCross/Dialog/Droid/Target/MvxElementValueTargetBinding.cs
+++ b/MvvmCross/Dialog/Droid/Target/MvxElementValueTargetBinding.cs
@@ -42,7 +42,6 @@ namespace MvvmCross.Dialog.Droid.Target
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             if (isDisposing)
             {
                 var editText = this.View;
@@ -51,6 +50,7 @@ namespace MvvmCross.Dialog.Droid.Target
                     editText.ValueChanged -= this.ElementOnValueChanged;
                 }
             }
+            base.Dispose(isDisposing);
         }
     }
 }


### PR DESCRIPTION
I had assumed that Disposing of a C# object with a corresponding Java peer
would sever the connection between the C# GC and the Android GC in the base
Dispose(bool) method.  Luckily I'm wrong and this actually happens in
Java.Lang.Object.Dispose() after we run through all of the Dispose(bool)
calls.

Still I think it's a good idea for an object to clean itself up before its
base gets a crack at it: constructors always start from the base and work
their way up while destructors should tear down.