### PR TITLE
Automate register of IMvxAndroidViewPresenter in MvxAndroidSetup

### DIFF
--- a/MvvmCross/Droid/Droid/Platform/MvxAndroidSetup.cs
+++ b/MvvmCross/Droid/Droid/Platform/MvxAndroidSetup.cs
@@ -123,6 +123,7 @@ namespace MvvmCross.Droid.Platform
         protected override IMvxViewDispatcher CreateViewDispatcher()
         {
             var presenter = this.CreateViewPresenter();
+            Mvx.RegisterSingleton(presenter);
             return new MvxAndroidViewDispatcher(presenter);
         }
 


### PR DESCRIPTION
Simplifies developer code by automatically registering the newly created Android presenter. Particularly useful when working with the Mvx caching fragment activities, where the activity will throw an exception if unable to resolve [IMvxAndroidViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/a29b0305ba8f652d485168ce6c79316778db0e5e/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs#L356). Additionally, matches Android to iOS that already automatically registers [IMvxIosViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/iOS/iOS/Platform/MvxIosSetup.cs#L137).