### PR TITLE
#1920 Made changes to multi region presenter for UWP so new navigatio…

### DIFF
--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsMultiRegionViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsMultiRegionViewPresenter.cs
@@ -34,8 +34,7 @@ namespace MvvmCross.Uwp.Views
 
             if (viewType.HasRegionAttribute())
             {
-                var converter = Mvx.Resolve<IMvxNavigationSerializer>();
-                var requestText = converter.Serializer.SerializeObject(request);
+                var requestText = GetRequestText(request);
 
                 var containerView = FindChild<Frame>(_rootFrame.UnderlyingControl, viewType.GetRegionName());
 

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -28,16 +28,7 @@ namespace MvvmCross.Uwp.Views
         {
             try
             {
-                var requestTranslator = Mvx.Resolve<IMvxWindowsViewModelRequestTranslator>();
-                string requestText = string.Empty;
-                if (request is MvxViewModelInstanceRequest)
-                {
-                    requestText = requestTranslator.GetRequestTextWithKeyFor(((MvxViewModelInstanceRequest)request).ViewModelInstance);
-                }
-                else
-                {
-                    requestText = requestTranslator.GetRequestTextFor(request);
-                }
+                var requestText = GetRequestText(request);
                 var viewsContainer = Mvx.Resolve<IMvxViewsContainer>();
                 var viewType = viewsContainer.GetViewType(request.ViewModelType);
 
@@ -48,6 +39,22 @@ namespace MvvmCross.Uwp.Views
                 MvxTrace.Trace("Error seen during navigation request to {0} - error {1}", request.ViewModelType.Name,
                                exception.ToLongString());
             }
+        }
+
+        protected string GetRequestText(MvxViewModelRequest request)
+        {
+            var requestTranslator = Mvx.Resolve<IMvxWindowsViewModelRequestTranslator>();
+            string requestText = string.Empty;
+            if (request is MvxViewModelInstanceRequest)
+            {
+                requestText = requestTranslator.GetRequestTextWithKeyFor(((MvxViewModelInstanceRequest)request).ViewModelInstance);
+            }
+            else
+            {
+                requestText = requestTranslator.GetRequestTextFor(request);
+            }
+
+            return requestText;
         }
 
         public override void ChangePresentation(MvxPresentationHint hint)

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Uwp.Views
             }
         }
 
-        protected string GetRequestText(MvxViewModelRequest request)
+        protected virtual string GetRequestText(MvxViewModelRequest request)
         {
             var requestTranslator = Mvx.Resolve<IMvxWindowsViewModelRequestTranslator>();
             string requestText = string.Empty;

--- a/TestProjects/Eventhooks/Eventhooks.Uwp/App.xaml.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Uwp/App.xaml.cs
@@ -12,7 +12,7 @@ namespace Eventhooks.Uwp
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    internal sealed partial class App : Application
+    public sealed partial class App : Application
     {
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code

--- a/TestProjects/Eventhooks/Eventhooks.Uwp/App.xaml.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Uwp/App.xaml.cs
@@ -55,11 +55,6 @@ namespace Eventhooks.Uwp
             {
                 if (rootFrame.Content == null)
                 {
-                    // When the navigation stack isn't restored navigate to the first page,
-                    // configuring the new page by passing required information as a navigation
-                    // parameter
-                    //rootFrame.Navigate(typeof(MainPage), e.Arguments);
-
                     var setup = new Setup(rootFrame);
                     setup.Initialize();
 

--- a/TestProjects/Eventhooks/Eventhooks.Uwp/Views/FirstView.xaml.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Uwp/Views/FirstView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Eventhooks.Core.ViewModels;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Uwp.Views;
+using Windows.UI.Core;
 
 namespace Eventhooks.Uwp.Views
 {
@@ -10,6 +11,8 @@ namespace Eventhooks.Uwp.Views
         public FirstView()
         {
             InitializeComponent();
+
+            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
         }
 
         public FirstViewModel FirstViewModel

--- a/TestProjects/Eventhooks/Eventhooks.Uwp/Views/SecondView.xaml.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Uwp/Views/SecondView.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using Eventhooks.Core.ViewModels;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Uwp.Views;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Navigation;
 
 namespace Eventhooks.Uwp.Views
 {
@@ -10,6 +12,19 @@ namespace Eventhooks.Uwp.Views
         public SecondView()
         {
             InitializeComponent();
+            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
+            SystemNavigationManager.GetForCurrentView().BackRequested += EditCustomer_BackRequested;
+        }
+
+        protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        {
+            base.OnNavigatingFrom(e);
+            SystemNavigationManager.GetForCurrentView().BackRequested -= EditCustomer_BackRequested;
+        }
+
+        private void EditCustomer_BackRequested(object sender, BackRequestedEventArgs e)
+        {
+            Frame.GoBack();
         }
 
         public SecondViewModel SecondViewModel


### PR DESCRIPTION
…n scheme does not cause an exception.

## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

## :arrow_heading_down: What is the current behavior?
For UWP the Multi Region View Presenter throws an exception on navigation

## :new: What is the new behavior (if this is a feature change)?
Using the multi-region view presenter uses the new navigation View Model Cache but does not throw an exception.

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Test UWP apps in a variety of scenarios using the old ShowViewModel syntax and the new navigation service.

## :memo: Links to relevant issues/docs
#1920

## :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop