### PR TITLE
Add ViewDidLayoutSubviewsCalled to IMvxEventSourceViewController on iOS

### DIFF
--- a/MvvmCross/Dialog/iOS/EventSourceDialogViewController.cs
+++ b/MvvmCross/Dialog/iOS/EventSourceDialogViewController.cs
@@ -63,6 +63,12 @@ namespace MvvmCross.Dialog.iOS
             this.ViewDidLoadCalled.Raise(this);
         }
 
+        public override void ViewDidLayoutSubviews()
+        {
+            base.ViewDidLayoutSubviews();
+            this.ViewDidLayoutSubviewsCalled.Raise(this);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -74,6 +80,8 @@ namespace MvvmCross.Dialog.iOS
 
         public event EventHandler ViewDidLoadCalled;
 
+        public event EventHandler ViewDidLayoutSubviewsCalled;
+        
         public event EventHandler<MvxValueEventArgs<bool>> ViewWillAppearCalled;
 
         public event EventHandler<MvxValueEventArgs<bool>> ViewDidAppearCalled;

--- a/MvvmCross/Platform/iOS/Views/IMvxEventSourceViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/IMvxEventSourceViewController.cs
@@ -15,6 +15,8 @@ namespace MvvmCross.Platform.iOS.Views
     {
         event EventHandler ViewDidLoadCalled;
 
+        event EventHandler ViewDidLayoutSubviewsCalled;
+        
         event EventHandler<MvxValueEventArgs<bool>> ViewWillAppearCalled;
 
         event EventHandler<MvxValueEventArgs<bool>> ViewDidAppearCalled;

--- a/MvvmCross/Platform/iOS/Views/MvxBaseViewControllerAdapter.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxBaseViewControllerAdapter.cs
@@ -34,9 +34,14 @@ namespace MvvmCross.Platform.iOS.Views
             this._eventSource.ViewWillDisappearCalled += this.HandleViewWillDisappearCalled;
             this._eventSource.DisposeCalled += this.HandleDisposeCalled;
             this._eventSource.ViewDidLoadCalled += this.HandleViewDidLoadCalled;
+            this._eventSource.ViewDidLayoutSubviewsCalled += this.HandleViewDidLayoutSubviewsCalled;
         }
 
         public virtual void HandleViewDidLoadCalled(object sender, EventArgs e)
+        {
+        }
+
+        public virtual void HandleViewDidLayoutSubviewsCalled(object sender, EventArgs e)
         {
         }
 

--- a/MvvmCross/Platform/iOS/Views/MvxEventSourceCollectionViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxEventSourceCollectionViewController.cs
@@ -64,6 +64,12 @@ namespace MvvmCross.Platform.iOS.Views
             this.ViewDidLoadCalled.Raise(this);
         }
 
+        public override void ViewDidLayoutSubviews()
+        {
+            base.ViewDidLayoutSubviews();
+            this.ViewDidLayoutSubviewsCalled.Raise(this);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -74,6 +80,8 @@ namespace MvvmCross.Platform.iOS.Views
         }
 
         public event EventHandler ViewDidLoadCalled;
+
+        public event EventHandler ViewDidLayoutSubviewsCalled;
 
         public event EventHandler<MvxValueEventArgs<bool>> ViewWillAppearCalled;
 

--- a/MvvmCross/Platform/iOS/Views/MvxEventSourcePageViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxEventSourcePageViewController.cs
@@ -22,6 +22,12 @@
             this.ViewDidLoadCalled.Raise(this);
         }
 
+        public override void ViewDidLayoutSubviews()
+        {
+            base.ViewDidLayoutSubviews();
+            this.ViewDidLayoutSubviewsCalled.Raise(this);
+        }
+
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
@@ -54,6 +60,8 @@
         }
 
         public event EventHandler ViewDidLoadCalled;
+
+        public event EventHandler ViewDidLayoutSubviewsCalled;
 
         public event EventHandler<MvxValueEventArgs<bool>> ViewWillAppearCalled;
 

--- a/MvvmCross/Platform/iOS/Views/MvxEventSourceTabBarController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxEventSourceTabBarController.cs
@@ -56,6 +56,12 @@ namespace MvvmCross.Platform.iOS.Views
             this.ViewDidLoadCalled.Raise(this);
         }
 
+        public override void ViewDidLayoutSubviews()
+        {
+            base.ViewDidLayoutSubviews();
+            this.ViewDidLayoutSubviewsCalled.Raise(this);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -66,6 +72,8 @@ namespace MvvmCross.Platform.iOS.Views
         }
 
         public event EventHandler ViewDidLoadCalled;
+
+        public event EventHandler ViewDidLayoutSubviewsCalled;
 
         public event EventHandler<MvxValueEventArgs<bool>> ViewWillAppearCalled;
 

--- a/MvvmCross/Platform/iOS/Views/MvxEventSourceTableViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxEventSourceTableViewController.cs
@@ -64,6 +64,12 @@ namespace MvvmCross.Platform.iOS.Views
             this.ViewDidLoadCalled.Raise(this);
         }
 
+        public override void ViewDidLayoutSubviews()
+        {
+            base.ViewDidLayoutSubviews();
+            this.ViewDidLayoutSubviewsCalled.Raise(this);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -74,6 +80,8 @@ namespace MvvmCross.Platform.iOS.Views
         }
 
         public event EventHandler ViewDidLoadCalled;
+
+        public event EventHandler ViewDidLayoutSubviewsCalled;
 
         public event EventHandler<MvxValueEventArgs<bool>> ViewWillAppearCalled;
 

--- a/MvvmCross/Platform/iOS/Views/MvxEventSourceViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxEventSourceViewController.cs
@@ -63,6 +63,12 @@ namespace MvvmCross.Platform.iOS.Views
             this.ViewDidLoadCalled.Raise(this);
         }
 
+        public override void ViewDidLayoutSubviews()
+        {
+            base.ViewDidLayoutSubviews();
+            this.ViewDidLayoutSubviewsCalled.Raise(this);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -73,6 +79,8 @@ namespace MvvmCross.Platform.iOS.Views
         }
 
         public event EventHandler ViewDidLoadCalled;
+
+        public event EventHandler ViewDidLayoutSubviewsCalled;
 
         public event EventHandler<MvxValueEventArgs<bool>> ViewWillAppearCalled;
 


### PR DESCRIPTION
Hi,

I needed to create a `ViewControllerAdapter` that listened to the `ViewDidLayoutSubviews` event but was surprised it was not part of the `IMvxEventSourceViewController` interface.  So I added it.

**What's this for?**
If you need to use `TopLayoutGuide.Length` or `BottomLayoutGuide.Length` Apple docs say:
"Query this property within your implementation of the viewDidLayoutSubviews() method."
So now you can make a `ViewControllerAdapter` to do that instead of overriding the `ViewDidLayoutSubviews` in every controller.

**Potential issues**
Custom controllers that don't inherit from `MvxEventSource*Controller` and implement the`IMvxEventSourceViewController` interface will need to be updated.


