### PR TITLE
- Fix Android crash when app restart

### DIFF
--- a/MvvmCross/Droid/Droid/Views/MvxActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxActivity.cs
@@ -66,7 +66,7 @@ namespace MvvmCross.Droid.Views
             onGlobalLayout = (sender, args) =>
             {
                 view.ViewTreeObserver.GlobalLayout -= onGlobalLayout;
-                ViewModel.Appeared();
+                ViewModel?.Appeared();
             };
 
             view.ViewTreeObserver.GlobalLayout += onGlobalLayout;
@@ -92,14 +92,14 @@ namespace MvvmCross.Droid.Views
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel.Appearing();
+            ViewModel?.Appearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel.Disappearing(); // we don't have anywhere to get this info
-            ViewModel.Disappeared();
+            ViewModel?.Disappearing(); // we don't have anywhere to get this info
+            ViewModel?.Disappeared();
         }
     }
 

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewsContainer.cs
@@ -114,7 +114,8 @@ namespace MvvmCross.Droid.Views
             {
                 {
                     mvxViewModel = Mvx.Resolve<IMvxChildViewModelCache>().Get(embeddedViewModelKey);
-                    return true;
+                    if(mvxViewModel != null)
+                        return true;
                 }
             }
             mvxViewModel = null;

--- a/MvvmCross/Droid/Droid/Views/MvxChildViewModelCache.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxChildViewModelCache.cs
@@ -26,7 +26,9 @@ namespace MvvmCross.Droid.Views
 
         public IMvxViewModel Get(int index)
         {
-            return this._viewModels[index];
+            IMvxViewModel viewModel;
+            _viewModels.TryGetValue(index, out viewModel);
+            return viewModel;
         }
 
         public void Remove(int index)


### PR DESCRIPTION
- When app restart, IMvxChildViewModelCache will be re-create, so there are no cached viewModels
 