### PR TITLE
Move bind extension methods namespace under MvvmCross.Binding.BindingContext for ease of use

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/BindingContext/MvxAppCompatPropertyBindingExtensions.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/BindingContext/MvxAppCompatPropertyBindingExtensions.cs
@@ -6,9 +6,10 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using Android.Support.V7.Widget;
+using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Droid.Support.V7.AppCompat.Widget;
 
-namespace MvvmCross.Droid.Support.V7.AppCompat
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxAppCompatPropertyBindingExtensions
     {

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvvmCross.Droid.Support.V7.AppCompat.csproj
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvvmCross.Droid.Support.V7.AppCompat.csproj
@@ -80,7 +80,7 @@
     <Compile Include="MvxAppCompatPropertyBinding.cs" />
     <Compile Include="MvxAppCompatActivity.cs" />
     <Compile Include="MvxAppCompatActivityHelper.cs" />
-    <Compile Include="MvxAppCompatPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxAppCompatPropertyBindingExtensions.cs" />
     <Compile Include="MvxAppCompatSetupHelper.cs" />
     <Compile Include="EventSource\MvxEventSourceAppCompatActivity.cs" />
     <Compile Include="MvxAppCompatDialogFragment.cs" />

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.Preference/BindingContext/MvxPreferencePropertyBindingExtensions.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.Preference/BindingContext/MvxPreferencePropertyBindingExtensions.cs
@@ -5,7 +5,9 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-namespace MvvmCross.Droid.Support.V7.Preference
+using MvvmCross.Droid.Support.V7.Preference;
+
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxPreferencePropertyBindingExtensions
     {

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.Preference/MvvmCross.Droid.Support.V7.Preference.csproj
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.Preference/MvvmCross.Droid.Support.V7.Preference.csproj
@@ -83,7 +83,7 @@
     <Compile Include="MvxEventSourcePreferenceFragmentCompat.cs" />
     <Compile Include="MvxPreferenceFragmentCompat.cs" />
     <Compile Include="MvxPreferencePropertyBinding.cs" />
-    <Compile Include="MvxPreferencePropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxPreferencePropertyBindingExtensions.cs" />
     <Compile Include="MvxPreferenceSetupHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Target\MvxListPreferenceTargetBinding.cs" />

--- a/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color.Droid/BindingContext/MvxAndroidColorPropertyBindingExtensions.cs
+++ b/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color.Droid/BindingContext/MvxAndroidColorPropertyBindingExtensions.cs
@@ -7,8 +7,9 @@
 
 using Android.Views;
 using Android.Widget;
+using MvvmCross.Plugins.Color.Droid.Binding;
 
-namespace MvvmCross.Plugins.Color.Droid.Binding
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxAndroidColorPropertyBindingExtensions
     {

--- a/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color.Droid/MvvmCross.Plugins.Color.Droid.csproj
+++ b/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color.Droid/MvvmCross.Plugins.Color.Droid.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <Compile Include="BindingTargets\MvxDefaultColorBindingSet.cs" />
     <Compile Include="Binding\MvxAndroidColorPropertyBinding.cs" />
-    <Compile Include="Binding\MvxAndroidColorPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxAndroidColorPropertyBindingExtensions.cs" />
     <Compile Include="MvxAndroidColor.cs" />
     <Compile Include="BindingTargets\MvxViewColorBinding.cs" />
     <Compile Include="MvxColorExtensions.cs" />

--- a/MvvmCross/Binding/Droid/BindingContext/MvxAndroidPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/Droid/BindingContext/MvxAndroidPropertyBindingExtensions.cs
@@ -8,97 +8,98 @@
 using Android.Preferences;
 using Android.Views;
 using Android.Widget;
+using MvvmCross.Binding.Droid;
 using MvvmCross.Binding.Droid.Views;
 
-namespace MvvmCross.Binding.Droid
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxAndroidPropertyBindingExtensions
     {
-        public static string BindClick(this View view) 
+        public static string BindClick(this View view)
             => MvxAndroidPropertyBinding.View_Click;
 
         public static string BindText(this TextView textview)
             => MvxAndroidPropertyBinding.TextView_Text;
 
-        public static string BindTextFormatted(this TextView textview) 
+        public static string BindTextFormatted(this TextView textview)
             => MvxAndroidPropertyBinding.TextView_TextFormatted;
 
-        public static string BindHint(this TextView textview) 
+        public static string BindHint(this TextView textview)
             => MvxAndroidPropertyBinding.TextView_Hint;
 
-        public static string BindPartialText(this MvxAutoCompleteTextView mvxAutoCompleteTextView) 
+        public static string BindPartialText(this MvxAutoCompleteTextView mvxAutoCompleteTextView)
             => MvxAndroidPropertyBinding.MvxAutoCompleteTextView_PartialText;
 
-        public static string BindSelectedObject(this MvxAutoCompleteTextView mvxAutoCompleteTextView) 
+        public static string BindSelectedObject(this MvxAutoCompleteTextView mvxAutoCompleteTextView)
             => MvxAndroidPropertyBinding.MvxAutoCompleteTextView_SelectedObject;
 
-        public static string BindChecked(this CompoundButton compoundButton) 
+        public static string BindChecked(this CompoundButton compoundButton)
             => MvxAndroidPropertyBinding.CompoundButton_Checked;
 
-        public static string BindProgress(this SeekBar seekBar) 
+        public static string BindProgress(this SeekBar seekBar)
             => MvxAndroidPropertyBinding.SeekBar_Progress;
 
-        public static string BindVisible(this View view) 
+        public static string BindVisible(this View view)
             => MvxAndroidPropertyBinding.View_Visible;
 
         public static string BindHidden(this View view)
             => MvxAndroidPropertyBinding.View_Hidden;
 
-        public static string BindBitmap(this ImageView imageView) 
+        public static string BindBitmap(this ImageView imageView)
             => MvxAndroidPropertyBinding.ImageView_Bitmap;
 
-        public static string BindDrawable(this ImageView imageView) 
+        public static string BindDrawable(this ImageView imageView)
             => MvxAndroidPropertyBinding.ImageView_Drawable;
 
-        public static string BindDrawableId(this ImageView imageView) 
+        public static string BindDrawableId(this ImageView imageView)
             => MvxAndroidPropertyBinding.ImageView_DrawableId;
 
         public static string BindDrawableName(this ImageView imageView)
             => MvxAndroidPropertyBinding.ImageView_DrawableName;
 
-        public static string BindResourceName(this ImageView imageView) 
+        public static string BindResourceName(this ImageView imageView)
             => MvxAndroidPropertyBinding.ImageView_ResourceName;
 
-        public static string BindAssetImagePath(this ImageView imageView) 
+        public static string BindAssetImagePath(this ImageView imageView)
             => MvxAndroidPropertyBinding.ImageView_AssetImagePath;
 
-        public static string BindSelectedItem(this MvxSpinner mvxSpinner) 
+        public static string BindSelectedItem(this MvxSpinner mvxSpinner)
             => MvxAndroidPropertyBinding.MvxSpinner_SelectedItem;
 
-        public static string BindSelectedItemPosition(this AdapterView adapterView) 
+        public static string BindSelectedItemPosition(this AdapterView adapterView)
             => MvxAndroidPropertyBinding.AdapterView_SelectedItemPosition;
 
-        public static string BindSelectedItem(this MvxListView mvxListView) 
+        public static string BindSelectedItem(this MvxListView mvxListView)
             => MvxAndroidPropertyBinding.MvxListView_SelectedItem;
 
-        public static string BindSelectedItem(this MvxExpandableListView mvxExpandableListView) 
+        public static string BindSelectedItem(this MvxExpandableListView mvxExpandableListView)
             => MvxAndroidPropertyBinding.MvxExpandableListView_SelectedItem;
 
-        public static string BindRating(this RatingBar ratingBar) 
+        public static string BindRating(this RatingBar ratingBar)
             => MvxAndroidPropertyBinding.RatingBar_Rating;
 
-        public static string BindLongClick(this View view) 
+        public static string BindLongClick(this View view)
             => MvxAndroidPropertyBinding.View_LongClick;
 
         public static string BindSelectedItem(this MvxRadioGroup mvxRadioGroup)
             => MvxAndroidPropertyBinding.MvxRadioGroup_SelectedItem;
 
-        public static string BindTextFocus(this EditText editText) 
+        public static string BindTextFocus(this EditText editText)
             => MvxAndroidPropertyBinding.EditText_TextFocus;
 
-        public static string BindQuery(this SearchView searchView) 
+        public static string BindQuery(this SearchView searchView)
             => MvxAndroidPropertyBinding.SearchView_Query;
 
-        public static string BindValue(this Preference preference) 
+        public static string BindValue(this Preference preference)
             => MvxAndroidPropertyBinding.Preference_Value;
 
-        public static string BindText(this EditTextPreference editTextPreference) 
+        public static string BindText(this EditTextPreference editTextPreference)
             => MvxAndroidPropertyBinding.EditTextPreference_Text;
 
-        public static string BindValue(this ListPreference listPreference) 
+        public static string BindValue(this ListPreference listPreference)
             => MvxAndroidPropertyBinding.ListPreference_Value;
 
-        public static string BindChecked(this TwoStatePreference twoStatePreference) 
+        public static string BindChecked(this TwoStatePreference twoStatePreference)
             => MvxAndroidPropertyBinding.TwoStatePreference_Checked;
     }
 }

--- a/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
+++ b/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
@@ -79,7 +79,7 @@
     <Compile Include="Binders\ViewTypeResolvers\MvxAxmlNameViewTypeResolver.cs" />
     <Compile Include="BindingContext\IMvxAndroidBindingContext.cs" />
     <Compile Include="MvxAndroidPropertyBinding.cs" />
-    <Compile Include="MvxAndroidPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxAndroidPropertyBindingExtensions.cs" />
     <Compile Include="MvxViewAssemblyBootstrapAction.cs" />
     <Compile Include="ResourceHelpers\IMvxAndroidBindingResource.cs" />
     <Compile Include="ResourceHelpers\IMvxAppResourceTypeFinder.cs" />

--- a/MvvmCross/Binding/Mac/BindingContext/MvxMacPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/Mac/BindingContext/MvxMacPropertyBindingExtensions.cs
@@ -6,8 +6,9 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using AppKit;
+using MvvmCross.Binding.Mac;
 
-namespace MvvmCross.Binding.Mac
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxMacPropertyBindingExtensions
     {

--- a/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
+++ b/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
@@ -55,7 +55,7 @@
   <ItemGroup>
     <Compile Include="MvxMacBindingBuilder.cs" />
     <Compile Include="MvxMacPropertyBinding.cs" />
-    <Compile Include="MvxMacPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxMacPropertyBindingExtensions.cs" />
     <Compile Include="Target\MvxNSViewVisibilityTargetBinding.cs" />
     <Compile Include="Target\MvxNSViewVisibleTargetBinding.cs" />
     <Compile Include="Target\MvxNSSliderValueTargetBinding.cs" />

--- a/MvvmCross/Binding/UWP/BindingContext/MvxWindowsPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/UWP/BindingContext/MvxWindowsPropertyBindingExtensions.cs
@@ -5,15 +5,10 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-using System.Windows;
+using MvvmCross.Binding.Uwp;
+using Windows.UI.Xaml;
 
-#if WINDOWS_COMMON
-namespace MvvmCross.BindingEx.WindowsCommon
-#endif
-
-#if WINDOWS_WPF
-namespace MvvmCross.BindingEx.Wpf
-#endif
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxWindowsPropertyBindingExtensions
     {

--- a/MvvmCross/Binding/UWP/MvvmCross.Binding.Uwp.csproj
+++ b/MvvmCross/Binding/UWP/MvvmCross.Binding.Uwp.csproj
@@ -53,7 +53,7 @@
     <Compile Include="MvxWindowsBindingBuilder.cs" />
     <Compile Include="MvxWindowsBindingCreator.cs" />
     <Compile Include="MvxWindowsPropertyBinding.cs" />
-    <Compile Include="MvxWindowsPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxWindowsPropertyBindingExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Properties\MvvmCross.Binding.UWP.rd.xml" />
     <Compile Include="MvxBinding\Target\MvxCollapsedTargetBinding.cs" />

--- a/MvvmCross/Binding/Wpf/BindingContext/MvxWindowsPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/Wpf/BindingContext/MvxWindowsPropertyBindingExtensions.cs
@@ -5,9 +5,17 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-using Windows.UI.Xaml;
+using System.Windows;
 
-namespace MvvmCross.Binding.Uwp
+#if WINDOWS_COMMON
+using MvvmCross.BindingEx.WindowsCommon;
+#endif
+
+#if WINDOWS_WPF
+using MvvmCross.BindingEx.Wpf;
+#endif
+
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxWindowsPropertyBindingExtensions
     {

--- a/MvvmCross/Binding/Wpf/MvvmCross.Binding.Wpf.csproj
+++ b/MvvmCross/Binding/Wpf/MvvmCross.Binding.Wpf.csproj
@@ -59,7 +59,7 @@
     <Compile Include="MvxWindowsAssemblyCache.cs" />
     <Compile Include="MvxWindowsBindingBuilder.cs" />
     <Compile Include="MvxWindowsPropertyBinding.cs" />
-    <Compile Include="MvxWindowsPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxWindowsPropertyBindingExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WindowsBinding\MvxWindowsBindingCreator.cs" />
   </ItemGroup>

--- a/MvvmCross/Binding/iOS/BindingContext/MvxIosPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/iOS/BindingContext/MvxIosPropertyBindingExtensions.cs
@@ -5,9 +5,10 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using MvvmCross.Binding.iOS;
 using UIKit;
 
-namespace MvvmCross.Binding.iOS
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxIosPropertyBindingExtensions
     {

--- a/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
+++ b/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <Compile Include="MvxIosBindingBuilder.cs" />
     <Compile Include="MvxIosPropertyBinding.cs" />
-    <Compile Include="MvxIosPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxIosPropertyBindingExtensions.cs" />
     <Compile Include="Target\MvxBaseUIDatePickerTargetBinding.cs" />
     <Compile Include="Target\MvxBaseUIViewVisibleTargetBinding.cs" />
     <Compile Include="Target\MvxUIActivityIndicatorViewHiddenTargetBinding.cs" />

--- a/MvvmCross/Binding/tvOS/BindingContext/MvxTvosPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/tvOS/BindingContext/MvxTvosPropertyBindingExtensions.cs
@@ -5,9 +5,10 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using MvvmCross.Binding.tvOS;
 using UIKit;
 
-namespace MvvmCross.Binding.tvOS
+namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxTvosPropertyBindingExtensions
     {

--- a/MvvmCross/Binding/tvOS/MvvmCross.Binding.tvOS.csproj
+++ b/MvvmCross/Binding/tvOS/MvvmCross.Binding.tvOS.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MvxTvosPropertyBinding.cs" />
-    <Compile Include="MvxTvosPropertyBindingExtensions.cs" />
+    <Compile Include="BindingContext\MvxTvosPropertyBindingExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MvxTvosBindingBuilder.cs" />
     <Compile Include="Target\MvxBaseUIViewVisibleTargetBinding.cs" />


### PR DESCRIPTION
This PR is related to #1628 and #1609 that added extension methods for Mvx defined target bindings.

I have changed the namespace for all extension method classes to be under the shared `MvvmCross.Binding.BindingContext` namespace. This namespace is the one that contains the `CreateBindingContext` and `CreateBindingSet` extension methods. Therefore once a developer has include the `MvvmCross.Binding.BindingContext` namespace they will automatically get access to all scoped binding extension method, and no long need to figure out any additional namespaces required from platform/android support or plugins.

Unfortunately, there is a side effect that affected Assembly namespaces are no longer nicely conform to there names. For example the Assembly `MvvmCross.Binding.iOS` would now include `MvvmCross.Binding.BindingContext` thereby breaking the naming conversion pattern.

![image](https://cloud.githubusercontent.com/assets/13716738/25485730/2d3541b6-2b5f-11e7-8a93-54c66edcd622.png)

I do feel however, that the benefit to the developer is greater.

I'm not sure if there is a more elegant way to achieve this?