### PR TITLE
Fix Android Fragment caching for new navigation

### DIFF
--- a/MvvmCross/Droid/Droid/Views/IMvxChildViewModelCache.cs
+++ b/MvvmCross/Droid/Droid/Views/IMvxChildViewModelCache.cs
@@ -8,6 +8,7 @@
 namespace MvvmCross.Droid.Views
 {
     using MvvmCross.Core.ViewModels;
+    using System;
 
     public interface IMvxChildViewModelCache
     {
@@ -15,6 +16,12 @@ namespace MvvmCross.Droid.Views
 
         IMvxViewModel Get(int index);
 
+        IMvxViewModel Get(Type viewModelType);
+
         void Remove(int index);
+
+        void Remove(Type viewModelType);
+
+        bool Exists(Type viewModelType);
     }
 }

--- a/MvvmCross/Droid/Droid/Views/MvxChildViewModelCache.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxChildViewModelCache.cs
@@ -7,8 +7,9 @@
 
 namespace MvvmCross.Droid.Views
 {
+    using System;
     using System.Collections.Generic;
-
+    using System.Linq;
     using MvvmCross.Core.ViewModels;
 
     public class MvxChildViewModelCache : IMvxChildViewModelCache
@@ -24,6 +25,11 @@ namespace MvvmCross.Droid.Views
             return index;
         }
 
+        public bool Exists(Type viewModelType)
+        {
+            return _viewModels.Values.Any(x => x.GetType() == viewModelType);
+        }
+
         public IMvxViewModel Get(int index)
         {
             IMvxViewModel viewModel;
@@ -31,9 +37,19 @@ namespace MvvmCross.Droid.Views
             return viewModel;
         }
 
+        public IMvxViewModel Get(Type viewModelType)
+        {
+            return _viewModels.Values.FirstOrDefault(x => x.GetType() == viewModelType);
+        }
+
         public void Remove(int index)
         {
             this._viewModels.Remove(index);
+        }
+
+        public void Remove(Type viewModelType)
+        {
+            _viewModels.Remove(_viewModels.FirstOrDefault(x => x.Value.GetType() == viewModelType).Key);
         }
     }
 }

--- a/MvvmCross/Droid/Shared/Fragments/MvxSharedFragmentExtensions.cs
+++ b/MvvmCross/Droid/Shared/Fragments/MvxSharedFragmentExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.Droid.Shared.Attributes;
+using MvvmCross.Droid.Views;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Exceptions;
 using MvvmCross.Platform.Platform;
@@ -47,6 +48,14 @@ namespace MvvmCross.Droid.Shared.Fragments
 
             if (request == null)
                 request = MvxViewModelRequest.GetDefaultRequest(viewModelType);
+
+            var viewModelCache = Mvx.Resolve<IMvxChildViewModelCache>();
+            if(viewModelCache.Exists(viewModelType))
+            {
+                var viewModelCached = viewModelCache.Get(viewModelType);
+                viewModelCache.Remove(viewModelType);
+                return viewModelCached;
+            }
 
             var loaderService = Mvx.Resolve<IMvxViewModelLoader>();
             var viewModel = loaderService.LoadViewModel(request, savedState);

--- a/MvvmCross/Droid/Shared/Presenter/MvxFragmentsPresenter.cs
+++ b/MvvmCross/Droid/Shared/Presenter/MvxFragmentsPresenter.cs
@@ -67,6 +67,11 @@ namespace MvvmCross.Droid.Shared.Presenter
             var serializedRequest = Serializer.Serializer.SerializeObject(request);
             bundle.PutString(ViewModelRequestBundleKey, serializedRequest);
 
+            if (request is MvxViewModelInstanceRequest)
+            {
+                Mvx.Resolve<IMvxChildViewModelCache>().Cache(((MvxViewModelInstanceRequest)request).ViewModelInstance);
+            }
+
             if (!_fragmentHostRegistrationSettings.IsActualHostValid(request.ViewModelType))
             {
                 Type newFragmentHostViewModelType =

--- a/TestProjects/Navigation/RoutingExample.Core/RoutingExample.Core.csproj
+++ b/TestProjects/Navigation/RoutingExample.Core/RoutingExample.Core.csproj
@@ -41,6 +41,7 @@
     <Compile Include="ViewModels\TestBViewModel.cs" />
     <Compile Include="ViewModels\TestAViewModel.cs" />
     <Compile Include="User.cs" />
+    <Compile Include="ViewModels\SecondHostViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross\Core\Binding\MvvmCross.Binding.csproj">

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/SecondHostViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/SecondHostViewModel.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+using RoutingExample.Core.ViewModels;
+
+namespace RoutingExample.Core.ViewModels
+{
+
+    public class SecondHostViewModel : MvxViewModel
+    {
+        private readonly IMvxNavigationService _routingService;
+
+        public SecondHostViewModel(IMvxNavigationService routingService)
+        {
+            _routingService = routingService;
+        }
+
+        private IMvxCommand _showACommand;
+
+        public IMvxCommand ShowACommand
+        {
+            get
+            {
+                return _showACommand ?? (_showACommand = new MvxAsyncCommand(async () =>
+                {
+                    await _routingService.Navigate<TestAViewModel, User>(new User("MvvmCross", "Test"));
+
+                    //await _routingService.Navigate("mvx://test/a");
+                }));
+            }
+        }
+
+        private IMvxCommand _showBCommand;
+
+        public IMvxCommand ShowBCommand
+        {
+            get
+            {
+                return _showBCommand ?? (_showBCommand = new MvxAsyncCommand(async () =>
+                {
+                    //var result = await _routingService.Navigate<User, User>("mvx://test/?id=" + Guid.NewGuid().ToString("N"), new User("MvvmCross2", "Test2"));
+                    var result = await _routingService.Navigate<TestBViewModel, User, User>(new User("MvvmCross", "Test"));
+                    var test = result?.FirstName;
+                }));
+            }
+        }
+
+        private IMvxCommand _showRandomCommand;
+
+        public IMvxCommand ShowRandomCommand
+        {
+            get
+            {
+                return _showRandomCommand ?? (_showRandomCommand = new MvxAsyncCommand(async () =>
+                {
+                    await _routingService.Navigate("mvx://random");
+                }));
+            }
+        }
+    }
+}

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
@@ -34,11 +34,14 @@ namespace RoutingExample.Core.ViewModels
 
         private User _user;
 
-        public IMvxAsyncCommand CloseViewModelCommand => new MvxAsyncCommand(async () => await Close(new User("Return result", "Something")));
+        public IMvxAsyncCommand CloseViewModelCommand => new MvxAsyncCommand(
+            () => Close(new User("Return result", "Something")));
+        public IMvxAsyncCommand OpenViewModelMainCommand => new MvxAsyncCommand(
+            () => Mvx.Resolve<IMvxNavigationService>().Navigate<MainViewModel>());
         public IMvxAsyncCommand OpenViewModelACommand => new MvxAsyncCommand(
-            async () => await Mvx.Resolve<IMvxNavigationService>().Navigate<TestAViewModel, User>(new User($"To A from {this.GetHashCode()}", "Something")));
+            () =>  Mvx.Resolve<IMvxNavigationService>().Navigate<TestAViewModel, User>(new User($"To A from {this.GetHashCode()}", "Something")));
         public IMvxAsyncCommand OpenViewModelBCommand => new MvxAsyncCommand(
-            async () => await Mvx.Resolve<IMvxNavigationService>().Navigate<TestBViewModel, User, User>(new User($"To B from {this.GetHashCode()}", "Something")));
+            () =>  Mvx.Resolve<IMvxNavigationService>().Navigate<TestBViewModel, User, User>(new User($"To B from {this.GetHashCode()}", "Something")));
 
         public override async Task Initialize(User parameter)
         {

--- a/TestProjects/Navigation/RoutingExample.Droid/Resources/layout/Test.axml
+++ b/TestProjects/Navigation/RoutingExample.Droid/Resources/layout/Test.axml
@@ -18,6 +18,12 @@
         android:layout_height="wrap_content" />
     <Button
         android:id="@+id/button1"
+        android:text="Open Main"
+        local:MvxBind="Click OpenViewModelMainCommand"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    <Button
+        android:id="@+id/button1"
         android:text="Open A"
         local:MvxBind="Click OpenViewModelACommand"
         android:layout_width="match_parent"

--- a/TestProjects/Navigation/RoutingExample.Droid/Resources/layout/secondhost.axml
+++ b/TestProjects/Navigation/RoutingExample.Droid/Resources/layout/secondhost.axml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:fitsSystemWindows="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:id="@+id/main_frame"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <FrameLayout
+            android:id="@+id/content_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true" />
+    </LinearLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/TestProjects/Navigation/RoutingExample.Droid/RoutingExample.Droid.csproj
+++ b/TestProjects/Navigation/RoutingExample.Droid/RoutingExample.Droid.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Setup.cs" />
     <Compile Include="TestAView.cs" />
     <Compile Include="TestBView.cs" />
+    <Compile Include="SecondHostView.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -109,6 +110,7 @@
     <AndroidResource Include="Resources\values\dimens.xml" />
     <AndroidResource Include="Resources\values\styles.xml" />
     <AndroidResource Include="Resources\values-v21\styles.xml" />
+    <AndroidResource Include="Resources\layout\secondhost.axml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\drawable\" />

--- a/TestProjects/Navigation/RoutingExample.Droid/SecondHostView.cs
+++ b/TestProjects/Navigation/RoutingExample.Droid/SecondHostView.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Net;
+using Android.App;
+using Android.Content;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Android.OS;
+using MvvmCross.Droid.Views;
+using MvvmCross.Platform;
+using RoutingExample.Core.ViewModels;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using Android.Content.PM;
+
+namespace RoutingExample.Droid
+{
+    [Activity(
+        Label = "Example", 
+        MainLauncher = true, 
+        Theme = "@style/AppTheme",
+        LaunchMode = LaunchMode.SingleTop,
+        Icon = "@mipmap/icon")]
+    [IntentFilter(new[] { Intent.ActionView }, DataScheme = "mvx",
+        Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable })]
+    [IntentFilter(new[] { Intent.ActionView }, DataScheme = "https", DataHost = "mvvmcross.com",
+        Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable })]
+    public class SecondHostView : MvxCachingFragmentCompatActivity<SecondHostViewModel>
+    {
+
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+
+            SetContentView(Resource.Layout.secondhost);
+        }
+
+        protected override void OnNewIntent(Intent intent)
+        {
+            base.OnNewIntent(intent);
+
+            if(!Mvx.CanResolve<IMvxNavigationService>()) return;
+
+            var url = WebUtility.UrlDecode(intent.DataString);
+
+            Mvx.Resolve<IMvxNavigationService>().Navigate(url);
+        }
+    }
+}
+

--- a/TestProjects/Navigation/RoutingExample.Droid/TestBView.cs
+++ b/TestProjects/Navigation/RoutingExample.Droid/TestBView.cs
@@ -14,7 +14,7 @@ using MvvmCross.Droid.Shared.Attributes;
 
 namespace RoutingExample.Droid
 {
-    [MvxFragment(typeof(MainViewModel), Resource.Id.content_frame, true)]
+    [MvxFragment(typeof(SecondHostViewModel), Resource.Id.content_frame, true)]
     public class TestBView : MvxFragment<TestBViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)


### PR DESCRIPTION
This fixes fragments not using the already created viewmodel.

The problem was that when showing a ViewModel which is in a Fragment the it serializes the MvxViewModelInstanceRequest, in there the instance is lost, so when the Activity is shown the Fragment creates a new type based on the ViewModelType, but there is already an existing instance of it available. This makes sure that the correct instance is restored.