### PR TITLE
Document: Fix header layout

### DIFF
--- a/docs/_sass/includes/_header.scss
+++ b/docs/_sass/includes/_header.scss
@@ -240,8 +240,14 @@
     justify-content: space-between;
 
     > .navigation {
-      ul li {
-        margin-right: $navigation-margin * 2;
+        ul {
+          li {
+            margin-right: $navigation-margin * 2;
+          }
+          
+          li:last-child {
+            margin-right: 0;
+          }
       }
     }
   }


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

The layout is skewed on Safari and Firefox.

Before:
![img_2429](https://user-images.githubusercontent.com/435620/27000854-2841a5c8-4df6-11e7-9edc-ac37280c7340.PNG)

After:
![img_2430](https://user-images.githubusercontent.com/435620/27000856-2adc5a76-4df6-11e7-8c2e-5e48acbbb79e.PNG)
