### PR TITLE
Don't mask exceptions when completing android initialization

### DIFF
--- a/MvvmCross/Droid/Droid/Platform/MvxAndroidSetupSingleton.cs
+++ b/MvvmCross/Droid/Droid/Platform/MvxAndroidSetupSingleton.cs
@@ -52,7 +52,7 @@ namespace MvvmCross.Droid.Platform
                         dispatcher.RequestMainThreadAction(() =>
                         {
                             _currentSplashScreen?.InitializationComplete();
-                        });
+                        }, false);
                     }
 
                     IsInitialisedTaskCompletionSource.SetResult(true);

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidMainThreadDispatcher.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidMainThreadDispatcher.cs
@@ -19,7 +19,15 @@ namespace MvvmCross.Droid.Views
             if (Application.SynchronizationContext == SynchronizationContext.Current)
                 action();
             else
-                Application.SynchronizationContext.Post(ignored => ExceptionMaskedAction(action), null);
+            {
+                Application.SynchronizationContext.Post(ignored => 
+                {
+                    if (maskExceptions)
+                        ExceptionMaskedAction(action);
+                    else
+                        action();
+                }, null);
+            }
 
             return true;
         }

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidMainThreadDispatcher.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidMainThreadDispatcher.cs
@@ -14,7 +14,7 @@ namespace MvvmCross.Droid.Views
 {
     public class MvxAndroidMainThreadDispatcher : MvxMainThreadDispatcher
     {
-        public bool RequestMainThreadAction(Action action)
+        public bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
             if (Application.SynchronizationContext == SynchronizationContext.Current)
                 action();

--- a/MvvmCross/Platform/Platform/Core/IMvxMainThreadDispatcher.cs
+++ b/MvvmCross/Platform/Platform/Core/IMvxMainThreadDispatcher.cs
@@ -11,6 +11,6 @@ namespace MvvmCross.Platform.Core
 {
     public interface IMvxMainThreadDispatcher
     {
-        bool RequestMainThreadAction(Action action);
+        bool RequestMainThreadAction(Action action, bool maskExceptions = true);
     }
 }


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Currently, if an exception occurs during the execution of the Start method of the class implementing IMvxAppStart on Android, this exception is masked and the Splash screen is never replaced with the first app screen. The expected behaviour would be that the app crashes on the unexpected exception. This makes it easier for developers to tackle bugs they may have introduced.

## :arrow_heading_down: What is the current behavior?
No exception is thrown when startup fails because it is wrapped.

## :new: What is the new behavior (if this is a feature change)?
The startup will throw and fail when an exception occurs.

## :boom: Does this PR introduce a breaking change?
No the parameter is optional and defaults to the old behaviour.

## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop