### PR TITLE
Fix Initialize order

### DIFF
--- a/MvvmCross/Core/Core/Navigation/MvxNavigationCache.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationCache.cs
@@ -4,40 +4,37 @@ namespace MvvmCross.Core.Navigation
 {
     public class MvxNavigationCache : IMvxNavigationCache
     {
-        private IDictionary<string, object> cache => new Dictionary<string, object>();
+        private IDictionary<string, object> Cache { get; } = new Dictionary<string, object>();
 
         public bool AddValue<T>(string key, T value)
         {
             if (Contains(key))
                 return false;
-            cache.Add(key, value);
+            Cache.Add(key, value);
             return true;
         }
 
         public T GetValueOrDefault<T>(string key, T defaultValue = default(T))
         {
-            object item;
-            bool found = cache.TryGetValue(key, out item);
-            if (found)
-            {
+            if (Cache.TryGetValue(key, out object item))
                 return (T)item;
-            }
+
             return defaultValue;
         }
 
         public void Remove(string key)
         {
-            cache.Remove(key);
+            Cache.Remove(key);
         }
 
         public void Clear()
         {
-            cache.Clear();
+            Cache.Clear();
         }
 
         public bool Contains(string key)
         {
-            return cache.ContainsKey(key);
+            return Cache.ContainsKey(key);
         }
     }
 }

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -129,6 +129,7 @@ namespace MvvmCross.Core.Navigation
             var regex = entry.Key;
             var match = regex.Match(path);
             var paramDict = BuildParamDictionary(regex, match);
+            var parameterValues = new MvxBundle(paramDict);
 
             var viewModelType = entry.Value;
             IMvxViewModel viewModel;
@@ -159,7 +160,7 @@ namespace MvvmCross.Core.Navigation
             {
                 viewModel = (IMvxViewModel)Mvx.IocConstruct(viewModelType);
             }
-            var parameterValues = new MvxBundle(paramDict);
+
             RunViewModelLifecycle(viewModel, parameterValues);
 
             return new MvxViewModelInstanceRequest(viewModel) { ParameterValues = parameterValues.SafeGetData(), PresentationValues = presentationBundle?.SafeGetData() };
@@ -218,7 +219,7 @@ namespace MvvmCross.Core.Navigation
 
         public virtual Task<bool> Close(IMvxViewModel viewModel)
         {
-            var args = new NavigateEventArgs();
+            var args = new NavigateEventArgs(viewModel);
             OnBeforeClose(this, args);
             var close = ViewDispatcher.ChangePresentation(new MvxClosePresentationHint(viewModel));
             OnAfterClose(this, args);
@@ -234,8 +235,8 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
         }
@@ -248,8 +249,8 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
         }
@@ -265,8 +266,8 @@ namespace MvvmCross.Core.Navigation
             var tcs = new TaskCompletionSource<TResult>();
             viewModel.SetClose(tcs, cancellationToken);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
 
@@ -291,8 +292,8 @@ namespace MvvmCross.Core.Navigation
             var tcs = new TaskCompletionSource<TResult>();
             viewModel.SetClose(tcs, cancellationToken);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
 
@@ -314,8 +315,8 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
         }
@@ -330,8 +331,8 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
         }
@@ -349,8 +350,8 @@ namespace MvvmCross.Core.Navigation
             var tcs = new TaskCompletionSource<TResult>();
             viewModel.SetClose(tcs, cancellationToken);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
 
@@ -378,8 +379,8 @@ namespace MvvmCross.Core.Navigation
             var tcs = new TaskCompletionSource<TResult>();
             viewModel.SetClose(tcs, cancellationToken);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
 
@@ -401,8 +402,8 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
         }
@@ -415,8 +416,8 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
         }
@@ -432,8 +433,8 @@ namespace MvvmCross.Core.Navigation
             var tcs = new TaskCompletionSource<TResult>();
             viewModel.SetClose(tcs, cancellationToken);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize();
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
 
@@ -460,8 +461,8 @@ namespace MvvmCross.Core.Navigation
             var tcs = new TaskCompletionSource<TResult>();
             viewModel.SetClose(tcs, cancellationToken);
 
-            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize(param);
+            ViewDispatcher.ShowViewModel(request);
 
             OnAfterNavigate(this, args);
 

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -158,10 +158,15 @@ namespace MvvmCross.Core.Navigation
             }
             else
             {
-                viewModel = (IMvxViewModel)Mvx.IocConstruct(viewModelType);
+                try
+                {
+                    viewModel = (IMvxViewModel)Mvx.IocConstruct(viewModelType);
+                }
+                catch (Exception exception)
+                {
+                    throw exception.MvxWrap("Problem creating viewModel of type {0}", viewModelType.Name);
+                }
             }
-
-            RunViewModelLifecycle(viewModel, parameterValues);
 
             return new MvxViewModelInstanceRequest(viewModel) { ParameterValues = parameterValues.SafeGetData(), PresentationValues = presentationBundle?.SafeGetData() };
         }
@@ -177,8 +182,6 @@ namespace MvvmCross.Core.Navigation
             {
                 throw exception.MvxWrap("Problem creating viewModel of type {0}", typeof(TViewModel).Name);
             }
-
-            RunViewModelLifecycle(viewModel, parameterValues, savedState);
 
             return viewModel;
         }
@@ -217,6 +220,44 @@ namespace MvvmCross.Core.Navigation
             return Task.FromResult(TryGetRoute(path, out entry));
         }
 
+        public virtual async Task<TResult> Navigate<TParameter, TResult> (MvxViewModelRequest request, IMvxViewModel viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
+        {
+            var args = new NavigateEventArgs(viewModel);
+            OnBeforeNavigate(this, args);
+
+            var tcs = new TaskCompletionSource<TResult>();
+            if(viewModel is IMvxViewModel<TParameter, TResult> vmParamResult)
+            {
+                vmParamResult.SetClose(tcs, cancellationToken);
+                await vmParamResult.Initialize(param);
+            }
+            else if (viewModel is IMvxViewModelResult<TResult> vmResult)
+                vmResult.SetClose(tcs, cancellationToken);
+            else if (viewModel is IMvxViewModel<TParameter> vmParam)
+                await vmParam.Initialize(param);
+              
+            await viewModel.Initialize();
+
+            RunViewModelLifecycle(viewModel, new MvxBundle(request.ParameterValues));
+
+            ViewDispatcher.ShowViewModel(request);
+            OnAfterNavigate(this, args);
+
+            if (viewModel is IMvxViewModel<TParameter, TResult> || viewModel is IMvxViewModelResult<TResult>)
+            {
+                try
+                {
+                    return await tcs.Task;
+                }
+                catch (Exception e)
+                {
+                    return default(TResult);
+                }
+            }
+            else
+                return default(TResult);
+        }
+
         public virtual Task<bool> Close(IMvxViewModel viewModel)
         {
             var args = new NavigateEventArgs(viewModel);
@@ -230,95 +271,32 @@ namespace MvvmCross.Core.Navigation
         public virtual async Task Navigate(string path, IMvxBundle presentationBundle = null)
         {
             var request = await NavigationRouteRequest(path, presentationBundle);
-            var viewModel = request.ViewModelInstance;
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            await viewModel.Initialize();
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
+            await Navigate<object, object>(request, request.ViewModelInstance, null, presentationBundle);
         }
 
         public virtual async Task Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class
         {
             var request = await NavigationRouteRequest(path, presentationBundle);
-            var viewModel = (IMvxViewModel<TParameter>)request.ViewModelInstance;
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            await viewModel.Initialize(param);
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
+            await Navigate<TParameter, object>(request, request.ViewModelInstance, param, presentationBundle);
         }
 
         public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             var request = await NavigationRouteRequest(path, presentationBundle);
-            var viewModel = (IMvxViewModelResult<TResult>)request.ViewModelInstance;
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs, cancellationToken);
-
-            await viewModel.Initialize();
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
-
-            try
-            {
-                return await tcs.Task;
-            }
-            catch
-            {
-                return default(TResult);
-            }
+            return await Navigate<object, TResult>(request, request.ViewModelInstance, null, presentationBundle, cancellationToken);
         }
 
         public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
         {
             var request = await NavigationRouteRequest(path, presentationBundle);
-            var viewModel = (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance;
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs, cancellationToken);
-
-            await viewModel.Initialize(param);
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
-
-            try
-            {
-                return await tcs.Task;
-            }
-            catch
-            {
-                return default(TResult);
-            }
+            return await Navigate<TParameter, TResult>(request, request.ViewModelInstance, param, presentationBundle, cancellationToken);
         }
 
         public virtual async Task Navigate<TViewModel>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel
         {
             var viewModel = LoadViewModel<TViewModel>();
             var request = new MvxViewModelInstanceRequest(viewModel){PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            await viewModel.Initialize();
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
+            await Navigate<object, object>(request, viewModel, null, presentationBundle);
         }
 
         public virtual async Task Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null)
@@ -327,14 +305,7 @@ namespace MvvmCross.Core.Navigation
         {
             var viewModel = (IMvxViewModel<TParameter>)LoadViewModel<TViewModel>();
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            await viewModel.Initialize(param);
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
+            await Navigate<TParameter, object>(request, viewModel, param, presentationBundle);
         }
 
         public virtual async Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -343,26 +314,7 @@ namespace MvvmCross.Core.Navigation
         {
             var viewModel = (IMvxViewModelResult<TResult>)LoadViewModel<TViewModel>();
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs, cancellationToken);
-
-            await viewModel.Initialize();
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
-
-            try
-            {
-                return await tcs.Task;
-            }
-            catch
-            {
-                return default(TResult);
-            }
+            return await Navigate<object, TResult>(request, viewModel, null, presentationBundle, cancellationToken);
         }
 
         public virtual async Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -372,108 +324,33 @@ namespace MvvmCross.Core.Navigation
         {
             var viewModel = (IMvxViewModel<TParameter, TResult>)LoadViewModel<TViewModel>();
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs, cancellationToken);
-
-            await viewModel.Initialize(param);
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
-
-            try
-            {
-                return await tcs.Task;
-            }
-            catch
-            {
-                return default(TResult);
-            }
+            return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken);
         }
 
         public virtual async Task Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null)
         {
-            RunViewModelLifecycle(viewModel);
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            await viewModel.Initialize();
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
+            await Navigate<object, object>(request, viewModel, null, presentationBundle);
         }
 
         public virtual async Task Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class
         {
-            RunViewModelLifecycle(viewModel);
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            await viewModel.Initialize(param);
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
+            await Navigate<TParameter, object>(request, viewModel, param, presentationBundle);
         }
 
         public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
-            RunViewModelLifecycle(viewModel);
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs, cancellationToken);
-
-            await viewModel.Initialize();
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
-
-            try
-            {
-                return await tcs.Task;
-            }
-            catch
-            {
-                return default(TResult);
-            }
+            return await Navigate<object, TResult>(request, viewModel, null, presentationBundle, cancellationToken);
         }
 
         public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TParameter : class
             where TResult : class
         {
-            RunViewModelLifecycle(viewModel);
             var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
-
-            var args = new NavigateEventArgs(viewModel);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<TResult>();
-            viewModel.SetClose(tcs, cancellationToken);
-
-            await viewModel.Initialize(param);
-            ViewDispatcher.ShowViewModel(request);
-
-            OnAfterNavigate(this, args);
-
-            try
-            {
-                return await tcs.Task;
-            }
-            catch
-            {
-                return default(TResult);
-            }
+            return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken);
         }
 
         protected virtual void OnBeforeNavigate(object sender, NavigateEventArgs e)

--- a/MvvmCross/Test/Test/Mocks/Dispatchers/NavigationMockDispatcher.cs
+++ b/MvvmCross/Test/Test/Mocks/Dispatchers/NavigationMockDispatcher.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
+using System.Linq;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.Platform.Core;
 
 namespace MvvmCross.Test.Mocks.Dispatchers
 {
-    public class NavigationMockDispatcher : MvxMainThreadDispatcher
-      , IMvxViewDispatcher
+    public class NavigationMockDispatcher 
+        : MvxMainThreadDispatcher, IMvxViewDispatcher
     {
         public readonly List<MvxViewModelRequest> Requests = new List<MvxViewModelRequest>();
         public readonly List<MvxPresentationHint> Hints = new List<MvxPresentationHint>();
@@ -22,25 +22,13 @@ namespace MvvmCross.Test.Mocks.Dispatchers
 
         public virtual bool ShowViewModel(MvxViewModelRequest request)
         {
-            var sb = new StringBuilder();
-
+            var debugString = $"ShowViewModel: '{request.ViewModelType.Name}' ";
             if (request.ParameterValues != null)
-            {
-                foreach (var pair in request.ParameterValues)
-                {
-                    sb.Append(string.Format("{{ {0}={1} }},", pair.Key, pair.Value));
-                }
-            }
-
-            if (sb.Length == 0)
-            {
-                Debug.WriteLine("ShowViewModel: '{0}' without parameters", request.ViewModelType.Name, string.Empty);
-            }
+                debugString += $"with parameters: {string.Join(",", request.ParameterValues.Select(pair => $"{{ {pair.Key}={pair.Value} }}"))}";
             else
-            {
-                Debug.WriteLine("ShowViewModel: '{0}' with parameters: {1}", request.ViewModelType.Name, sb);
-            }
-            
+                debugString += "without parameters";
+            Debug.WriteLine(debugString);
+
             Requests.Add(request);
             return true;
         }

--- a/MvvmCross/Test/Test/MvvmCross.Test.csproj
+++ b/MvvmCross/Test/Test/MvvmCross.Test.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Mocks\TestViews\NotTest2View.cs" />
     <Compile Include="Mocks\TestViews\NotTest3View.cs" />
     <Compile Include="Mocks\TestViews\OddNameOddness.cs" />
+    <Compile Include="Navigation\NavigationCacheTests.cs" />
     <Compile Include="Parse\MvxStringDictionaryTextSerializerTest.cs" />
     <Compile Include="Platform\MvxSimplePropertyDictionaryExtensionMethodsTests.cs" />
     <Compile Include="Platform\MvxStringToTypeParserTest.cs" />

--- a/MvvmCross/Test/Test/MvvmCross.Test.csproj
+++ b/MvvmCross/Test/Test/MvvmCross.Test.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Mocks\TestViews\NotTest3View.cs" />
     <Compile Include="Mocks\TestViews\OddNameOddness.cs" />
     <Compile Include="Navigation\NavigationCacheTests.cs" />
+    <Compile Include="Navigation\NavigationServiceTests.cs" />
     <Compile Include="Parse\MvxStringDictionaryTextSerializerTest.cs" />
     <Compile Include="Platform\MvxSimplePropertyDictionaryExtensionMethodsTests.cs" />
     <Compile Include="Platform\MvxStringToTypeParserTest.cs" />

--- a/MvvmCross/Test/Test/Navigation/NavigationCacheTests.cs
+++ b/MvvmCross/Test/Test/Navigation/NavigationCacheTests.cs
@@ -1,0 +1,110 @@
+﻿using MvvmCross.Core.Navigation;
+using NUnit.Framework;
+
+namespace MvvmCross.Test.Navigation
+{
+    [TestFixture]
+    public class NavigationCacheTests
+    {
+        [Test]
+        [TestCase("a", 1, 1)]
+        [TestCase("a", -1, -1)]
+        [TestCase("a", int.MaxValue, int.MaxValue)]
+        [TestCase("a", int.MinValue, int.MinValue)]
+        [TestCase("a", default(int), default(int))]
+        [TestCase("a", 1337, 1337)]
+        public void Test_IntsCanBeCached(string key, int value, int expected)
+        {
+            SimpleTest(new MvxNavigationCache(), key, value, expected);
+        }
+
+        [Test]
+        [TestCase("a", 1.0, 1.0)]
+        [TestCase("a", -1.0, -1.0)]
+        [TestCase("a", double.MaxValue, double.MaxValue)]
+        [TestCase("a", double.MinValue, double.MinValue)]
+        [TestCase("a", default(double), default(double))]
+        [TestCase("a", 1337.0, 1337.0)]
+        public void Test_DoublesCanBeCached(string key, double value, double expected)
+        {
+            SimpleTest(new MvxNavigationCache(), key, value, expected);
+        }
+
+        [Test]
+        [TestCase("a", "a", "a")]
+        [TestCase("a", "", "")]
+        [TestCase("a", null, null)]
+        public void Test_StringsCanBeCached(string key, string value, string expected)
+        {
+            SimpleTest(new MvxNavigationCache(), key, value, expected);
+        }
+
+        private static void SimpleTest<T>(IMvxNavigationCache cache, string key, T value, T expected)
+        {
+            Assert.IsTrue(cache.AddValue(key, value));
+            var addedValue = cache.GetValueOrDefault<T>(key);
+            Assert.AreEqual(expected, addedValue);
+        }
+
+        [Test]
+        public void Test_MixedTypesCanBeCached()
+        {
+            var cache = new MvxNavigationCache();
+
+            SimpleTest(cache, "a", 1, 1);
+            SimpleTest(cache, "b", 1.0, 1.0);
+            SimpleTest(cache, "c", 1.0f, 1.0f);
+            SimpleTest(cache, "d", "hello", "hello");
+            var obj = new TestObject();
+            SimpleTest(cache, "e", obj, obj);
+        }
+
+        [Test]
+        public void Test_CacheCanClear()
+        {
+            var cache = new MvxNavigationCache();
+            cache.AddValue("a", 0);
+            cache.AddValue("b", 0);
+            cache.AddValue("c", 0);
+            cache.AddValue("d", 0);
+
+            Assert.IsTrue(cache.Contains("a"));
+            Assert.IsTrue(cache.Contains("b"));
+            Assert.IsTrue(cache.Contains("c"));
+            Assert.IsTrue(cache.Contains("d"));
+
+            cache.Clear();
+
+            Assert.IsFalse(cache.Contains("a"));
+            Assert.IsFalse(cache.Contains("b"));
+            Assert.IsFalse(cache.Contains("c"));
+            Assert.IsFalse(cache.Contains("d"));
+        }
+
+        [Test]
+        public void Test_CacheCanRemoveItem()
+        {
+            var cache = new MvxNavigationCache();
+            cache.AddValue("e", 0);
+            cache.AddValue("f", 0);
+            cache.AddValue("g", 0);
+            cache.AddValue("h", 0);
+
+            Assert.IsTrue(cache.Contains("e"));
+            Assert.IsTrue(cache.Contains("f"));
+            Assert.IsTrue(cache.Contains("g"));
+            Assert.IsTrue(cache.Contains("h"));
+
+            cache.Remove("g");
+
+            Assert.IsFalse(cache.Contains("g"));
+            Assert.IsTrue(cache.Contains("e"));
+            Assert.IsTrue(cache.Contains("f"));
+            Assert.IsTrue(cache.Contains("h"));
+        }
+    }
+
+    public class TestObject
+    {
+    }
+}

--- a/MvvmCross/Test/Test/Navigation/NavigationCacheTests.cs
+++ b/MvvmCross/Test/Test/Navigation/NavigationCacheTests.cs
@@ -102,9 +102,9 @@ namespace MvvmCross.Test.Navigation
             Assert.IsTrue(cache.Contains("f"));
             Assert.IsTrue(cache.Contains("h"));
         }
-    }
 
-    public class TestObject
-    {
+        public class TestObject
+        {
+        }
     }
 }

--- a/MvvmCross/Test/Test/Navigation/NavigationServiceTests.cs
+++ b/MvvmCross/Test/Test/Navigation/NavigationServiceTests.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Moq;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.Platform;
 using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform;
 using MvvmCross.Test.Core;
 using MvvmCross.Test.Mocks.Dispatchers;
 using NUnit.Framework;
@@ -77,18 +75,16 @@ namespace MvvmCross.Test.Navigation
             mockVm.Verify(vm => vm.Init(), Times.Once);
             Assert.IsTrue(MockDispatcher.Object.Requests.Count > 0);
         }
-    }
 
-    public class SimpleTestViewModel : MvxViewModel
-    {
-        public virtual void Init()
+        public class SimpleTestViewModel : MvxViewModel
         {
-            
-        }
+            public virtual void Init()
+            {
+            }
 
-        public virtual void Init(string hello)
-        {
-            
+            public virtual void Init(string hello)
+            {
+            }
         }
     }
 }

--- a/MvvmCross/Test/Test/Navigation/NavigationServiceTests.cs
+++ b/MvvmCross/Test/Test/Navigation/NavigationServiceTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.Platform;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Platform;
+using MvvmCross.Test.Core;
+using MvvmCross.Test.Mocks.Dispatchers;
+using NUnit.Framework;
+
+namespace MvvmCross.Test.Navigation
+{
+    [TestFixture]
+    public class NavigationServiceTests
+        : MvxIoCSupportingTest
+    {
+        protected Mock<NavigationMockDispatcher> MockDispatcher { get; set; }
+
+        [SetUp]
+        public void SetupTest()
+        {
+            Setup();
+
+            SetInvariantCulture();
+
+            MockDispatcher = new Mock<NavigationMockDispatcher>(MockBehavior.Loose) { CallBase = true };
+            var navigationService = new MvxNavigationService
+            {
+                ViewDispatcher = MockDispatcher.Object
+            };
+            Ioc.RegisterSingleton<IMvxNavigationService>(navigationService);
+            Ioc.RegisterSingleton<IMvxStringToTypeParser>(new MvxStringToTypeParser());
+        }
+
+        [Test]
+        public async Task Test_NavigateNoBundle()
+        {
+            var navigationService = Ioc.Resolve<IMvxNavigationService>();
+
+            await navigationService.Navigate<SimpleTestViewModel>();
+
+            MockDispatcher.Verify(
+                x => x.ShowViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleTestViewModel))),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task Test_NavigateWithBundle()
+        {
+            var navigationService = Ioc.Resolve<IMvxNavigationService>();
+
+            var mockVm = new Mock<SimpleTestViewModel>();
+
+            var bundle = new MvxBundle();
+            bundle.Write(new { hello = "world" });
+
+            await navigationService.Navigate(mockVm.Object, bundle);
+
+            mockVm.Verify(vm => vm.Initialize(), Times.Once);
+            mockVm.Verify(vm => vm.Init(), Times.Once);
+
+            // todo fix NavigationService not allowing parameter values in request and only presentation values
+            //mockVm.Verify(vm => vm.Init(It.Is<string>(s => s == "world")), Times.Once);
+        }
+
+        [Test]
+        public async Task Test_NavigateViewModelInstance()
+        {
+            var navigationService = Ioc.Resolve<IMvxNavigationService>();
+
+            var mockVm = new Mock<SimpleTestViewModel>();
+
+            await navigationService.Navigate(mockVm.Object);
+
+            mockVm.Verify(vm => vm.Initialize(), Times.Once);
+            mockVm.Verify(vm => vm.Init(), Times.Once);
+            Assert.IsTrue(MockDispatcher.Object.Requests.Count > 0);
+        }
+    }
+
+    public class SimpleTestViewModel : MvxViewModel
+    {
+        public virtual void Init()
+        {
+            
+        }
+
+        public virtual void Init(string hello)
+        {
+            
+        }
+    }
+}

--- a/MvvmCross/Test/Test/Navigation/RoutingServiceTests.cs
+++ b/MvvmCross/Test/Test/Navigation/RoutingServiceTests.cs
@@ -63,7 +63,8 @@ namespace MvvmCross.Test.Navigation
 
         protected void SetupRoutings()
         {
-            RoutingService = new MvxNavigationService(){
+            RoutingService = new MvxNavigationService
+            {
                 ViewDispatcher = MockDispatcher.Object
             };
         }
@@ -94,7 +95,6 @@ namespace MvvmCross.Test.Navigation
                 Times.Once);
         }
 
-
         [Test]
         public async Task TestRegexWithParametersAsync()
         {
@@ -105,7 +105,6 @@ namespace MvvmCross.Test.Navigation
                 Times.Once);
         }
 
-
         [Test]
         public async Task TestFacadeAsync()
         {
@@ -115,6 +114,5 @@ namespace MvvmCross.Test.Navigation
                 x => x.ShowViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(ViewModelA))),
                 Times.Once);
         }
-
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Core/AppStart.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/AppStart.cs
@@ -18,7 +18,7 @@ namespace RoutingExample.Core
         {
             try
             {
-                _navigationService.Navigate<MainViewModel>().Wait();
+                _navigationService.Navigate<MainViewModel>().GetAwaiter().GetResult();
             }
             catch (System.Exception e)
             {

--- a/TestProjects/Navigation/RoutingExample.Core/AppStart.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/AppStart.cs
@@ -1,4 +1,5 @@
-﻿using MvvmCross.Core.Navigation;
+﻿using System.Threading.Tasks;
+using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using RoutingExample.Core.ViewModels;
 
@@ -15,7 +16,13 @@ namespace RoutingExample.Core
 
         public void Start(object hint = null)
         {
-            _navigationService.Navigate<MainViewModel>();
+            try
+            {
+                _navigationService.Navigate<MainViewModel>().Wait();
+            }
+            catch (System.Exception e)
+            {
+            }
         }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
@@ -4,7 +4,6 @@ using MvvmCross.Core.ViewModels;
 
 namespace RoutingExample.Core.ViewModels
 {
-
     public class MainViewModel : MvxViewModel
     {
         private readonly IMvxNavigationService _navigationService;
@@ -17,7 +16,6 @@ namespace RoutingExample.Core.ViewModels
         public override void Start()
         {
             base.Start();
-
         }
 
         public override async Task Initialize()

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
@@ -22,7 +22,7 @@ namespace RoutingExample.Core.ViewModels
 
         public override async Task Initialize()
         {
-            await _navigationService.Navigate<ViewModelA>();
+            //await _navigationService.Navigate<ViewModelA>();
         }
 
         private IMvxCommand _showACommand;


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix for https://github.com/MvvmCross/MvvmCross/issues/1968

## :arrow_heading_down: What is the current behavior?
Initialize is not called before events

## :new: What is the new behavior (if this is a feature change)?
It is now called.

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop