### PR TITLE
#1940 Made changes to UWP navigation so:

### DIFF
--- a/MvvmCross/Windows/Uwp/Views/IMvxWindowsViewModelRequestTranslator.cs
+++ b/MvvmCross/Windows/Uwp/Views/IMvxWindowsViewModelRequestTranslator.cs
@@ -17,5 +17,7 @@ namespace MvvmCross.Uwp.Views
         string GetRequestTextWithKeyFor(IMvxViewModel existingViewModelToUse);
 
         void RemoveSubViewModelWithKey(int key);
+
+        int RequestTextGetKey(string requestText);
     }
 }

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsExtensionMethods.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsExtensionMethods.cs
@@ -42,9 +42,13 @@ namespace MvvmCross.Uwp.Views
             storeView.ViewModel = viewModel;
         }
 
-        public static void OnViewDestroy(this IMvxWindowsView storeView)
+        public static void OnViewDestroy(this IMvxWindowsView storeView, int key)
         {
-            // nothing to do currently
+            if (key > 0)
+            {
+                var viewModelLoader = Mvx.Resolve<IMvxWindowsViewModelRequestTranslator>();
+                viewModelLoader.RemoveSubViewModelWithKey(key);
+            }
         }
 
         public static bool HasRegionAttribute(this Type view)

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewsContainer.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewsContainer.cs
@@ -5,6 +5,7 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Collections.Generic;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
@@ -31,7 +32,6 @@ namespace MvvmCross.Uwp.Views
             {
                 var key = int.Parse(viewModelKey);
                 var viewModel = Mvx.Resolve<IMvxChildViewModelCache>().Get(key);
-                RemoveSubViewModelWithKey(key);
                 return viewModel;
             }
 
@@ -39,7 +39,7 @@ namespace MvvmCross.Uwp.Views
             return loaderService.LoadViewModel(request, savedState);
         }
 
-        #region Implementation of IMvxAndroidViewModelRequestTranslator
+        #region Implementation of IMvxWindowsViewModelRequestTranslator
         public string GetRequestTextFor(MvxViewModelRequest request)
         {
             var returnData = new Dictionary<string, string>();
@@ -69,6 +69,22 @@ namespace MvvmCross.Uwp.Views
         public void RemoveSubViewModelWithKey(int key)
         {
             Mvx.Resolve<IMvxChildViewModelCache>().Remove(key);
+        }
+
+        public int RequestTextGetKey(string requestText)
+        {
+            var returnValue = 0;
+            var converter = Mvx.Resolve<IMvxNavigationSerializer>();
+            var dictionary = converter.Serializer.DeserializeObject<Dictionary<string, string>>(requestText);
+
+            dictionary.TryGetValue(ExtrasKey, out string serializedRequest);
+            var request = converter.Serializer.DeserializeObject<MvxViewModelRequest>(serializedRequest);
+
+            if (dictionary.TryGetValue(SubViewModelKey, out string viewModelKey))
+            {
+                returnValue = int.Parse(viewModelKey);
+            }
+            return returnValue;
         }
         #endregion Implementation of IMvxWindowsViewModelRequestTranslator
     }


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

## :arrow_heading_down: What is the current behavior?
Navigating back through back stack to view displayed using the new navigation service looses the view model and view is displayed without a view model when NavigationCahceMode is disabled.

Navigating to a new view that has been shown before will use only the first view model instance when NavigationCacheMode is enabled. New calls to these views never replace the view model.

## :new: What is the new behavior (if this is a feature change)?
-Navigating through the back stack properly restores the existing instances of ViewModels to the new instances of the views that are created when NavigationCahceMode is disabled.

-Navigating to a new view that has been shown before will replace the current view model with the new one when NavigationCacheMode is enabled.

## :boom: Does this PR introduce a breaking change?
There is the possibility of the user manually removes a view from the back stack (something like Frame.BackStack.Remove()) that they will leave references to view models in the cache that will never be recovered until the application is unloaded. Calling things like Frame.GoBack() will work fine because all the normal navigation events are fired.

## :bug: Recommendations for testing
Implement in various navigation scenarios on UWP.

## :memo: Links to relevant issues/docs
#1940

## :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop