### PR TITLE
Updated the XamarinSidebar sample to use the navigationservice

### DIFF
--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/App.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/App.cs
@@ -1,4 +1,6 @@
 using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Platform;
 using MvvmCross.Platform.IoC;
 
 namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
@@ -13,7 +15,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-            RegisterAppStart(new AppStart());
+            RegisterAppStart(new AppStart(Mvx.Resolve<IMvxNavigationService>()));
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/App.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/App.cs
@@ -15,7 +15,11 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-            RegisterAppStart(new AppStart(Mvx.Resolve<IMvxNavigationService>()));
+            Mvx.ConstructAndRegisterSingleton<IMvxAppStart, AppStart>();
+            var appStart = Mvx.Resolve<IMvxAppStart>();
+
+            // register the appstart object
+            RegisterAppStart(appStart);
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/AppStart.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/AppStart.cs
@@ -8,16 +8,10 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
     public class AppStart : MvxNavigatingObject, IMvxAppStart
     {
         private readonly IMvxNavigationService _navigationService;
-        private Func<IMvxNavigationService> resolve;
 
         public AppStart(IMvxNavigationService navigationService)
         {
             _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
-        }
-
-        public AppStart(Func<IMvxNavigationService> resolve)
-        {
-            this.resolve = resolve;
         }
 
         /// <summary>

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/AppStart.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/AppStart.cs
@@ -1,3 +1,5 @@
+using System;
+using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 
@@ -5,13 +7,26 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
 {
     public class AppStart : MvxNavigatingObject, IMvxAppStart
     {
+        private readonly IMvxNavigationService _navigationService;
+        private Func<IMvxNavigationService> resolve;
+
+        public AppStart(IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+        }
+
+        public AppStart(Func<IMvxNavigationService> resolve)
+        {
+            this.resolve = resolve;
+        }
+
         /// <summary>
         /// Start is called on startup of the app
         /// Hint contains information in case the app is started with extra parameters
         /// </summary>
         public void Start(object hint = null)
         {
-            ShowViewModel<CenterPanelViewModel>();
+            _navigationService.Navigate<CenterPanelViewModel>();
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/CenterPanelViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/CenterPanelViewModel.cs
@@ -1,11 +1,17 @@
+using System;
+using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 
 namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 {
     public class CenterPanelViewModel : BaseViewModel
     {
-        public CenterPanelViewModel()
+        private readonly IMvxNavigationService _navigationService;
+
+        public CenterPanelViewModel(IMvxNavigationService navigationService)
         {
+            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+
             ExampleValue = "Center Panel";
         }
 
@@ -31,7 +37,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
         /// </remarks>
         private void ShowMasterCommandExecuted()
         {
-            ShowViewModel<MasterViewModel>();
+            _navigationService.Navigate<MasterViewModel>();
         }
 
         public IMvxCommand ShowKeyboardHandlingCommand
@@ -47,7 +53,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
         /// </summary>
         private void ShowKeyboardHandlingCommandExecuted()
         {
-            ShowViewModel<KeyboardHandlingViewModel>();
+            _navigationService.Navigate<KeyboardHandlingViewModel>();
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/LeftPanelViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/LeftPanelViewModel.cs
@@ -1,10 +1,20 @@
+using System;
+using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 
 namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 {
     public class LeftPanelViewModel : BaseViewModel
-    {      
+    {
+        private readonly IMvxNavigationService _navigationService;
+
         private MvxCommand _showExampleMenuItemCommand;
+        private MvxCommand _showMasterViewCommand;
+
+        public LeftPanelViewModel(IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+        }
 
         public MvxCommand ShowExampleMenuItemCommand
         {
@@ -17,10 +27,8 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 
         private void DoShowExampleMenuItem()
         {
-            ShowViewModel<ExampleMenuItemViewModel>();
+            _navigationService.Navigate<ExampleMenuItemViewModel>();
         }
-
-        private MvxCommand _showMasterViewCommand;
 
         public MvxCommand ShowMasterViewCommand
         {
@@ -33,7 +41,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 
         private void ShowMasterView()
         {
-            ShowViewModel<MasterViewModel>();
+            _navigationService.Navigate<MasterViewModel>();
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
@@ -1,11 +1,17 @@
+using System;
+using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 
 namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 {
     public class MasterViewModel : BaseViewModel
     {
-        public MasterViewModel()
+        private readonly IMvxNavigationService _navigationService;
+
+        public MasterViewModel(IMvxNavigationService navigationService)
         {
+            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+
             ExampleValue = "Master View";
         }
 
@@ -19,7 +25,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 
         private void ShowDetailCommandExecuted()
         {
-            ShowViewModel<DetailViewModel>();
+            _navigationService.Navigate<DetailViewModel>();
         }
     }
 }


### PR DESCRIPTION


## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Updates the XamarinSidebarSample test project to use the new navigationservice. This change was triggered by a complaint from @martijn00 that the XamarinSidebar implementation doesn't seem to work with the navigation service. 

## :arrow_heading_down: What is the current behavior?
Current implementation uses the old `ShowViewModel<TViewModel>()` method to trigger a navigation request.

## :new: What is the new behaviour (if this is a feature change)?
Use the `IMvxNavigationService` implementation to trigger a navigation request

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Run the "MvvmCross.iOS.Support.XamarinSidebarSample.iOS" iOS-Support test project (part of the MvvmCross_All.sln

## :memo: Links to relevant issues/docs
none

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop