### PR TITLE
Add more checks to avoid illegal states

### DIFF
--- a/MvvmCross-Plugins/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
+++ b/MvvmCross-Plugins/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
@@ -5,6 +5,7 @@ using Android.Gms.Common.Apis;
 using Android.Gms.Location;
 using Android.OS;
 using MvvmCross.Platform.Exceptions;
+using MvvmCross.Platform;
 using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Plugins.Location.Fused.Droid
@@ -21,84 +22,97 @@ namespace MvvmCross.Plugins.Location.Fused.Droid
 		private readonly MvxAndroidFusedLocationWatcher _owner;
         private readonly Context _context;
 
-		public FusedLocationHandler (MvxAndroidFusedLocationWatcher owner, Context context)
+		public FusedLocationHandler(MvxAndroidFusedLocationWatcher owner, Context context)
 		{
 			_owner = owner;
             _context = context;
 		}
 
-		public void Start (MvxLocationOptions options)
+		public void Start(MvxLocationOptions options)
 		{
             if (_client == null)
             {
                 EnsureGooglePlayServiceAvailable(_context);
                 Initialize(_context);
             }
+
+            if (_client.IsConnected || _client.IsConnecting)
+                throw new MvxException("Start has already been called. Please call Stop and try again");
             
-            _request = CreateLocationRequest (options);
-			_client.Connect ();
+            _request = CreateLocationRequest(options);
+			_client.Connect();
 		}
 
-		public void Stop ()
+		public void Stop()
 		{
 			if (_client == null)
 				return;
 
-			LocationServices.FusedLocationApi.RemoveLocationUpdates(_client, this);
-			_client.Disconnect();
+            if (_client.IsConnected)
+                LocationServices.FusedLocationApi.RemoveLocationUpdates(_client, this);
+
+            if (_client.IsConnected || _client.IsConnecting)
+            {
+                _client.Disconnect();
+                _client = null;
+            }
 		}
 
-		public Android.Locations.Location GetLastKnownLocation ()
+		public Android.Locations.Location GetLastKnownLocation()
 		{
 			if (_client.IsConnected)
 				return LocationServices.FusedLocationApi.GetLastLocation(_client);
 			return null;
 		}
 
-		public void OnConnected (Bundle connectionHint)
-		{
-			LocationServices.FusedLocationApi.RequestLocationUpdates (_client, _request, this, Looper.MainLooper);
+        public void OnConnected(Bundle connectionHint)
+        {
+            LocationServices.FusedLocationApi.RequestLocationUpdates(_client, _request, this, Looper.MainLooper);
 
-			var location = LocationServices.FusedLocationApi.GetLastLocation(_client);
-			if (location != null)
-				_owner.OnLocationUpdated (location);
+            var location = LocationServices.FusedLocationApi.GetLastLocation(_client);
+            if (location != null)
+                _owner.OnLocationUpdated(location);
+
+            Mvx.TaggedTrace(MvxTraceLevel.Diagnostic, "Plugin.Location.Fused", "OnConnected");
+        }
+
+		public void OnConnectionSuspended(int cause)
+		{
+            // disconnected
+            Mvx.TaggedTrace(MvxTraceLevel.Diagnostic, "Plugin.Location.Fused", "OnConnectionSuspended: {0}", cause);
 		}
 
-		public void OnConnectionSuspended (int cause)
+		public void OnConnectionFailed(ConnectionResult result)
 		{
-			// disconnected
-			MvxTrace.Trace ("Plugin.Location.Fused.OnConnectionSuspended: " + cause);
+			_owner.OnLocationError(ToMvxLocationErrorCode(result));
+            Mvx.TaggedTrace(MvxTraceLevel.Diagnostic, "Plugin.Location.Fused", "OnConnectionFailed: {0}", result);
+
+            _client?.Reconnect();
 		}
 
-		public void OnConnectionFailed (ConnectionResult result)
-		{
-			_owner.OnLocationError (ToMvxLocationErrorCode (result));
-			MvxTrace.Trace ("Plugin.Location.Fused.OnConnectionFailed: " + result);
-		}
+		public override void OnLocationResult(LocationResult result) =>
+			_owner.OnLocationUpdated(result.LastLocation);
 
-		public override void OnLocationResult (LocationResult result) =>
-			_owner.OnLocationUpdated (result.LastLocation);
-
-		public override void OnLocationAvailability (LocationAvailability locationAvailability)
+		public override void OnLocationAvailability(LocationAvailability locationAvailability)
 		{
 			var available = locationAvailability != null && locationAvailability.IsLocationAvailable;
-			_owner.OnLocationAvailabilityChanged (available);
+			_owner.OnLocationAvailabilityChanged(available);
 		}
 
-		private void EnsureGooglePlayServiceAvailable (Context context)
+		private void EnsureGooglePlayServiceAvailable(Context context)
 		{
 			var availability = GoogleApiAvailability.Instance;
-			var result = availability.IsGooglePlayServicesAvailable (context);
+			var result = availability.IsGooglePlayServicesAvailable(context);
 			if (result != ConnectionResult.Success)
 			{
 				var errorMessage = "GooglePlayService is not available";
-				if (availability.IsUserResolvableError (result))
-					errorMessage = availability.GetErrorString (result);
-				throw new MvxException (errorMessage);
+				if (availability.IsUserResolvableError(result))
+					errorMessage = availability.GetErrorString(result);
+				throw new MvxException(errorMessage);
 			}
 		}
 
-		private void Initialize (Context context)
+		private void Initialize(Context context)
 		{
 			_client = new GoogleApiClient.Builder(context)
 				.AddApi(LocationServices.API)
@@ -107,7 +121,7 @@ namespace MvvmCross.Plugins.Location.Fused.Droid
 				.Build();
 		}
 
-		private static LocationRequest CreateLocationRequest (MvxLocationOptions options)
+		private static LocationRequest CreateLocationRequest(MvxLocationOptions options)
 		{
 			// NOTE options.TrackingMode is not supported
 			var request = LocationRequest.Create();
@@ -130,7 +144,7 @@ namespace MvvmCross.Plugins.Location.Fused.Droid
 			return request;
 		}
 
-		private static MvxLocationErrorCode ToMvxLocationErrorCode (ConnectionResult connectionResult)
+		private static MvxLocationErrorCode ToMvxLocationErrorCode(ConnectionResult connectionResult)
 		{
 			var errorCode = connectionResult.ErrorCode;
             var mvxErrorCode = MvxLocationErrorCode.ServiceUnavailable;

--- a/MvvmCross-Plugins/Location/MvvmCross.Plugins.Location.Fused.Droid/MvxAndroidFusedLocationWatcher.cs
+++ b/MvvmCross-Plugins/Location/MvvmCross.Plugins.Location.Fused.Droid/MvxAndroidFusedLocationWatcher.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.Plugins.Location.Fused.Droid
 			if (_locationHandler == null)
 				_locationHandler = new FusedLocationHandler(this, Context);
 
-			_locationHandler.Start (options);
+			_locationHandler.Start(options);
 		}
 
         protected override void PlatformSpecificStop() => _locationHandler.Stop();


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

## :arrow_heading_down: What is the current behavior?
IllegalStateException can be thrown when trying to call Stop on IMvxLocationWatcher prematurely, due to client not being connected yet.

Calling Stop, then Start again, would never result in new location updates.

## :new: What is the new behavior (if this is a feature change)?
This should now not be thrown as guards have been introduced.

Stop, Start should now work and yield location updates.

Automatically reconnect client if it disconnects, if Start was called.

## :boom: Does this PR introduce a breaking change?
Shouldn't no.

## :bug: Recommendations for testing
Play with the LocationWatcher on Android

## :memo: Links to relevant issues/docs
#1955 

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop