### PR TITLE
Resolves problem when no menu is configured

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -120,7 +120,7 @@
                 return null;
             }
 
-            if (types != null && types.Length > 0)
+            if (types != null && types.Length > 1)
             {
                 Mvx.Trace(MvxTraceLevel.Warning, $"Found more then one {location.ToString()} panel, using the first one in the array ({types[0].ToString()}).");
             }

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -38,6 +38,7 @@
 			if (leftSideMenu == null && rightSideMenu == null)
 			{	
 				Mvx.Trace(MvxTraceLevel.Warning, $"No sidemenu found. To use a sidemenu decorate the viewcontroller class with the 'MvxPanelPresentationAttribute' class and set the panel to 'Left' or 'Right'.");
+				AttachNavigationController();
 				return;
 			}
 
@@ -62,6 +63,12 @@
                 ConfigureSideMenu(RightSidebarController);
             }
         }
+
+		protected virtual void AttachNavigationController()
+		{
+			this.AddChildViewController(NavigationController);
+			this.View.AddSubview(NavigationController.View);
+		}
 
         protected virtual UIViewController ResolveSideMenu(MvxPanelEnum location)
         {

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -30,7 +30,7 @@
 		public bool HasLeftMenu => LeftSidebarController != null && LeftSidebarController.MenuAreaController != null;
 		public bool HasRightMenu => RightSidebarController != null && RightSidebarController.MenuAreaController != null;
 
-        private void SetupSideMenu()
+        protected virtual void SetupSideMenu()
         {
 			var leftSideMenu = ResolveSideMenu(MvxPanelEnum.Left);
 			var rightSideMenu = ResolveSideMenu(MvxPanelEnum.Right);
@@ -63,7 +63,7 @@
             }
         }
 
-        private UIViewController ResolveSideMenu(MvxPanelEnum location)
+        protected virtual UIViewController ResolveSideMenu(MvxPanelEnum location)
         {
             var assembly = Assembly.GetEntryAssembly();
 
@@ -85,14 +85,14 @@
             return CreateInstance(types[0]) as UIViewController;
         }
 
-        private IMvxIosView CreateInstance(Type viewControllerType)
+        protected virtual IMvxIosView CreateInstance(Type viewControllerType)
         {
             var viewModelType = GetBaseType(viewControllerType);
             var presenter = Mvx.Resolve<IMvxIosViewPresenter>();
             return presenter.CreateViewControllerFor(new MvxViewModelRequest(viewModelType, null, null, null));
         }
 
-        private Type GetBaseType(Type type)
+        protected virtual Type GetBaseType(Type type)
         {
             while (type.BaseType != null)
             {
@@ -111,7 +111,7 @@
             throw new InvalidOperationException("Unable to locate ViewModel type on ViewController.");
         }
 
-        private void ConfigureSideMenu(SidebarController sidebarController)
+        protected virtual void ConfigureSideMenu(SidebarController sidebarController)
         {
             var mvxSideMenuSettings = sidebarController.MenuAreaController as IMvxSidebarMenu;
 
@@ -178,7 +178,7 @@
                 OpenMenu(RightSidebarController);
         }
 
-        private void OpenMenu(SidebarController sidebarController)
+        protected virtual void OpenMenu(SidebarController sidebarController)
         {
             if (sidebarController != null && !sidebarController.IsOpen)
                 sidebarController.OpenMenu();

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -15,8 +15,6 @@
     public class MvxSidebarPanelController : UIViewController, IMvxSideMenu
     {
         private readonly UIViewController _subRootViewController;
-        private UIViewController _leftSideMenu;
-        private UIViewController _rightSideMenu;
 
         public MvxSidebarPanelController(UINavigationController navigationController)
         {
@@ -25,70 +23,43 @@
         }
 
         public bool StatusBarHidden { get; set; }
-
-        public bool ToggleStatusBarHiddenOnOpen { get; set; } = false;
-
-        public new UINavigationController NavigationController { get; private set; }
-
-        public SidebarController LeftSidebarController { get; private set; }
-
+		public bool ToggleStatusBarHiddenOnOpen { get; set; } = false;
+		public new UINavigationController NavigationController { get; private set; }
+		public SidebarController LeftSidebarController { get; private set; }
         public SidebarController RightSidebarController {get; private set; }
-
-        public UIViewController LeftSideMenu
-        {
-            get { return _leftSideMenu; }
-            set
-            {
-                _leftSideMenu = value;
-                SetupSideMenu();
-            }
-        }
-
-        public UIViewController RightSideMenu
-        {
-            get { return _rightSideMenu; }
-            set
-            {
-                _rightSideMenu = value;
-                SetupSideMenu();
-            }
-        }
-
-        public bool HasLeftMenu => LeftSideMenu != null;
-
-        public bool HasRightMenu => RightSideMenu != null;
-
+		public bool HasLeftMenu => LeftSidebarController != null && LeftSidebarController.MenuAreaController != null;
+		public bool HasRightMenu => RightSidebarController != null && RightSidebarController.MenuAreaController != null;
 
         private void SetupSideMenu()
         {
-			_leftSideMenu = ResolveSideMenu(MvxPanelEnum.Left);
-			_rightSideMenu = ResolveSideMenu(MvxPanelEnum.Right);
+			var leftSideMenu = ResolveSideMenu(MvxPanelEnum.Left);
+			var rightSideMenu = ResolveSideMenu(MvxPanelEnum.Right);
 
-			if (_leftSideMenu == null && _rightSideMenu == null)
+			if (leftSideMenu == null && rightSideMenu == null)
 			{	
 				Mvx.Trace(MvxTraceLevel.Warning, $"No sidemenu found. To use a sidemenu decorate the viewcontroller class with the 'MvxPanelPresentationAttribute' class and set the panel to 'Left' or 'Right'.");
 				return;
 			}
 
-            if (_leftSideMenu != null && _rightSideMenu != null)
+            if (leftSideMenu != null && rightSideMenu != null)
             {
-                LeftSidebarController = new SidebarController(_subRootViewController, NavigationController, _leftSideMenu);
-                ConfigureSideMenu(_leftSideMenu, LeftSidebarController);
+                LeftSidebarController = new SidebarController(_subRootViewController, NavigationController, leftSideMenu);
+                ConfigureSideMenu(LeftSidebarController);
 
-                RightSidebarController = new SidebarController(this, _subRootViewController, _rightSideMenu);
-                ConfigureSideMenu(_rightSideMenu, RightSidebarController);
+                RightSidebarController = new SidebarController(this, _subRootViewController, rightSideMenu);
+                ConfigureSideMenu(RightSidebarController);
             }
-            else if (_leftSideMenu != null)
+            else if (leftSideMenu != null)
             {
-                LeftSidebarController = new SidebarController(this, NavigationController, _leftSideMenu);
+                LeftSidebarController = new SidebarController(this, NavigationController, leftSideMenu);
                 RightSidebarController = null;
-                ConfigureSideMenu(_leftSideMenu, LeftSidebarController);
+                ConfigureSideMenu(LeftSidebarController);
             }
-            else if (_rightSideMenu != null)
+            else if (rightSideMenu != null)
             {
                 LeftSidebarController = null;
-                RightSidebarController = new SidebarController(this, NavigationController, _rightSideMenu);
-                ConfigureSideMenu(_rightSideMenu, RightSidebarController);
+                RightSidebarController = new SidebarController(this, NavigationController, rightSideMenu);
+                ConfigureSideMenu(RightSidebarController);
             }
         }
 
@@ -140,9 +111,9 @@
             throw new InvalidOperationException("Unable to locate ViewModel type on ViewController.");
         }
 
-        private void ConfigureSideMenu(UIViewController viewController, SidebarController sidebarController)
+        private void ConfigureSideMenu(SidebarController sidebarController)
         {
-            var mvxSideMenuSettings = viewController as IMvxSidebarMenu;
+            var mvxSideMenuSettings = sidebarController.MenuAreaController as IMvxSidebarMenu;
 
             if (mvxSideMenuSettings != null)
             {

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -15,8 +15,6 @@
     public class MvxSidebarPanelController : UIViewController, IMvxSideMenu
     {
         private readonly UIViewController _subRootViewController;
-        private bool _isInitializing;
-        private bool _isInitialized;
         private UIViewController _leftSideMenu;
         private UIViewController _rightSideMenu;
 
@@ -60,26 +58,18 @@
 
         public bool HasRightMenu => RightSideMenu != null;
 
-        public void Initialize()
-        {
-            _isInitializing = true;
-
-            try
-            {
-                _leftSideMenu = ResolveSideMenu(MvxPanelEnum.Left);
-                _rightSideMenu = ResolveSideMenu(MvxPanelEnum.Right);
-
-                SetupSideMenu();
-            }
-            finally
-            {
-                _isInitializing = false;
-                _isInitialized = true;
-            }
-        }
 
         private void SetupSideMenu()
         {
+			_leftSideMenu = ResolveSideMenu(MvxPanelEnum.Left);
+			_rightSideMenu = ResolveSideMenu(MvxPanelEnum.Right);
+
+			if (_leftSideMenu == null && _rightSideMenu == null)
+			{	
+				Mvx.Trace(MvxTraceLevel.Warning, $"No sidemenu found. To use a sidemenu decorate the viewcontroller class with the 'MvxPanelPresentationAttribute' class and set the panel to 'Left' or 'Right'.");
+				return;
+			}
+
             if (_leftSideMenu != null && _rightSideMenu != null)
             {
                 LeftSidebarController = new SidebarController(_subRootViewController, NavigationController, _leftSideMenu);
@@ -99,10 +89,6 @@
                 LeftSidebarController = null;
                 RightSidebarController = new SidebarController(this, NavigationController, _rightSideMenu);
                 ConfigureSideMenu(_rightSideMenu, RightSidebarController);
-            }
-            else
-            {
-                Mvx.Trace(MvxTraceLevel.Warning, $"No sidemenu found. To use a sidemenu decorate the viewcontroller class with the 'MvxPanelPresentationAttribute' class and set the panel to 'Left' or 'Right'.");
             }
         }
 
@@ -177,10 +163,7 @@
         {
             base.ViewDidLoad();
 
-            if (!_isInitialized && !_isInitializing)
-            {
-                Mvx.Trace(MvxTraceLevel.Warning, "The instance of 'MvxSidebarPanelController' class is not initialized. Showing or hiding the sidemenu could show unexpected behaviour. Please call the 'Initialize()' method after constructing the 'MvxSidebarPanelController' class.");
-            }
+			SetupSideMenu();
         }
 
         public override UIStatusBarAnimation PreferredStatusBarUpdateAnimation

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -118,11 +118,8 @@
 
             RootViewController = new MvxSidebarPanelController(MasterNavigationController);
             RootViewController.Initialize();
-
-            ParentRootViewController = new UINavigationController(RootViewController);
-            ParentRootViewController.NavigationBarHidden = true;
-
-            SetWindowRootViewController(ParentRootViewController);
+           
+            SetWindowRootViewController(RootViewController);
 
             Mvx.RegisterSingleton<IMvxSideMenu>(RootViewController);
         }

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -117,7 +117,6 @@
             OnMasterNavigationControllerCreated();
 
             RootViewController = new MvxSidebarPanelController(MasterNavigationController);
-            RootViewController.Initialize();
            
             SetWindowRootViewController(RootViewController);
 

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -23,7 +23,7 @@
             AddPresentationHintHandler<MvxSidebarResetRootPresentationHint>(PresentationHintHandler);
         }
 
-        private bool PresentationHintHandler(MvxPanelPresentationHint hint)
+        protected virtual bool PresentationHintHandler(MvxPanelPresentationHint hint)
         {
             if (hint == null)
                 return false;


### PR DESCRIPTION
This PR ensures that the application will keep on working correctly in case there is no menu configured (meaning the `MvxSidebarPanelController` is unable to find any class that is decorated with the `MvxPanelPresentation` attribute where the `panel` parameter is set to left or right).

Also included is some minor refactoring cleaning up the implementation.