### PR TITLE
Fixes #1861 duplicate Library Output added in NuGet

### DIFF
--- a/nuspec/MvvmCross.Core.nuspec
+++ b/nuspec/MvvmCross.Core.nuspec
@@ -32,7 +32,6 @@ This package contains the 'Core' libraries for MvvmCross
 
 		<!-- uap -->
 		<file src="..\bin\Release\Mvx\Uwp\MvvmCross.Uwp.*" target="lib\uap10.0" />
-		<file src="..\bin\Release\Mvx\Uwp\MvvmCross.Uwp\Properties\MvvmCross.Uwp.rd.xml" target="lib\uap10.0\MvvmCross.Uwp\Properties" />
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Core.dll" target="lib\uap10.0" />
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Core.pdb" target="lib\uap10.0" />
 		

--- a/nuspec/MvvmCross.Forms.nuspec
+++ b/nuspec/MvvmCross.Forms.nuspec
@@ -23,8 +23,6 @@ This package contains MvvmCross to use with Xamarin.Forms</description>
 		<!-- uap -->
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Forms.*" target="lib\uap10.0" />
 		<file src="..\bin\Release\Mvx\Uwp\MvvmCross.Forms.Uwp.*" target="lib\uap10.0" />
-		<file src="..\bin\Release\Mvx\Uwp\MvvmCross.Forms.Uwp\Properties\MvvmCross.Forms.Uwp.rd.xml" 
-			target="lib\uap10.0\MvvmCross.Forms.Uwp\Properties" />
 
 		<!-- droid -->
 		<file src="..\bin\Release\Mvx\Portable\MvvmCross.Forms.*" target="lib\MonoAndroid70" />


### PR DESCRIPTION
We already compile rd.xml Library Output into the assembly. Hence it is not needed to add it to the NuGet also.

This PR removes that from the nuspecs.