### PR TITLE
Solve bug where auto replacement is not updated through the binding

### DIFF
--- a/MvvmCross/Binding/iOS/Target/MvxUITextViewTextTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUITextViewTextTargetBinding.cs
@@ -46,7 +46,16 @@ namespace MvvmCross.Binding.iOS.Target
                 return;
             }
 
-            target.Changed += this.EditTextOnChanged;
+			var textStorage = target.LayoutManager?.TextStorage;
+
+			if (textStorage == null)
+			{ 
+			    MvxBindingTrace.Trace(MvxTraceLevel.Error,
+						  "Error - NSTextStorage of UITextView is null in MvxUITextViewTextTargetBinding");
+				return;
+			}
+
+            textStorage.DidProcessEditing += this.EditTextOnChanged;
             this._subscribed = true;
         }
 


### PR DESCRIPTION
Instead of listening to the `TextChanged` event the binding will now listen to the `DidProcessEditing` event of the NSTextStorageDelegate instance associated with the UITextView class. This will make sure that auto correct replacements are also caught and will trigger a change event in MvvmCross. This PR fixes #1555