### PR TITLE
#1398

### DIFF
--- a/MvvmCross/Core/Binding/BindingContext/MvxTaskBasedBindingContext.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxTaskBasedBindingContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.Bindings;
@@ -117,9 +118,18 @@ namespace MvvmCross.Binding.BindingContext
                 this._delayedActions.Clear();
             }
 
+            // Copy the lists to ensure that if the main thread modifies the collection
+            // once we are on the background thread we don't get an InvalidOperationException. 
+            // Issue: #1398
+            // View bindings need to be deep copied
+            var viewBindingsCopy = this._viewBindings.Select(vb => new KeyValuePair<object, IList<MvxBindingContext.TargetAndBinding>>(vb.Key, vb.Value.ToList()))
+                                                     .ToList();
+
+            var directBindingsCopy = this._directBindings.ToList();
+
             Action setBindingsAction = (() =>
                 {
-                    foreach (var binding in this._viewBindings)
+                    foreach (var binding in viewBindingsCopy)
                     {
                         foreach (var bind in binding.Value)
                         {
@@ -127,7 +137,7 @@ namespace MvvmCross.Binding.BindingContext
                         }
                     }
 
-                    foreach (var binding in this._directBindings)
+                    foreach (var binding in directBindingsCopy)
                     {
                         binding.Binding.DataContext = this._dataContext;
                     }

--- a/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
@@ -53,8 +53,8 @@ namespace MvvmCross.Core.ViewModels
                 {
                     foreach (var thing in this._eventHandlers)
                     {
-                        if (thing.IsAlive
-                            && ((EventHandler)thing.Target) == value)
+                        var target = thing.Target;
+                        if (target != null && (EventHandler)target == value)
                         {
                             this._eventHandlers.Remove(thing);
                             break;


### PR DESCRIPTION
Fixed threading issue in MvxTaskBasedBindingContext where collections were being iterated over on a background thread when they could be modified on the main thread. Now take copies of the collections on the main thread before iterating over the copies in the background thread