### PR TITLE
WeakReference.IsAlive may not be accurate if true

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
@@ -53,8 +53,8 @@ namespace MvvmCross.Core.ViewModels
                 {
                     foreach (var thing in this._eventHandlers)
                     {
-                        if (thing.IsAlive
-                            && ((EventHandler)thing.Target) == value)
+                        var target = thing.Target;
+                        if (target != null && (EventHandler)target == value)
                         {
                             this._eventHandlers.Remove(thing);
                             break;


### PR DESCRIPTION
The correct way to check for live-ness is to test Target for non-null.
If IsAlive is false then we know the target has been GCed.  If true then
it could be GCed between the check and the access.