### PR TITLE
Speed up ioc type cache

### DIFF
--- a/MvvmCross/Platform/Platform/IoC/MvxTypeCache.cs
+++ b/MvvmCross/Platform/Platform/IoC/MvxTypeCache.cs
@@ -33,20 +33,21 @@ namespace MvvmCross.Platform.IoC
                 return;
 
             var viewType = typeof(TType);
-            var query = from type in assembly.ExceptionSafeGetTypes()
-                        where viewType.IsAssignableFrom(type)
-                        select type;
+            var query = assembly.DefinedTypes.Where(ti => ti.IsSubclassOf(viewType)).Select(ti => ti.AsType());
 
             foreach (var type in query)
             {
-                if (!string.IsNullOrEmpty(type.FullName))
+                var fullName = type.FullName;
+                if (!string.IsNullOrEmpty(fullName))
                 {
-                    this.FullNameCache[type.FullName] = type;
-                    this.LowerCaseFullNameCache[type.FullName.ToLowerInvariant()] = type;
+                    this.FullNameCache[fullName] = type;
+                    this.LowerCaseFullNameCache[fullName.ToLowerInvariant()] = type;
                 }
-                if (!string.IsNullOrEmpty(type.Name))
+
+                var name = type.Name;
+                if (!string.IsNullOrEmpty(name))
                 {
-                    this.NameCache[type.Name] = type;
+                    this.NameCache[name] = type;
                 }
             }
 

--- a/MvvmCross/Platform/Platform/IoC/MvxTypeCache.cs
+++ b/MvvmCross/Platform/Platform/IoC/MvxTypeCache.cs
@@ -5,31 +5,23 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
 namespace MvvmCross.Platform.IoC
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-
     public class MvxTypeCache<TType> : IMvxTypeCache<TType>
     {
-        public Dictionary<string, Type> LowerCaseFullNameCache { get; private set; }
-        public Dictionary<string, Type> FullNameCache { get; private set; }
-        public Dictionary<string, Type> NameCache { get; private set; }
-        public Dictionary<Assembly, bool> CachedAssemblies { get; private set; }
-
-        public MvxTypeCache()
-        {
-            this.LowerCaseFullNameCache = new Dictionary<string, Type>();
-            this.FullNameCache = new Dictionary<string, Type>();
-            this.NameCache = new Dictionary<string, Type>();
-            this.CachedAssemblies = new Dictionary<Assembly, bool>();
-        }
+        public Dictionary<string, Type> LowerCaseFullNameCache { get; } = new Dictionary<string, Type>();
+        public Dictionary<string, Type> FullNameCache { get; } = new Dictionary<string, Type>();
+        public Dictionary<string, Type> NameCache { get; } = new Dictionary<string, Type>();
+        public Dictionary<Assembly, bool> CachedAssemblies { get; } = new Dictionary<Assembly, bool>();
 
         public void AddAssembly(Assembly assembly)
         {
-            if (this.CachedAssemblies.ContainsKey(assembly))
+            if (CachedAssemblies.ContainsKey(assembly))
                 return;
 
             var viewType = typeof(TType);
@@ -40,18 +32,16 @@ namespace MvvmCross.Platform.IoC
                 var fullName = type.FullName;
                 if (!string.IsNullOrEmpty(fullName))
                 {
-                    this.FullNameCache[fullName] = type;
-                    this.LowerCaseFullNameCache[fullName.ToLowerInvariant()] = type;
+                    FullNameCache[fullName] = type;
+                    LowerCaseFullNameCache[fullName.ToLowerInvariant()] = type;
                 }
 
                 var name = type.Name;
                 if (!string.IsNullOrEmpty(name))
-                {
-                    this.NameCache[name] = type;
-                }
+                    NameCache[name] = type;
             }
 
-            this.CachedAssemblies[assembly] = true;
+            CachedAssemblies[assembly] = true;
         }
     }
 }


### PR DESCRIPTION
This is a clean version of #1704 where style and actual functional changes are not in same commit.

As mentioned in #1704 this improves the `AddAssembly` method significantly as the `LINQ` query here is much much faster.