### PR TITLE
Added support for view model instantiation using segue on iOS

### DIFF
--- a/MvvmCross/iOS/iOS/MvvmCross.iOS.csproj
+++ b/MvvmCross/iOS/iOS/MvvmCross.iOS.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Platform\IMvxIosPlatformProperties.cs" />
     <Compile Include="Platform\MvxIosDisplayDensity.cs" />
     <Compile Include="Platform\MvxIosFormFactor.cs" />
+    <Compile Include="Views\IMvxIosViewSegue.cs" />
     <Compile Include="Views\IMvxModalIosView.cs" />
     <Compile Include="Platform\MvxApplicationDelegate.cs" />
     <Compile Include="Platform\MvxIosPlatformProperties.cs" />

--- a/MvvmCross/iOS/iOS/MvvmCross.iOS.csproj
+++ b/MvvmCross/iOS/iOS/MvvmCross.iOS.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Views\IMvxIosViewsContainer.cs" />
     <Compile Include="Views\MvxCanCreateIosViewExtensionMethods.cs" />
     <Compile Include="Views\MvxFormFactorSpecificAttribute.cs" />
+    <Compile Include="Views\MvxSegueExtensionMethods.cs" />
     <Compile Include="Views\MvxViewControllerAdaptingExtensions.cs" />
     <Compile Include="Views\MvxBindingViewControllerAdapter.cs" />
     <Compile Include="Views\MvxTabBarViewController.cs" />

--- a/MvvmCross/iOS/iOS/Views/IMvxIosViewSegue.cs
+++ b/MvvmCross/iOS/iOS/Views/IMvxIosViewSegue.cs
@@ -1,0 +1,11 @@
+namespace MvvmCross.iOS.Views
+{
+
+    using Foundation;
+    using UIKit;
+
+    public interface IMvxIosViewSegue
+    {
+        object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender);
+    }
+}

--- a/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
@@ -20,7 +20,6 @@ namespace MvvmCross.iOS.Views
     public class MvxCollectionViewController
         : MvxEventSourceCollectionViewController
           , IMvxIosView
-          , IMvxIosViewSegue
     {
         protected MvxCollectionViewController(UICollectionViewLayout layout)
             : base(layout)
@@ -60,11 +59,6 @@ namespace MvvmCross.iOS.Views
         {
             base.PrepareForSegue(segue, sender);
             this.ViewModelRequestForSegue(segue, sender);
-        }
-
-        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            return null;
         }
     }
 

--- a/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
@@ -20,6 +20,7 @@ namespace MvvmCross.iOS.Views
     public class MvxCollectionViewController
         : MvxEventSourceCollectionViewController
           , IMvxIosView
+          , IMvxIosViewSegue
     {
         protected MvxCollectionViewController(UICollectionViewLayout layout)
             : base(layout)
@@ -54,6 +55,17 @@ namespace MvvmCross.iOS.Views
         public MvxViewModelRequest Request { get; set; }
 
         public IMvxBindingContext BindingContext { get; set; }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.ViewModelRequestForSegue(segue, sender);
+        }
+
+        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            return null;
+        }
     }
 
     public class MvxCollectionViewController<TViewModel>
@@ -76,12 +88,6 @@ namespace MvvmCross.iOS.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
-        }
-
-        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            base.PrepareForSegue(segue, sender);
-            this.ViewModelRequestForSegue(segue);
-        }
+        }   
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
@@ -81,7 +81,7 @@ namespace MvvmCross.iOS.Views
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
         {
             base.PrepareForSegue(segue, sender);
-            this.InstantiateViewModelForSegue(segue);
+            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
@@ -77,5 +77,11 @@ namespace MvvmCross.iOS.Views
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
         }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.InstantiateViewModelForSegue(segue);
+        }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
@@ -9,6 +9,7 @@
     using MvvmCross.Platform.iOS.Views;
 
     using UIKit;
+    using Foundation;
 
     public class MvxPageViewController : MvxEventSourcePageViewController, IMvxIosView
     {
@@ -125,6 +126,12 @@
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
+        }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.InstantiateViewModelForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
@@ -11,7 +11,7 @@
     using UIKit;
     using Foundation;
 
-    public class MvxPageViewController : MvxEventSourcePageViewController, IMvxIosView
+    public class MvxPageViewController : MvxEventSourcePageViewController, IMvxIosView, IMvxIosViewSegue
     {
         private Dictionary<string, UIViewController> _pagedViewControllerCache = null;
 
@@ -110,6 +110,17 @@
             }
             return (retVal);
         }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.ViewModelRequestForSegue(segue, sender);
+        }
+
+        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            return null;
+        }
     }
 
     public class MvxPageViewController<TViewModel> : MvxPageViewController, IMvxIosView<TViewModel> where TViewModel : class, IMvxPageViewModel
@@ -126,12 +137,6 @@
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
-        }
-
-        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            base.PrepareForSegue(segue, sender);
-            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
@@ -11,7 +11,7 @@
     using UIKit;
     using Foundation;
 
-    public class MvxPageViewController : MvxEventSourcePageViewController, IMvxIosView, IMvxIosViewSegue
+    public class MvxPageViewController : MvxEventSourcePageViewController, IMvxIosView
     {
         private Dictionary<string, UIViewController> _pagedViewControllerCache = null;
 
@@ -115,11 +115,6 @@
         {
             base.PrepareForSegue(segue, sender);
             this.ViewModelRequestForSegue(segue, sender);
-        }
-
-        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            return null;
         }
     }
 

--- a/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
@@ -131,7 +131,7 @@
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
         {
             base.PrepareForSegue(segue, sender);
-            this.InstantiateViewModelForSegue(segue);
+            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
@@ -19,7 +19,7 @@ namespace MvvmCross.iOS.Views {
             return prop?.PropertyType;
         }
 
-        internal static void InstantiateViewModelForSegue(this UIViewController _, UIStoryboardSegue segue)
+        internal static void InstantiateViewModelForSegue(this IMvxEventSourceViewController _, UIStoryboardSegue segue)
         {
             var view = segue.DestinationViewController as IMvxIosView;
             if (view != null && view.Request == null)

--- a/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
@@ -19,7 +19,7 @@ namespace MvvmCross.iOS.Views {
             return prop?.PropertyType;
         }
 
-        internal static void InstantiateViewModelForSegue(this IMvxEventSourceViewController _, UIStoryboardSegue segue)
+        internal static void ViewModelRequestForSegue(this IMvxEventSourceViewController _, UIStoryboardSegue segue)
         {
             var view = segue.DestinationViewController as IMvxIosView;
             if (view != null && view.Request == null)

--- a/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
@@ -42,7 +42,7 @@
 
         private static void ViewModelRequestForSegueImpl(this IMvxEventSourceViewController self, UIStoryboardSegue segue, IDictionary<string, string> parameterValues)
         {
-            self.ViewModelRequestForSegueImpl(segue, new MvxBundle(parameterValues.ToSimplePropertyDictionary()));
+            self.ViewModelRequestForSegueImpl(segue, new MvxBundle(parameterValues));
         }
 
         private static void ViewModelRequestForSegueImpl(this IMvxEventSourceViewController _, UIStoryboardSegue segue, IMvxBundle parameterBundle = null)

--- a/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxSegueExtensionMethods.cs
@@ -1,0 +1,36 @@
+﻿using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.Views;
+using MvvmCross.Platform.iOS.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using UIKit;
+
+namespace MvvmCross.iOS.Views {
+    internal static class MvxSegueExtensionMethods {
+
+        internal static Type GetViewModelType(this IMvxView view)
+        {
+            var viewType = view.GetType();
+            var props = viewType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var prop = props.Where(p => p.Name == "ViewModel").FirstOrDefault();
+            return prop?.PropertyType;
+        }
+
+        internal static void InstantiateViewModelForSegue(this UIViewController _, UIStoryboardSegue segue)
+        {
+            var view = segue.DestinationViewController as IMvxIosView;
+            if (view != null && view.Request == null)
+            {
+                var type = view.GetViewModelType();
+                if (type != null)
+                {
+                    var by = new MvxRequestedBy(MvxRequestedByType.Other, $"Segue: {segue.Identifier}");
+                    view.Request = new MvxViewModelRequest(type, null, null, by);
+                }
+            }
+        }
+    }
+}

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -73,7 +73,7 @@ namespace MvvmCross.iOS.Views
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
         {
             base.PrepareForSegue(segue, sender);
-            this.InstantiateViewModelForSegue(segue);
+            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -17,7 +17,6 @@ namespace MvvmCross.iOS.Views
     public class MvxTabBarViewController
         : MvxEventSourceTabBarController
           , IMvxIosView
-          , IMvxIosViewSegue
     {
         protected MvxTabBarViewController()
         {
@@ -55,11 +54,6 @@ namespace MvvmCross.iOS.Views
         {
             base.PrepareForSegue(segue, sender);
             this.ViewModelRequestForSegue(segue, sender);
-        }
-
-        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            return null;
         }
     }
 

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -8,10 +8,11 @@
 namespace MvvmCross.iOS.Views
 {
     using System;
-
+    using Foundation;
     using MvvmCross.Binding.BindingContext;
     using MvvmCross.Core.ViewModels;
     using MvvmCross.Platform.iOS.Views;
+    using UIKit;
 
     public class MvxTabBarViewController
         : MvxEventSourceTabBarController
@@ -66,6 +67,13 @@ namespace MvvmCross.iOS.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
+        }
+
+        // CHECKME: won't this interfer with the hack for TabBar in LoadViewModel()
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.InstantiateViewModelForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -17,6 +17,7 @@ namespace MvvmCross.iOS.Views
     public class MvxTabBarViewController
         : MvxEventSourceTabBarController
           , IMvxIosView
+          , IMvxIosViewSegue
     {
         protected MvxTabBarViewController()
         {
@@ -48,6 +49,18 @@ namespace MvvmCross.iOS.Views
         public MvxViewModelRequest Request { get; set; }
 
         public IMvxBindingContext BindingContext { get; set; }
+
+        // CHECKME: won't this interfer with the hack for TabBar in LoadViewModel()
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.ViewModelRequestForSegue(segue, sender);
+        }
+
+        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            return null;
+        }
     }
 
     public class MvxTabBarViewController<TViewModel>
@@ -67,13 +80,6 @@ namespace MvvmCross.iOS.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
-        }
-
-        // CHECKME: won't this interfer with the hack for TabBar in LoadViewModel()
-        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            base.PrepareForSegue(segue, sender);
-            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -49,7 +49,6 @@ namespace MvvmCross.iOS.Views
 
         public IMvxBindingContext BindingContext { get; set; }
 
-        // CHECKME: won't this interfer with the hack for TabBar in LoadViewModel()
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
         {
             base.PrepareForSegue(segue, sender);

--- a/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
@@ -109,7 +109,7 @@ namespace MvvmCross.iOS.Views
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
         {
             base.PrepareForSegue(segue, sender);
-            this.InstantiateViewModelForSegue(segue);
+            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
@@ -105,5 +105,11 @@ namespace MvvmCross.iOS.Views
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
         }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.InstantiateViewModelForSegue(segue);
+        }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
@@ -20,7 +20,6 @@ namespace MvvmCross.iOS.Views
     public class MvxTableViewController
         : MvxEventSourceTableViewController
           , IMvxIosView
-          , IMvxIosViewSegue
     {
         protected MvxTableViewController(UITableViewStyle style = UITableViewStyle.Plain)
             : base(style)
@@ -85,11 +84,6 @@ namespace MvvmCross.iOS.Views
         {
             base.PrepareForSegue(segue, sender);
             this.ViewModelRequestForSegue(segue, sender);
-        }
-
-        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            return null;
         }
     }
 

--- a/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
@@ -20,6 +20,7 @@ namespace MvvmCross.iOS.Views
     public class MvxTableViewController
         : MvxEventSourceTableViewController
           , IMvxIosView
+          , IMvxIosViewSegue
     {
         protected MvxTableViewController(UITableViewStyle style = UITableViewStyle.Plain)
             : base(style)
@@ -79,6 +80,17 @@ namespace MvvmCross.iOS.Views
         public MvxViewModelRequest Request { get; set; }
 
         public IMvxBindingContext BindingContext { get; set; }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.ViewModelRequestForSegue(segue, sender);
+        }
+
+        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender)
+        {
+            return null;
+        }
     }
 
     public class MvxTableViewController<TViewModel>
@@ -104,12 +116,6 @@ namespace MvvmCross.iOS.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
-        }
-
-        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)
-        {
-            base.PrepareForSegue(segue, sender);
-            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxViewController.cs
@@ -80,7 +80,7 @@ namespace MvvmCross.iOS.Views
 
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender) {
             base.PrepareForSegue(segue, sender);
-            this.InstantiateViewModelForSegue(segue);
+            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxViewController.cs
@@ -14,6 +14,7 @@ namespace MvvmCross.iOS.Views
     using MvvmCross.Binding.BindingContext;
     using MvvmCross.Core.ViewModels;
     using MvvmCross.Platform.iOS.Views;
+    using UIKit;
 
     public class MvxViewController
         : MvxEventSourceViewController
@@ -75,6 +76,11 @@ namespace MvvmCross.iOS.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
+        }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender) {
+            base.PrepareForSegue(segue, sender);
+            this.InstantiateViewModelForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxViewController.cs
@@ -19,6 +19,7 @@ namespace MvvmCross.iOS.Views
     public class MvxViewController
         : MvxEventSourceViewController
           , IMvxIosView
+          , IMvxIosViewSegue
     {
         public MvxViewController()
         {
@@ -52,6 +53,15 @@ namespace MvvmCross.iOS.Views
         public MvxViewModelRequest Request { get; set; }
 
         public IMvxBindingContext BindingContext { get; set; }
+
+        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender) {
+            base.PrepareForSegue(segue, sender);
+            this.ViewModelRequestForSegue(segue, sender);
+        }
+
+        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender) {
+            return null;
+        }
     }
 
     public class MvxViewController<TViewModel>
@@ -76,11 +86,6 @@ namespace MvvmCross.iOS.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
-        }
-
-        public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender) {
-            base.PrepareForSegue(segue, sender);
-            this.ViewModelRequestForSegue(segue);
         }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxViewController.cs
@@ -19,7 +19,6 @@ namespace MvvmCross.iOS.Views
     public class MvxViewController
         : MvxEventSourceViewController
           , IMvxIosView
-          , IMvxIosViewSegue
     {
         public MvxViewController()
         {
@@ -57,10 +56,6 @@ namespace MvvmCross.iOS.Views
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender) {
             base.PrepareForSegue(segue, sender);
             this.ViewModelRequestForSegue(segue, sender);
-        }
-
-        public virtual object PrepareViewModelParametersForSegue(UIStoryboardSegue segue, NSObject sender) {
-            return null;
         }
     }
 


### PR DESCRIPTION
Hi there,

MVVMCross is real cool but there were a small piece of code missing to handle segue on iOS using storyboards.

I added `MvxSegueExtensionMethods` in order to handle view model instantiation:

- `GetViewModelType()` has been added to `IMvxView` to retrieve the view model type at runtime
- `InstantiateViewModelForSegue()` has been added to `IMvxEventSourceViewController` to handle view model instantiation. It would be nice to have it on `UIViewController` but we cannot modifiy the class directly and we would have expose the method publicly instead of the current `internal`.

All the `Mvx_ViewController` classes have been modifier to override `PrepareForSegue()` and call `InstantiateViewModelForSegue()`.

We should check that this doesn't interfer  with the hack for TabBar in `LoadViewModel()`.

A sample project showing this in action is available here:
https://www.dropbox.com/s/8gmtm7jkjgmxo0n/MVVMCross_SeguePoC.zip?dl=0

Let me know if you have any question!
Thanks!

Chris
