### PR TITLE
Fixes issues 1876 and 1880

### DIFF
--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -45,7 +45,6 @@ namespace MvvmCross.Droid.Views
             if (request is MvxViewModelInstanceRequest)
             {
                 var instanceRequest = requestTranslator.GetIntentWithKeyFor(((MvxViewModelInstanceRequest)request).ViewModelInstance);
-                requestTranslator.RemoveSubViewModelWithKey(instanceRequest.Item2);
                 return instanceRequest.Item1;
             }
             return requestTranslator.GetIntentFor(request);


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix: makes sure ViewModel isn't instantiated twice on Android

## :arrow_heading_down: What is the current behavior?
ViewModel gets instantiated double on Android while navigating to it using the new NavigationService.

## :new: What is the new behavior (if this is a feature change)?
ViewModel only gets instantiated one time

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Reproduction steps are described in #1880

## :memo: Links to relevant issues/docs
Fixes #1876 and #1880

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop