### PR TITLE
Adds target binding for UIPageControl on iOS

### DIFF
--- a/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
+++ b/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Target\MvxUIDatePickerTimeTargetBinding.cs" />
     <Compile Include="Target\MvxUILabelTextTargetBinding.cs" />
     <Compile Include="Target\MvxUISearchBarTextTargetBinding.cs" />
+    <Compile Include="Target\MvxUIPageControlCurrentPageTargetBinding.cs" />
     <Compile Include="Target\MvxUIStepperValueTargetBinding.cs" />
     <Compile Include="Target\MvxUITextFieldShouldReturnTargetBinding.cs" />
     <Compile Include="Target\MvxUITextFieldTextFocusTargetBinding.cs" />

--- a/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
@@ -1,4 +1,4 @@
-// MvxIosBindingBuilder.cs
+﻿// MvxIosBindingBuilder.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -121,6 +121,11 @@ namespace MvvmCross.Binding.iOS
                 typeof(MvxUIStepperValueTargetBinding),
                 typeof(UIStepper),
                 MvxIosPropertyBinding.UIStepper_Value);
+
+            registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxUIPageControlCurrentPageTargetBinding),
+                typeof(UIPageControl),
+                MvxIosPropertyBinding.UIPageControl_CurrentPage);
 
             registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxUISegmentedControlSelectedSegmentTargetBinding),

--- a/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
+++ b/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
@@ -1,4 +1,4 @@
-// MvxIosPropertyBinding.cs
+﻿// MvxIosPropertyBinding.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -28,6 +28,7 @@ namespace MvvmCross.Binding.iOS
         public const string UIView_Hidden = "Hidden";
         public const string UISlider_Value = "Value";
         public const string UIStepper_Value = "Value";
+        public const string UIPageControl_CurrentPage = "CurrentPage";
         public const string UISegmentedControl_SelectedSegment = "SelectedSegment";
         public const string UIDatePicker_Date = "Date";
         public const string UITextField_ShouldReturn = "ShouldReturn";

--- a/MvvmCross/Binding/iOS/Target/MvxUIPageControlCurrentPageTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUIPageControlCurrentPageTargetBinding.cs
@@ -1,0 +1,66 @@
+﻿// MvxUIStepperValueTargetBinding.cs
+
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+
+using System;
+using System.Reflection;
+using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.Platform;
+using UIKit;
+
+namespace MvvmCross.Binding.iOS.Target
+{
+    public class MvxUIPageControlCurrentPageTargetBinding
+        : MvxPropertyInfoTargetBinding<UIPageControl>
+    {
+        private bool _subscribed;
+
+        public MvxUIPageControlCurrentPageTargetBinding(object target, PropertyInfo targetPropertyInfo)
+            : base(target, targetPropertyInfo)
+        {
+        }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            var view = target as UIPageControl;
+            if (view == null)
+                return;
+
+            view.CurrentPage = (nint)value;
+        }
+
+        private void HandleValueChanged(object sender, EventArgs e)
+        {
+            var view = View;
+            if (view == null) return;
+            FireValueChanged(view.CurrentPage);
+        }
+
+        public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
+
+        public override void SubscribeToEvents()
+        {
+            var pageControl = View;
+            if (pageControl == null)
+            {
+                MvxBindingTrace.Trace(MvxTraceLevel.Error, "UIPageControl is null in MvxUIPageControlCurrentPageTargetBinding");
+                return;
+            }
+
+            _subscribed = true;
+            pageControl.ValueChanged += HandleValueChanged;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            if (!isDisposing) return;
+            var pageControl = View;
+            if (pageControl == null || !_subscribed) return;
+
+            pageControl.ValueChanged -= HandleValueChanged;
+            _subscribed = false;
+        }
+    }
+}

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -478,6 +478,7 @@ UIKit.UISlider | Value
 UIKit.UISwitch | On
 UIKit.UIProgressView | Progress
 UIKit.UISegmentedControl | SelectedSegment
+UIKit.UIPageControl | CurrentPage
 UIKit.UIActivityIndicatorView | Hidden
 MvvmCross.Binding.iOS.Views.MvxCollectionViewSource | ItemsSource
 MvvmCross.Binding.iOS.Views.MvxTableViewSource | ItemsSource
@@ -654,6 +655,7 @@ UIKit.UIActivityIndicatorView | Hidden | BindHidden()
 UIKit.UISlider | Value | BindValue()
 UIKit.UIStepper | Value | BindValue()
 UIKit.UISegmentedControl | SelectedSegment | BindSelectedSegment()
+UIKit.UIPageControl | CurrentPage | BindCurrentPage()
 UIKit.UIDatePicker | Date | BindDate()
 UIKit.UITextField | ShouldReturn | BindShouldReturn()
 UIKit.UIDatePicker | Time | BindTime()


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Added feature.

## :arrow_heading_down: What is the current behavior?

Cannot do a two-way binding to UIPageControl on iOS.

## :new: What is the new behavior (if this is a feature change)?

This change adds a target binding with two-way support for binding to the `CurrentPage` property on a `UIPageControl`.

## :boom: Does this PR introduce a breaking change?

No.

## :bug: Recommendations for testing

Create two-way bindings to a `UIPageControl` and watch it happen.

## :memo: Links to relevant issues/docs

No issues found.

Data binding documentation updated as part of the PR.

## :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop