### PR TITLE
Add setvalueimpl for SearchView Query and change to TwoWay.

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/Target/MvxAppCompatSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/Target/MvxAppCompatSearchViewQueryTextTargetBinding.cs
@@ -20,7 +20,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Target
 
         public override Type TargetType => typeof(string);
 
-        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWayToSource;
+        public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 
         protected SearchView SearchView => (SearchView)this.Target;
 
@@ -31,9 +31,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Target
                 HandleQueryTextChanged);
         }
 
-        protected override void SetValueImpl(object target, object value)
-        {
-        }
+        protected override void SetValueImpl(object target, object value) =>
+            ((SearchView)target).SetQuery((string)value, true);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/Target/MvxAppCompatSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/Target/MvxAppCompatSearchViewQueryTextTargetBinding.cs
@@ -1,14 +1,11 @@
+﻿using System;
+using Android.Support.V7.Widget;
+using MvvmCross.Binding;
+using MvvmCross.Binding.Droid.Target;
 using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Droid.Support.V7.AppCompat.Target
 {
-    using System;
-
-    using Android.Support.V7.Widget;
-
-    using MvvmCross.Binding;
-    using MvvmCross.Binding.Droid.Target;
-
     public class MvxAppCompatSearchViewQueryTextTargetBinding : MvxAndroidTargetBinding
     {
         private IDisposable _subscription;
@@ -22,7 +19,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 
-        protected SearchView SearchView => (SearchView)this.Target;
+        protected SearchView SearchView => (SearchView)Target;
 
         public override void SubscribeToEvents()
         {
@@ -47,7 +44,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Target
 
         private void HandleQueryTextChanged(object sender, SearchView.QueryTextChangeEventArgs e)
         {
-            var target = this.Target as SearchView;
+            var target = Target as SearchView;
 
             if (target == null)
             {
@@ -55,7 +52,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Target
             }
 
             var value = target.Query;
-            this.FireValueChanged(value);
+            FireValueChanged(value);
         }
     }
 }

--- a/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
+++ b/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
@@ -43,6 +43,7 @@
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Java.Interop" />
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
     <Reference Include="mscorlib" />

--- a/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
+++ b/MvvmCross/Binding/Droid/MvvmCross.Binding.Droid.csproj
@@ -43,7 +43,6 @@
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Java.Interop" />
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
     <Reference Include="mscorlib" />

--- a/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
@@ -27,11 +27,8 @@ namespace MvvmCross.Binding.Droid.Target
                 HandleQueryTextChanged);
         }
 
-        protected override void SetValueImpl(object target, object value)
-        {
-            if (target is SearchView sv)
-                sv.SetQuery((string)value, true);
-        }
+        protected override void SetValueImpl(object target, object value) => 
+            ((SearchView)target).SetQuery((string)value, true);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross/Binding/Droid/Target/MvxSearchViewQueryTextTargetBinding.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Android.Widget;
 using MvvmCross.Platform.WeakSubscription;
 
@@ -16,7 +16,7 @@ namespace MvvmCross.Binding.Droid.Target
 
         public override Type TargetType => typeof(string);
 
-        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWayToSource;
+        public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 
         protected SearchView SearchView => (SearchView)Target;
 
@@ -29,6 +29,8 @@ namespace MvvmCross.Binding.Droid.Target
 
         protected override void SetValueImpl(object target, object value)
         {
+            if (target is SearchView sv)
+                sv.SetQuery((string)value, true);
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

## :arrow_heading_down: What is the current behavior?
ViewModel -> SearchView changes are not reflected in the SearchView

## :new: What is the new behavior (if this is a feature change)?
Fixes the above

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Add EditText and SearchView to a layout, bind to same string property in ViewModel. Test that when typing in SearchView changes text in VM and EditText and vice versa.

## :memo: Links to relevant issues/docs
#1882 

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop