### PR TITLE
Fix bug with Sidebar removing all nav controller buttons

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
@@ -11,10 +11,6 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
         {
             UIBarButtonItem barButtonItem;
 
-            // Make there are currently no left or right buttons
-            viewController.NavigationItem.SetLeftBarButtonItem(null, true);
-            viewController.NavigationItem.SetRightBarButtonItem(null, true);
-
             if(sidebarPanelController.HasLeftMenu)
             {
                 var mvxSidebarMenu = sidebarPanelController.LeftSidebarController.MenuAreaController as IMvxSidebarMenu;
@@ -29,7 +25,6 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
                 var mvxSidebarMenu = sidebarPanelController.RightSidebarController.MenuAreaController as IMvxSidebarMenu;
                 sidebarPanelController.RightSidebarController.MenuLocation = MenuLocations.Right;
                 barButtonItem = CreateBarButtonItem(sidebarPanelController.RightSidebarController, mvxSidebarMenu);
-
 
                 viewController.NavigationItem.SetRightBarButtonItem(barButtonItem, true);
             }


### PR DESCRIPTION
Both left and right bar button items are being set to null even if only one side is being used for a menu. As a consequence, the right bar button item I was setting (I only make use of a left menu) in `ViewDidLoad` of my centre panel was being removed unless I set it in `ViewWillAppear`.

I can't see the need for setting the button items to null, but if there is a reason that I'm missing the statements should probably instead go inside their respective left/right if scopes.