### PR TITLE
Reduce memory pressure in MvxNotifyPropertyChanged

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNotifyPropertyChanged.cs
@@ -8,6 +8,7 @@
 namespace MvvmCross.Core.ViewModels
 {
     using System;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq.Expressions;
     using System.Runtime.CompilerServices;
@@ -84,7 +85,7 @@ namespace MvvmCross.Core.ViewModels
 
         protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
         {
-            if (Equals(storage, value))
+            if (EqualityComparer<T>.Default.Equals(storage, value))
             {
                 return false;
             }

--- a/MvvmCross/Core/Core/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNotifyPropertyChanged.cs
@@ -19,6 +19,7 @@ namespace MvvmCross.Core.ViewModels
         : MvxMainThreadDispatchingObject
         , IMvxNotifyPropertyChanged
     {
+        private static readonly PropertyChangedEventArgs AllPropertiesChanged = new PropertyChangedEventArgs(string.Empty);
         public event PropertyChangedEventHandler PropertyChanged;
 
         private bool _shouldAlwaysRaiseInpcOnUserInterfaceThread;
@@ -53,8 +54,7 @@ namespace MvvmCross.Core.ViewModels
 
         public virtual void RaiseAllPropertiesChanged()
         {
-            var changedArgs = new PropertyChangedEventArgs(string.Empty);
-            this.RaisePropertyChanged(changedArgs);
+            this.RaisePropertyChanged(AllPropertiesChanged);
         }
 
         public virtual void RaisePropertyChanged(PropertyChangedEventArgs changedArgs)

--- a/MvvmCross/Core/Core/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNotifyPropertyChanged.cs
@@ -64,22 +64,17 @@ namespace MvvmCross.Core.ViewModels
                 == MvxInpcInterceptionResult.DoNotRaisePropertyChanged)
                 return;
 
-            var raiseAction = new Action(() =>
-                    {
-                        PropertyChanged?.Invoke(this, changedArgs);
-                    });
-
             if (this.ShouldAlwaysRaiseInpcOnUserInterfaceThread())
             {
                 // check for subscription before potentially causing a cross-threaded call
                 if (this.PropertyChanged == null)
                     return;
 
-                this.InvokeOnMainThread(raiseAction);
+                this.InvokeOnMainThread(() => PropertyChanged?.Invoke(this, changedArgs));
             }
             else
             {
-                raiseAction();
+                PropertyChanged?.Invoke(this, changedArgs);
             }
         }
 


### PR DESCRIPTION
For applications that raise a lot of PropertyChanged notifications like https://github.com/inormis/MvxSIGSEVTest with a timer this helps shave off some allocations (thousands of objects).

The first commit avoids boxing allocations when setting value types (int, bool, etc).  The second statically allocates the all property changed notification.  Previously we were allocating an Action every time a property changes.  The third commit only does this if we need it.

Room for improvement: we could cache all PropertyChangedEventArgs in a static Dictionary but that is left as a followup if wanted.