### PR TITLE
MvxIosViewPresenter: TabBarViewController as child 

### DIFF
--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using MvvmCross.Core.ViewModels;
+using MvvmCross.iOS.Views.Presenters;
+using MvvmCross.Platform;
 using UIKit;
 
 namespace MvvmCross.iOS.Views
@@ -21,9 +23,20 @@ namespace MvvmCross.iOS.Views
         {
         }
 
+        public override void ViewWillDisappear(bool animated)
+        {
+            base.ViewWillDisappear(animated);
+
+            if (IsMovingFromParentViewController)
+            {
+                var presenter = Mvx.Resolve<IMvxIosViewPresenter>() as MvxIosViewPresenter;
+                presenter.CloseTabBarViewController();
+            }
+        }
+
         public virtual void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabAccessibilityIdentifier = null)
         {
-            if(!string.IsNullOrEmpty(tabAccessibilityIdentifier))
+            if (!string.IsNullOrEmpty(tabAccessibilityIdentifier))
                 viewController.View.AccessibilityIdentifier = tabAccessibilityIdentifier;
 
             // setup Tab
@@ -31,7 +44,7 @@ namespace MvvmCross.iOS.Views
 
             // add Tab
             var currentTabs = new List<UIViewController>();
-            if(ViewControllers != null)
+            if (ViewControllers != null)
             {
                 currentTabs = ViewControllers.ToList();
             }
@@ -46,7 +59,7 @@ namespace MvvmCross.iOS.Views
         {
             viewController.Title = title;
 
-            if(!string.IsNullOrEmpty(iconName))
+            if (!string.IsNullOrEmpty(iconName))
                 viewController.TabBarItem = new UITabBarItem(title, UIImage.FromBundle(iconName), _tabsCount);
 
             _tabsCount++;
@@ -57,7 +70,7 @@ namespace MvvmCross.iOS.Views
             var navigationController = (UINavigationController)SelectedViewController;
 
             // if the current selected ViewController is not a NavigationController, then a child cannot be shown
-            if(navigationController == null)
+            if (navigationController == null)
             {
                 return false;
             }
@@ -75,7 +88,7 @@ namespace MvvmCross.iOS.Views
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
             var navController = SelectedViewController as UINavigationController;
-            if(navController != null)
+            if (navController != null)
             {
                 navController.PopViewController(true);
                 return true;
@@ -85,7 +98,7 @@ namespace MvvmCross.iOS.Views
             var toClose = ViewControllers.Where(v => v.GetType() != typeof(MvxNavigationController))
                                          .Select(v => v.GetIMvxIosView())
                                          .FirstOrDefault(mvxView => mvxView.ViewModel == viewModel);
-            if(toClose != null)
+            if (toClose != null)
             {
                 var newTabs = ViewControllers.Where(v => v.GetIMvxIosView() != toClose);
                 ViewControllers = newTabs.ToArray();
@@ -116,10 +129,10 @@ namespace MvvmCross.iOS.Views
             {
                 var topViewController = (SelectedViewController as UINavigationController)?.TopViewController ?? SelectedViewController;
 
-                if(topViewController.PresentedViewController != null)
+                if (topViewController.PresentedViewController != null)
                 {
                     var presentedNavigationController = topViewController.PresentedViewController as UINavigationController;
-                    if(presentedNavigationController != null)
+                    if (presentedNavigationController != null)
                     {
                         return presentedNavigationController.TopViewController;
                     }

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using CoreGraphics;
@@ -149,9 +149,6 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxChildPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            if (viewController is IMvxTabBarViewController)
-                throw new MvxException("A TabBarViewController cannot be presented as a child. Consider using Root instead");
-
             if (viewController is IMvxSplitViewController)
                 throw new MvxException("A SplitViewController cannot be presented as a child. Consider using Root instead");
 
@@ -161,15 +158,18 @@ namespace MvvmCross.iOS.Views.Presenters
                 return;
             }
 
-            if (TabBarViewController != null)
+            if (TabBarViewController != null && TabBarViewController.ShowChildView(viewController))
             {
-                TabBarViewController.ShowChildView(viewController);
                 return;
             }
 
             if (MasterNavigationController != null)
             {
                 MasterNavigationController.PushViewController(viewController, attribute.Animated);
+
+                if (viewController is IMvxTabBarViewController)
+                    TabBarViewController = viewController as IMvxTabBarViewController;
+
                 return;
             }
 
@@ -355,7 +355,7 @@ namespace MvvmCross.iOS.Views.Presenters
             ModalNavigationController = null;
         }
 
-        protected void CloseTabBarViewController()
+        public void CloseTabBarViewController()
         {
             if (TabBarViewController == null)
                 return;

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -355,7 +355,7 @@ namespace MvvmCross.iOS.Views.Presenters
             ModalNavigationController = null;
         }
 
-        public void CloseTabBarViewController()
+        protected void CloseTabBarViewController()
         {
             if (TabBarViewController == null)
                 return;

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -355,7 +355,7 @@ namespace MvvmCross.iOS.Views.Presenters
             ModalNavigationController = null;
         }
 
-        protected void CloseTabBarViewController()
+        public void CloseTabBarViewController()
         {
             if (TabBarViewController == null)
                 return;

--- a/TestProjects/Playground/Playground.iOS/Views/Tab3View.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/Tab3View.cs
@@ -7,7 +7,7 @@ using Playground.Core.ViewModels;
 namespace Playground.iOS.Views
 {
     [MvxFromStoryboard("Main")]
-    [MvxTabPresentation]
+    [MvxTabPresentation(WrapInNavigationController = false)]
     public partial class Tab3View : MvxViewController<Tab3ViewModel>, IMvxTabBarItemViewController
     {
         public Tab3View(IntPtr handle) : base(handle)

--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -7,7 +7,7 @@ using UIKit;
 namespace Playground.iOS.Views
 {
     [MvxFromStoryboard("Main")]
-    [MvxRootPresentation]
+    //[MvxRootPresentation]
     public partial class TabsRootView : MvxTabBarViewController<TabsRootViewModel>
     {
         private bool _isPresentedFirstTime = true;
@@ -20,7 +20,7 @@ namespace Playground.iOS.Views
         {
             base.ViewWillAppear(animated);
 
-            if(ViewModel != null && _isPresentedFirstTime)
+            if (ViewModel != null && _isPresentedFirstTime)
             {
                 _isPresentedFirstTime = false;
                 ViewModel.ShowInitialViewModelsCommand.Execute(null);
@@ -30,9 +30,9 @@ namespace Playground.iOS.Views
         protected override void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName)
         {
             // you can override this method to set title or iconName
-            if(string.IsNullOrEmpty(title))
+            if (string.IsNullOrEmpty(title))
                 title = "Tab 2";
-            if(string.IsNullOrEmpty(iconName))
+            if (string.IsNullOrEmpty(iconName))
                 iconName = "ic_tabbar_menu";
 
             base.SetTitleAndTabBarItem(viewController, title, iconName);


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix and/or Feature.

## :arrow_heading_down: What is the current behavior?

When trying to show a TabBarController as child using the MvxIosViewPresenter, app crashes with exception saying MvxTabBarViewController cannot be shown as child.

## :new: What is the new behavior (if this is a feature change)?

App doesn't crash and MvxTabBarViewController is displayed as a child

## :boom: Does this PR introduce a breaking change?

No.

## :bug: Recommendations for testing

Run Playground.iOS and tap on "Initiate Tabs navigation". 

## :memo: Links to relevant issues/docs

Issue: #1967 

Didn't find anything that could be improved in the doc, since this PR introduces the expected behavior.

## :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop