### PR TITLE
added features to be able to provided the selected image on tab item

### DIFF
--- a/MvvmCross/iOS/iOS/Views/IMvxTabBarItemViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/IMvxTabBarItemViewController.cs
@@ -4,5 +4,7 @@
     {
         string TabName { get; }
         string TabIconName { get; }
+        
+        string TabSelectedIconName { get;  }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
@@ -7,6 +7,8 @@ namespace MvvmCross.iOS.Views
     {
         void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabSelectedIconName = null, string tabAccessibilityIdentifier = null);
 
+        void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabAccessibilityIdentifier = null);
+
         bool ShowChildView(UIViewController viewController);
 
         bool CloseChildViewModel(IMvxViewModel viewModel);

--- a/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
@@ -5,7 +5,7 @@ namespace MvvmCross.iOS.Views
 {
     public interface IMvxTabBarViewController
     {
-        void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabAccessibilityIdentifier = null);
+        void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabSelectedIconName = null, string tabAccessibilityIdentifier = null);
 
         bool ShowChildView(UIViewController viewController);
 

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -34,6 +34,12 @@ namespace MvvmCross.iOS.Views
             }
         }
 
+        //keep changes for selected icon from breaking current release
+        public virtual void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabAccessibilityIdentifier = null)
+        {
+            ShowTabView(viewController, tabTitle, tabIconName, null, tabAccessibilityIdentifier);
+        }
+
         public virtual void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabSelectedIconName = null, string tabAccessibilityIdentifier = null)
         {
             if (!string.IsNullOrEmpty(tabAccessibilityIdentifier))
@@ -53,6 +59,12 @@ namespace MvvmCross.iOS.Views
 
             // update current Tabs
             ViewControllers = currentTabs.ToArray();
+        }
+
+        //keep changes for selected icon from breaking current release
+        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName)
+        {
+            SetTitleAndTabBarItem(viewController, title, iconName, null);
         }
 
         protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName, string selectedIconName = null)

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -34,13 +34,13 @@ namespace MvvmCross.iOS.Views
             }
         }
 
-        public virtual void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabAccessibilityIdentifier = null)
+        public virtual void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabSelectedIconName = null, string tabAccessibilityIdentifier = null)
         {
             if (!string.IsNullOrEmpty(tabAccessibilityIdentifier))
                 viewController.View.AccessibilityIdentifier = tabAccessibilityIdentifier;
 
             // setup Tab
-            SetTitleAndTabBarItem(viewController, tabTitle, tabIconName);
+            SetTitleAndTabBarItem(viewController, tabTitle, tabIconName, tabSelectedIconName);
 
             // add Tab
             var currentTabs = new List<UIViewController>();
@@ -55,12 +55,15 @@ namespace MvvmCross.iOS.Views
             ViewControllers = currentTabs.ToArray();
         }
 
-        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName)
+        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName, string selectedIconName = null)
         {
             viewController.Title = title;
 
             if (!string.IsNullOrEmpty(iconName))
                 viewController.TabBarItem = new UITabBarItem(title, UIImage.FromBundle(iconName), _tabsCount);
+
+            if (!string.IsNullOrEmpty(selectedIconName))
+                viewController.TabBarItem.SelectedImage = UIImage.FromBundle(selectedIconName);
 
             _tabsCount++;
         }

--- a/MvvmCross/iOS/iOS/Views/Presenters/Attributes/MvxTabPresentationAttribute.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/Attributes/MvxTabPresentationAttribute.cs
@@ -6,6 +6,8 @@
 
         public string TabIconName { get; set; }
 
+        public string TabSelectedIconName { get; set; }
+
         public bool WrapInNavigationController { get; set; } = true;
 
         public string TabAccessibilityIdentifier { get; set; }

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -188,10 +188,13 @@ namespace MvvmCross.iOS.Views.Presenters
 
             string tabName = attribute.TabName;
             string tabIconName = attribute.TabIconName;
+            string tabSelectedIconName = attribute.TabSelectedIconName;
+
             if (viewController is IMvxTabBarItemViewController tabBarItem)
             {
                 tabName = tabBarItem.TabName;
                 tabIconName = tabBarItem.TabIconName;
+                tabSelectedIconName = tabBarItem.TabSelectedIconName;
             }
 
             if (attribute.WrapInNavigationController)
@@ -201,6 +204,7 @@ namespace MvvmCross.iOS.Views.Presenters
                 viewController,
                 tabName,
                 tabIconName,
+                tabSelectedIconName,
                 attribute.TabAccessibilityIdentifier);
         }
 

--- a/TestProjects/Playground/Playground.iOS/Views/Tab3View.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/Tab3View.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
@@ -16,6 +16,8 @@ namespace Playground.iOS.Views
 
         public string TabName => "Third";
         public string TabIconName => "settings";
+
+        public string TabSelectedIconName => "settings";
 
         public override void ViewDidLoad()
         {


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

## :arrow_heading_down: What is the current behavior?
you can set a tab bar item's image, but not the selected image

## :new: What is the new behavior (if this is a feature change)?
you can provide the selected image icon

## :boom: Does this PR introduce a breaking change?
I don't think so because the string for selected image can be null and if it's null then it's not set on the tab bar item

## :bug: Recommendations for testing
I updated the code in the play ground for testing

## :memo: Links to relevant issues/docs
I mentioned this in slack to the team

## :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop