### PR TITLE
PreferredContentSize

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/Attributes/MvxModalPresentationAttribute.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/Attributes/MvxModalPresentationAttribute.cs
@@ -1,4 +1,5 @@
-﻿using UIKit;
+﻿using CoreGraphics;
+using UIKit;
 
 namespace MvvmCross.iOS.Views.Presenters.Attributes
 {
@@ -9,6 +10,8 @@ namespace MvvmCross.iOS.Views.Presenters.Attributes
         public UIModalPresentationStyle ModalPresentationStyle { get; set; } = UIModalPresentationStyle.FullScreen;
 
         public UIModalTransitionStyle ModalTransitionStyle { get; set; } = UIModalTransitionStyle.CoverVertical;
+
+        public CGSize PreferredContentSize { get; set; }
 
         public bool Animated { get; set; } = true;
     }

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -1,12 +1,12 @@
-﻿﻿using System;
- using System.Collections.Generic;
- using System.Linq;
- using CoreGraphics;
- using MvvmCross.Core.ViewModels;
- using MvvmCross.iOS.Views.Presenters.Attributes;
- using MvvmCross.Platform.Exceptions;
- using MvvmCross.Platform.Platform;
- using UIKit;
+﻿﻿﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CoreGraphics;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.iOS.Views.Presenters.Attributes;
+using MvvmCross.Platform.Exceptions;
+using MvvmCross.Platform.Platform;
+using UIKit;
 
 namespace MvvmCross.iOS.Views.Presenters
 {

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -1,6 +1,7 @@
 ﻿﻿using System;
  using System.Collections.Generic;
  using System.Linq;
+ using CoreGraphics;
  using MvvmCross.Core.ViewModels;
  using MvvmCross.iOS.Views.Presenters.Attributes;
  using MvvmCross.Platform.Exceptions;
@@ -219,6 +220,8 @@ namespace MvvmCross.iOS.Views.Presenters
 
             viewController.ModalPresentationStyle = attribute.ModalPresentationStyle;
             viewController.ModalTransitionStyle = attribute.ModalTransitionStyle;
+            if (attribute.PreferredContentSize != default(CGSize))
+                viewController.PreferredContentSize = attribute.PreferredContentSize;
 
             _window.RootViewController.PresentViewController(
                 viewController,

--- a/docs/_documentation/platform/ios-view-presenter.md
+++ b/docs/_documentation/platform/ios-view-presenter.md
@@ -43,6 +43,7 @@ There are several attribute members that the view class can customize:
 - WrapInNavigationController: If set to `true`, a modal navigation stack will be initiated (following child presentations will be displayed inside the modal stack). The default value is `false`.
 - ModalPresentationStyle: Corresponds to the `ModalPresentationStyle` property of UIViewController. The default value is `UIModalPresentationStyle.FullScreen`.
 - ModalTransitionStyle: Corresponds to the `ModalTransitionStyle` property of UIViewController. The default value is `UIModalTransitionStyle.CoverVertical`.
+- PreferredContentSize : Corresponds to the `PreferredContentSize` property of UIViewController. Property works for iPad only.
 - Animated: If set to true, the presentation will be animated. The default value is `true`.
 
 

--- a/docs/_documentation/platform/ios-view-presenter.md
+++ b/docs/_documentation/platform/ios-view-presenter.md
@@ -43,7 +43,7 @@ There are several attribute members that the view class can customize:
 - WrapInNavigationController: If set to `true`, a modal navigation stack will be initiated (following child presentations will be displayed inside the modal stack). The default value is `false`.
 - ModalPresentationStyle: Corresponds to the `ModalPresentationStyle` property of UIViewController. The default value is `UIModalPresentationStyle.FullScreen`.
 - ModalTransitionStyle: Corresponds to the `ModalTransitionStyle` property of UIViewController. The default value is `UIModalTransitionStyle.CoverVertical`.
-- PreferredContentSize : Corresponds to the `PreferredContentSize` property of UIViewController. Property works for iPad only.
+- PreferredContentSize : Corresponds to the `PreferredContentSize` property of UIViewController. The property works for iPad only.
 - Animated: If set to true, the presentation will be animated. The default value is `true`.
 
 


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

## :arrow_heading_down: What is the current behavior?
Now you can use 4 parameters in MvxModalPresentationAttribute

## :new: What is the new behavior (if this is a feature change)?
PR will add new, fifth paramater - PreferredContentSize. It can set content size of your modal view.

## :boom: Does this PR introduce a breaking change?
Nope

## :bug: Recommendations for testing
I'm not sure if it works on iPhone because minimum width of content size should be 320. It definitely works on iPad.

## :memo: Links to relevant issues/docs
[Official doc](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621476-preferredcontentsize)

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop