### PR TITLE
revert changes in MvxCollectionViewSource

### DIFF
--- a/MvvmCross/Binding/iOS/Views/MvxCollectionViewSource.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxCollectionViewSource.cs
@@ -92,55 +92,7 @@ namespace MvvmCross.Binding.iOS.Views
 
         protected virtual void CollectionChangedOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
-            if (args.Action == NotifyCollectionChangedAction.Remove)
-            {
-                CollectionView.PerformBatchUpdates(() => 
-                {
-                    var startIndex = args.OldStartingIndex;
-                    var indexes = new NSIndexPath[args.OldItems.Count];
-                    for(var i=0; i<indexes.Length; i++)
-                        indexes[i] = NSIndexPath.FromRowSection(startIndex+i, 0);
-                    CollectionView.DeleteItems(indexes);
-                }, ok => { });
-            }
-            else if (args.Action == NotifyCollectionChangedAction.Add)
-            {
-                CollectionView.PerformBatchUpdates(() =>
-                {
-                    var startIndex = args.NewStartingIndex;
-                    var indexes = new NSIndexPath[args.NewItems.Count];
-                    for (var i = 0; i < indexes.Length; i++)
-                        indexes[i] = NSIndexPath.FromRowSection(startIndex + i, 0);
-                    CollectionView.InsertItems(indexes);
-                }, ok => { });
-            }
-            else if (args.Action == NotifyCollectionChangedAction.Move)
-            {
-                CollectionView.PerformBatchUpdates(() =>
-                {
-                    var oldCount = args.OldItems.Count;
-                    var newCount = args.NewItems.Count;
-                    var indexes = new NSIndexPath[oldCount + newCount];
-
-                    var startIndex = args.OldStartingIndex;
-                    for (var i = 0; i < oldCount; i++)
-                        indexes[i] = NSIndexPath.FromRowSection(startIndex + i, 0);
-                    startIndex = args.NewStartingIndex;
-                    for (var i = oldCount; i < oldCount + newCount; i++)
-                        indexes[i] = NSIndexPath.FromRowSection(startIndex + i, 0);
-
-                    CollectionView.ReloadItems(indexes);
-                }, ok => { });
-            }
-            else
-            {
-                //Wait for all previous updates / animations to finish, otherwise it crashes with a consistency exception.
-                //Unit test case: using a non empty ObservableCollection, call .Clear() then .Add(items) on the observablecollection.
-                CollectionView.PerformBatchUpdates(() => { }, animationsCompleted =>
-                {
-                    ReloadData();
-                });
-            }
+            ReloadData();
         }
         
         public override nint GetItemsCount(UICollectionView collectionView, nint section)


### PR DESCRIPTION
I moved all code related to animating items in a new MvxCollectionViewSourceAnimated class, so existing apps won't be affected.