### PR TITLE
change parameter type to TInit

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModelInitializer.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModelInitializer.cs
@@ -11,6 +11,6 @@ namespace MvvmCross.Core.ViewModels
 
     public interface IMvxViewModelInitializer<TInit> : IMvxViewModel
     {
-        Task Init(string parameter);
+        Task Init(TInit parameter);
     }
 }


### PR DESCRIPTION
Parameter used to be a string, but this was incorrect. Should be the
generic type TInit.