### PR TITLE
Add support for canceling awaiting a result on a viewmodel

### DIFF
--- a/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using MvvmCross.Core.Navigation.EventArguments;
 using MvvmCross.Core.ViewModels;
@@ -25,13 +26,13 @@ namespace MvvmCross.Core.Navigation
 
         Task Navigate<TViewModel>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel;
         Task Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel<TParameter> where TParameter : class;
-        Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModelResult<TResult> where TResult : class;
-        Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class;
+        Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult> where TResult : class;
+        Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class;
 
         Task Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null);
         Task Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class;
-        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null) where TResult : class;
-        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class where TResult : class;
+        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
+        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -40,8 +41,8 @@ namespace MvvmCross.Core.Navigation
         /// <returns>A task to await upon</returns>
         Task Navigate(string path, IMvxBundle presentationBundle = null);
         Task Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class;
-        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null) where TResult : class;
-        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class where TResult : class;
+        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
+        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
 
         /// <summary>
         /// Verifies if the provided Uri can be routed to a ViewModel request.

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MvvmCross.Core.Navigation.EventArguments;
 using MvvmCross.Core.Platform;
@@ -255,7 +256,7 @@ namespace MvvmCross.Core.Navigation
             OnAfterNavigate(this, args);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null) where TResult : class
+        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             var request = await NavigationRouteRequest(path, presentationBundle);
             var viewModel = (IMvxViewModelResult<TResult>)request.ViewModelInstance;
@@ -264,7 +265,7 @@ namespace MvvmCross.Core.Navigation
             OnBeforeNavigate(this, args);
 
             var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs);
+            viewModel.SetClose(tcs, cancellationToken);
 
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
@@ -281,7 +282,7 @@ namespace MvvmCross.Core.Navigation
             }
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class where TResult : class
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
         {
             var request = await NavigationRouteRequest(path, presentationBundle);
             var viewModel = (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance;
@@ -290,7 +291,7 @@ namespace MvvmCross.Core.Navigation
             OnBeforeNavigate(this, args);
 
             var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs);
+            viewModel.SetClose(tcs, cancellationToken);
 
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
@@ -337,7 +338,7 @@ namespace MvvmCross.Core.Navigation
             OnAfterNavigate(this, args);
         }
 
-        public virtual async Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null)
+        public virtual async Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModelResult<TResult>
             where TResult : class
         {
@@ -348,7 +349,7 @@ namespace MvvmCross.Core.Navigation
             OnBeforeNavigate(this, args);
 
             var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs);
+            viewModel.SetClose(tcs, cancellationToken);
 
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
@@ -365,7 +366,7 @@ namespace MvvmCross.Core.Navigation
             }
         }
 
-        public virtual async Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null)
+        public virtual async Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModel<TParameter, TResult>
             where TParameter : class
             where TResult : class
@@ -377,7 +378,7 @@ namespace MvvmCross.Core.Navigation
             OnBeforeNavigate(this, args);
 
             var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs);
+            viewModel.SetClose(tcs, cancellationToken);
 
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
@@ -422,7 +423,7 @@ namespace MvvmCross.Core.Navigation
             OnAfterNavigate(this, args);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null) where TResult : class
+        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             RunViewModelLifecycle(viewModel);
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
@@ -431,7 +432,7 @@ namespace MvvmCross.Core.Navigation
             OnBeforeNavigate(this, args);
 
             var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs);
+            viewModel.SetClose(tcs, cancellationToken);
 
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
@@ -448,7 +449,7 @@ namespace MvvmCross.Core.Navigation
             }
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null)
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TParameter : class
             where TResult : class
         {
@@ -459,7 +460,7 @@ namespace MvvmCross.Core.Navigation
             OnBeforeNavigate(this, args);
 
             var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs);
+            viewModel.SetClose(tcs, cancellationToken);
 
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -5,6 +5,7 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MvvmCross.Core.ViewModels
@@ -40,7 +41,7 @@ namespace MvvmCross.Core.ViewModels
     //TODO: Can we keep the IMvxViewModel syntax here? Compiler complains
     public interface IMvxViewModelResult<TResult> : IMvxViewModel where TResult : class
     {
-        void SetClose(TaskCompletionSource<TResult> tcs);
+        void SetClose(TaskCompletionSource<TResult> tcs, CancellationToken cancellationToken);
         Task<bool> Close(TResult result);
     }
 

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Exceptions;
@@ -99,11 +100,16 @@ namespace MvvmCross.Core.ViewModels
     public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult> where TResult : class
     {
         TaskCompletionSource<TResult> _tcs;
+        CancellationToken _cancellationToken;
         bool _isClosing;
 
-        public void SetClose(TaskCompletionSource<TResult> tcs)
+        public void SetClose(TaskCompletionSource<TResult> tcs, CancellationToken cancellationToken)
         {
             _tcs = tcs ?? throw new ArgumentNullException(nameof(tcs));
+            _cancellationToken = cancellationToken;
+            _cancellationToken.Register(() => {
+                Close(this);
+            });
         }
 
         public virtual Task<bool> Close(TResult result)


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

It add support for canceling a navigation which waits for a result to come back

## :arrow_heading_down: What is the current behavior?

## :new: What is the new behavior (if this is a feature change)?

You can put in your token and cancel that when you want the page to close and come back to the viewmodel you were on.

## :boom: Does this PR introduce a breaking change?

No

## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop