### PR TITLE
Change misleading trace message

### DIFF
--- a/MvvmCross/Core/Binding/Bindings/MvxBindingModeExtensionMethods.cs
+++ b/MvvmCross/Core/Binding/Bindings/MvxBindingModeExtensionMethods.cs
@@ -25,7 +25,7 @@ namespace MvvmCross.Binding.Bindings
             {
                 case MvxBindingMode.Default:
                     MvxBindingTrace.Trace(MvxTraceLevel.Warning,
-                                          "Mode of default seen for binding - assuming OneWay");
+                                          "Mode of default seen for binding - assuming TwoWay");
                     return true;
 
                 case MvxBindingMode.OneWay:
@@ -47,7 +47,7 @@ namespace MvvmCross.Binding.Bindings
             {
                 case MvxBindingMode.Default:
                     MvxBindingTrace.Trace(MvxTraceLevel.Warning,
-                                          "Mode of default seen for binding - assuming OneWay");
+                                          "Mode of default seen for binding - assuming TwoWay");
                     return true;
 
                 case MvxBindingMode.OneWay:
@@ -69,7 +69,7 @@ namespace MvvmCross.Binding.Bindings
             {
                 case MvxBindingMode.Default:
                     MvxBindingTrace.Trace(MvxTraceLevel.Warning,
-                                          "Mode of default seen for binding - assuming OneWay");
+                                          "Mode of default seen for binding - assuming TwoWay");
                     return true;
 
                 case MvxBindingMode.OneWay:


### PR DESCRIPTION
For MvxBindingMode.Default binding mode both methods RequireSourceObservation and RequiresTargetObservation return true just like for MvxBindingMode.TwoWay mode, but trace assumes us that default mode is equal to MvxBindingMode.OneWay.