### PR TITLE
iOS View Presenter: Default child presentation when using MvxTabBarController as Root

### DIFF
--- a/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
@@ -11,5 +11,7 @@ namespace MvvmCross.iOS.Views
         bool ShowChildView(UIViewController viewController);
 
         bool CloseChildViewModel(IMvxViewModel viewModel);
+
+        bool CanShowChildView(UIViewController viewController);
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -67,6 +67,11 @@ namespace MvvmCross.iOS.Views
             return true;
         }
 
+        public virtual bool CanShowChildView(UIViewController viewController)
+        {
+            return SelectedViewController is UINavigationController;
+        }
+
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
             var navController = SelectedViewController as UINavigationController;

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -376,7 +376,10 @@ namespace MvvmCross.iOS.Views.Presenters
                 return attributes;
             }
 
-            if (MasterNavigationController == null)
+            if(MasterNavigationController == null
+                &&
+               (TabBarViewController == null || !TabBarViewController.CanShowChildView(viewController))
+              )
             {
                 MvxTrace.Trace($"PresentationAttribute nor MasterNavigationController found for {viewController.GetType().Name}. Assuming Root presentation");
                 return new MvxRootPresentationAttribute() { WrapInNavigationController = true };


### PR DESCRIPTION
Fixes #1834.

The current problem is, when using default attributes the presenter only checks for a MasterNavigationController and if it's null then it assumes a Root presentation mode. This PR adds the feature of default child presentation when using a MvxTabBarController as Root.