### PR TITLE
Test project.uwp

### DIFF
--- a/TestProjects/Forms/Example001CSharp/Example.UWP/Example.UWP.csproj
+++ b/TestProjects/Forms/Example001CSharp/Example.UWP/Example.UWP.csproj
@@ -141,6 +141,14 @@
       <Project>{0797D39C-C59B-4FE2-BB16-AB6FA0119C69}</Project>
       <Name>MvvmCross.Forms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\MvvmCross\Binding\UWP\MvvmCross.Binding.Uwp.csproj">
+      <Project>{637533ee-756b-4817-94b2-7c1e56132208}</Project>
+      <Name>MvvmCross.Binding.Uwp</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\MvvmCross\Core\Binding\MvvmCross.Binding.csproj">
+      <Project>{64dcd397-9019-41e8-a928-e5f5c5df185b}</Project>
+      <Name>MvvmCross.Binding</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\MvvmCross\Core\Core\MvvmCross.Core.csproj">
       <Project>{B6E27475-E7D0-448C-A5CC-5097DCA1E2DD}</Project>
       <Name>MvvmCross.Core</Name>

--- a/TestProjects/Forms/Example001CSharp/Example.UWP/project.json
+++ b/TestProjects/Forms/Example001CSharp/Example.UWP/project.json
@@ -1,5 +1,8 @@
 ﻿{
   "dependencies": {
+    "Microsoft.ApplicationInsights": "2.3.0",
+    "Microsoft.ApplicationInsights.PersistenceChannel": "1.2.3",
+    "Microsoft.ApplicationInsights.WindowsApps": "1.1.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Xamarin.Forms": "2.3.4.247"
   },

--- a/TestProjects/Forms/Example001XAML/Example.UWP/Example.UWP.csproj
+++ b/TestProjects/Forms/Example001XAML/Example.UWP/Example.UWP.csproj
@@ -141,6 +141,14 @@
       <Project>{0797D39C-C59B-4FE2-BB16-AB6FA0119C69}</Project>
       <Name>MvvmCross.Forms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\MvvmCross\Binding\UWP\MvvmCross.Binding.Uwp.csproj">
+      <Project>{637533ee-756b-4817-94b2-7c1e56132208}</Project>
+      <Name>MvvmCross.Binding.Uwp</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\MvvmCross\Core\Binding\MvvmCross.Binding.csproj">
+      <Project>{64dcd397-9019-41e8-a928-e5f5c5df185b}</Project>
+      <Name>MvvmCross.Binding</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\MvvmCross\Core\Core\MvvmCross.Core.csproj">
       <Project>{B6E27475-E7D0-448C-A5CC-5097DCA1E2DD}</Project>
       <Name>MvvmCross.Core</Name>

--- a/TestProjects/Forms/Example001XAML/Example.UWP/project.json
+++ b/TestProjects/Forms/Example001XAML/Example.UWP/project.json
@@ -1,5 +1,8 @@
 ﻿{
   "dependencies": {
+    "Microsoft.ApplicationInsights": "2.3.0",
+    "Microsoft.ApplicationInsights.PersistenceChannel": "1.2.3",
+    "Microsoft.ApplicationInsights.WindowsApps": "1.1.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Xamarin.Forms": "2.3.4.247"
   },


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
## :arrow_heading_down: What is the current behavior?
`Example001CSharp/Example.UWP/Example.UWP.csproj` and  `Example001XAML/Example.UWP/Example.UWP.csproj` can't compile.

## :new: What is the new behavior (if this is a feature change)?
Both `Example001CSharp/Example.UWP/Example.UWP.csproj` and `Example001XAML/Example.UWP/Example.UWP.csproj` can compile without errors.
## :boom: Does this PR introduce a breaking change?
No
## :bug: Recommendations for testing
Compile `Example001CSharp/Example.UWP/Example.UWP.csproj` and `Example001XAML/Example.UWP/Example.UWP.csproj` and see if there are errors.
## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop