### PR TITLE
Fix IsTagged and IsRepository logic in build script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,8 @@
 #tool nuget:?package=GitVersion.CommandLine
 #tool nuget:?package=gitlink
 #tool nuget:?package=vswhere
-#addin "Cake.Incubator"
+#addin nuget:?package=Cake.Incubator
+#addin nuget:?package=Cake.Git
 
 var sln = new FilePath("MvvmCross_All.sln");
 var outputDir = new DirectoryPath("artifacts");
@@ -277,18 +278,22 @@ bool IsRepository(string repoName)
 
 bool IsTagged()
 {
-	var toReturn = false;
-	int commitsSinceTag = -1;
-	if (int.TryParse(versionInfo.CommitsSinceVersionSource, out commitsSinceTag))
+	var path = MakeAbsolute(sln).GetDirectory().FullPath;
+	using (var repo = new LibGit2Sharp.Repository(path))
 	{
-		// if tag is current commit this will be 0
-		if (commitsSinceTag == 0)
-			toReturn = true;
+		var head = repo.Head;
+		var headSha = head.Tip.Sha;
+		
+		var tag = repo.Tags.FirstOrDefault(t => t.Target.Sha == headSha);
+		if (tag == null)
+		{
+			Information("HEAD is not tagged");
+			return false;
+		}
+
+		Information("HEAD is tagged: {0}", tag.FriendlyName);
+		return true;
 	}
-
-	Information("Commits since tag {0}, is tagged: {1}", commitsSinceTag, toReturn);
-
-	return toReturn;
 }
 
 Tuple<string, string> GetNugetKeyAndSource()

--- a/build.cake
+++ b/build.cake
@@ -272,7 +272,22 @@ bool IsRepository(string repoName)
 	}
 	else
 	{
-		return true;
+		try
+		{
+			var path = MakeAbsolute(sln).GetDirectory().FullPath;
+			using (var repo = new LibGit2Sharp.Repository(path))
+			{
+				var origin = repo.Network.Remotes.FirstOrDefault(
+					r => r.Name.ToLowerInvariant() == "origin");
+				return origin.Url.ToLowerInvariant() == 
+					"https://github.com/" + repoName.ToLowerInvariant();
+			}
+		}
+		catch(Exception ex)
+		{
+			Information("Failed to lookup repository: {0}", ex);
+			return false;
+		}
 	}
 }
 


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

## :arrow_heading_down: What is the current behavior?
Sometimes tags are not detected as expected. IsRepository always returns true.

## :new: What is the new behavior (if this is a feature change)?
Now uses LibGit2Sharp through Cake.Git to get Git Tag for HEAD

Uses LibGit2Sharp to find origin and match against that to see if this repo was the one who triggered build.

## :boom: Does this PR introduce a breaking change?
Nope

## :bug: Recommendations for testing
See if release build is OK and uploaded to NuGet

## :memo: Links to relevant issues/docs
#1874 

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop