### PR TITLE
Add generic interfaces for IMvxCommand

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/IMvxAsyncCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxAsyncCommand.cs
@@ -7,4 +7,10 @@ namespace MvvmCross.Core.ViewModels
         Task ExecuteAsync(object parameter = null);
         void Cancel();
     }
+
+    public interface IMvxAsyncCommand<T> : IMvxCommand<T>
+    {
+        Task ExecuteAsync(T parameter);
+        void Cancel();
+    }
 }

--- a/MvvmCross/Core/Core/ViewModels/IMvxCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxCommand.cs
@@ -5,17 +5,30 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System;
 using System.Windows.Input;
 
 namespace MvvmCross.Core.ViewModels
 {
-    public interface IMvxCommand
-        : ICommand
+    public interface IMvxCommand : ICommand
     {
         void RaiseCanExecuteChanged();
 
         void Execute();
 
         bool CanExecute();
+    }
+
+    public interface IMvxCommand<T> : ICommand
+    {
+        [Obsolete("Use the strongly typed version of Execute instead", true)]
+        new void Execute(object parameter);
+
+        [Obsolete("Use the strongly typed version of CanExecute instead", true)]
+        new bool CanExecute(object parameter);
+
+        void Execute(T parameter);
+
+        bool CanExecute(T parameter);
     }
 }

--- a/MvvmCross/Core/Core/ViewModels/MvxAsyncCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxAsyncCommand.cs
@@ -187,10 +187,7 @@ namespace MvvmCross.Core.ViewModels
         public MvxAsyncCommand(Func<CancellationToken, Task> execute, Func<bool> canExecute = null, bool allowConcurrentExecutions = false)
             : base(allowConcurrentExecutions)
         {
-            if (execute == null)
-                throw new ArgumentNullException(nameof(execute));
-
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
             _canExecute = canExecute;
         }
 
@@ -222,7 +219,7 @@ namespace MvvmCross.Core.ViewModels
 
     public class MvxAsyncCommand<T>
         : MvxAsyncCommandBase
-        , IMvxAsyncCommand
+        , IMvxAsyncCommand<T>
     {
         private readonly Func<T, CancellationToken, Task> _execute;
         private readonly Func<T, bool> _canExecute;
@@ -240,26 +237,23 @@ namespace MvvmCross.Core.ViewModels
         public MvxAsyncCommand(Func<T, CancellationToken, Task> execute, Func<T, bool> canExecute = null, bool allowConcurrentExecutions = false)
             : base(allowConcurrentExecutions)
         {
-            if (execute == null)
-                throw new ArgumentNullException(nameof(execute));
-
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
             _canExecute = canExecute;
         }
 
+        public Task ExecuteAsync(T parameter)
+            => ExecuteAsync(parameter, false);
+    
+        public void Execute(T parameter)
+            => base.Execute(parameter);
+
+        public bool CanExecute(T parameter)
+            => base.CanExecute(parameter);
+
         protected override bool CanExecuteImpl(object parameter)
-        {
-            return _canExecute == null || _canExecute((T)typeof(T).MakeSafeValueCore(parameter));
-        }
+            => _canExecute == null || _canExecute((T)typeof(T).MakeSafeValueCore(parameter));
 
         protected override Task ExecuteAsyncImpl(object parameter)
-        {
-            return _execute((T)typeof(T).MakeSafeValueCore(parameter), CancelToken);
-        }
-
-        public async Task ExecuteAsync(object parameter)
-        {
-            await base.ExecuteAsync(parameter, false).ConfigureAwait(false);
-        }
+            => _execute((T)typeof(T).MakeSafeValueCore(parameter), CancelToken);
     }
 }

--- a/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
@@ -163,14 +163,10 @@ namespace MvvmCross.Core.ViewModels
         }
 
         public bool CanExecute(object parameter)
-        {
-            return _canExecute == null || _canExecute();
-        }
+            => _canExecute == null || _canExecute();
 
         public bool CanExecute()
-        {
-            return CanExecute(null);
-        }
+            => CanExecute(null);
 
         public void Execute(object parameter)
         {
@@ -181,14 +177,12 @@ namespace MvvmCross.Core.ViewModels
         }
 
         public void Execute()
-        {
-            Execute(null);
-        }
+            => Execute(null);
     }
 
     public class MvxCommand<T>
         : MvxCommandBase
-        , IMvxCommand
+        , IMvxCommand, IMvxCommand<T>
     {
         private readonly Func<T, bool> _canExecute;
         private readonly Action<T> _execute;
@@ -205,26 +199,29 @@ namespace MvvmCross.Core.ViewModels
         }
 
         public bool CanExecute(object parameter)
-        {
-            return _canExecute == null || _canExecute((T)typeof(T).MakeSafeValueCore(parameter));
-        }
+            => _canExecute == null || _canExecute((T)typeof(T).MakeSafeValueCore(parameter));
 
         public bool CanExecute()
-        {
-            return CanExecute(null);
-        }
+            => CanExecute(null);
+
+        public bool CanExecute(T parameter)
+            => _canExecute == null || _canExecute(parameter);
 
         public void Execute(object parameter)
         {
-            if (CanExecute(parameter))
-            {
-                _execute((T)typeof(T).MakeSafeValueCore(parameter));
-            }
+            if (!CanExecute(parameter)) return;
+
+            _execute((T)typeof(T).MakeSafeValueCore(parameter));
         }
 
         public void Execute()
+            => Execute(null);
+
+        public void Execute(T parameter)
         {
-            Execute(null);
+            if (!CanExecute(parameter)) return;
+
+            _execute(parameter);
         }
     }
 }


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This adds the `IMvxCommand<T>` and the `IMvxAsyncCommand<T>` interfaces.

## :arrow_heading_down: What is the current behavior?
One doesn't have type safety when using the command interfaces

## :new: What is the new behavior (if this is a feature change)?
Some type safety is added

## :boom: Does this PR introduce a breaking change?
Nope, but it could. The reason `MvxCommand<T>` implements both `IMvxCommand` and `IMvxCommand<T>` is because `IMvxCommandBuilder` would break horribly if it didn't. I didn't want to make this breaking, but I wasn't even aware of the existence of `IMvxCommandBuilder`. 

Is it used? Honest question, I do not know.

## :bug: Recommendations for testing
Please verify Windows projects are working fine, since I'm on a Mac 👍 

## :memo: Links to relevant issues/docs
Closes #1946 

## :thinking: Checklist before submitting

- [ ] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop