### PR TITLE
MvxImageViewResourceNameTargetBinding (VectorDrawable resources)

### DIFF
--- a/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
+++ b/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Views\MvxRelativeLayout.cs" />
     <Compile Include="Views\MvxFrameLayout.cs" />
     <Compile Include="Views\MvxTableLayout.cs" />
+    <Compile Include="Target\MvxImageViewResourceNameTargetBinding.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Platform\Droid\MvvmCross.Platform.Droid.csproj">

--- a/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
@@ -111,6 +111,8 @@ namespace MvvmCross.Binding.Droid
                                                             imageView => new MvxImageViewDrawableTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<ImageView>("DrawableName",
                                                             imageView => new MvxImageViewDrawableNameTargetBinding(imageView));
+			registry.RegisterCustomBindingFactory<ImageView>("ResourceName",
+															imageView => new MvxImageViewResourceNameTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<ImageView>("AssetImagePath",
                                                              imageView => new MvxImageViewImageTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<MvxSpinner>("SelectedItem",

--- a/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewDrawableTargetBinding.cs
@@ -7,54 +7,57 @@
 
 using System;
 using Android.Graphics.Drawables;
-using Android.Widget;
 using Android.OS;
+using Android.Widget;
 using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Droid.Target
 {
 	public class MvxImageViewDrawableTargetBinding
-        : MvxAndroidTargetBinding
-    {
-        protected ImageView ImageView => (ImageView)Target;
+		: MvxAndroidTargetBinding
+	{
+		protected ImageView ImageView => (ImageView)Target;
 
-        public MvxImageViewDrawableTargetBinding(ImageView imageView)
-            : base(imageView)
-        {
-        }
+		public MvxImageViewDrawableTargetBinding(ImageView imageView)
+			: base(imageView)
+		{
+		}
 
-        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
+		public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(int);
+		public override Type TargetType => typeof(int);
 
-        protected override void SetValueImpl(object target, object value)
-        {
-            var imageView = (ImageView)target;
+		protected override void SetValueImpl(object target, object value)
+		{
+			var imageView = (ImageView)target;
 
-            if (!(value is int))
-            {
-                MvxBindingTrace.Trace(MvxTraceLevel.Warning,
-                    "Value was not a valid Drawable");
-                imageView.SetImageDrawable(null);
-                return;
-            }
+			if(!(value is int))
+			{
+				MvxBindingTrace.Trace(MvxTraceLevel.Warning,
+					"Value was not a valid Drawable");
+				imageView.SetImageDrawable(null);
+				return;
+			}
 
-            var intValue = (int)value;
+			var intValue = (int)value;
 
-            if (intValue == 0)
-                imageView.SetImageDrawable(null);
-            else
-            {
-                var context = imageView.Context;
-				Drawable drawable;
-				if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
-					drawable = context?.Resources?.GetDrawable(intValue, context.Theme);
-				else
-					drawable = context?.Resources?.GetDrawable(intValue);
+			if(intValue == 0)
+				imageView.SetImageDrawable(null);
+			else
+				this.SetImage(imageView, intValue);
+		}
 
-				if (drawable != null)
-					imageView.SetImageDrawable(drawable);
-            }
-        }
-    }
+		protected virtual void SetImage(ImageView imageView, int id)
+		{
+			var context = imageView.Context;
+			Drawable drawable;
+			if(Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+				drawable = context?.Resources?.GetDrawable(id, context.Theme);
+			else
+				drawable = context?.Resources?.GetDrawable(id);
+
+			if(drawable != null)
+				imageView.SetImageDrawable(drawable);
+		}
+	}
 }

--- a/MvvmCross/Binding/Droid/Target/MvxImageViewResourceNameTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewResourceNameTargetBinding.cs
@@ -1,0 +1,24 @@
+﻿// MvxImageViewResourceNameTargetBinding.cs
+
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using Android.Widget;
+
+namespace MvvmCross.Binding.Droid.Target
+{
+	public class MvxImageViewResourceNameTargetBinding : MvxImageViewDrawableNameTargetBinding
+	{
+		public MvxImageViewResourceNameTargetBinding(ImageView imageView)
+			: base(imageView)
+		{
+		}
+
+		protected override void SetImage(ImageView imageView, int id)
+		{
+			imageView.SetImageResource(id);
+		}
+	}
+}


### PR DESCRIPTION
Hi guys,

I've added MvxImageViewResourceNameTargetBinding to Android target bindings, that is like MvxImageViewDrawableNameTargetBinding but it uses SetImageResource instead of SetImageDrawable. Also refactored a bit MvxImageViewDrawableTargetBinding to reuse some code.

I've done this because MvxImageViewDrawableNameTargetBinding doesn't load VectorDrawable resources pre-Lollipop.

I'm not sure if this should be here or in MvvmCross-AndroidSupport, but I think it could be here because SetImageResource doesn't belong specifically/only to AndroidSupport.

I hope it helps.