### PR TITLE
Added Visibility.Hidden

### DIFF
--- a/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility.Droid/MvxDroidVisibility.cs
+++ b/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility.Droid/MvxDroidVisibility.cs
@@ -11,11 +11,19 @@ using MvvmCross.Platform.UI;
 namespace MvvmCross.Plugins.Visibility.Droid
 {
     [Preserve(AllMembers = true)]
-	public class MvxDroidVisibility : IMvxNativeVisibility
+    public class MvxDroidVisibility : IMvxNativeVisibility
     {
         public object ToNative(MvxVisibility visibility)
         {
-            return visibility == MvxVisibility.Visible ? ViewStates.Visible : ViewStates.Gone;
+            switch (visibility)
+            {
+                case MvxVisibility.Collapsed:
+                    return ViewStates.Gone;
+                case MvxVisibility.Hidden:
+                    return ViewStates.Invisible;
+                default:
+                    return ViewStates.Visible;
+            }
         }
     }
 }

--- a/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility/MvxBaseVisibilityValueConverter.cs
+++ b/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility/MvxBaseVisibilityValueConverter.cs
@@ -43,49 +43,5 @@ namespace MvvmCross.Plugins.Visibility
         {
             return base.ConvertBack(value, targetType, parameter, culture);
         }
-
-        protected virtual bool IsATrueValue(object value, object parameter, bool defaultValue)
-        {
-            if (value == null)
-            {
-                return false;
-            }
-
-            if (value is bool)
-            {
-                return (bool)value;
-            }
-
-            if (value is int)
-            {
-                if (parameter == null)
-                {
-                    return (int)value > 0;
-                }
-                else
-                {
-                    return (int)value > int.Parse(parameter.ToString());
-                }
-            }
-
-            if (value is double)
-            {
-                return (double)value > 0;
-            }
-
-            if (value is string)
-            {
-                return !string.IsNullOrWhiteSpace(value as string);
-            }
-
-            // 19/Mar/2013 - decided *not* to test IEnumerable - if user's need this then they will have to provide overrides
-            //if (value is IEnumerable)
-            //{
-            //    var enumerable = value as IEnumerable;
-            //    return enumerable.GetEnumerator().MoveNext();
-            //}
-
-            return defaultValue;
-        }
     }
 }

--- a/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility/MvxInvertedVisibilityValueConverter.cs
+++ b/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility/MvxInvertedVisibilityValueConverter.cs
@@ -7,6 +7,7 @@
 
 using MvvmCross.Platform.UI;
 using System.Globalization;
+using MvvmCross.Platform.ExtensionMethods;
 
 namespace MvvmCross.Plugins.Visibility
 {
@@ -15,8 +16,21 @@ namespace MvvmCross.Plugins.Visibility
     {
         protected override MvxVisibility Convert(object value, object parameter, CultureInfo culture)
         {
-            var visibility = !IsATrueValue(value, parameter, true);
-            return visibility ? MvxVisibility.Visible : MvxVisibility.Collapsed;
+            bool hide = parameter.ConvertToBooleanCore();
+            switch (base.Convert(value, parameter, culture))
+            {
+                case (MvxVisibility.Visible):
+                    if (hide)
+                    {
+                        return MvxVisibility.Hidden;
+                    }
+                    else
+                    {
+                        return MvxVisibility.Collapsed;
+                    }
+                default:
+                    return MvxVisibility.Visible;
+            }
         }
     }
 }

--- a/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility/MvxVisibilityValueConverter.cs
+++ b/MvvmCross-Plugins/Visibility/MvvmCross.Plugins.Visibility/MvxVisibilityValueConverter.cs
@@ -7,6 +7,7 @@
 
 using MvvmCross.Platform.UI;
 using System.Globalization;
+using MvvmCross.Platform.ExtensionMethods;
 
 namespace MvvmCross.Plugins.Visibility
 {
@@ -15,8 +16,15 @@ namespace MvvmCross.Plugins.Visibility
     {
         protected override MvxVisibility Convert(object value, object parameter, CultureInfo culture)
         {
-            var visibility = IsATrueValue(value, parameter, true);
-            return visibility ? MvxVisibility.Visible : MvxVisibility.Collapsed;
+            bool visible = value.ConvertToBooleanCore();
+            bool hide = parameter.ConvertToBooleanCore();
+
+            if (!visible)
+            {
+                return hide ? MvxVisibility.Hidden : MvxVisibility.Collapsed;
+            }
+
+            return MvxVisibility.Visible;
         }
     }
-}	
+}

--- a/MvvmCross/Platform/Platform/UI/MvxVisibility.cs
+++ b/MvvmCross/Platform/Platform/UI/MvxVisibility.cs
@@ -11,6 +11,7 @@ namespace MvvmCross.Platform.UI
     public enum MvxVisibility : byte
     {
         Visible,
-        Collapsed
+        Collapsed,
+        Hidden
     }
 }


### PR DESCRIPTION
To allow more flexibility in hiding views, many platforms also support another type of Hidden. The default implementation of Windows as well(https://msdn.microsoft.com/en-us/library/system.windows.visibility(v=vs.110).aspx), but it was never implemented in MVVMCross (https://github.com/MvvmCross/MvvmCross/blob/8a824c797747f74716fc64c2fd0e8765c29b16ab/MvvmCross/Platform/Platform/UI/MvxVisibility.cs).

I added the missing Hidden attribute and tidied up the converters and implemented the Android variant. Which allows now to just make an item 'Invisible' instead of 'gone' which also increases performance on Android. The overload happens in the converter and needs to be set to true to set visibility to Visibility.Hidden instead of Visibility.Collapse.

`Visibility Visibility(IsLoading, true)`