### PR TITLE
Fix crash when composing email without attachments

### DIFF
--- a/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -134,6 +134,9 @@ namespace MvvmCross.Plugins.Email.Droid
         {
             base.ProcessMvxIntentResult(result);
 
+            if (filesToDelete?.Count == 0)
+                return;
+
             // on return, delete all attachments from external cache
             foreach (File file in filesToDelete)
             {

--- a/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -134,7 +134,7 @@ namespace MvvmCross.Plugins.Email.Droid
         {
             base.ProcessMvxIntentResult(result);
 
-            if (filesToDelete?.Count == 0)
+            if (filesToDelete == null || filesToDelete?.Count == 0)
                 return;
 
             // on return, delete all attachments from external cache

--- a/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
+++ b/MvvmCross-Plugins/Email/MvvmCross.Plugins.Email.Droid/MvxComposeEmailTask.cs
@@ -134,7 +134,7 @@ namespace MvvmCross.Plugins.Email.Droid
         {
             base.ProcessMvxIntentResult(result);
 
-            if (filesToDelete == null || filesToDelete?.Count == 0)
+            if (filesToDelete == null || filesToDelete.Count == 0)
                 return;
 
             // on return, delete all attachments from external cache


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce?  

This is a bug fix of a crash that happens when you compose an email without giving the attachments parameter.

## :arrow_heading_down: What is the current behaviour?

If you call the compose email without attachments, on ProcessMvxIntentResult of the MvxComposeEmailTask (Android) the app will crash.

## :new: What is the new behaviour (if this is a feature change)?

No crash doing the same action.

## :boom: Does this PR introduce a breaking change?

No.

## :bug: Recommendations for testing

Nothing.

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [ ] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop