### PR TITLE
Removed invalid code in App.cs example

### DIFF
--- a/docs/_documentation/tipcalc-tutorial/the-core-project.md
+++ b/docs/_documentation/tipcalc-tutorial/the-core-project.md
@@ -71,10 +71,10 @@ Within this folder create a new Interface which will be used for calculating tip
 ```c#
 namespace TipCalc.Core.Services
 {
-public interface ICalculation
-{
-    double TipAmount(double subTotal, int generosity);
-}
+    public interface ICalculation
+    {
+        double TipAmount(double subTotal, int generosity);
+    }
 }
 ```
 
@@ -83,13 +83,13 @@ Within this folder create an implementation of this interface:
 ```c#
 namespace TipCalc.Core.Services
 {
-public class Calculation : ICalculation
-{
-    public double TipAmount(double subTotal, int generosity)
+    public class Calculation : ICalculation
     {
-        return subTotal * ((double)generosity)/100.0;
+        public double TipAmount(double subTotal, int generosity)
+        {
+            return subTotal * ((double)generosity)/100.0;
+        }
     }
-}
 }
 ```
 
@@ -119,72 +119,72 @@ using TipCalc.Core.Services;
 
 namespace TipCalc.Core.ViewModels
 {
-public class TipViewModel : MvxViewModel
-{
-    readonly ICalculation _calculation;
-
-    public TipViewModel(ICalculation calculation)
+    public class TipViewModel : MvxViewModel
     {
-        _calculation = calculation;
-    }
+        readonly ICalculation _calculation;
 
-    public override void Start()
-    {
-        _subTotal = 100;
-        _generosity = 10;
-        Recalculate();
-        base.Start();
-    }
-
-    double _subTotal;
-
-    public double SubTotal
-    {
-        get {
-            return _subTotal;
-        }
-        set
+        public TipViewModel(ICalculation calculation)
         {
-            _subTotal = value;
-            RaisePropertyChanged(() => SubTotal);
+            _calculation = calculation;
+        }
+
+        public override void Start()
+        {
+            _subTotal = 100;
+            _generosity = 10;
             Recalculate();
+            base.Start();
         }
-    }
 
-    int _generosity;
+        double _subTotal;
 
-    public int Generosity
-    {
-        get {
-            return _generosity;
-        }
-        set
+        public double SubTotal
         {
-            _generosity = value;
-            RaisePropertyChanged(() => Generosity);
-            Recalculate();
+            get {
+                return _subTotal;
+            }
+            set
+            {
+                _subTotal = value;
+                RaisePropertyChanged(() => SubTotal);
+                Recalculate();
+            }
         }
-    }
 
-    double _tip;
+        int _generosity;
 
-    public double Tip
-    {
-        get {
-            return _tip;
-        }
-        set
+        public int Generosity
         {
-            _tip = value;
-            RaisePropertyChanged(() => Tip);
+            get {
+                return _generosity;
+            }
+            set
+            {
+                _generosity = value;
+                RaisePropertyChanged(() => Generosity);
+                Recalculate();
+            }
+        }
+
+        double _tip;
+
+        public double Tip
+        {
+            get {
+                return _tip;
+            }
+            set
+            {
+                _tip = value;
+                RaisePropertyChanged(() => Tip);
+            }
+        }
+
+        void Recalculate()
+        {
+            Tip = _calculation.TipAmount(SubTotal, Generosity);
         }
     }
-
-    void Recalculate()
-    {
-        Tip = _calculation.TipAmount(SubTotal, Generosity);
-    }
-}
 }
 ```
 
@@ -321,19 +321,14 @@ using TipCalc.Core.ViewModels;
 
 namespace TipCalc.Core
 {
-public class App : MvxApplication
-{
-    public App()
+    public class App : MvxApplication
     {
-        Mvx.RegisterType<ICalculation, Calculation>();
-        Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<TipViewModel>());
+        public App()
+        {
+            Mvx.RegisterType<ICalculation, Calculation>();
+            Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<TipViewModel>());
+        }
     }
-}
-}
-"language": "csharp"
-"name": "App.cs"
-}
-]
 }
 ```
 


### PR DESCRIPTION
I removed invalid "code" from the App.cs example.  It appeared to me to be possibly some json that somehow got pasted in to the example.  While I was at it I went ahead and fixed indentation on a number of examples in this document.

## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs
## :arrow_heading_down: What is the current behavior?
The current app.cs example cannot compile
## :new: What is the new behavior (if this is a feature change)?
It now can compile and has proper C# code
## :boom: Does this PR introduce a breaking change?
No
## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop