### PR TITLE
Added ContainsImage to IMvxImageCache and added support for android.resource schema in MvxAndroidLocalFileImageLoader.

### DIFF
--- a/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
+++ b/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
@@ -43,8 +43,7 @@ namespace MvvmCross.Plugins.DownloadCache.Droid
             {
                 var substrings = localPath.Split(new[] { "/" }, StringSplitOptions.None);
                 var resourceId = int.Parse(substrings[substrings.Length - 1]);
-                var resourcePath = Android.App.Application.Context.Resources.GetResourceEntryName(resourceId);
-                bitmap = await LoadResourceBitmapAsync(resourcePath).ConfigureAwait(false);
+                bitmap = await LoadResourceBitmapAsync(resourceId).ConfigureAwait(false);
             }
             else
             {
@@ -73,10 +72,14 @@ namespace MvvmCross.Plugins.DownloadCache.Droid
                                       "Value '{0}' was not a known drawable name", resourcePath);
                 return null;
             }
+            return await LoadResourceBitmapAsync(id).ConfigureAwait(false);
+        }
 
-            return
-                await BitmapFactory.DecodeResourceAsync(resources, id,
-                    new BitmapFactory.Options { InPurgeable = true }).ConfigureAwait(false);
+        private async Task<Bitmap> LoadResourceBitmapAsync(int resourceId)
+        {
+            var resources = AndroidGlobals.ApplicationContext.Resources;
+            return await BitmapFactory.DecodeResourceAsync(resources, resourceId,
+                new BitmapFactory.Options { InPurgeable = true }).ConfigureAwait(false);
         }
 
         private static async Task<Bitmap> LoadBitmapAsync(string localPath, int maxWidth, int maxHeight)

--- a/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
+++ b/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
@@ -34,9 +34,16 @@ namespace MvvmCross.Plugins.DownloadCache.Droid
             {
                 shouldAddToCache = false;
             }
-            else if (localPath.StartsWith(ResourcePrefix))
+            else if (localPath.ToLower().StartsWith(ResourcePrefix))
             {
                 var resourcePath = localPath.Substring(ResourcePrefix.Length);
+                bitmap = await LoadResourceBitmapAsync(resourcePath).ConfigureAwait(false);
+            }
+            else if (localPath.ToLower().StartsWith("android.resource"))
+            {
+                var substrings = localPath.Split(new[] { "/" }, StringSplitOptions.None);
+                var resourceId = int.Parse(substrings[substrings.Length - 1]);
+                var resourcePath = Android.App.Application.Context.Resources.GetResourceEntryName(resourceId);
                 bitmap = await LoadResourceBitmapAsync(resourcePath).ConfigureAwait(false);
             }
             else

--- a/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache/IMvxImageCache.cs
+++ b/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache/IMvxImageCache.cs
@@ -11,6 +11,7 @@ namespace MvvmCross.Plugins.DownloadCache
 {
     public interface IMvxImageCache<T>
     {
+        bool ContainsImage(string url);
         Task<T> RequestImage(string url);
     }
 }

--- a/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
+++ b/MvvmCross-Plugins/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
@@ -37,6 +37,14 @@ namespace MvvmCross.Plugins.DownloadCache
 
         #region IMvxImageCache<T> Members
 
+        public bool ContainsImage(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return false;
+
+            return _entriesByHttpUrl.ContainsKey(url);
+        }
+
         public Task<T> RequestImage(string url)
         {
             var tcs = new TaskCompletionSource<T>();


### PR DESCRIPTION
Added ContainsImage to IMvxImageCache so it's possible to check if a Image is cached or not. In my specific case, I only want to do a fade-in animation when the image isn't in the cache.

I also added support for the android.resource schema in the MvxAndroidLocalFileImageLoader. 