### PR TITLE
Docs - Added margin to bottom of tables

### DIFF
--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -415,6 +415,7 @@ a:visited {
 table {
     padding: 0;
     border-spacing: 0px;
+    margin-bottom: 15px;
 }
 
 table tr {


### PR DESCRIPTION
I'm not to sure how to run and test the documentation site locally. But my hope is that by adding a bottom margin to table elements it will improve separation of content areas. From this:

![image](https://cloud.githubusercontent.com/assets/13716738/26283875/aec61772-3e2f-11e7-89dd-5657bac39a70.png)

to this:

![image](https://cloud.githubusercontent.com/assets/13716738/26283883/c2a1e884-3e2f-11e7-9879-2a25ba0ca178.png)
