### PR TITLE
Add missing MvxRecyclerViewHolder(IntPtr, JniHandleOwnership) constructor

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
@@ -143,6 +143,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         {
             this.ExecuteCommandOnItem(this.LongClick);
         }
+
         public MvxRecyclerViewHolder(View itemView, IMvxAndroidBindingContext context)
             : this(itemView, context, 0)
         {
@@ -153,6 +154,11 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         {
             _viewType = viewType;
             this._bindingContext = context;
+        }
+
+        public MvxRecyclerViewHolder(IntPtr handle, JniHandleOwnership ownership)
+            : base(handle, ownership)
+        {
         }
 
         public virtual void OnAttachedToWindow()


### PR DESCRIPTION
Add the missing JNI constructor for MvxRecyclerViewHolder.

I just got bit by this in a commercial app.