### PR TITLE
Adapter tweaks

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxAutoCompleteTextView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxAutoCompleteTextView.cs
@@ -88,6 +88,9 @@ namespace MvvmCross.Binding.Droid.Views
                     value.PartialTextChanged += AdapterOnPartialTextChanged;
 
                 base.Adapter = value;
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFrameLayout.cs
@@ -86,12 +86,14 @@ namespace MvvmCross.Binding.Droid.Views
                 {
                     _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
-
-                if (_adapter == null)
+                else
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxGridView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxGridView.cs
@@ -65,12 +65,11 @@ namespace MvvmCross.Binding.Droid.Views
                     value.ItemsSource = existing.ItemsSource;
                     value.ItemTemplateId = existing.ItemTemplateId;
                 }
-                if (existing != null)
-                {
-                    existing.ItemsSource = null;
-                }
 
                 base.Adapter = value;
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxLinearLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxLinearLayout.cs
@@ -86,12 +86,14 @@ namespace MvvmCross.Binding.Droid.Views
                 {
                     _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
-
-                if (_adapter == null)
+                else
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxListView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxListView.cs
@@ -65,12 +65,11 @@ namespace MvvmCross.Binding.Droid.Views
                     value.ItemsSource = existing.ItemsSource;
                     value.ItemTemplateId = existing.ItemTemplateId;
                 }
-                if (existing != null)
-                {
-                    existing.ItemsSource = null;
-                }
                 
                 base.Adapter = value;
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxRadioGroup.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxRadioGroup.cs
@@ -111,12 +111,14 @@ namespace MvvmCross.Binding.Droid.Views
                 {
                     _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
-
-                if (_adapter == null)
+                else
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxRelativeLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxRelativeLayout.cs
@@ -86,12 +86,14 @@ namespace MvvmCross.Binding.Droid.Views
                 {
                     _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
-
-                if (_adapter == null)
+                else
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
@@ -62,12 +62,11 @@ namespace MvvmCross.Binding.Droid.Views
                     value.ItemTemplateId = existing.ItemTemplateId;
                     value.DropDownItemTemplateId = existing.DropDownItemTemplateId;
                 }
-                if (existing != null)
-                {
-                    existing.ItemsSource = null;
-                }
 
                 base.Adapter = value;
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 

--- a/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxSpinner.cs
@@ -60,6 +60,7 @@ namespace MvvmCross.Binding.Droid.Views
                 {
                     value.ItemsSource = existing.ItemsSource;
                     value.ItemTemplateId = existing.ItemTemplateId;
+                    value.DropDownItemTemplateId = existing.DropDownItemTemplateId;
                 }
                 if (existing != null)
                 {

--- a/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxTableLayout.cs
@@ -86,12 +86,14 @@ namespace MvvmCross.Binding.Droid.Views
                 {
                     _adapter.DataSetChanged += AdapterOnDataSetChanged;
                 }
-
-                if (_adapter == null)
+                else
                 {
                     MvxBindingTrace.Warning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
+
+                if (existing != null)
+                    existing.ItemsSource = null;
             }
         }
 


### PR DESCRIPTION
MvxSpinner should use the new adapter's DropDownItemTemplateId.  Unassigns old adapter ItemsSource so we don't get multiple change events.