### PR TITLE
Improved support for binding to interfaces

### DIFF
--- a/MvvmCross/Core/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
@@ -116,6 +116,12 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
             {
                 return factory;
             }
+            var implementedInterfaces = type.GetTypeInfo().ImplementedInterfaces;
+            foreach (var implementedInterface in implementedInterfaces)
+            {
+                factory = this.FindSpecificFactory(implementedInterface, name);
+                if (factory != null) return factory;
+            }
             var baseType = type.GetTypeInfo().BaseType;
             if (baseType != null)
                 return this.FindSpecificFactory(baseType, name);

--- a/MvvmCross/Core/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
@@ -116,15 +116,16 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
             {
                 return factory;
             }
+            var baseType = type.GetTypeInfo().BaseType;
+            if (baseType != null)
+                factory = this.FindSpecificFactory(baseType, name);
+            if (factory != null) return factory;
             var implementedInterfaces = type.GetTypeInfo().ImplementedInterfaces;
             foreach (var implementedInterface in implementedInterfaces)
             {
                 factory = this.FindSpecificFactory(implementedInterface, name);
                 if (factory != null) return factory;
             }
-            var baseType = type.GetTypeInfo().BaseType;
-            if (baseType != null)
-                return this.FindSpecificFactory(baseType, name);
             return null;
         }
     }


### PR DESCRIPTION
When binding to IMenuItem, the Binding Registry search for IMenuItemInvoker, which isn't registered.

The fallback search only search for base classes. 

The added code make it search the implemented interfaces also.