### PR TITLE
Move the sidebar attribute to the root to avoid annoyance with usings

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvvmCross.iOS.Support.XamarinSidebar.csproj
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvvmCross.iOS.Support.XamarinSidebar.csproj
@@ -43,7 +43,6 @@
     </Compile>
     <Compile Include="MvxSidebarPresenter.cs" />
     <Compile Include="Extensions\ViewControllerExtensions.cs" />
-    <Compile Include="Attributes\MvxSidebarPresentationAttribute.cs" />
     <Compile Include="MvxPanelEnum.cs" />
     <Compile Include="MvxPanelHintType.cs" />
     <Compile Include="MvxSplitViewBehaviour.cs" />
@@ -52,6 +51,7 @@
     <Compile Include="Views\MvxBaseSplitViewController.cs" />
     <Compile Include="Views\MvxSidebarViewController.cs" />
     <Compile Include="Views\MvxSplitViewControllerHost.cs" />
+    <Compile Include="MvxSidebarPresentationAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresentationAttribute.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresentationAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using MvvmCross.iOS.Views.Presenters.Attributes;
 
-namespace MvvmCross.iOS.Support.XamarinSidebar.Attributes
+namespace MvvmCross.iOS.Support.XamarinSidebar
 {
     public class MvxSidebarPresentationAttribute : MvxBasePresentationAttribute
     {

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -1,5 +1,4 @@
 ﻿using MvvmCross.Core.ViewModels;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebar.Extensions;
 using MvvmCross.iOS.Support.XamarinSidebar.Views;
 using MvvmCross.iOS.Views;

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSidebarViewController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSidebarViewController.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Reflection;
 using MvvmCross.Core.ViewModels;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters;
 using MvvmCross.Platform;

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSplitViewControllerHost.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSplitViewControllerHost.cs
@@ -1,5 +1,4 @@
-﻿using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
-using UIKit;
+﻿using UIKit;
 
 namespace MvvmCross.iOS.Support.XamarinSidebar.Views
 {

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/CenterPanelView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/CenterPanelView.cs
@@ -2,7 +2,6 @@ using Cirrious.FluentLayouts.Touch;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Support.XamarinSidebar;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 using UIKit;
 

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/DetailView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/DetailView.cs
@@ -2,7 +2,6 @@ using Cirrious.FluentLayouts.Touch;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Support.XamarinSidebar;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 using UIKit;
 

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/ExampleMenuItemView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/ExampleMenuItemView.cs
@@ -2,7 +2,6 @@ using Cirrious.FluentLayouts.Touch;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Support.XamarinSidebar;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 using UIKit;
 

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/KeyboardHandlingView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/KeyboardHandlingView.cs
@@ -2,7 +2,6 @@ using Cirrious.FluentLayouts.Touch;
 using Foundation;
 using MvvmCross.iOS.Support.Views;
 using MvvmCross.iOS.Support.XamarinSidebar;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 using UIKit;
 

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/LeftPanelView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/LeftPanelView.cs
@@ -3,7 +3,6 @@ using CoreGraphics;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Support.XamarinSidebar;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 using UIKit;
 

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
@@ -2,7 +2,6 @@ using Cirrious.FluentLayouts.Touch;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Support.XamarinSidebar;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebar.Views;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 using MvvmCross.Platform;

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/RightPanelView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/RightPanelView.cs
@@ -2,7 +2,6 @@ using Cirrious.FluentLayouts.Touch;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Support.XamarinSidebar;
-using MvvmCross.iOS.Support.XamarinSidebar.Attributes;
 using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
 using UIKit;
 


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
When adding an attribute for the Sidemenu you need include 2 usings. This is a bit annoying, and because we have only 1 attribute, i think we should move this to the root.

## :arrow_heading_down: What is the current behavior?
2 usings

## :new: What is the new behavior (if this is a feature change)?
1 usings

## :boom: Does this PR introduce a breaking change?
A little bit since 1 using will become unnecessary, but since we already use the other one it will just continue to work.

## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop