### PR TITLE
Add support for own base class, ShowViewModel with parameter serialization

### DIFF
--- a/MvvmCross/Core/Core/MvvmCross.Core.csproj
+++ b/MvvmCross/Core/Core/MvvmCross.Core.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Platform\IMvxSettings.cs" />
     <Compile Include="ViewModels\IMvxTypeFinder.cs" />
     <Compile Include="ViewModels\IMvxViewModelByNameRegistry.cs" />
+    <Compile Include="ViewModels\IMvxViewModelInitializer.cs" />
     <Compile Include="ViewModels\IMvxViewModelTypeFinder.cs" />
     <Compile Include="ViewModels\IMvxTypeToTypeLookupBuilder.cs" />
     <Compile Include="ViewModels\IMvxViewModelByNameLookup.cs" />

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModelInitializer.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModelInitializer.cs
@@ -1,0 +1,16 @@
+﻿// IMvxViewModelInitializer.cs
+
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+namespace MvvmCross.Core.ViewModels
+{
+    using System.Threading.Tasks;
+
+    public interface IMvxViewModelInitializer<TInit> : IMvxViewModel
+    {
+        Task Init(string parameter);
+    }
+}

--- a/MvvmCross/Core/Core/ViewModels/MvxNavigatingObject.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNavigatingObject.cs
@@ -34,14 +34,15 @@ namespace MvvmCross.Core.ViewModels
             return false;
         }
 
-		/// <summary>
-		///     ShowViewModel with non-primitive type object using json to pass object to the next ViewModel
-		/// 	Be aware that pasing big objects will block your UI, and should be handled async by yourself
-		/// </summary>
-		/// <param name="parameter">The generic object you want to pass onto the next ViewModel</param>
+        /// <summary>
+        /// ShowViewModel with non-primitive type object using json to pass object to the next ViewModel
+        /// Be aware that pasing big objects will block your UI, and should be handled async by yourself
+        /// </summary>
+        /// <param name="parameter">The generic object you want to pass onto the next ViewModel</param>
         protected bool ShowViewModel<TViewModel, TInit>(TInit parameter,
-												 IMvxBundle presentationBundle = null,
-												 MvxRequestedBy requestedBy = null) where TViewModel : MvxViewModel<TInit>
+                                                 IMvxBundle presentationBundle = null,
+                                                 MvxRequestedBy requestedBy = null) 
+            where TViewModel : IMvxViewModelInitializer<TInit>
         {
             IMvxJsonConverter serializer;
             if (!Mvx.TryResolve(out serializer))

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -54,7 +54,7 @@ namespace MvvmCross.Core.ViewModels
         }
     }
 
-    public abstract class MvxViewModel<TInit> : MvxViewModel
+    public abstract class MvxViewModel<TInit> : MvxViewModel, IMvxViewModelInitializer<TInit>
     {
         public async Task Init(string parameter)
         {


### PR DESCRIPTION
Switches out the concert `MvxViewModel<TInit>` type requirement to use an interface `IMvxViewModelInitializer<TInit>` instead for [`ShowViewModel<TViewModel, TInit>`](https://github.com/MvvmCross/MvvmCross/blob/4.0/MvvmCross/Core/Core/ViewModels/MvxNavigatingObject.cs#L42).

The limitation of forcing the concert type is that it will require projects that implement their own abstract base ViewModel to either always specify an Init parameter type class or maintain multiple base ViewModels with possibly the same code and the only difference being the inherited type.

Switching to an interface allows for any single ViewModel to implement the feature of ViewModel parameter serialization in isolation or implement it in an extended base class type. The developer will have to implement their own deserializer much the same as currently done in  `MvxViewModel<TInit>`.
