### PR TITLE
When using MvxTaskBasedBindingContext (default) with full link enabled.

### DIFF
--- a/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
@@ -11,6 +11,13 @@ namespace $rootnamespace$
     [Preserve(AllMembers = true)]
     public class LinkerPleaseInclude
     {
+		public void Include(MvxTaskBasedBindingContext c)
+        {
+            c.Dispose();
+            var c2 = new MvxTaskBasedBindingContext();
+            c2.Dispose();
+        }
+
         public void Include(UIButton uiButton)
         {
             uiButton.TouchUpInside += (s, e) =>


### PR DESCRIPTION
When using MvxTaskBasedBindingContext (default) with full link enabled,
this code is required to prevent xamarin from optimizing it away,
as it mvvmcross code uses only an interface.