### PR TITLE
Prevent KeyNotFoundException from always being throw MvxIosViewPresenter 

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -90,11 +90,14 @@ namespace MvvmCross.iOS.Views.Presenters
             var attribute = GetPresentationAttributes(viewController);
             var attributeType = attribute.GetType();
 
-            if (!_attributeTypesToShowMethodDictionary.TryGetValue(attributeType, 
+            if (_attributeTypesToShowMethodDictionary.TryGetValue(attributeType, 
                 out Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest> showAction))
-                throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
-
-            showAction.Invoke(viewController, attribute, request);
+            {
+                showAction.Invoke(viewController, attribute, request);
+                return;
+            }
+            
+            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
         }
 
         protected virtual void ShowRootViewController(

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -90,11 +90,11 @@ namespace MvvmCross.iOS.Views.Presenters
             var attribute = GetPresentationAttributes(viewController);
             var attributeType = attribute.GetType();
 
-            if (_attributeTypesToShowMethodDictionary.TryGetValue(attributeType, 
+            if (!_attributeTypesToShowMethodDictionary.TryGetValue(attributeType, 
                 out Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest> showAction))
-                showAction.Invoke(viewController, attribute, request);
+                throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
 
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            showAction.Invoke(viewController, attribute, request);
         }
 
         protected virtual void ShowRootViewController(


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
## :arrow_heading_down: What is the current behavior?

## :new: What is the new behavior (if this is a feature change)?

## :boom: Does this PR introduce a breaking change?

## :bug: Recommendations for testing
Run the [TestProjects/Playground/Playground.iOS](https://github.com/MvvmCross/MvvmCross/tree/develop/TestProjects/Playground/Playground.iOS) app in the repo

## :memo: Links to relevant issues/docs

https://github.com/MvvmCross/MvvmCross/commit/d4d1d804b2160f212700e58e985cfe5e3df66de5#commitcomment-22742635
#1991

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop