### PR TITLE
Fix for #1759 (PictureChooser iOS incorrect scaling)

### DIFF
--- a/MvvmCross-Plugins/PictureChooser/MvvmCross.Plugins.PictureChooser.iOS/UIImageHelpers.cs
+++ b/MvvmCross-Plugins/PictureChooser/MvvmCross.Plugins.PictureChooser.iOS/UIImageHelpers.cs
@@ -55,7 +55,7 @@ namespace MvvmCross.Plugins.PictureChooser.iOS
 
             var destRect = new CGRect(0, 0, (nfloat)scaledWidth, (nfloat)scaledHeight);
 
-            UIGraphics.BeginImageContextWithOptions(destRect.Size, false, 0);
+            UIGraphics.BeginImageContextWithOptions(destRect.Size, false, 1);
             image.Draw(destRect);
 
             var newImage = UIGraphics.GetImageFromCurrentImageContext();


### PR DESCRIPTION
The image when resized was using an image context with “use device
scale” specified. 2 on @2x devices and 3 on @3x devices.

UIGraphics.BeginImageContextWithOptions(destRect.Size, false, 0);

Instead it should have been fixed at 1.

UIGraphics.BeginImageContextWithOptions(destRect.Size, false, 1);