### PR TITLE
Add editorconfig file to help with with formatting and conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+﻿root=true
+
+[*]
+end_of_line = crlf
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.xml]
+indent_style = space
+
+[*.cs]
+indent_size = 4
+
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = true:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion


### PR DESCRIPTION
Visual Studio 2017 now brings [support](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes#coding-convention-configuration-and-enforcement). 
Additional current [limitation](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes#editorconfig-is-not-supported-in-xml-files) (Not working in xml and no new line feature).

Coding style options can be changed. [Microsoft documentation](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference) on meaning of options.
Currently, all options are set as suggestions only. 
Additionally, I have set the convention to spaces over tabs