### PR TITLE
Fix Testproject compiling & runtime errors

### DIFF
--- a/TestProjects/Android-Support/Fragments/Example.Droid/Example.Droid.csproj
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Example.Droid.csproj
@@ -428,6 +428,10 @@
       <Project>{0D471B62-CB8E-4814-81A6-4C0B774A8825}</Project>
       <Name>MvvmCross.Plugins.Visibility</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\MvvmCross-Plugins\Visibility\MvvmCross.Plugins.Visibility.Droid\MvvmCross.Plugins.Visibility.Droid.csproj">
+      <Project>{36228B32-A08B-477B-9320-EC5EA5DF05A3}</Project>
+      <Name>MvvmCross.Plugins.Visibility.Droid</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/TestProjects/Eventhooks/Eventhooks.Droid/Eventhooks.Droid.csproj
+++ b/TestProjects/Eventhooks/Eventhooks.Droid/Eventhooks.Droid.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
+    <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="..\..\..\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
## :arrow_heading_down: What is the current behavior?
1. There is an MvxException when running Example.Droid.csproj

    `MvvmCross.Platform.Exceptions.MvxException: could not load plugin assembly for type MvvmCross.Plugins.Visibility.PluginLoader`
 
2. Project of 'TestProjects/Eventhooks/Eventhooks.Droid/Eventhooks.Droid.csproj' can't be compiled.

## :new: What is the new behavior (if this is a feature change)?

1. Example.Droid.csproj can run without exception.
2. Eventhooks.Droid.csproj can be compiled.
## :boom: Does this PR introduce a breaking change?
No.
## :bug: Recommendations for testing
1. Run Example.Droid.csproj.
2. Compile Eventhooks.Droid.csproj 
## :memo: Links to relevant issues/docs
#1927 
#1935 
## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop


Project reference of`MvvmCross.Plugins.Visibility.Droid.csproj` is added back to fix `Example.Droid.csproj`'s run time exception.
The project reference was there but was removed in #1927 

File `Resource.designer.cs` is added back to fix the compiling error.
The file was in the project but was removed in #1935 