### PR TITLE
Don't depend on NUnit, no code uses it in this package

### DIFF
--- a/nuspec/MvvmCross.Tests.nuspec
+++ b/nuspec/MvvmCross.Tests.nuspec
@@ -13,7 +13,6 @@ This package contains the 'Test Helpers' for MvvmCross
 		<dependencies>
 			<dependency id="MvvmCross.Core" version="[$version$]" />
 			<dependency id="MvvmCross.Platform" version="[$version$]" />
-			<dependency id="NUnit" version="3.6.0" />
 		</dependencies>
 	</metadata>
 	<files>


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

## :arrow_heading_down: What is the current behavior?
NuGet package depends on NUnit

## :new: What is the new behavior (if this is a feature change)?
Does not depend on NUnit

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Install NuGet package from local build and see that it does not pull in NUnit

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop