### PR TITLE
Explicitly remove views from the RecyclerView when it is detached

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerView.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerView.cs
@@ -50,6 +50,17 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             base.SetLayoutManager(layout);
         }
 
+        protected override void OnDetachedFromWindow()
+        {
+            base.OnDetachedFromWindow();
+
+            // Remove all the views that are currently in play.
+            // This clears out all of the ViewHolder DataContexts by detaching the ViewHolder.
+            // Eventually the GC will come along and clear out the binding contexts.
+            // Issue #1405
+            this.GetLayoutManager()?.RemoveAllViews();
+        }
+
         public new IMvxRecyclerAdapter Adapter
         {
             get { return base.GetAdapter() as IMvxRecyclerAdapter; }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
@@ -132,9 +132,12 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
 
         protected override void Dispose(bool disposing)
         {
+            // Clean up the binding context since nothing
+            // explicitly Disposes of the ViewHolder.
+            _bindingContext?.ClearAllBindings();
+
             if (disposing)
             {
-                _bindingContext.ClearAllBindings();
                 _cachedDataContext = null;
 
                 if (ItemView != null)


### PR DESCRIPTION
This clears out the visible view holders which nulls the DataContext (but keeps a cached copy in the view holder).

It does not clear the BindingContext which has to wait for the finalizer to run.  My original approach to solving #1405 was to clear the BindingContext but there does not appear to be an easily deterministic way to do this.

Fixes #1405