### PR TITLE
Allow user to specify the LayoutManager in axml

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerView.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerView.cs
@@ -32,7 +32,8 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             if (adapter == null)
                 return;
 
-            SetLayoutManager(new LinearLayoutManager(context));
+            if (base.GetLayoutManager() == null)
+                SetLayoutManager(new LinearLayoutManager(context));
 
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             var itemTemplateSelector = MvxRecyclerViewAttributeExtensions.BuildItemTemplateSelector(context, attrs);


### PR DESCRIPTION
The base RecyclerView takes care of instantiating the layout manager
if using `app:layoutManager`

Fixes #1512