### PR TITLE
Kevinf/1880 memory leak

### DIFF
--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewsContainer.cs
@@ -114,8 +114,11 @@ namespace MvvmCross.Droid.Views
             {
                 {
                     mvxViewModel = Mvx.Resolve<IMvxChildViewModelCache>().Get(embeddedViewModelKey);
-                    if(mvxViewModel != null)
+                    if (mvxViewModel != null)
+                    {
+                        RemoveSubViewModelWithKey(embeddedViewModelKey);
                         return true;
+                    }
                 }
             }
             mvxViewModel = null;


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Removes memory leak

## :arrow_heading_down: What is the current behavior?
Android now currently and correctly maps view models from the navigator into the activity but never cleans up the cache where the view models are stored for the activity to grab when it is done loading. This has caused a memory leak that I verified with the profiler as the ViewModels mapped this way now stay in the cache forever. 

The original person who introduced the bug was correct that the cache needed to be cleaned up, it was just done it in the wrong place.

## :new: What is the new behavior (if this is a feature change)?
ViewModel is removed from the cache, removing the memory leak. The fix was verified using profiler.

## :boom: Does this PR introduce a breaking change?
No 

## :bug: Recommendations for testing
Verify view models created using NavigationService passing parameters are being cleaned up correctly.

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop