### PR TITLE
AddToBackStack flag FullFragging fix

### DIFF
--- a/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
+++ b/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
@@ -226,6 +226,7 @@ namespace MvvmCross.Droid.FullFragging.Caching
 				//Otherwise, create one and cache it
 				fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
 					bundle) as IMvxFragmentView;
+				currentFragment = fragInfo.CachedFragment as Fragment;
 				OnFragmentCreated(fragInfo, ft);
 			}
 


### PR DESCRIPTION
AddToBackStack flag has not been respected by ShowFragment method when Fragment was not available in cache.

Fixes issue: #1427