### PR TITLE
Drawable target binding

### DIFF
--- a/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
+++ b/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
@@ -81,6 +81,7 @@
     <Compile Include="ResourceHelpers\MvxAndroidBindingResource.cs" />
     <Compile Include="ResourceHelpers\MvxAppResourceTypeFinder.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
+    <Compile Include="Target\MvxImageViewImageDrawableTargetBinding.cs" />
     <Compile Include="Target\MvxListPreferenceTargetBinding.cs" />
     <Compile Include="Target\MvxAndroidPropertyInfoTargetBinding.cs" />
     <Compile Include="Target\MvxTextViewHintTargetBinding.cs" />

--- a/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
@@ -107,6 +107,8 @@ namespace MvvmCross.Binding.Droid
                                                             view => new MvxViewHiddenBinding(view));
             registry.RegisterCustomBindingFactory<ImageView>("Bitmap",
                                                             imageView => new MvxImageViewBitmapTargetBinding(imageView));
+            registry.RegisterCustomBindingFactory<ImageView>("Drawable",
+                                                            imageView => new MvxImageViewImageDrawableTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<ImageView>("DrawableId",
                                                             imageView => new MvxImageViewDrawableTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<ImageView>("DrawableName",

--- a/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Binding/Droid/MvxAndroidBindingBuilder.cs
@@ -6,25 +6,24 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.Preferences;
+using Android.Graphics;
+using Android.Views;
+using Android.Widget;
+
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Droid.Binders;
+using MvvmCross.Binding.Droid.Binders.ViewTypeResolvers;
+using MvvmCross.Binding.Droid.BindingContext;
+using MvvmCross.Binding.Droid.ResourceHelpers;
+using MvvmCross.Binding.Droid.Target;
+using MvvmCross.Binding.Droid.Views;
+using MvvmCross.Platform;
+using MvvmCross.Platform.IoC;
+using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Droid
 {
-    using Android.Graphics;
-    using Android.Views;
-    using Android.Widget;
-
-    using MvvmCross.Binding.BindingContext;
-    using MvvmCross.Binding.Bindings.Target.Construction;
-    using MvvmCross.Binding.Droid.Binders;
-    using MvvmCross.Binding.Droid.Binders.ViewTypeResolvers;
-    using MvvmCross.Binding.Droid.BindingContext;
-    using MvvmCross.Binding.Droid.ResourceHelpers;
-    using MvvmCross.Binding.Droid.Target;
-    using MvvmCross.Binding.Droid.Views;
-    using MvvmCross.Platform;
-    using MvvmCross.Platform.IoC;
-    using MvvmCross.Platform.Platform;
-
     public class MvxAndroidBindingBuilder
         : MvxBindingBuilder
     {
@@ -113,8 +112,8 @@ namespace MvvmCross.Binding.Droid
                                                             imageView => new MvxImageViewDrawableTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<ImageView>("DrawableName",
                                                             imageView => new MvxImageViewDrawableNameTargetBinding(imageView));
-			registry.RegisterCustomBindingFactory<ImageView>("ResourceName",
-															imageView => new MvxImageViewResourceNameTargetBinding(imageView));
+            registry.RegisterCustomBindingFactory<ImageView>("ResourceName",
+                                                            imageView => new MvxImageViewResourceNameTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<ImageView>("AssetImagePath",
                                                              imageView => new MvxImageViewImageTargetBinding(imageView));
             registry.RegisterCustomBindingFactory<MvxSpinner>("SelectedItem",

--- a/MvvmCross/Binding/Droid/Target/MvxImageViewImageDrawableTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxImageViewImageDrawableTargetBinding.cs
@@ -1,0 +1,26 @@
+using System;
+using Android.Graphics.Drawables;
+using Android.Widget;
+
+namespace MvvmCross.Binding.Droid.Target
+{
+    public class MvxImageViewImageDrawableTargetBinding : MvxAndroidTargetBinding
+    {
+        public MvxImageViewImageDrawableTargetBinding(ImageView target)
+            : base(target)
+        {
+        }
+
+        public override Type TargetType => typeof(ImageView);
+
+        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            var view = (ImageView)target;
+            var drawable = value as Drawable;
+
+            view.SetImageDrawable(drawable);
+        }
+    }
+}


### PR DESCRIPTION
Allow the user to bind to an instance of Drawable directly if for example a Converter returns one.