### PR TITLE
update current navigation and move tipcalc explanation to the tutorial section

### DIFF
--- a/docs/_documentation/fundamentals/navigation.md
+++ b/docs/_documentation/fundamentals/navigation.md
@@ -4,224 +4,55 @@ title: Navigation
 category: Fundamentals
 order: 3
 ---
-This article will cover some of the techniques available within MvvmCross for navigating between Page-level **ViewModels**.
+MvvmCross uses `ViewModel first navigation`. Meaning the we navigate from ViewModel to ViewModel and not from View to View. In MvvmCross the ViewModel will lookup its corresponding View. By doing so we don't have to write platform specific navigation and we can manage everything from within our core.
 
-### What do we mean by Page?
+## Simple ViewModel navigation
 
-MvvmCross was born for making modern Mobile apps - for building apps for iPhone, Android, and Windows Phone.
-
-These apps are generally Page-based - that is they generally involve User-Interfaces which show a single page at a time and which often involve the user experience moving forwards and backwards through the application workflow.
-
-There are variations on this, especially for Tabbed or Pivoting user interfaces; for Dialogs; and for Split displays. We'll introduce some of these briefly at the end of this article.
-
-## The initial navigation
-
-In the TipCalc walkthough, we built most of our initial MvvmCross applications to use the `IMvxAppStart` interface as a starting mechanism.
-
-An implementation of this interface was registered by the core `App` like:
-
-     Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<TipViewModel>());
-
-This implementation was then used in the `AppDelegate` and `App.Xaml` start sequences within the UI projects.
-
-The exception was Android - where we explicitly specified one of our Activities/Views with the `MainLauncher=true` property value within the `[Activity]` attribute.
-
-To use the `IMvxAppStart` instruction in Android as well, the easiest way is to add a splashscreen which will be displayed briefly while the application starts.
-
-### Adding a splashscreen to an Android app
-
-To add a splashscreen:
-
-1. Remove the `MainLauncher=true` property from any existing `Activity` attributes.
-
-2. Add some simple AXML for a splashscreen. For example, a very simple screen might be:
-
-```xml
-    <?xml version="1.0" encoding="utf-8"?>
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent">
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="loading..." />
-    </FrameLayout>
-```
-
-   Note that this splashscreen will be displayed before the MvvmCross system is fully booted - so you **cannot** use data-binding within the splashscreen AXML.
-
-3. Add a simple Activity for the splashscreen. This will contain C# like:
+To navigate from a ViewModel to another ViewModel you can use `ShowViewModel` command.
+The `ShowViewModel` command will take a `Generic` type which should represent the ViewModel that you want to navigate to.
 
 ```c#
-using Android.App;
-using Cirrious.MvvmCross.Droid.Views;
-
-namespace CalcApp.UI.Droid
-{
-[Activity(Label = "My App", MainLauncher = true, NoHistory = true, Icon = "@drawable/icon")]
-public class SplashScreenActivity
-    : MvxSplashScreenActivity
-{
-    public SplashScreenActivity()
-    : base(Resource.Layout.SplashScreen)
-    {
-    }
-}
-}
+ShowViewModel<TViewModel>();
 ```
 
-  This `SplashScreenActivity` uses the base `MvxSplashScreenActivity` which will start the MvvmCross framework and, when initialization is complete, will then use the `IMvxAppStart` interface.
-
-### Supporting more advanced startup 
-
-The `TipCalc` app has a very simple startup instruction:
-
-`Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<TipViewModel>()); `
-
-This was an instruction to: **always start the app with a `TipViewModel`**
-
-If you wanted instead to start with a different `ViewModel` - e.g. with `LoginViewModel` then you'd have to replace this with:
-
-`Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<LoginViewModel>());`
-
-If you wanted instead to start with some logic, then you can do this by providing a custom `IMvxAppStart` implementation - e.g.:
+If we want to for example navigate to the DetailViewModel we only have to call the command from within another ViewModel.
 
 ```c#
-public class CustomAppStart
-    : MvxNavigatingObject
-    , IMvxAppStart
-{
-    private readonly ILoginService _service;
-
-    public CustomAppStart(ILoginService service)
-    {
-        _service = service;
-    }
-
-    public void Start(object hint = null)
-    {
-        if (!_service.IsLoggedIn)
-        {
-            ShowViewModel<LoginViewModel>();
-        }
-        else
-        {
-            ShowViewModel<TipViewModel>();
-        }
-    }
-}
+ShowViewModel<DetailViewModel>();
 ```
 
-Notice that to request this initial navigation, the `CustomAppStart` uses the `ShowViewModel<TViewModel>` method on the `MvxNavigatingObject` base class. We'll see this method used throughout this article - it is the core of the MvvmCross navigation mechanism.
+To move back to the previous ViewModel we can call `Close(this);` on the ViewModel that we want to close.
 
-If you wanted to do even more here, e.g. if you wanted to use parameters passed to the app from the operating system, then this is also possible - these can be passed from the platform-specific startup code to the `IMvxAppStart.Start(object hint)` method using the `hint` and can then also be passed on to the displayed `ViewModel`.
+## Navigation with parameters - using a complex parameter object
 
-## Simple Navigation between Page-level ViewModels
-
-When your app is displaying a `ViewModel` page, say `FirstViewModel`, then that first page can request that the display is moved forwards to a new `ViewModel` page, say `SecondViewModel` by using a call like:
-
-     ShowViewModel<SecondViewModel>();
-
-When the `FirstViewModel` makes this request, then the MvvmCross framework will:
-
-- locate a View to use as a page for `SecondViewModel` within the app - normally this will be `SecondView`
-- create a new instance of this `SecondView`
-- create a `SecondViewModel` and provide it as the `DataContext` for the new `SecondView`
-- ask the operating system to display the `SecondView`
-
-### In action - an Android app
-
-To see an example of this, let's set up a simple Android application.
-
-1. Create a Core Portable Class Library application - exactly as we did in the `TipCalc` example.
-
-2. Within this Core application add two `ViewModel`s:
+Every object can be passed to another ViewModel as a parameter. If its is desired to pass data along in the form of a more complex parameter it can be done like so:
 
 ```c#
-using System;
-using System.Windows.Input;
-using Cirrious.CrossCore.Platform;
-using Cirrious.MvvmCross.ViewModels;
+ShowViewModel<TViewModel, TParameter>(new TParameter());
+```
 
-namespace MyApp.Core
+To be able to retrieve this the receiving class should implement the expected parameter on a class level and implement the correct init:
+
+```c#
+public class MyViewModel : MvxViewModel<TParameter>
 {
-public class FirstViewModel : MvxViewModel
-{
-    public ICommand GoCommand
+    protected override Task Init(TParameter parameter)
     {
-        get
-        {
-            return new MvxCommand(() => ShowViewModel<SecondViewModel>();
-        }
+        // use the parameters here
     }
 }
-
-public class SecondViewModel : MvxViewModel
-{
-}
-}
 ```
 
-3. For `IMvxAppStart` choose to always show the `FirstViewModel` using:
+MvvmCross uses JSON to serialize the object and to use complex parameters you should have the MvvmCross Json plugin installed or register your own IMvxJsonConverter.
 
-    `Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<FirstViewModel>());`
-
-4. Create an Android UI for this app - just as we did in the `TipCalc` sample
-
-5. Add simple Android views for both `FirstView` and `SecondView`.
-
-6. For `FirstView` include a button - and bind it's `Click` event to the `GoCommand` within the `FirstViewModel`
-
-```xml
-    <?xml version="1.0" encoding="utf-8"?>
-    <LinearLayout
-      xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:local="http://schemas.android.com/apk/res/MyApp.UI.Droid"
-      android:layout_width="fill_parent"
-      android:layout_height="fill_parent"
-      >
-    	<Button
-    	  android:layout_width="fill_parent"
-    	  android:layout_height="wrap_content"
-    	  android:text="Go"
-    	  android:textSize="40dp"
-    	  local:MvxBind="Click GoCommand"
-    	  />
-    </LinearLayout>
-```
- 
-7. For `SecondView` include only some 'simple' text:
-
-```xml
-	<?xml version="1.0" encoding="utf-8"?>
-	<LinearLayout
-	  xmlns:android="http://schemas.android.com/apk/res/android"
-	  xmlns:local="http://schemas.android.com/apk/res/MyApp.UI.Droid"
-	  android:layout_width="fill_parent"
-	  android:layout_height="fill_parent"
-	  >
-		<TextView
-		  android:layout_width="fill_parent"
-		  android:layout_height="wrap_content"
-		  android:text="This is the Second View"
-		  android:textSize="40dp"
-		  />
-	</LinearLayout>
-```
- 
-8. As discussed above in 'The initial navigation' add a SplashScreen for this Droid app.
-
-When this application runs, you should see a simple UI for `FirstView` with a `FirstViewModel` data context, and when you press the 'Go' button, you should see the display shift to a `SecondView` with a `SecondViewModel` data context
-
-## Navigation with parameters - using a parameter object
+## Navigation with parameters - using a simple parameter object
 
 As you write apps, you may frequently find that you want to parameterize a `ViewModel` navigation.
 
 For example, you may encounter List-Detail situations - where:
 
-- The Master view shows a list of items. 
-- When the user selects one of these, then the app will navigate to a Detail view 
+- The Master view shows a list of items.
+- When the user selects one of these, then the app will navigate to a Detail view
 - The Detail view will then shows that specific selected item.
 
 To achieve this, the navigation from `MasterViewModel` to `DetailViewModel` will normally be achieved by:
@@ -240,7 +71,7 @@ public class DetailParameters
 
 - the `MasterViewModel` makes `ShowViewModel` a call like:
 
-    `ShowViewModel<DetailViewModel>(new DetailParameters() { Index = 2 });`
+`ShowViewModel<DetailViewModel>(new DetailParameters() { Index = 2 });`
 
 - the `DetailViewModel` declares an `Init` method in order to receive this `DetailParameters`:
 
@@ -253,23 +84,15 @@ public void Init(DetailParameters parameters)
 
 **Note** that the `DetailParameters` class used here must be a 'simple' class used only for these navigations:
 
-- it must contain a parameterless constructor 
+- it must contain a parameterless constructor
 - it should contain only public properties with both `get` and `set` access
-- these properties should be only of types: 
-  - `int`
-  - `long`
-  - `double`
-  - `string`
-  - `Guid`
-  - enumeration values
-
-The reason for this limitations are that the navigation object itself needs to be serialized - it needs to be passed through mechanisms like Xaml urls on WindowsPhone, and like Intent parameter bundles on Android.
-
-If you do ever want to pass more complex objects between ViewModels during navigation, then you will need to find an alternative mechanism - e.g. perhaps caching the object in SQLite and using an index to identify the object.
-
-## In action - an iOS example
-
-TODO
+- these properties should be only of types:
+- `int`
+- `long`
+- `double`
+- `string`
+- `Guid`
+- enumeration values
 
 ## Navigation with parameters - using an anonymous parameter object
 
@@ -281,52 +104,22 @@ For example, you can:
 
 - use a call to `ShowViewModel` like:
 
-    `ShowViewModel<DetailViewModel>(new { index = 2 });`
+`ShowViewModel<DetailViewModel>(new { index = 2 });`
 
 - in the `DetailViewModel` declare an `Init` method in order to receive this `index` as:
 
 ```c#
 public void Init(int index)
 {
-    // use the index here
+// use the index here
 }
 ```
 
 **Note** that due to serialization requirements, the only available parameter types used within this technique are only:
 
-  - `int`
-  - `long`
-  - `double`
-  - `string`
-  - `Guid`
-  - enumeration values
-
-**Note** that in order to use this technique on Windows platforms, you will need to add a `InternalsVisibleTo` line within the `AssemblyInfo.cs` file for the Core project.
-
-    `[assembly: InternalsVisibleTo("Cirrious.MvvmCross")]`
-
-This is because anonymous classes within C# are `internal` by default - so Cirrious.MvvmCross can only use reflection on them if `InternalsVisibleTo` is specified.
-
-##In action - a WindowsPhone example
-
-TODO
-
-##How to move 'back'?
-
-TODO
-
-###How do I remove ViewModels from the back stack?
-
-TODO
-
-##What if I don't want 'Pages'?
-
-TODO
-
-###Tabs
-###Navigation within Tabs
-###Modal Windows
-###Dialogs
-
-TODO
-
+- `int`
+- `long`
+- `double`
+- `string`
+- `Guid`
+- enumeration values

--- a/docs/_documentation/tutorials/the-tip-calc-navigation.md
+++ b/docs/_documentation/tutorials/the-tip-calc-navigation.md
@@ -1,0 +1,308 @@
+---
+layout: documentation
+title: The TipCalc navigation
+category: Tutorials
+order: 3
+---
+This article will cover some of the techniques available within MvvmCross for navigating between Page-level **ViewModels**.
+
+### What do we mean by Page?
+
+MvvmCross was born for making modern Mobile apps - for building apps for iPhone, Android, and Windows Phone.
+
+These apps are generally Page-based - that is they generally involve User-Interfaces which show a single page at a time and which often involve the user experience moving forwards and backwards through the application workflow.
+
+There are variations on this, especially for Tabbed or Pivoting user interfaces; for Dialogs; and for Split displays. We'll introduce some of these briefly at the end of this article.
+
+## The initial navigation
+
+In the TipCalc walkthough, we built most of our initial MvvmCross applications to use the `IMvxAppStart` interface as a starting mechanism.
+
+An implementation of this interface was registered by the core `App` like:
+
+     Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<TipViewModel>());
+
+This implementation was then used in the `AppDelegate` and `App.Xaml` start sequences within the UI projects.
+
+The exception was Android - where we explicitly specified one of our Activities/Views with the `MainLauncher=true` property value within the `[Activity]` attribute.
+
+To use the `IMvxAppStart` instruction in Android as well, the easiest way is to add a splashscreen which will be displayed briefly while the application starts.
+
+### Adding a splashscreen to an Android app
+
+To add a splashscreen:
+
+1. Remove the `MainLauncher=true` property from any existing `Activity` attributes.
+
+2. Add some simple AXML for a splashscreen. For example, a very simple screen might be:
+
+```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="loading..." />
+    </FrameLayout>
+```
+
+   Note that this splashscreen will be displayed before the MvvmCross system is fully booted - so you **cannot** use data-binding within the splashscreen AXML.
+
+3. Add a simple Activity for the splashscreen. This will contain C# like:
+
+```c#
+using Android.App;
+using Cirrious.MvvmCross.Droid.Views;
+
+namespace CalcApp.UI.Droid
+{
+[Activity(Label = "My App", MainLauncher = true, NoHistory = true, Icon = "@drawable/icon")]
+public class SplashScreenActivity
+    : MvxSplashScreenActivity
+{
+    public SplashScreenActivity()
+    : base(Resource.Layout.SplashScreen)
+    {
+    }
+}
+}
+```
+
+  This `SplashScreenActivity` uses the base `MvxSplashScreenActivity` which will start the MvvmCross framework and, when initialization is complete, will then use the `IMvxAppStart` interface.
+
+### Supporting more advanced startup 
+
+The `TipCalc` app has a very simple startup instruction:
+
+`Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<TipViewModel>()); `
+
+This was an instruction to: **always start the app with a `TipViewModel`**
+
+If you wanted instead to start with a different `ViewModel` - e.g. with `LoginViewModel` then you'd have to replace this with:
+
+`Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<LoginViewModel>());`
+
+If you wanted instead to start with some logic, then you can do this by providing a custom `IMvxAppStart` implementation - e.g.:
+
+```c#
+public class CustomAppStart
+    : MvxNavigatingObject
+    , IMvxAppStart
+{
+    private readonly ILoginService _service;
+
+    public CustomAppStart(ILoginService service)
+    {
+        _service = service;
+    }
+
+    public void Start(object hint = null)
+    {
+        if (!_service.IsLoggedIn)
+        {
+            ShowViewModel<LoginViewModel>();
+        }
+        else
+        {
+            ShowViewModel<TipViewModel>();
+        }
+    }
+}
+```
+
+Notice that to request this initial navigation, the `CustomAppStart` uses the `ShowViewModel<TViewModel>` method on the `MvxNavigatingObject` base class. We'll see this method used throughout this article - it is the core of the MvvmCross navigation mechanism.
+
+If you wanted to do even more here, e.g. if you wanted to use parameters passed to the app from the operating system, then this is also possible - these can be passed from the platform-specific startup code to the `IMvxAppStart.Start(object hint)` method using the `hint` and can then also be passed on to the displayed `ViewModel`.
+
+## Simple Navigation between Page-level ViewModels
+
+When your app is displaying a `ViewModel` page, say `FirstViewModel`, then that first page can request that the display is moved forwards to a new `ViewModel` page, say `SecondViewModel` by using a call like:
+
+     ShowViewModel<SecondViewModel>();
+
+When the `FirstViewModel` makes this request, then the MvvmCross framework will:
+
+- locate a View to use as a page for `SecondViewModel` within the app - normally this will be `SecondView`
+- create a new instance of this `SecondView`
+- create a `SecondViewModel` and provide it as the `DataContext` for the new `SecondView`
+- ask the operating system to display the `SecondView`
+
+### In action - an Android app
+
+To see an example of this, let's set up a simple Android application.
+
+1. Create a Core Portable Class Library application - exactly as we did in the `TipCalc` example.
+
+2. Within this Core application add two `ViewModel`s:
+
+```c#
+using System;
+using System.Windows.Input;
+using Cirrious.CrossCore.Platform;
+using Cirrious.MvvmCross.ViewModels;
+
+namespace MyApp.Core
+{
+public class FirstViewModel : MvxViewModel
+{
+    public ICommand GoCommand
+    {
+        get
+        {
+            return new MvxCommand(() => ShowViewModel<SecondViewModel>();
+        }
+    }
+}
+
+public class SecondViewModel : MvxViewModel
+{
+}
+}
+```
+
+3. For `IMvxAppStart` choose to always show the `FirstViewModel` using:
+
+    `Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<FirstViewModel>());`
+
+4. Create an Android UI for this app - just as we did in the `TipCalc` sample
+
+5. Add simple Android views for both `FirstView` and `SecondView`.
+
+6. For `FirstView` include a button - and bind it's `Click` event to the `GoCommand` within the `FirstViewModel`
+
+```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <LinearLayout
+      xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:local="http://schemas.android.com/apk/res/MyApp.UI.Droid"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      >
+    	<Button
+    	  android:layout_width="fill_parent"
+    	  android:layout_height="wrap_content"
+    	  android:text="Go"
+    	  android:textSize="40dp"
+    	  local:MvxBind="Click GoCommand"
+    	  />
+    </LinearLayout>
+```
+ 
+7. For `SecondView` include only some 'simple' text:
+
+```xml
+	<?xml version="1.0" encoding="utf-8"?>
+	<LinearLayout
+	  xmlns:android="http://schemas.android.com/apk/res/android"
+	  xmlns:local="http://schemas.android.com/apk/res/MyApp.UI.Droid"
+	  android:layout_width="fill_parent"
+	  android:layout_height="fill_parent"
+	  >
+		<TextView
+		  android:layout_width="fill_parent"
+		  android:layout_height="wrap_content"
+		  android:text="This is the Second View"
+		  android:textSize="40dp"
+		  />
+	</LinearLayout>
+```
+ 
+8. As discussed above in 'The initial navigation' add a SplashScreen for this Droid app.
+
+When this application runs, you should see a simple UI for `FirstView` with a `FirstViewModel` data context, and when you press the 'Go' button, you should see the display shift to a `SecondView` with a `SecondViewModel` data context
+
+## Navigation with parameters - using a parameter object
+
+As you write apps, you may frequently find that you want to parameterize a `ViewModel` navigation.
+
+For example, you may encounter List-Detail situations - where:
+
+- The Master view shows a list of items. 
+- When the user selects one of these, then the app will navigate to a Detail view 
+- The Detail view will then shows that specific selected item.
+
+To achieve this, the navigation from `MasterViewModel` to `DetailViewModel` will normally be achieved by:
+
+- we declare a class `DetailParameters` for the navigation:
+
+```c#
+public class DetailParameters
+{
+    public int Index {
+        get;
+        set;
+    }
+}
+```
+
+- the `MasterViewModel` makes `ShowViewModel` a call like:
+
+    `ShowViewModel<DetailViewModel>(new DetailParameters() { Index = 2 });`
+
+- the `DetailViewModel` declares an `Init` method in order to receive this `DetailParameters`:
+
+```c#
+public void Init(DetailParameters parameters)
+{
+    // use the parameters here
+}
+```
+
+**Note** that the `DetailParameters` class used here must be a 'simple' class used only for these navigations:
+
+- it must contain a parameterless constructor 
+- it should contain only public properties with both `get` and `set` access
+- these properties should be only of types: 
+  - `int`
+  - `long`
+  - `double`
+  - `string`
+  - `Guid`
+  - enumeration values
+
+The reason for this limitations are that the navigation object itself needs to be serialized - it needs to be passed through mechanisms like Xaml urls on WindowsPhone, and like Intent parameter bundles on Android.
+
+If you do ever want to pass more complex objects between ViewModels during navigation, then you will need to find an alternative mechanism - e.g. perhaps caching the object in SQLite and using an index to identify the object.
+
+## In action - an iOS example
+
+TODO
+
+## Navigation with parameters - using an anonymous parameter object
+
+For simple navigations, declaring a formal `Parameters` object can feel like 'overkill' - like 'hard work'.
+
+In these situations you can instead use anonymous classes and named method arguments.
+
+For example, you can:
+
+- use a call to `ShowViewModel` like:
+
+    `ShowViewModel<DetailViewModel>(new { index = 2 });`
+
+- in the `DetailViewModel` declare an `Init` method in order to receive this `index` as:
+
+```c#
+public void Init(int index)
+{
+    // use the index here
+}
+```
+
+**Note** that due to serialization requirements, the only available parameter types used within this technique are only:
+
+  - `int`
+  - `long`
+  - `double`
+  - `string`
+  - `Guid`
+  - enumeration values
+
+**Note** that in order to use this technique on Windows platforms, you will need to add a `InternalsVisibleTo` line within the `AssemblyInfo.cs` file for the Core project.
+
+    `[assembly: InternalsVisibleTo("Cirrious.MvvmCross")]`
+
+This is because anonymous classes within C# are `internal` by default - so Cirrious.MvvmCross can only use reflection on them if `InternalsVisibleTo` is specified.


### PR DESCRIPTION
Updated the current navigation for the fundamentals page off the docs and move the TipCalc article to the tutorials section. The tutorials sections still needs to be sorted 