### PR TITLE
Allow table view cells which don't inherit MvxTableViewCell in MvxBaseTableViewSource

### DIFF
--- a/MvvmCross/Binding/iOS/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxBaseTableViewSource.cs
@@ -106,7 +106,7 @@ namespace MvvmCross.Binding.iOS.Views
             var item = this.GetItemAt(indexPath);
             var cell = this.GetOrCreateCellFor(tableView, indexPath, item);
 
-            var bindable = cell as MvxTableViewCell;
+            var bindable = cell as IMvxBindable;
 
             if (bindable != null)
             {


### PR DESCRIPTION
Discovered this as we upgraded from 3.5 to 4.4 - one of our `UITableViewCell` implementations were not receiving a data context, despite a table view source that inherits `MvxBaseTableViewSource`.

Is there any mileage in adding a log here when the cell doesn't implement `IMvxBindable`?