### PR TITLE
Make sure the correct default presentation attribute is returned

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -64,7 +64,7 @@ namespace MvvmCross.iOS.Views.Presenters
         {
             base.ChangePresentation(hint);
 
-            if(hint is MvxClosePresentationHint)
+            if (hint is MvxClosePresentationHint)
             {
                 Close((hint as MvxClosePresentationHint).ViewModelToClose);
             }
@@ -88,7 +88,7 @@ namespace MvvmCross.iOS.Views.Presenters
             var attribute = GetPresentationAttributes(viewController);
 
             Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest> showAction;
-            if(!_attributeTypesToShowMethodDictionary.TryGetValue(attribute.GetType(), out showAction))
+            if (!_attributeTypesToShowMethodDictionary.TryGetValue(attribute.GetType(), out showAction))
                 throw new KeyNotFoundException($"The type {attribute.GetType().Name} is not configured in the presenter dictionary");
 
             showAction.Invoke(viewController, attribute, request);
@@ -100,7 +100,7 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxViewModelRequest request)
         {
             // check if viewController is a TabBarController
-            if(viewController is IMvxTabBarViewController)
+            if (viewController is IMvxTabBarViewController)
             {
                 TabBarViewController = viewController as IMvxTabBarViewController;
                 SetWindowRootViewController(viewController);
@@ -113,7 +113,7 @@ namespace MvvmCross.iOS.Views.Presenters
             }
 
             // check if viewController is a SplitViewController
-            if(viewController is IMvxSplitViewController)
+            if (viewController is IMvxSplitViewController)
             {
                 SplitViewController = viewController as IMvxSplitViewController;
                 SetWindowRootViewController(viewController);
@@ -126,7 +126,7 @@ namespace MvvmCross.iOS.Views.Presenters
             }
 
             // check if viewController is trying to initialize a navigation stack
-            if(attribute.WrapInNavigationController)
+            if (attribute.WrapInNavigationController)
             {
                 viewController = new MvxNavigationController(viewController);
                 MasterNavigationController = viewController as MvxNavigationController;
@@ -148,25 +148,25 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxChildPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            if(viewController is IMvxTabBarViewController)
+            if (viewController is IMvxTabBarViewController)
                 throw new MvxException("A TabBarViewController cannot be presented as a child. Consider using Root instead");
 
-            if(viewController is IMvxSplitViewController)
+            if (viewController is IMvxSplitViewController)
                 throw new MvxException("A SplitViewController cannot be presented as a child. Consider using Root instead");
 
-            if(ModalNavigationController != null)
+            if (ModalNavigationController != null)
             {
                 ModalNavigationController.PushViewController(viewController, attribute.Animated);
                 return;
             }
 
-            if(TabBarViewController != null)
+            if (TabBarViewController != null)
             {
                 TabBarViewController.ShowChildView(viewController);
                 return;
             }
 
-            if(MasterNavigationController != null)
+            if (MasterNavigationController != null)
             {
                 MasterNavigationController.PushViewController(viewController, attribute.Animated);
                 return;
@@ -180,10 +180,10 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxTabPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            if(TabBarViewController == null)
+            if (TabBarViewController == null)
                 throw new MvxException("Trying to show a tab without a TabBarViewController, this is not possible!");
 
-            if(attribute.WrapInNavigationController)
+            if (attribute.WrapInNavigationController)
                 viewController = new MvxNavigationController(viewController);
 
             TabBarViewController.ShowTabView(
@@ -199,11 +199,11 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxViewModelRequest request)
         {
             // if there is currently a modal ViewController, dismiss it forced (otherwise nothing happens when presenting)
-            if(_window.RootViewController.PresentedViewController != null)
+            if (_window.RootViewController.PresentedViewController != null)
                 _window.RootViewController.DismissViewController(attribute.Animated, null);
 
             // setup modal based on attribute
-            if(attribute.WrapInNavigationController)
+            if (attribute.WrapInNavigationController)
             {
                 viewController = new MvxNavigationController(viewController);
                 ModalNavigationController = viewController as MvxNavigationController;
@@ -223,7 +223,7 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxMasterSplitViewPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            if(SplitViewController == null)
+            if (SplitViewController == null)
                 throw new MvxException("Trying to show a master page without a SplitViewController, this is not possible!");
 
             SplitViewController.ShowMasterView(viewController, attribute.WrapInNavigationController);
@@ -234,7 +234,7 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxDetailSplitViewPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            if(SplitViewController == null)
+            if (SplitViewController == null)
                 throw new MvxException("Trying to show a detail page without a SplitViewController, this is not possible!");
 
             SplitViewController.ShowDetailView(viewController, attribute.WrapInNavigationController);
@@ -249,19 +249,19 @@ namespace MvvmCross.iOS.Views.Presenters
         public virtual void Close(IMvxViewModel toClose)
         {
             // check if there is a modal presented
-            if(_window.RootViewController.PresentedViewController != null && CloseModalViewController(toClose))
+            if (_window.RootViewController.PresentedViewController != null && CloseModalViewController(toClose))
                 return;
 
             // if the current root is a TabBarViewController, delegate close responsibility to it
-            if(TabBarViewController != null && TabBarViewController.CloseChildViewModel(toClose))
+            if (TabBarViewController != null && TabBarViewController.CloseChildViewModel(toClose))
                 return;
 
             // if the current root is a SplitViewController, delegate close responsibility to it
-            if(SplitViewController != null && SplitViewController.CloseChildViewModel(toClose))
+            if (SplitViewController != null && SplitViewController.CloseChildViewModel(toClose))
                 return;
 
             // if the current root is a NavigationController, close it in the stack
-            if(MasterNavigationController != null && TryCloseViewControllerInsideStack(MasterNavigationController, toClose))
+            if (MasterNavigationController != null && TryCloseViewControllerInsideStack(MasterNavigationController, toClose))
                 return;
 
             MvxTrace.Warning($"Could not close ViewModel type {toClose.GetType().Name}");
@@ -270,12 +270,12 @@ namespace MvvmCross.iOS.Views.Presenters
         protected virtual bool CloseModalViewController(IMvxViewModel toClose)
         {
             // check if there is a modal stack presented
-            if(ModalNavigationController != null)
+            if (ModalNavigationController != null)
             {
-                if(TryCloseViewControllerInsideStack(ModalNavigationController, toClose))
+                if (TryCloseViewControllerInsideStack(ModalNavigationController, toClose))
                 {
                     // First() is the RootViewController of the stack. If it is being closed, then remove the nav stack
-                    if(ModalNavigationController.ViewControllers.First().GetIMvxIosView().ViewModel == toClose)
+                    if (ModalNavigationController.ViewControllers.First().GetIMvxIosView().ViewModel == toClose)
                     {
                         _window.RootViewController.DismissViewController(true, null);
                         CloseModalNavigationController();
@@ -293,17 +293,17 @@ namespace MvvmCross.iOS.Views.Presenters
         {
             // check for top view controller
             var topView = navController.TopViewController.GetIMvxIosView();
-            if(topView != null && topView.ViewModel == toClose)
+            if (topView != null && topView.ViewModel == toClose)
             {
                 navController.PopViewController(true);
                 return true;
             }
 
             // loop through stack
-            foreach(var viewController in navController.ViewControllers)
+            foreach (var viewController in navController.ViewControllers)
             {
                 var mvxView = viewController.GetIMvxIosView();
-                if(mvxView.ViewModel == toClose)
+                if (mvxView.ViewModel == toClose)
                 {
                     var newViewControllers = navController.ViewControllers.Where(v => v != viewController).ToArray();
                     navController.ViewControllers = newViewControllers;
@@ -321,47 +321,47 @@ namespace MvvmCross.iOS.Views.Presenters
 
         protected void CloseMasterNavigationController()
         {
-            if(MasterNavigationController == null)
+            if (MasterNavigationController == null)
                 return;
 
-            foreach(var item in MasterNavigationController.ViewControllers)
+            foreach (var item in MasterNavigationController.ViewControllers)
                 item.DidMoveToParentViewController(null);
             MasterNavigationController = null;
         }
 
         protected void CloseModalNavigationController()
         {
-            if(ModalNavigationController == null)
+            if (ModalNavigationController == null)
                 return;
 
-            foreach(var item in ModalNavigationController.ViewControllers)
+            foreach (var item in ModalNavigationController.ViewControllers)
                 item.DidMoveToParentViewController(null);
             ModalNavigationController = null;
         }
 
         protected void CloseTabBarViewController()
         {
-            if(TabBarViewController == null)
+            if (TabBarViewController == null)
                 return;
 
-            foreach(var item in (TabBarViewController as UITabBarController).ViewControllers)
+            foreach (var item in (TabBarViewController as UITabBarController).ViewControllers)
                 item.DidMoveToParentViewController(null);
             TabBarViewController = null;
         }
 
         protected void CloseSplitViewController()
         {
-            if(SplitViewController == null)
+            if (SplitViewController == null)
                 return;
 
-            foreach(var item in (SplitViewController as UISplitViewController).ViewControllers)
+            foreach (var item in (SplitViewController as UISplitViewController).ViewControllers)
                 item.DidMoveToParentViewController(null);
             SplitViewController = null;
         }
 
         protected virtual void SetWindowRootViewController(UIViewController controller)
         {
-            foreach(var v in _window.Subviews)
+            foreach (var v in _window.Subviews)
                 v.RemoveFromSuperview();
 
             _window.AddSubview(controller.View);
@@ -371,12 +371,19 @@ namespace MvvmCross.iOS.Views.Presenters
         protected MvxBasePresentationAttribute GetPresentationAttributes(UIViewController viewController)
         {
             var attributes = viewController.GetType().GetCustomAttributes(typeof(MvxBasePresentationAttribute), true).FirstOrDefault() as MvxBasePresentationAttribute;
-            if(attributes == null)
+            if (attributes != null)
             {
-                MvxTrace.Trace($"PresentationAttribute not found for {viewController.GetType().Name}, assuming animated Child presentation");
-                attributes = new MvxChildPresentationAttribute();
+                return attributes;
             }
-            return attributes;
+
+            if (MasterNavigationController == null)
+            {
+                MvxTrace.Trace($"PresentationAttribute nor MasterNavigationController found for {viewController.GetType().Name}. Assuming Root presentation");
+                return new MvxRootPresentationAttribute() { WrapInNavigationController = true };
+            }
+
+            MvxTrace.Trace($"PresentationAttribute not found for {viewController.GetType().Name}. Assuming animated Child presentation");
+            return new MvxChildPresentationAttribute();
         }
     }
 }


### PR DESCRIPTION
This change ensures the `GetPresentationAttributes` method returns the correct presentation attribute in case there is no presentation attribute found on the ViewController. In case there is no `MvxNavigationController` instance is available it will return a `MvxRootPresentationAttribute` otherwise a `MvxChildPresentationAttribute` is returned.

This will solve the problem where the `MvxException` (with the message "Trying to show View type: CenterPanelView as child, but there is no current Root!") is being thrown.