### PR TITLE
Fixed permission error on Gmail application on Android (Email Plugin)

### DIFF
--- a/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -19,11 +19,11 @@ using MvvmCross.Platform.Droid.Views;
 namespace MvvmCross.Plugins.Email.Droid
 {
     [Preserve(AllMembers = true)]
-	public class MvxComposeEmailTask
+    public class MvxComposeEmailTask
         : MvxAndroidTask
         , IMvxComposeEmailTaskEx
     {
-		private List<Java.IO.File> filesToDelete;
+        private List<Java.IO.File> filesToDelete;
 
         public void ComposeEmail(string to, string cc = null, string subject = null, string body = null, bool isHtml = false, string dialogTitle = null)
         {
@@ -77,39 +77,39 @@ namespace MvvmCross.Plugins.Email.Droid
                 DoOnActivity(activity => {
                     filesToDelete = new List<Java.IO.File>();
 
-					foreach (var file in attachments)
-					{
-						// fix for Gmail error
-						using (var memoryStream = new MemoryStream())
-						{
-							var fileName = Path.GetFileNameWithoutExtension(file.FileName);
-							var extension = Path.GetExtension(file.FileName);
+                    foreach (var file in attachments)
+                    {
+                        // fix for Gmail error
+                        using (var memoryStream = new MemoryStream())
+                        {
+                            var fileName = Path.GetFileNameWithoutExtension(file.FileName);
+                            var extension = Path.GetExtension(file.FileName);
 
-							// save file in external cache (required so Gmail app can independently access it, otherwise Gmail won't take the attachment)
-							var newFile = new Java.IO.File(activity.ExternalCacheDir, fileName + extension);
+                            // save file in external cache (required so Gmail app can independently access it, otherwise Gmail won't take the attachment)
+                            var newFile = new Java.IO.File(activity.ExternalCacheDir, fileName + extension);
 
-							file.Content.CopyTo(memoryStream);
-							var bytes = memoryStream.ToArray();
-							using (var localFileStream = new FileOutputStream(newFile))
-							{
-								localFileStream.Write(bytes);
-							}
+                            file.Content.CopyTo(memoryStream);
+                            var bytes = memoryStream.ToArray();
+                            using (var localFileStream = new FileOutputStream(newFile))
+                            {
+                                localFileStream.Write(bytes);
+                            }
 
-							newFile.SetReadable(true, false);
-							newFile.DeleteOnExit();
-							uris.Add(Uri.FromFile(newFile));
+                            newFile.SetReadable(true, false);
+                            newFile.DeleteOnExit();
+                            uris.Add(Uri.FromFile(newFile));
 
-							filesToDelete.Add(newFile);
-						}
-					}
+                            filesToDelete.Add(newFile);
+                        }
+                    }
                 });
 
                 if (uris.Any())
                     emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
             }
 
-			emailIntent.AddFlags(ActivityFlags.GrantReadUriPermission);
-			emailIntent.AddFlags(ActivityFlags.GrantWriteUriPermission);
+            emailIntent.AddFlags(ActivityFlags.GrantReadUriPermission);
+            emailIntent.AddFlags(ActivityFlags.GrantWriteUriPermission);
 
             // fix for GMail App 5.x (File not found / permission denied when using "StartActivity")
             StartActivityForResult(0, Intent.CreateChooser(emailIntent, dialogTitle ?? string.Empty));
@@ -119,19 +119,19 @@ namespace MvvmCross.Plugins.Email.Droid
 
         public bool CanSendAttachments => true;
 
-		protected override void ProcessMvxIntentResult(MvxIntentResultEventArgs result)
-		{
-			base.ProcessMvxIntentResult(result);
+        protected override void ProcessMvxIntentResult(MvxIntentResultEventArgs result)
+        {
+            base.ProcessMvxIntentResult(result);
 
-			// on return, delete all attachments from external cache
-			foreach (Java.IO.File file in filesToDelete)
-			{
-				if (file.Exists())
-				{
-					file.Delete();
-				}
-			}
-			filesToDelete.Clear();
-		}
+            // on return, delete all attachments from external cache
+            foreach (Java.IO.File file in filesToDelete)
+            {
+                if (file.Exists())
+                {
+                    file.Delete();
+                }
+            }
+            filesToDelete.Clear();
+        }
     }
 }

--- a/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -13,6 +13,8 @@ using MvvmCross.Platform.Droid.Platform;
 using System.Collections.Generic;
 using System.Linq;
 using Java.IO;
+using System.IO;
+using MvvmCross.Platform.Droid.Views;
 
 namespace MvvmCross.Plugins.Email.Droid
 {
@@ -21,6 +23,8 @@ namespace MvvmCross.Plugins.Email.Droid
         : MvxAndroidTask
         , IMvxComposeEmailTaskEx
     {
+		private List<Java.IO.File> filesToDelete;
+
         public void ComposeEmail(string to, string cc = null, string subject = null, string body = null, bool isHtml = false, string dialogTitle = null)
         {
             var toArray = to == null ? null: new[] { to };
@@ -71,24 +75,41 @@ namespace MvvmCross.Plugins.Email.Droid
                 var uris = new List<IParcelable>();
 
                 DoOnActivity(activity => {
-                    foreach (var file in attachments)
-                    {
-                        File localfile;
-                        using (var localFileStream = activity.OpenFileOutput(
-                            file.FileName, FileCreationMode.WorldReadable))
-                        {
-                            localfile = activity.GetFileStreamPath(file.FileName);
-                            file.Content.CopyTo(localFileStream);
-                        }
-                        localfile.SetReadable(true, false);
-                        uris.Add(Uri.FromFile(localfile));
-                        localfile.DeleteOnExit(); // Schedule to delete file when VM quits.
-                    }
+                    filesToDelete = new List<Java.IO.File>();
+
+					foreach (var file in attachments)
+					{
+						// fix for Gmail error
+						using (var memoryStream = new MemoryStream())
+						{
+							var fileName = Path.GetFileNameWithoutExtension(file.FileName);
+							var extension = Path.GetExtension(file.FileName);
+
+							// save file in external cache (required so Gmail app can independently access it, otherwise Gmail won't take the attachment)
+							var newFile = new Java.IO.File(activity.ExternalCacheDir, fileName + extension);
+
+							file.Content.CopyTo(memoryStream);
+							var bytes = memoryStream.ToArray();
+							using (var localFileStream = new FileOutputStream(newFile))
+							{
+								localFileStream.Write(bytes);
+							}
+
+							newFile.SetReadable(true, false);
+							newFile.DeleteOnExit();
+							uris.Add(Uri.FromFile(newFile));
+
+							filesToDelete.Add(newFile);
+						}
+					}
                 });
 
                 if (uris.Any())
                     emailIntent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
             }
+
+			emailIntent.AddFlags(ActivityFlags.GrantReadUriPermission);
+			emailIntent.AddFlags(ActivityFlags.GrantWriteUriPermission);
 
             // fix for GMail App 5.x (File not found / permission denied when using "StartActivity")
             StartActivityForResult(0, Intent.CreateChooser(emailIntent, dialogTitle ?? string.Empty));
@@ -97,5 +118,20 @@ namespace MvvmCross.Plugins.Email.Droid
         public bool CanSendEmail => true;
 
         public bool CanSendAttachments => true;
+
+		protected override void ProcessMvxIntentResult(MvxIntentResultEventArgs result)
+		{
+			base.ProcessMvxIntentResult(result);
+
+			// on return, delete all attachments from external cache
+			foreach (Java.IO.File file in filesToDelete)
+			{
+				if (file.Exists())
+				{
+					file.Delete();
+				}
+			}
+			filesToDelete.Clear();
+		}
     }
 }

--- a/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
@@ -53,6 +53,16 @@ namespace $rootnamespace$
             sb.ProgressChanged += (sender, args) => sb.Progress = sb.Progress + 1;
         }
 
+        public void Include(RadioGroup radioGroup)
+        {
+            radioGroup.CheckedChange += (sender, args) => radioGroup.Check(args.CheckedId);
+        }
+
+        public void Include(RadioButton radioButton)
+        {
+            radioButton.CheckedChange += (sender, args) => radioButton.Checked = args.IsChecked;
+        }
+
         public void Include(Activity act)
         {
             act.Title = act.Title + "";


### PR DESCRIPTION
The Email Plugin fails when trying to send attachments using Gmail on Android 6.x or above (see [issue 116](https://github.com/MvvmCross/MvvmCross-Plugins/issues/116)). This fix is based on the [workaround provided by dlpopescuw](https://github.com/MvvmCross/MvvmCross-Plugins/issues/116#issuecomment-229148348).