### PR TITLE
Check phone capabilities before calling

### DIFF
--- a/MvvmCross-Plugins/PhoneCall/MvvmCross.Plugins.PhoneCall.Droid/MvxPhoneCallTask.cs
+++ b/MvvmCross-Plugins/PhoneCall/MvvmCross.Plugins.PhoneCall.Droid/MvxPhoneCallTask.cs
@@ -7,7 +7,9 @@
 
 using Android.Content;
 using Android.Net;
+using Android.OS;
 using Android.Telephony;
+using Java.Util;
 using MvvmCross.Platform.Droid.Platform;
 
 namespace MvvmCross.Plugins.PhoneCall.Droid
@@ -17,15 +19,18 @@ namespace MvvmCross.Plugins.PhoneCall.Droid
         : MvxAndroidTask
           , IMvxPhoneCallTask
     {
-        #region IMvxPhoneCallTask Members
-
         public void MakePhoneCall(string name, string number)
         {
-            var phoneNumber = PhoneNumberUtils.FormatNumber(number);
+            string phoneNumber;
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+                phoneNumber = PhoneNumberUtils.FormatNumber(number, Locale.GetDefault(Locale.Category.Format).Country);
+            else
+#pragma warning disable 618
+                phoneNumber = PhoneNumberUtils.FormatNumber(number);
+#pragma warning restore 618
+
             var newIntent = new Intent(Intent.ActionDial, Uri.Parse("tel:" + phoneNumber));
             StartActivity(newIntent);
         }
-
-        #endregion
     }
 }

--- a/MvvmCross-Plugins/PhoneCall/MvvmCross.Plugins.PhoneCall.iOS/MvxPhoneCallTask.cs
+++ b/MvvmCross-Plugins/PhoneCall/MvvmCross.Plugins.PhoneCall.iOS/MvxPhoneCallTask.cs
@@ -13,14 +13,10 @@ namespace MvvmCross.Plugins.PhoneCall.iOS
     [Preserve(AllMembers = true)]
 	public class MvxPhoneCallTask : MvxIosTask, IMvxPhoneCallTask
     {
-        #region IMvxPhoneCallTask Members
-
         public void MakePhoneCall(string name, string number)
         {            
             var url = new NSUrl("tel:" + System.Uri.EscapeUriString(number));
             DoUrlOpen(url);
         }
-
-        #endregion IMvxPhoneCallTask Members
     }
 }

--- a/MvvmCross/Platform/iOS/Platform/MvxIosTask.cs
+++ b/MvvmCross/Platform/iOS/Platform/MvxIosTask.cs
@@ -15,7 +15,8 @@ namespace MvvmCross.Platform.iOS.Platform
     {
         protected bool DoUrlOpen(NSUrl url)
         {
-            return UIApplication.SharedApplication.OpenUrl(url);
+            var sharedApp = UIApplication.SharedApplication;
+            return sharedApp.CanOpenUrl(url) && sharedApp.OpenUrl(url);
         }
     }
 }


### PR DESCRIPTION
This partially fixes #95, if we want the user to know why nothing is happening when calling the task, we should probably return `Task<bool>` instead of void to let them get a status.

This just protects someone from potentially crashing the app.

Also fixes a warning in Droid.