### PR TITLE
Fix `MissingMethodException` when using `MvxImageView` pre-Android API 21

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxImageView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxImageView.cs
@@ -85,15 +85,17 @@ namespace MvvmCross.Binding.Droid.Views
             }
         }
 
-        public MvxImageView(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes) 
+        public MvxImageView(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes)
             : base(context, attrs, defStyleAttr, defStyleRes)
         {
             Init(context, attrs);
         }
 
         public MvxImageView(Context context, IAttributeSet attrs, int defStyleAttr)
-            : this(context, attrs, defStyleAttr, 0)
+            : base(context, attrs, defStyleAttr) // Don't call overload constructor since it is added in API 21
+                                                 // which could cause missing method exceptions on earlier API levels 
         {
+            Init(context, attrs);
         }
 
         public MvxImageView(Context context, IAttributeSet attrs)
@@ -150,7 +152,7 @@ namespace MvvmCross.Binding.Droid.Views
             typedArray.Recycle();
         }
 
-        public override void SetImageBitmap (Bitmap bm)
+        public override void SetImageBitmap(Bitmap bm)
         {
             if (Handle != IntPtr.Zero)
             {
@@ -159,7 +161,7 @@ namespace MvvmCross.Binding.Droid.Views
                     // Don't try to update disposed or recycled bitmap
                     return;
                 }
-                base.SetImageBitmap (bm);
+                base.SetImageBitmap(bm);
 
                 MvxMainThreadDispatcher.Instance.RequestMainThreadAction(() =>
                 {


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

## :arrow_heading_down: What is the current behavior?
When using the MvxImageView control on Android API 20 and lower (everything before API 21) you'll get a `MissingMethodException`. This is caused due to the new constructor `ImageView(Context context, AttributeSet attrs, int defStyle, int defStyleRes)` which was only added in API 21.

## :new: What is the new behavior (if this is a feature change)?
The `MissingMethodException` is no longer thrown because the new constructor is only called for API 21 and higher.

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Create a simple Android application which targets any API lower then 21 and include a MvxImageView control.

## :memo: Links to relevant issues/docs
The following external references exists:
- http://blog.danlew.net/2016/07/19/a-deep-dive-into-android-view-constructors/
- https://github.com/koral--/android-gif-drawable/issues/197

## :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [N/A] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [N/A] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop