### PR TITLE
Protect Android Bindings

### DIFF
--- a/MvvmCross/Binding/Droid/Binders/MvxAndroidViewBinder.cs
+++ b/MvvmCross/Binding/Droid/Binders/MvxAndroidViewBinder.cs
@@ -25,8 +25,7 @@ namespace MvvmCross.Binding.Droid.Binders
 
     public class MvxAndroidViewBinder : IMvxAndroidViewBinder
     {
-        private readonly List<KeyValuePair<object, IMvxUpdateableBinding>> _viewBindings
-            = new List<KeyValuePair<object, IMvxUpdateableBinding>>();
+        private readonly List<KeyValuePair<object, IMvxUpdateableBinding>> _viewBindings = new List<KeyValuePair<object, IMvxUpdateableBinding>>();
 
         private readonly object _source;
 

--- a/MvvmCross/Binding/Droid/Binders/MvxBindingLayoutInflaterFactory.cs
+++ b/MvvmCross/Binding/Droid/Binders/MvxBindingLayoutInflaterFactory.cs
@@ -24,8 +24,7 @@ namespace MvvmCross.Binding.Droid.Binders
         private IMvxAndroidViewFactory _androidViewFactory;
         private IMvxAndroidViewBinder _binder;
 
-        public MvxBindingLayoutInflaterFactory(
-            object source)
+        public MvxBindingLayoutInflaterFactory(object source)
         {
             this._source = source;
         }

--- a/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
+++ b/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ResourceHelpers\MvxAppResourceTypeFinder.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Target\MvxListPreferenceTargetBinding.cs" />
+    <Compile Include="Target\MvxAndroidPropertyInfoTargetBinding.cs" />
     <Compile Include="Target\MvxTextViewHintTargetBinding.cs" />
     <Compile Include="Target\MvxEditTextPreferenceTextTargetBinding.cs" />
     <Compile Include="Target\MvxExpandableListViewSelectedItemTargetBinding.cs" />

--- a/MvvmCross/Binding/Droid/Target/MvxAdapterViewSelectedItemPositionTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAdapterViewSelectedItemPositionTargetBinding.cs
@@ -8,6 +8,7 @@
 using System;
 using Android.Widget;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -16,7 +17,7 @@ namespace MvvmCross.Binding.Droid.Target
     {
         protected AdapterView AdapterView => (AdapterView)Target;
 
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         public MvxAdapterViewSelectedItemPositionTargetBinding(AdapterView adapterView)
             : base(adapterView)
@@ -42,8 +43,8 @@ namespace MvvmCross.Binding.Droid.Target
             if (adapterView == null)
                 return;
 
-            _subscribed = true;
-            adapterView.ItemSelected += AdapterViewOnItemSelected;
+            _subscription = adapterView.WeakSubscribe<AdapterView, AdapterView.ItemSelectedEventArgs>(
+                nameof(adapterView.ItemSelected), AdapterViewOnItemSelected);
         }
 
         public override Type TargetType => typeof(Int32);
@@ -52,13 +53,10 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var adapterView = AdapterView;
-                if (adapterView != null && _subscribed)
-                {
-                    adapterView.ItemSelected -= AdapterViewOnItemSelected;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
+
             base.Dispose(isDisposing);
         }
     }

--- a/MvvmCross/Binding/Droid/Target/MvxAdapterViewSelectedItemPositionTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAdapterViewSelectedItemPositionTargetBinding.cs
@@ -7,13 +7,12 @@
 
 using System;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxAdapterViewSelectedItemPositionTargetBinding
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         protected AdapterView AdapterView => (AdapterView)Target;
 

--- a/MvvmCross/Binding/Droid/Target/MvxAndroidPropertyInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAndroidPropertyInfoTargetBinding.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using MvvmCross.Binding.Bindings.Target;
+
+namespace MvvmCross.Binding.Droid.Target
+{
+    public abstract class MvxAndroidPropertyInfoTargetBinding : MvxPropertyInfoTargetBinding
+    {
+        protected MvxAndroidPropertyInfoTargetBinding(object target, PropertyInfo targetPropertyInfo)
+            : base(target, targetPropertyInfo)
+        {
+            
+        }
+
+        protected override bool ShouldSkipSetValueForPlatformSpecificReasons(object target, object value)
+        {
+            return MvxAndroidTargetBinding.TargetIsInvalid(target);
+        }
+    }
+
+    public abstract class MvxAndroidPropertyInfoTargetBinding<TView>
+        : MvxPropertyInfoTargetBinding<TView> where TView : class
+    {
+        protected MvxAndroidPropertyInfoTargetBinding(object target, PropertyInfo targetPropertyInfo)
+            : base(target, targetPropertyInfo)
+        {
+        }
+
+        protected override bool ShouldSkipSetValueForPlatformSpecificReasons(object target, object value)
+        {
+            return MvxAndroidTargetBinding.TargetIsInvalid(target);
+        }
+    }
+}

--- a/MvvmCross/Binding/Droid/Target/MvxAndroidTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAndroidTargetBinding.cs
@@ -5,9 +5,12 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
+using Android.Runtime;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Droid;
+using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -23,5 +26,21 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected IMvxAndroidGlobals AndroidGlobals
             => _androidGlobals ?? (_androidGlobals = Mvx.Resolve<IMvxAndroidGlobals>());
+
+        protected override bool ShouldSkipSetValueForPlatformSpecificReasons(object target, object value)
+        {
+            return TargetIsInvalid(target);
+        }
+
+        public static bool TargetIsInvalid(object target)
+        {
+            var javaTarget = target as IJavaObject;
+            if (javaTarget != null && javaTarget.Handle == IntPtr.Zero)
+            {
+                MvxBindingTrace.Trace(MvxTraceLevel.Warning, "Weak Target has been GCed by Android {0}", javaTarget.GetType().Name);
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewPartialTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewPartialTextTargetBinding.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Droid.Views;
+using MvvmCross.Platform.WeakSubscription;
 using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Droid.Target
@@ -17,7 +18,7 @@ namespace MvvmCross.Binding.Droid.Target
     public class MvxAutoCompleteTextViewPartialTextTargetBinding
        : MvxPropertyInfoTargetBinding<MvxAutoCompleteTextView>
     {
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         public MvxAutoCompleteTextViewPartialTextTargetBinding(object target, PropertyInfo targetPropertyInfo)
             : base(target, targetPropertyInfo)
@@ -43,20 +44,17 @@ namespace MvvmCross.Binding.Droid.Target
             if (autoComplete == null)
                 return;
 
-            _subscribed = true;
-            autoComplete.PartialTextChanged += AutoCompleteOnPartialTextChanged;
+            _subscription = autoComplete.WeakSubscribe(
+                nameof(autoComplete.PartialTextChanged),
+                AutoCompleteOnPartialTextChanged);
         }
 
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)
             {
-                var autoComplete = View;
-                if (autoComplete != null && _subscribed)
-                {
-                    autoComplete.PartialTextChanged -= AutoCompleteOnPartialTextChanged;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
 
             base.Dispose(isDisposing);

--- a/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewPartialTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewPartialTextTargetBinding.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Reflection;
 
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.WeakSubscription;
 using MvvmCross.Platform.Platform;
@@ -16,7 +15,7 @@ using MvvmCross.Platform.Platform;
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxAutoCompleteTextViewPartialTextTargetBinding
-       : MvxPropertyInfoTargetBinding<MvxAutoCompleteTextView>
+       : MvxAndroidPropertyInfoTargetBinding<MvxAutoCompleteTextView>
     {
         private IDisposable _subscription;
 

--- a/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewSelectedObjectTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewSelectedObjectTargetBinding.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Reflection;
 
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.WeakSubscription;
 using MvvmCross.Platform.Platform;
@@ -16,7 +15,7 @@ using MvvmCross.Platform.Platform;
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxAutoCompleteTextViewSelectedObjectTargetBinding
-        : MvxPropertyInfoTargetBinding<MvxAutoCompleteTextView>
+        : MvxAndroidPropertyInfoTargetBinding<MvxAutoCompleteTextView>
     {
         private IDisposable _subscription;
 

--- a/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewSelectedObjectTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxAutoCompleteTextViewSelectedObjectTargetBinding.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Droid.Views;
+using MvvmCross.Platform.WeakSubscription;
 using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Droid.Target
@@ -17,7 +18,7 @@ namespace MvvmCross.Binding.Droid.Target
     public class MvxAutoCompleteTextViewSelectedObjectTargetBinding
         : MvxPropertyInfoTargetBinding<MvxAutoCompleteTextView>
     {
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         public MvxAutoCompleteTextViewSelectedObjectTargetBinding(object target, PropertyInfo targetPropertyInfo)
             : base(target, targetPropertyInfo)
@@ -44,20 +45,17 @@ namespace MvvmCross.Binding.Droid.Target
             if (autoComplete == null)
                 return;
 
-            _subscribed = true;
-            autoComplete.SelectedObjectChanged += AutoCompleteOnSelectedObjectChanged;
+            _subscription = autoComplete.WeakSubscribe(
+                nameof(autoComplete.SelectedObjectChanged),
+                AutoCompleteOnSelectedObjectChanged);
         }
 
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)
             {
-                var autoComplete = View;
-                if (autoComplete != null && _subscribed)
-                {
-                    autoComplete.SelectedObjectChanged -= AutoCompleteOnSelectedObjectChanged;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
 
             base.Dispose(isDisposing);

--- a/MvvmCross/Binding/Droid/Target/MvxBaseViewVisibleBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxBaseViewVisibleBinding.cs
@@ -7,12 +7,11 @@
 
 using System;
 using Android.Views;
-using MvvmCross.Binding.Bindings.Target;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public abstract class MvxBaseViewVisibleBinding
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         protected View View => (View)Target;
 

--- a/MvvmCross/Binding/Droid/Target/MvxCompoundButtonCheckedTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxCompoundButtonCheckedTargetBinding.cs
@@ -9,13 +9,15 @@ using System.Reflection;
 using Android.Widget;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.Platform;
+using System;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxCompoundButtonCheckedTargetBinding
         : MvxPropertyInfoTargetBinding<CompoundButton>
     {
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         public MvxCompoundButtonCheckedTargetBinding(object target, PropertyInfo targetPropertyInfo)
             : base(target, targetPropertyInfo)
@@ -33,9 +35,10 @@ namespace MvvmCross.Binding.Droid.Target
                                       "Error - compoundButton is null in MvxCompoundButtonCheckedTargetBinding");
                 return;
             }
-
-            _subscribed = true;
-            compoundButton.CheckedChange += CompoundButtonOnCheckedChange;
+            
+            _subscription = compoundButton.WeakSubscribe<CompoundButton, CompoundButton.CheckedChangeEventArgs>(
+                nameof(compoundButton.CheckedChange),
+                CompoundButtonOnCheckedChange);
         }
 
         private void CompoundButtonOnCheckedChange(object sender, CompoundButton.CheckedChangeEventArgs args)
@@ -47,12 +50,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var compoundButton = View;
-                if (compoundButton != null && _subscribed)
-                {
-                    compoundButton.CheckedChange -= CompoundButtonOnCheckedChange;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
 
             base.Dispose(isDisposing);

--- a/MvvmCross/Binding/Droid/Target/MvxCompoundButtonCheckedTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxCompoundButtonCheckedTargetBinding.cs
@@ -7,7 +7,6 @@
 
 using System.Reflection;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.Platform;
 using System;
 using MvvmCross.Platform.WeakSubscription;
@@ -15,7 +14,7 @@ using MvvmCross.Platform.WeakSubscription;
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxCompoundButtonCheckedTargetBinding
-        : MvxPropertyInfoTargetBinding<CompoundButton>
+        : MvxAndroidPropertyInfoTargetBinding<CompoundButton>
     {
         private IDisposable _subscription;
 

--- a/MvvmCross/Binding/Droid/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
@@ -3,6 +3,7 @@ using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.Platform;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -16,7 +17,7 @@ namespace MvvmCross.Binding.Droid.Target
         : MvxConvertingTargetBinding
     {
         private object _currentValue;
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         public MvxExpandableListViewSelectedItemTargetBinding(MvxExpandableListView target)
             : base(target)
@@ -63,20 +64,16 @@ namespace MvvmCross.Binding.Droid.Target
             if (listView == null)
                 return;
 
-            listView.ChildClick += OnChildClick;
-            _subscribed = true;
+            _subscription = listView.WeakSubscribe<ExpandableListView, ExpandableListView.ChildClickEventArgs>(
+                nameof(listView.ChildClick),
+                OnChildClick);
         }
 
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)
             {
-                var listView = (ExpandableListView)ListView;
-                if (listView != null && _subscribed)
-                {
-                    listView.ChildClick -= OnChildClick;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Binding/Droid/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
@@ -2,7 +2,6 @@ using System;
 using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.Platform;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
@@ -14,7 +13,7 @@ namespace MvvmCross.Binding.Droid.Target
     //     if null or equal respectively.  This class foregoes this so that if the bound value of
     //     SelectedItem is set to null we can "override" _currentValue.
     public class MvxExpandableListViewSelectedItemTargetBinding 
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         private object _currentValue;
         private IDisposable _subscription;
@@ -32,14 +31,14 @@ namespace MvvmCross.Binding.Droid.Target
             //if (value == null || value == _currentValue)
             //    return;
 
+            var listView = (MvxExpandableListView)target;
+
             if (value == null)
             {
                 _currentValue = null;
-                ListView.ClearChoices();
+                listView.ClearChoices();
                 return;
             }
-
-            var listView = (MvxExpandableListView)target;
             var positions = ((MvxExpandableListAdapter)listView.ExpandableListAdapter).GetPositions(value);
             if (positions == null)
             {

--- a/MvvmCross/Binding/Droid/Target/MvxListPreferenceTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxListPreferenceTargetBinding.cs
@@ -4,7 +4,7 @@ namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxListPreferenceTargetBinding : MvxPreferenceValueTargetBinding
     {
-        public MvxListPreferenceTargetBinding(Preference preference)
+        public MvxListPreferenceTargetBinding(ListPreference preference)
             : base(preference)
         {
         }

--- a/MvvmCross/Binding/Droid/Target/MvxListViewSelectedItemTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxListViewSelectedItemTargetBinding.cs
@@ -9,7 +9,6 @@ using System;
 using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.Platform;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
@@ -17,7 +16,7 @@ namespace MvvmCross.Binding.Droid.Target
 #warning Can this be expanded to GridView too? Or to others?
 
     public class MvxListViewSelectedItemTargetBinding
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         protected MvxListView ListView => (MvxListView)Target;
 

--- a/MvvmCross/Binding/Droid/Target/MvxListViewSelectedItemTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxListViewSelectedItemTargetBinding.cs
@@ -10,6 +10,7 @@ using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.Platform;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -21,7 +22,7 @@ namespace MvvmCross.Binding.Droid.Target
         protected MvxListView ListView => (MvxListView)Target;
 
         private object _currentValue;
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         public MvxListViewSelectedItemTargetBinding(MvxListView view)
             : base(view)
@@ -68,8 +69,7 @@ namespace MvvmCross.Binding.Droid.Target
             if (listView == null)
                 return;
 
-            listView.ItemClick += OnItemClick;
-            _subscribed = true;
+            _subscription = listView.WeakSubscribe<ListView, AdapterView.ItemClickEventArgs>(nameof(listView.ItemClick), OnItemClick);
         }
 
         public override Type TargetType => typeof(object);
@@ -78,12 +78,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var listView = (ListView)ListView;
-                if (listView != null && _subscribed)
-                {
-                    listView.ItemClick -= OnItemClick;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Binding/Droid/Target/MvxPreferenceValueTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxPreferenceValueTargetBinding.cs
@@ -2,12 +2,15 @@
 using Android.Preferences;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxPreferenceValueTargetBinding 
         : MvxConvertingTargetBinding
     {
+        private IDisposable _subscription;
+
         public MvxPreferenceValueTargetBinding(Preference preference)
             : base(preference)
         { }
@@ -20,7 +23,9 @@ namespace MvvmCross.Binding.Droid.Target
 
         public override void SubscribeToEvents()
         {
-            Preference.PreferenceChange += HandlePreferenceChange;
+            _subscription = Preference.WeakSubscribe<Preference, Preference.PreferenceChangeEventArgs>(
+                nameof(Preference.PreferenceChange),
+                HandlePreferenceChange);
         }
 
         protected void HandlePreferenceChange(object sender, Preference.PreferenceChangeEventArgs e)
@@ -36,10 +41,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                if (Preference != null)
-                {
-                    Preference.PreferenceChange -= HandlePreferenceChange;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
 
             base.Dispose(isDisposing);

--- a/MvvmCross/Binding/Droid/Target/MvxPreferenceValueTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxPreferenceValueTargetBinding.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using Android.Preferences;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxPreferenceValueTargetBinding 
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         private IDisposable _subscription;
 

--- a/MvvmCross/Binding/Droid/Target/MvxRadioGroupSelectedItemBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxRadioGroupSelectedItemBinding.cs
@@ -8,13 +8,12 @@
 using System;
 using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxRadioGroupSelectedItemBinding 
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         private object _currentValue;
         private IDisposable _subscription;
@@ -44,7 +43,8 @@ namespace MvvmCross.Binding.Droid.Target
         private void RadioGroupCheckedChanged(object sender, RadioGroup.CheckedChangeEventArgs args)
         {
             var radioGroup = (MvxRadioGroup)Target;
-            if (radioGroup == null) { return; }
+            if (radioGroup == null)
+                return;
 
             object newValue = null;
             var r = radioGroup.FindViewById<RadioButton>(args.CheckedId);

--- a/MvvmCross/Binding/Droid/Target/MvxRadioGroupSelectedItemBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxRadioGroupSelectedItemBinding.cs
@@ -9,6 +9,7 @@ using System;
 using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -16,11 +17,14 @@ namespace MvvmCross.Binding.Droid.Target
         : MvxConvertingTargetBinding
     {
         private object _currentValue;
+        private IDisposable _subscription;
 
         public MvxRadioGroupSelectedItemBinding(MvxRadioGroup radioGroup)
             : base(radioGroup)
         {
-            radioGroup.CheckedChange += RadioGroupCheckedChanged;
+            _subscription = radioGroup.WeakSubscribe<RadioGroup, RadioGroup.CheckedChangeEventArgs>(
+                nameof(RadioGroup.CheckedChange),
+                RadioGroupCheckedChanged);
         }
 
         private bool CheckValueChanged(object newValue)
@@ -106,11 +110,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var radioGroup = (MvxRadioGroup)Target;
-                if (radioGroup != null)
-                {
-                    radioGroup.CheckedChange -= RadioGroupCheckedChanged;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Binding/Droid/Target/MvxRatingBarRatingTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxRatingBarRatingTargetBinding.cs
@@ -7,13 +7,12 @@
 
 using System;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxRatingBarRatingTargetBinding 
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         protected RatingBar RatingBar => (RatingBar)Target;
 

--- a/MvvmCross/Binding/Droid/Target/MvxRatingBarRatingTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxRatingBarRatingTargetBinding.cs
@@ -8,6 +8,7 @@
 using System;
 using Android.Widget;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -16,6 +17,8 @@ namespace MvvmCross.Binding.Droid.Target
     {
         protected RatingBar RatingBar => (RatingBar)Target;
 
+        private IDisposable _subscription;
+
         public MvxRatingBarRatingTargetBinding(RatingBar target)
             : base(target)
         {
@@ -23,7 +26,9 @@ namespace MvvmCross.Binding.Droid.Target
 
         public override void SubscribeToEvents()
         {
-            RatingBar.RatingBarChange += RatingBar_RatingBarChange;
+            _subscription = RatingBar.WeakSubscribe<RatingBar, RatingBar.RatingBarChangeEventArgs>(
+                nameof(RatingBar.RatingBarChange),
+                RatingBar_RatingBarChange);
         }
 
         private void RatingBar_RatingBarChange(object sender, RatingBar.RatingBarChangeEventArgs e)
@@ -51,11 +56,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var target = Target as RatingBar;
-                if (target != null)
-                {
-                    target.RatingBarChange -= RatingBar_RatingBarChange;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
@@ -1,12 +1,11 @@
 using System;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxSearchViewQueryTextTargetBinding 
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         public MvxSearchViewQueryTextTargetBinding(object target)
             : base(target)

--- a/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
@@ -1,6 +1,7 @@
 using System;
 using Android.Widget;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -12,6 +13,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
         }
 
+        private IDisposable _subscription;
+
         public override Type TargetType => typeof(string);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWayToSource;
@@ -20,7 +23,9 @@ namespace MvvmCross.Binding.Droid.Target
 
         public override void SubscribeToEvents()
         {
-            SearchView.QueryTextChange += HandleQueryTextChanged;
+            _subscription = SearchView.WeakSubscribe<SearchView, SearchView.QueryTextChangeEventArgs>(
+                nameof(SearchView.QueryTextChange),
+                HandleQueryTextChanged);
         }
 
         protected override void SetValueImpl(object target, object value)
@@ -31,11 +36,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var target = Target as SearchView;
-                if (target != null)
-                {
-                    target.QueryTextChange -= HandleQueryTextChanged;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
 
             base.Dispose(isDisposing);

--- a/MvvmCross/Binding/Droid/Target/MvxSeekBarProgressTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxSeekBarProgressTargetBinding.cs
@@ -9,6 +9,8 @@ using System.Reflection;
 using Android.Widget;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.Platform;
+using System;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -20,7 +22,7 @@ namespace MvvmCross.Binding.Droid.Target
         {
         }
 
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         // this variable isn't used, but including this here prevents Mono from optimising the call out!
         private int JustForReflection
@@ -55,20 +57,17 @@ namespace MvvmCross.Binding.Droid.Target
                 return;
             }
 
-            seekBar.ProgressChanged += SeekBarProgressChanged;
-            _subscribed = true;
+            _subscription = seekBar.WeakSubscribe<SeekBar, SeekBar.ProgressChangedEventArgs>(
+                nameof(seekBar.ProgressChanged),
+                SeekBarProgressChanged);
         }
 
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)
             {
-                var view = View;
-                if (view != null && _subscribed)
-                {
-                    view.ProgressChanged -= SeekBarProgressChanged;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Binding/Droid/Target/MvxSpinnerSelectedItemBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxSpinnerSelectedItemBinding.cs
@@ -9,13 +9,12 @@ using System;
 using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.Platform;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxSpinnerSelectedItemBinding
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         protected MvxSpinner Spinner => (MvxSpinner)Target;
 

--- a/MvvmCross/Binding/Droid/Target/MvxSpinnerSelectedItemBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxSpinnerSelectedItemBinding.cs
@@ -10,6 +10,7 @@ using Android.Widget;
 using MvvmCross.Binding.Droid.Views;
 using MvvmCross.Platform.Platform;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -19,7 +20,7 @@ namespace MvvmCross.Binding.Droid.Target
         protected MvxSpinner Spinner => (MvxSpinner)Target;
 
         private object _currentValue;
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         public MvxSpinnerSelectedItemBinding(MvxSpinner spinner)
             : base(spinner)
@@ -84,8 +85,9 @@ namespace MvvmCross.Binding.Droid.Target
             if (spinner == null)
                 return;
 
-            spinner.ItemSelected += SpinnerItemSelected;
-            _subscribed = true;
+            _subscription = spinner.WeakSubscribe<AdapterView, AdapterView.ItemSelectedEventArgs>(
+                nameof(spinner.ItemSelected),
+                SpinnerItemSelected);
         }
 
         public override Type TargetType => typeof(object);
@@ -94,12 +96,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var spinner = Spinner;
-                if (spinner != null && _subscribed)
-                {
-                    spinner.ItemSelected -= SpinnerItemSelected;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewFocusTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewFocusTargetBinding.cs
@@ -8,13 +8,12 @@
 using System;
 using Android.Views;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxTextViewFocusTargetBinding
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         private IDisposable _subscription;
 

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewFocusTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewFocusTargetBinding.cs
@@ -9,13 +9,14 @@ using System;
 using Android.Views;
 using Android.Widget;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxTextViewFocusTargetBinding
         : MvxConvertingTargetBinding
     {
-        private bool _subscribed;
+        private IDisposable _subscription;
 
         protected EditText TextField => Target as EditText;
 
@@ -40,8 +41,9 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (TextField == null) return;
 
-            TextField.FocusChange += HandleLostFocus;
-            _subscribed = true;
+            _subscription = TextField.WeakSubscribe<View, View.FocusChangeEventArgs>(
+                nameof(TextField.FocusChange),
+                HandleLostFocus);
         }
 
         private void HandleLostFocus(object sender, View.FocusChangeEventArgs e)
@@ -56,11 +58,8 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                if (TextField != null && _subscribed)
-                {
-                    TextField.FocusChange -= HandleLostFocus;
-                    _subscribed = false;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewHintTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewHintTargetBinding.cs
@@ -1,11 +1,10 @@
 using System;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxTextViewHintTargetBinding 
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         public MvxTextViewHintTargetBinding(TextView target)
             : base(target) {}

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewTextFormattedTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewTextFormattedTargetBinding.cs
@@ -8,7 +8,6 @@
 using System;
 using Android.Text;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.ExtensionMethods;
 using MvvmCross.Platform.WeakSubscription;
 using MvvmCross.Platform.Platform;
@@ -16,7 +15,7 @@ using MvvmCross.Platform.Platform;
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxTextViewTextFormattedTargetBinding
-        : MvxConvertingTargetBinding, IMvxEditableTextView
+        : MvxAndroidTargetBinding, IMvxEditableTextView
     {
         private readonly bool _isEditTextBinding;
         private IDisposable _subscription;

--- a/MvvmCross/Binding/Droid/Target/MvxTextViewTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxTextViewTextTargetBinding.cs
@@ -8,7 +8,6 @@
 using System;
 using Android.Text;
 using Android.Widget;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.ExtensionMethods;
 using MvvmCross.Platform.WeakSubscription;
 using MvvmCross.Platform.Platform;
@@ -16,7 +15,7 @@ using MvvmCross.Platform.Platform;
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxTextViewTextTargetBinding
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
         , IMvxEditableTextView
     {
         private readonly bool _isEditTextBinding;

--- a/MvvmCross/Binding/Droid/Target/MvxViewClickBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxViewClickBinding.cs
@@ -9,12 +9,10 @@ using System;
 using System.Windows.Input;
 using Android.Views;
 using MvvmCross.Platform.WeakSubscription;
-using MvvmCross.Binding.Bindings.Target;
 
 namespace MvvmCross.Binding.Droid.Target
 {
-    public class MvxViewClickBinding
-        : MvxConvertingTargetBinding
+    public class MvxViewClickBinding : MvxAndroidTargetBinding
     {
         private ICommand _command;
         private IDisposable _clickSubscription;

--- a/MvvmCross/Binding/Droid/Target/MvxViewLongClickBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxViewLongClickBinding.cs
@@ -8,13 +8,12 @@
 using System;
 using System.Windows.Input;
 using Android.Views;
-using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
     public class MvxViewLongClickBinding
-        : MvxConvertingTargetBinding
+        : MvxAndroidTargetBinding
     {
         private ICommand _command;
         private IDisposable _subscription;

--- a/MvvmCross/Binding/Droid/Target/MvxViewLongClickBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxViewLongClickBinding.cs
@@ -9,6 +9,7 @@ using System;
 using System.Windows.Input;
 using Android.Views;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Droid.Target
 {
@@ -16,13 +17,14 @@ namespace MvvmCross.Binding.Droid.Target
         : MvxConvertingTargetBinding
     {
         private ICommand _command;
+        private IDisposable _subscription;
 
         protected View View => (View)Target;
 
         public MvxViewLongClickBinding(View view)
             : base(view)
         {
-            view.LongClick += ViewOnLongClick;
+            _subscription = view.WeakSubscribe<View, View.LongClickEventArgs>(nameof(view.LongClick), ViewOnLongClick);
         }
 
         private void ViewOnLongClick(object sender, View.LongClickEventArgs longClickEventArgs)
@@ -49,11 +51,10 @@ namespace MvvmCross.Binding.Droid.Target
         {
             if (isDisposing)
             {
-                var view = View;
-                if (view != null)
-                {
-                    view.LongClick -= ViewOnLongClick;
-                }
+                _subscription?.Dispose();
+                _subscription = null;
+
+                _command = null;
             }
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Core/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/MvxFullBinding.cs
@@ -193,8 +193,7 @@ namespace MvvmCross.Binding.Bindings
             });
         }
 
-        private void UpdateSourceFromTarget(
-            object value)
+        private void UpdateSourceFromTarget(object value)
         {
             if (value == MvxBindingConstant.DoNothing)
                 return;

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
@@ -80,8 +80,7 @@ namespace MvvmCross.Binding.Bindings.Target
         protected sealed override void FireValueChanged(object newValue)
         {
             // we don't allow 'reentrant' updates of any kind from target to source
-            if (_isUpdatingTarget
-                || _isUpdatingSource)
+            if (_isUpdatingTarget || _isUpdatingSource)
                 return;
 
             MvxBindingTrace.Trace(MvxTraceLevel.Diagnostic, "Firing changed to " + (newValue ?? ""));

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
@@ -27,13 +27,16 @@ namespace MvvmCross.Binding.Bindings.Target
 
         public override void SetValue(object value)
         {
-            MvxBindingTrace.Trace(MvxTraceLevel.Diagnostic, "Receiving setValue to " + (value ?? ""));
+            MvxBindingTrace.Trace(MvxTraceLevel.Diagnostic, "Receiving SetValue to " + (value ?? ""));
             var target = Target;
             if (target == null)
             {
                 MvxBindingTrace.Trace(MvxTraceLevel.Warning, "Weak Target is null in {0} - skipping set", GetType().Name);
                 return;
             }
+
+            if (ShouldSkipSetValueForPlatformSpecificReasons(target, value))
+                return;
 
             if (ShouldSkipSetValueForViewSpecificReasons(target, value))
                 return;
@@ -67,6 +70,11 @@ namespace MvvmCross.Binding.Bindings.Target
         }
 
         protected virtual bool ShouldSkipSetValueForViewSpecificReasons(object target, object value)
+        {
+            return false;
+        }
+
+        protected virtual bool ShouldSkipSetValueForPlatformSpecificReasons(object target, object value)
         {
             return false;
         }

--- a/MvvmCross/Platform/Droid/MvvmCross.Platform.Droid.csproj
+++ b/MvvmCross/Platform/Droid/MvvmCross.Platform.Droid.csproj
@@ -62,6 +62,8 @@
     <Compile Include="Views\MvxIntentRequestCode.cs" />
     <Compile Include="Views\MvxIntentResultEventArgs.cs" />
     <Compile Include="Views\MvxStartActivityForResultParameters.cs" />
+    <Compile Include="WeakSubscription\MvxAndroidTargetEventSubscription.cs" />
+    <Compile Include="WeakSubscription\MvxAndroidWeakSubscriptionExtensionMethods.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Platform\MvvmCross.Platform.csproj">

--- a/MvvmCross/Platform/Droid/MvxReplaceableJavaContainer.cs
+++ b/MvvmCross/Platform/Droid/MvxReplaceableJavaContainer.cs
@@ -7,9 +7,7 @@
 
 namespace MvvmCross.Platform.Droid
 {
-    using Java.Lang;
-
-    public class MvxReplaceableJavaContainer : Object
+    public class MvxReplaceableJavaContainer : Java.Lang.Object
     {
         public object Object { get; set; }
 

--- a/MvvmCross/Platform/Droid/WeakSubscription/MvxAndroidTargetEventSubscription.cs
+++ b/MvvmCross/Platform/Droid/WeakSubscription/MvxAndroidTargetEventSubscription.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Reflection;
+using Android.Runtime;
+using MvvmCross.Platform.WeakSubscription;
+
+namespace MvvmCross.Platform.Droid.WeakSubscription
+{
+    /// <summary>
+    /// Weak subscription to an event where the target may be an IJavaObject
+    /// and could be collected by the Android runtime before being collected by the Mono GC.
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TEventArgs"></typeparam>
+    public class MvxAndroidTargetEventSubscription<TSource, TEventArgs> : MvxWeakEventSubscription<TSource, TEventArgs>
+        where TSource : class
+    {
+        public MvxAndroidTargetEventSubscription(TSource source, string sourceEventName, EventHandler<TEventArgs> targetEventHandler)
+            : base(source, sourceEventName, targetEventHandler)
+        {
+        }
+
+        public MvxAndroidTargetEventSubscription(TSource source, EventInfo sourceEventInfo, EventHandler<TEventArgs> targetEventHandler)
+            : base(source, sourceEventInfo, targetEventHandler)
+        {
+        }
+
+        protected override object GetTargetObject()
+        {
+            // If the object has been GCed by java but NOT mono
+            // then it is invalid and should not be manipulated.
+            var target = base.GetTargetObject();
+            var javaObj = target as IJavaObject;
+            if (javaObj != null && javaObj.Handle == IntPtr.Zero)
+            {
+                return null;
+            }
+            return target;
+        }
+
+        protected override Delegate CreateEventHandler()
+        {
+            return new EventHandler<TEventArgs>(this.OnSourceEvent);
+        }
+    }
+
+    public class MvxJavaEventSubscription<TSource> : MvxWeakEventSubscription<TSource> where TSource : class
+    {
+        public MvxJavaEventSubscription(TSource source, string sourceEventName, EventHandler targetEventHandler)
+            : base(source, sourceEventName, targetEventHandler)
+        {
+        }
+
+        public MvxJavaEventSubscription(TSource source, EventInfo sourceEventInfo, EventHandler targetEventHandler)
+            : base(source, sourceEventInfo, targetEventHandler)
+        {
+        }
+
+        protected override object GetTargetObject()
+        {
+            // If the object has been GCed by java but NOT mono
+            // then it is invalid and should not be manipulated.
+            var target = base.GetTargetObject();
+            var javaObj = target as IJavaObject;
+            if (javaObj != null && javaObj.Handle == IntPtr.Zero)
+            {
+                return null;
+            }
+            return target;
+        }
+
+        protected override Delegate CreateEventHandler()
+        {
+            return new EventHandler(this.OnSourceEvent);
+        }
+    }
+}

--- a/MvvmCross/Platform/Droid/WeakSubscription/MvxAndroidWeakSubscriptionExtensionMethods.cs
+++ b/MvvmCross/Platform/Droid/WeakSubscription/MvxAndroidWeakSubscriptionExtensionMethods.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace MvvmCross.Platform.Droid.WeakSubscription
+{
+    public static class MvxAndroidWeakSubscriptionExtensionMethods
+    {
+        public static MvxJavaEventSubscription<TSource> WeakSubscribe<TSource>(this TSource source, string eventName, EventHandler eventHandler)
+            where TSource : class
+        {
+            return new MvxJavaEventSubscription<TSource>(source, eventName, eventHandler);
+        }
+
+        public static MvxAndroidTargetEventSubscription<TSource, TEventArgs> WeakSubscribe<TSource, TEventArgs>(this TSource source, string eventName, EventHandler<TEventArgs> eventHandler)
+            where TSource : class
+        {
+            return new MvxAndroidTargetEventSubscription<TSource, TEventArgs>(source, eventName, eventHandler);
+        }
+    }
+}

--- a/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakEventSubscription.cs
@@ -12,8 +12,7 @@ namespace MvvmCross.Platform.WeakSubscription
 
     using MvvmCross.Platform.Exceptions;
 
-    public class MvxWeakEventSubscription<TSource, TEventArgs>
-        : IDisposable
+    public class MvxWeakEventSubscription<TSource, TEventArgs> : IDisposable
         where TSource : class
         where TEventArgs : EventArgs
     {
@@ -68,6 +67,113 @@ namespace MvvmCross.Platform.WeakSubscription
 
         //This is the method that will handle the event of source.
         protected void OnSourceEvent(object sender, TEventArgs e)
+        {
+            var target = this._targetReference.Target;
+            if (target != null)
+            {
+                this._eventHandlerMethodInfo.Invoke(target, new[] { sender, e });
+            }
+            else
+            {
+                this.RemoveEventHandler();
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.RemoveEventHandler();
+            }
+        }
+
+        private void RemoveEventHandler()
+        {
+            if (!this._subscribed)
+                return;
+
+            var source = (TSource)this._sourceReference.Target;
+            if (source != null)
+            {
+                this._sourceEventInfo.GetRemoveMethod().Invoke(source, new object[] { this._ourEventHandler });
+                this._subscribed = false;
+            }
+        }
+
+        private void AddEventHandler()
+        {
+            if (this._subscribed)
+                throw new MvxException("Should not call _subscribed twice");
+
+            var source = (TSource)this._sourceReference.Target;
+            if (source != null)
+            {
+                this._sourceEventInfo.GetAddMethod().Invoke(source, new object[] { this._ourEventHandler });
+                this._subscribed = true;
+            }
+        }
+    }
+
+    public class MvxWeakEventSubscription<TSource> : IDisposable
+        where TSource : class
+    {
+        private readonly WeakReference _targetReference;
+        private readonly WeakReference _sourceReference;
+
+        private readonly MethodInfo _eventHandlerMethodInfo;
+
+        private readonly EventInfo _sourceEventInfo;
+
+        // we store a copy of our Delegate/EventHandler in order to prevent it being
+        // garbage collected while the `client` still has ownership of this subscription
+        private readonly Delegate _ourEventHandler;
+
+        private bool _subscribed;
+
+        public MvxWeakEventSubscription(
+            TSource source,
+            string sourceEventName,
+            EventHandler targetEventHandler)
+            : this(source, typeof(TSource).GetEvent(sourceEventName), targetEventHandler)
+        {
+        }
+
+        protected MvxWeakEventSubscription(
+            TSource source,
+            EventInfo sourceEventInfo,
+            EventHandler targetEventHandler)
+        {
+            if (source == null)
+                throw new ArgumentNullException();
+
+            if (sourceEventInfo == null)
+                throw new ArgumentNullException(nameof(sourceEventInfo),
+                                                "missing source event info in MvxWeakEventSubscription");
+
+            this._eventHandlerMethodInfo = targetEventHandler.GetMethodInfo();
+            this._targetReference = new WeakReference(targetEventHandler.Target);
+            this._sourceReference = new WeakReference(source);
+            this._sourceEventInfo = sourceEventInfo;
+
+            // TODO: need to move this virtual call out of the constructor - need to implement a separate Init() method
+            this._ourEventHandler = this.CreateEventHandler();
+
+            this.AddEventHandler();
+        }
+
+        protected virtual Delegate CreateEventHandler()
+        {
+            return new EventHandler(this.OnSourceEvent);
+        }
+
+        //This is the method that will handle the event of source.
+        protected void OnSourceEvent(object sender, EventArgs e)
         {
             var target = this._targetReference.Target;
             if (target != null)

--- a/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakEventSubscription.cs
@@ -5,19 +5,18 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
+using System.Reflection;
+using MvvmCross.Platform.Exceptions;
+
 namespace MvvmCross.Platform.WeakSubscription
 {
-    using System;
-    using System.Reflection;
-
-    using MvvmCross.Platform.Exceptions;
-
     public class MvxWeakEventSubscription<TSource, TEventArgs> : IDisposable
         where TSource : class
         where TEventArgs : EventArgs
     {
         private readonly WeakReference _targetReference;
-        private readonly WeakReference _sourceReference;
+        private readonly WeakReference<TSource> _sourceReference;
 
         private readonly MethodInfo _eventHandlerMethodInfo;
 
@@ -51,7 +50,7 @@ namespace MvvmCross.Platform.WeakSubscription
 
             this._eventHandlerMethodInfo = targetEventHandler.GetMethodInfo();
             this._targetReference = new WeakReference(targetEventHandler.Target);
-            this._sourceReference = new WeakReference(source);
+            this._sourceReference = new WeakReference<TSource>(source);
             this._sourceEventInfo = sourceEventInfo;
 
             // TODO: need to move this virtual call out of the constructor - need to implement a separate Init() method
@@ -98,8 +97,8 @@ namespace MvvmCross.Platform.WeakSubscription
             if (!this._subscribed)
                 return;
 
-            var source = (TSource)this._sourceReference.Target;
-            if (source != null)
+            TSource source;
+            if (this._sourceReference.TryGetTarget(out source))
             {
                 this._sourceEventInfo.GetRemoveMethod().Invoke(source, new object[] { this._ourEventHandler });
                 this._subscribed = false;
@@ -111,8 +110,8 @@ namespace MvvmCross.Platform.WeakSubscription
             if (this._subscribed)
                 throw new MvxException("Should not call _subscribed twice");
 
-            var source = (TSource)this._sourceReference.Target;
-            if (source != null)
+            TSource source;
+            if (this._sourceReference.TryGetTarget(out source))
             {
                 this._sourceEventInfo.GetAddMethod().Invoke(source, new object[] { this._ourEventHandler });
                 this._subscribed = true;
@@ -124,7 +123,7 @@ namespace MvvmCross.Platform.WeakSubscription
         where TSource : class
     {
         private readonly WeakReference _targetReference;
-        private readonly WeakReference _sourceReference;
+        private readonly WeakReference<TSource> _sourceReference;
 
         private readonly MethodInfo _eventHandlerMethodInfo;
 
@@ -158,7 +157,7 @@ namespace MvvmCross.Platform.WeakSubscription
 
             this._eventHandlerMethodInfo = targetEventHandler.GetMethodInfo();
             this._targetReference = new WeakReference(targetEventHandler.Target);
-            this._sourceReference = new WeakReference(source);
+            this._sourceReference = new WeakReference<TSource>(source);
             this._sourceEventInfo = sourceEventInfo;
 
             // TODO: need to move this virtual call out of the constructor - need to implement a separate Init() method
@@ -205,8 +204,8 @@ namespace MvvmCross.Platform.WeakSubscription
             if (!this._subscribed)
                 return;
 
-            var source = (TSource)this._sourceReference.Target;
-            if (source != null)
+            TSource source;
+            if (this._sourceReference.TryGetTarget(out source))
             {
                 this._sourceEventInfo.GetRemoveMethod().Invoke(source, new object[] { this._ourEventHandler });
                 this._subscribed = false;
@@ -218,8 +217,8 @@ namespace MvvmCross.Platform.WeakSubscription
             if (this._subscribed)
                 throw new MvxException("Should not call _subscribed twice");
 
-            var source = (TSource)this._sourceReference.Target;
-            if (source != null)
+            TSource source;
+            if (this._sourceReference.TryGetTarget(out source))
             {
                 this._sourceEventInfo.GetAddMethod().Invoke(source, new object[] { this._ourEventHandler });
                 this._subscribed = true;

--- a/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakEventSubscription.cs
@@ -13,7 +13,6 @@ namespace MvvmCross.Platform.WeakSubscription
 {
     public class MvxWeakEventSubscription<TSource, TEventArgs> : IDisposable
         where TSource : class
-        where TEventArgs : EventArgs
     {
         private readonly WeakReference _targetReference;
         private readonly WeakReference<TSource> _sourceReference;
@@ -64,10 +63,15 @@ namespace MvvmCross.Platform.WeakSubscription
             return new EventHandler<TEventArgs>(this.OnSourceEvent);
         }
 
+        protected virtual object GetTargetObject()
+        {
+            return _targetReference.Target;
+        }
+
         //This is the method that will handle the event of source.
         protected void OnSourceEvent(object sender, TEventArgs e)
         {
-            var target = this._targetReference.Target;
+            var target = GetTargetObject();
             if (target != null)
             {
                 this._eventHandlerMethodInfo.Invoke(target, new[] { sender, e });
@@ -166,6 +170,11 @@ namespace MvvmCross.Platform.WeakSubscription
             this.AddEventHandler();
         }
 
+        protected virtual object GetTargetObject()
+        {
+            return _targetReference.Target;
+        }
+
         protected virtual Delegate CreateEventHandler()
         {
             return new EventHandler(this.OnSourceEvent);
@@ -174,7 +183,7 @@ namespace MvvmCross.Platform.WeakSubscription
         //This is the method that will handle the event of source.
         protected void OnSourceEvent(object sender, EventArgs e)
         {
-            var target = this._targetReference.Target;
+            var target = GetTargetObject();
             if (target != null)
             {
                 this._eventHandlerMethodInfo.Invoke(target, new[] { sender, e });

--- a/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakSubscriptionExtensionMethods.cs
+++ b/MvvmCross/Platform/Platform/WeakSubscription/MvxWeakSubscriptionExtensionMethods.cs
@@ -68,5 +68,17 @@ namespace MvvmCross.Platform.WeakSubscription
         {
             return new MvxCanExecuteChangedEventSubscription(source, eventHandler);
         }
+
+        public static MvxWeakEventSubscription<TSource> WeakSubscribe<TSource>(this TSource source, string eventName, EventHandler eventHandler)
+            where TSource : class
+        {
+            return new MvxWeakEventSubscription<TSource>(source, eventName, eventHandler);
+        }
+
+        public static MvxWeakEventSubscription<TSource, TEventArgs> WeakSubscribe<TSource, TEventArgs>(this TSource source, string eventName, EventHandler<TEventArgs> eventHandler)
+            where TSource : class
+        {
+            return new MvxWeakEventSubscription<TSource, TEventArgs>(source, eventName, eventHandler);
+        }
     }
 }


### PR DESCRIPTION
Occasionally we can get in a state where an object has been garbage collected by the Android GC but not Mono.  This is most common with `MvxRecyclerView` where we can't deterministically destroy the bindings.

To protect against this we need to detect invalid Java Handles and skip setting binding values.  Part of this change introduces a weak event subscription model that also takes this into account.  We now weak subscribe to Android Views/Widgets in an attempt to reduce the refcount on the Mono side.  The latter change is more of a precautionary measure but is part of the reason we're seeing: https://github.com/MvvmCross/MvvmCross/issues/1405

Fixes: https://github.com/MvvmCross/MvvmCross/issues/1402

This is the first part of a two part fix for:
https://github.com/MvvmCross/MvvmCross/issues/1405
https://github.com/MvvmCross/MvvmCross/issues/1444

