### PR TITLE
replace create MvxNavigationController method call in MvxIosViewPrese…

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -201,7 +201,7 @@ namespace MvvmCross.iOS.Views.Presenters
             }
 
             if (attribute.WrapInNavigationController)
-                viewController = new MvxNavigationController(viewController);
+                viewController = CreateNavigationController(viewController);
 
             TabBarViewController.ShowTabView(
                 viewController,
@@ -223,7 +223,7 @@ namespace MvvmCross.iOS.Views.Presenters
             // setup modal based on attribute
             if (attribute.WrapInNavigationController)
             {
-                viewController = ModalNavigationController = new MvxNavigationController(viewController);
+                viewController = ModalNavigationController = CreateNavigationController(viewController);
             }
 
             viewController.ModalPresentationStyle = attribute.ModalPresentationStyle;

--- a/TestProjects/Playground/Playground.iOS/Setup.cs
+++ b/TestProjects/Playground/Playground.iOS/Setup.cs
@@ -1,4 +1,4 @@
-﻿using MvvmCross.Core.ViewModels;
+﻿﻿using MvvmCross.Core.ViewModels;
 using MvvmCross.iOS.Platform;
 using MvvmCross.iOS.Views.Presenters;
 using MvvmCross.Platform.Platform;
@@ -32,6 +32,7 @@ namespace Playground.iOS
         protected override IMvxIosViewPresenter CreatePresenter()
         {
             return new MvxIosViewPresenter(ApplicationDelegate, Window);
+
         }
     }
 }


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.
## :arrow_heading_down: What is the current behavior?
Could not hide all the NavigationBar by CreateNavigationController method call in MvxIosViewPresenter.
## :new: What is the new behavior (if this is a feature change)?
Could hide all the NavigationBar by CreateNavigationController method call in MvxIosViewPresenter.
## :boom: Does this PR introduce a breaking change?
No.
## :bug: Recommendations for testing
Run Playground.iOS and show view with WrapInNavigationController attribute will call CreateNavigationController(vc).
## :memo: Links to relevant issues/docs
Issue: No Create.
Docs: No Update.
## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop