### PR TITLE
Improve error checking for ReadOnly property

### DIFF
--- a/MvvmCross/Core/Binding/Bindings/Target/MvxPropertyInfoTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxPropertyInfoTargetBinding.cs
@@ -12,6 +12,7 @@ namespace MvvmCross.Binding.Bindings.Target
 
     using MvvmCross.Binding.Attributes;
     using MvvmCross.Platform;
+    using MvvmCross.Platform.Exceptions;
 
     public class MvxPropertyInfoTargetBinding : MvxConvertingTargetBinding
     {
@@ -47,7 +48,15 @@ namespace MvvmCross.Binding.Bindings.Target
         {
 #warning Check this is Unity compatible :/
             var setMethod = this.TargetPropertyInfo.GetSetMethod();
-            setMethod.Invoke(target, new object[] { value });
+
+            if (setMethod != null)
+            {
+                setMethod.Invoke(target, new object[] { value });
+            }
+            else
+            {
+                throw new MvxException("No Set method found for property {0}. Check property not read-only", this.TargetPropertyInfo.Name);
+            }
         }
     }
 


### PR DESCRIPTION
Improve error checking in the scenario where the developer binds to a ReadOnly property. Stupid thing to do I know but without this Exception I found it very hard to debug what the problem was on the iOS platform.
