### PR TITLE
#1921 Changed wpf implementation to use view model parameter sent wit…

### DIFF
--- a/MvvmCross/Windows/Wpf/Views/MvxWpfViewsContainer.cs
+++ b/MvvmCross/Windows/Wpf/Views/MvxWpfViewsContainer.cs
@@ -37,8 +37,15 @@ namespace MvvmCross.Wpf.Views
             if (viewControl == null)
                 throw new MvxException("Loaded View is not a FrameworkElement " + viewType);
 
-            var viewModelLoader = Mvx.Resolve<IMvxViewModelLoader>();
-            wpfView.ViewModel = viewModelLoader.LoadViewModel(request, null);
+            if (request is MvxViewModelInstanceRequest instanceRequest)
+            {
+                wpfView.ViewModel = instanceRequest.ViewModelInstance;
+            }
+            else
+            {
+                var viewModelLoader = Mvx.Resolve<IMvxViewModelLoader>();
+                wpfView.ViewModel = viewModelLoader.LoadViewModel(request, null);
+            }
 
             return viewControl;
         }

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/App.xaml.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/App.xaml.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows;
+﻿using MvvmCross.Core.ViewModels;
+using MvvmCross.Platform;
+using MvvmCross.Wpf.Views;
+using System.Windows;
+using System;
 
 namespace Eventhooks.Wpf
 {
@@ -7,5 +11,27 @@ namespace Eventhooks.Wpf
     /// </summary>
     public partial class App : Application
     {
+        bool _setupComplete = false;
+
+        void DoSetup()
+        {
+            var presenter = new MvxSimpleWpfViewPresenter(MainWindow);
+
+            var setup = new Setup(Dispatcher, presenter);
+            setup.Initialize();
+
+            var start = Mvx.Resolve<IMvxAppStart>();
+            start.Start();
+
+            _setupComplete = true;
+        }
+
+        protected override void OnActivated(EventArgs e)
+        {
+            if (!_setupComplete)
+                DoSetup();
+
+            base.OnActivated(e);
+        }
     }
 }

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/Eventhooks.Wpf.csproj
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/Eventhooks.Wpf.csproj
@@ -48,6 +48,13 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Setup.cs" />
+    <Compile Include="Views\FirstView.xaml.cs">
+      <DependentUpon>FirstView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SecondView.xaml.cs">
+      <DependentUpon>SecondView.xaml</DependentUpon>
+    </Compile>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -60,6 +67,14 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="Views\FirstView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SecondView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\AssemblyInfo.cs">
@@ -87,5 +102,28 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\MvvmCross\Core\Core\MvvmCross.Core.csproj">
+      <Project>{b6e27475-e7d0-448c-a5cc-5097dca1e2dd}</Project>
+      <Name>MvvmCross.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross\Platform\Platform\MvvmCross.Platform.csproj">
+      <Project>{cff6f25a-3c3b-44ee-a54c-2ed4aaff3adb}</Project>
+      <Name>MvvmCross.Platform</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross\Platform\Wpf\MvvmCross.Platform.Wpf.csproj">
+      <Project>{3688d6fc-e7f4-485f-8b27-96c0a8c7eaed}</Project>
+      <Name>MvvmCross.Platform.Wpf</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross\Windows\Wpf\MvvmCross.Wpf.csproj">
+      <Project>{3786ea13-a491-4917-9b49-fbe76ba87fab}</Project>
+      <Name>MvvmCross.Wpf</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Eventhooks.Core\Eventhooks.Core.csproj">
+      <Project>{4720e13f-daa5-4fb8-86b5-1c12117f0553}</Project>
+      <Name>Eventhooks.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/MainWindow.xaml
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/MainWindow.xaml
@@ -5,8 +5,5 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Eventhooks.Wpf"
         mc:Ignorable="d"
-        Title="MainWindow" Height="350" Width="525">
-    <Grid>
-        
-    </Grid>
+        Title="Eventhooks" Height="350" Width="525">
 </Window>

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/Setup.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/Setup.cs
@@ -1,0 +1,24 @@
+﻿using MvvmCross.Wpf.Platform;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MvvmCross.Wpf.Views;
+using System.Windows.Threading;
+using MvvmCross.Core.ViewModels;
+
+namespace Eventhooks.Wpf
+{
+    public class Setup : MvxWpfSetup
+    {
+        public Setup(Dispatcher uiThreadDispatcher, IMvxWpfViewPresenter presenter) : base(uiThreadDispatcher, presenter)
+        {
+        }
+
+        protected override IMvxApplication CreateApp()
+        {
+            return new Core.App();
+        }
+    }
+}

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/Views/FirstView.xaml
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/Views/FirstView.xaml
@@ -1,0 +1,11 @@
+﻿<views:MvxWpfView 
+            x:Class="Eventhooks.Wpf.Views.FirstView"
+            xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Eventhooks.Wpf.Views"
+             mc:Ignorable="d" >
+    <Button Content="Second View" HorizontalAlignment="Stretch" VerticalAlignment="Center" Command="{Binding ShowSecondView}" />
+</views:MvxWpfView>

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/Views/FirstView.xaml.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/Views/FirstView.xaml.cs
@@ -1,0 +1,32 @@
+﻿using Eventhooks.Core.ViewModels;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Wpf.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Eventhooks.Wpf.Views
+{
+    /// <summary>
+    /// Interaction logic for FirstView.xaml
+    /// </summary>
+    [MvxViewFor(typeof(FirstViewModel))]
+    public partial class FirstView : MvxWpfView
+    {
+        public FirstView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/Views/SecondView.xaml
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/Views/SecondView.xaml
@@ -1,0 +1,12 @@
+﻿<views:MvxWpfView 
+            x:Class="Eventhooks.Wpf.Views.SecondView"
+            xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+            xmlns:local="clr-namespace:Eventhooks.Wpf.Views"
+            mc:Ignorable="d" 
+            d:DesignHeight="300" d:DesignWidth="300">
+    <TextBox TextWrapping="Wrap" Text="Second View" VerticalAlignment="Stretch"  HorizontalAlignment="Stretch"/>
+</views:MvxWpfView>

--- a/TestProjects/Eventhooks/Eventhooks.Wpf/Views/SecondView.xaml.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Wpf/Views/SecondView.xaml.cs
@@ -1,0 +1,32 @@
+﻿using Eventhooks.Core.ViewModels;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Wpf.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Eventhooks.Wpf.Views
+{
+    /// <summary>
+    /// Interaction logic for SecondView.xaml
+    /// </summary>
+    [MvxViewFor(typeof(SecondViewModel))]
+    public partial class SecondView : MvxWpfView
+    {
+        public SecondView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
…h request by new navigation service. Updated wfp event hooks sample application to be more complete.

## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

## :arrow_heading_down: What is the current behavior?
When using the new navigation service the view model created with the request is ignored, instead the original ShowViewModel behavior is used creating a second view model ignoring the one from the request that has the parameter passed to it.

## :new: What is the new behavior (if this is a feature change)?
Only one view model is created when the new navigation service is used and the parameter properly passed to it.

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Test in a variety of scenarios for navigation. I tested about three of the many possible scenarios

## :memo: Links to relevant issues/docs
#1921, #1943 

## :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop