### PR TITLE
Add sidebar menu open/close callbacks

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
@@ -45,6 +45,14 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
                     , UIBarButtonItemStyle.Plain
                     , (sender, args) =>
                     {
+                        if (sidebarController.IsOpen)
+                        {
+                            mvxSidebarMenu.MenuWillClose();
+                        }
+                        else
+                        {
+                            mvxSidebarMenu.MenuWillOpen();
+                        }
                         sidebarController.MenuWidth = mvxSidebarMenu.MenuWidth;
                         sidebarController.ViewWillAppear(false);
                         sidebarController.ToggleMenu();

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/IMvxSidebarMenu.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/IMvxSidebarMenu.cs
@@ -12,6 +12,10 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
         UIImage MenuButtonImage { get; }
         int MenuWidth { get; }
         bool ReopenOnRotate { get; }
+        void MenuWillOpen();
+        void MenuDidOpen();
+        void MenuWillClose();
+        void MenuDidClose();
     }
 }
 

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSidebarViewController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSidebarViewController.cs
@@ -134,10 +134,19 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
                 sidebarController.HasShadowing = mvxSideMenuSettings.HasShadowing;
                 sidebarController.DisablePanGesture = mvxSideMenuSettings.DisablePanGesture;
                 sidebarController.ReopenOnRotate = mvxSideMenuSettings.ReopenOnRotate;
-                sidebarController.StateChangeHandler += (object sender, bool e) =>
+                sidebarController.StateChangeHandler += (object sender, bool isOpen) =>
                 {
                     sidebarController.MenuWidth = mvxSideMenuSettings.MenuWidth;
                     sidebarController.ViewWillAppear(mvxSideMenuSettings.AnimateMenu);
+
+                    if (isOpen)
+                    {
+                        mvxSideMenuSettings.MenuDidOpen();
+                    }
+                    else
+                    {
+                        mvxSideMenuSettings.MenuDidClose();
+                    }
                 };
             }
         }
@@ -175,11 +184,8 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
 
         public void CloseMenu()
         {
-            if(LeftSidebarController != null && LeftSidebarController.IsOpen)
-                LeftSidebarController.CloseMenu();
-
-            if(RightSidebarController != null && RightSidebarController.IsOpen)
-                RightSidebarController.CloseMenu();
+            CloseMenu(LeftSidebarController);
+            CloseMenu(RightSidebarController);
         }
 
         public void Open(MvxPanelEnum panelEnum)
@@ -192,8 +198,22 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
 
         protected virtual void OpenMenu(SidebarController sidebarController)
         {
-            if(sidebarController != null && !sidebarController.IsOpen)
+            if (sidebarController != null && !sidebarController.IsOpen)
+            {
+                var sidebarMenu = sidebarController.MenuAreaController as IMvxSidebarMenu;
+                sidebarMenu?.MenuWillOpen();
                 sidebarController.OpenMenu();
+            }
+        }
+
+        protected virtual void CloseMenu(SidebarController sidebarController)
+        {
+            if (sidebarController != null && sidebarController.IsOpen)
+            {
+                var sidebarMenu = sidebarController.MenuAreaController as IMvxSidebarMenu;
+                sidebarMenu?.MenuWillClose();
+                sidebarController.CloseMenu();
+            }
         }
 
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/BaseMenuViewController.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/BaseMenuViewController.cs
@@ -27,5 +27,20 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.iOS.Views
             get { return UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone; }
         }
 
+        public virtual void MenuWillOpen()
+        {
+        }
+
+        public virtual void MenuDidOpen()
+        {
+        }
+
+        public virtual void MenuWillClose()
+        {
+        }
+
+        public virtual void MenuDidClose()
+        {
+        }
     }
 }


### PR DESCRIPTION
This PR adds `MenuWillOpen()`, `MenuDidOpen()`, `MenuWillClose()` and `MenuDidClose()` callbacks to the view controller implementing `IMvxSidebarMenu`.

As Xamarin Sidebar doesn't integrate with view controller lifecycle events, the only way to receive notifications about the menu opening/closing is through its `StateChangeHandler`, which MvvmCross currently doesn't do much with. For some reason, `StateChangeHandler` is only invoked after the menu open/close animation has completed, which I find undesirable (I'd like to update viewmodel properties prior to menu open). As such, I've included callbacks that will execute as soon as menu toggle/open/close are requested as well as callbacks that will execute upon animation completion. 

Due to the interface modifications, this is a minor breaking change.