### PR TITLE
Added overridable methods to MvxAdapter for index modification.

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/IMvxRecyclerAdapter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/IMvxRecyclerAdapter.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         ICommand ItemClick { get; set; }
         ICommand ItemLongClick { get; set; }
 
-        object GetItem(int position);
+        object GetItem(int viewPosition);
 
         int ItemTemplateId { get; set; }
     }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -167,9 +167,32 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
 
         public override int ItemCount => _itemsSource.Count();
 
-        public virtual object GetItem(int position)
+        public virtual object GetItem(int viewPosition)
         {
-            return _itemsSource.ElementAt(position);
+            var itemsSourcePosition = GetItemsSourcePosition(viewPosition);
+
+            if (itemsSourcePosition >= 0 && itemsSourcePosition < _itemsSource.Count())
+            {
+                return _itemsSource.ElementAt(itemsSourcePosition);
+            }
+
+            return null;
+        }
+
+        protected virtual int GetViewPosition(object item)
+        {
+            var itemsSourcePosition = _itemsSource.GetPosition(item);
+            return GetViewPosition(itemsSourcePosition);
+        }
+
+        protected virtual int GetViewPosition(int itemsSourcePosition)
+        {
+            return itemsSourcePosition;
+        }
+
+        protected virtual int GetItemsSourcePosition(int viewPosition)
+        {
+            return viewPosition;
         }
 
         public int ItemTemplateId { get; set; }
@@ -213,7 +236,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                 switch (e.Action)
                 {
                     case NotifyCollectionChangedAction.Add:
-                        NotifyItemRangeInserted(e.NewStartingIndex, e.NewItems.Count);
+                        NotifyItemRangeInserted(GetViewPosition(e.NewStartingIndex), GetViewPosition(e.NewItems.Count));
                         break;
                     case NotifyCollectionChangedAction.Move:
                         for (int i = 0; i < e.NewItems.Count; i++)
@@ -221,14 +244,14 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                             var oldItem = e.OldItems[i];
                             var newItem = e.NewItems[i];
 
-                            NotifyItemMoved(this.ItemsSource.GetPosition(oldItem), this.ItemsSource.GetPosition(newItem));
+                            NotifyItemMoved(GetViewPosition(oldItem), GetViewPosition(newItem));
                         }
                         break;
                     case NotifyCollectionChangedAction.Replace:
-                        NotifyItemRangeChanged(e.NewStartingIndex, e.NewItems.Count);
+                        NotifyItemRangeChanged(GetViewPosition(e.NewStartingIndex), GetViewPosition(e.NewItems.Count));
                         break;
                     case NotifyCollectionChangedAction.Remove:
-                        NotifyItemRangeRemoved(e.OldStartingIndex, e.OldItems.Count);
+                        NotifyItemRangeRemoved(GetViewPosition(e.OldStartingIndex), GetViewPosition(e.OldItems.Count));
                         break;
                     case NotifyCollectionChangedAction.Reset:
                         NotifyDataSetChanged();


### PR DESCRIPTION
Added these protected virtual methods to give more customisability. There are no behavioural changes. The additional customisability allows you to create custom adapters that add items in between or at the top or bottom of the list. Here an example of an adapter that adds a header by overriding these virtual methods.

``` C#
public class HeaderAdapter : MvxRecyclerAdapter
{
    public HeaderAdapter(IMvxAndroidBindingContext bindingContext) : base(bindingContext)
    {
    }

    public override int ItemCount => (ItemsSource as IList).Count + 1;

    protected override int GetViewPosition(int itemsSourcePosition)
    {
        return itemsSourcePosition + 1;
    }

    protected override int GetItemsSourcePosition(int viewPosition)
    {
        return base.GetItemsSourcePosition(viewPosition) - 1;
    }

    public override object GetItem(int viewPosition)
    {
        if (viewPosition == 0)
            return null;

        return base.GetItem(viewPosition);
    }

    public override int GetItemViewType(int position)
    {
        if (position == 0)
            return 6;

        return base.GetItemViewType(position);
    }

    public override void OnBindViewHolder(Android.Support.V7.Widget.RecyclerView.ViewHolder holder, int position)
    {
        if (position == 0)
        {
            ((IMvxRecyclerViewHolder)holder).DataContext = BindingContext.DataContext;
        }
        else
            base.OnBindViewHolder(holder, position);
    }
}
```

And then you could use the integer returned from GetItemViewType inside a template selector and return the corresponding layout.

This should also make it easier to reimplement header and footer support inside MvvmCross properly with custom adapter support.