### PR TITLE
Fix for issue 1995 without breaking method signatures

### DIFF
--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -64,20 +64,20 @@ namespace MvvmCross.iOS.Views
         //keep changes for selected icon from breaking current release
         protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName)
         {
-            SetTitleAndTabBarItem(viewController, title, iconName, null);
-        }
+            _tabsCount++;
 
-        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName, string selectedIconName = null)
-        {
             viewController.Title = title;
 
             if (!string.IsNullOrEmpty(iconName))
                 viewController.TabBarItem = new UITabBarItem(title, UIImage.FromBundle(iconName), _tabsCount);
+        }
+
+        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName, string selectedIconName)
+        {
+            SetTitleAndTabBarItem(viewController, title, iconName);
 
             if (!string.IsNullOrEmpty(selectedIconName))
                 viewController.TabBarItem.SelectedImage = UIImage.FromBundle(selectedIconName);
-
-            _tabsCount++;
         }
 
         public virtual bool ShowChildView(UIViewController viewController)


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix to ensure that the method with signature `SetTitleAndTabBarItem(UIViewController, string, string)` will still be executed even when the overload method adding the `selectedImageName` parameter is being called.

## :arrow_heading_down: What is the current behavior?
Method `SetTitleAndTabBarItem(UIViewController, string, string)` is no longer executed

## :new: What is the new behavior (if this is a feature change)?
Method `SetTitleAndTabBarItem(UIViewController, string, string)` will be executed

## :boom: Does this PR introduce a breaking change?
nope (fixes one)

## :bug: Recommendations for testing
Run the `Playground` test project to see it still works

## :memo: Links to relevant issues/docs
closes #1995

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop