### PR TITLE
Replaced `Init` and `Start` with `Initialize` method

### DIFF
--- a/nuspec/CoreContent/MainViewModel.cs.pp
+++ b/nuspec/CoreContent/MainViewModel.cs.pp
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using MvvmCross.Core.ViewModels;
 
 namespace $rootnamespace$.ViewModels
@@ -8,14 +9,11 @@ namespace $rootnamespace$.ViewModels
         {
         }
         
-        //TODO: For more information see: https://www.mvvmcross.com/documentation/fundamentals/navigation
-        public void Init()
-        {
-        }
-        
-        public override void Start()
+        public override Task Initialize()
         {
             //TODO: Add starting logic here
+		    
+            return base.Initialize();
         }
         
         public IMvxCommand ResetTextCommand => new MvxCommand(ResetText);


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature - update the MvvmCross Starter Pack code to make use of new MvvmCross 5 features.

I am wondering if I should also already inject the `MvxNavigationService` into the `MainViewModel`, it will not be used directly but changes are that most people will do navigation from here. And it will be a nice introduction to the new navigation service.

## :arrow_heading_down: What is the current behavior?
In the current version the generated `MainViewModel` uses the `Init` and `Start` methods to initialise the viewmodel.

## :new: What is the new behavior (if this is a feature change)?
Use the new `Initialize` method to allow for async support.

## :boom: Does this PR introduce a breaking change?
Nope (if released with version 5.0.1 or later). Earlier versions don't call `Initialize` from the `AppStart` method.

## :bug: Recommendations for testing
See breaking change.

## :memo: Links to relevant issues/docs
none

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop