### PR TITLE
The `AppBarLayout` should be direct child of the `CoordinatedLayout`

### DIFF
--- a/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/fragment_example_viewpager.axml
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/fragment_example_viewpager.axml
@@ -1,36 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:local="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/main_content"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-  <LinearLayout android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
-    <android.support.design.widget.AppBarLayout
-        android:id="@+id/appbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
-      <android.support.v7.widget.Toolbar
-          android:id="@+id/toolbar"
-          android:layout_width="match_parent"
-          android:layout_height="?attr/actionBarSize"
-          android:background="?attr/colorPrimary"
-          local:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-          local:layout_scrollFlags="scroll|enterAlways" />
-      <android.support.design.widget.TabLayout
-          android:id="@+id/tabs"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:paddingLeft="16dp"
-          local:tabGravity="center"
-          local:tabMode="scrollable" />
-    </android.support.design.widget.AppBarLayout>
-    <android.support.v4.view.ViewPager
-        android:id="@+id/viewpager"
-        android:layout_width="match_parent"
-        android:layout_height="fill_parent"
-        local:layout_behavior="@string/appbar_scrolling_view_behavior" />
-  </LinearLayout>
+<android.support.design.widget.CoordinatorLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:local="http://schemas.android.com/apk/res-auto"
+	android:id="@+id/main_content"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+	<android.support.design.widget.AppBarLayout
+		android:id="@+id/appbar"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+		<android.support.v7.widget.Toolbar
+			android:id="@+id/toolbar"
+			android:layout_width="match_parent"
+			android:layout_height="?attr/actionBarSize"
+			android:background="?attr/colorPrimary"
+			local:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+			local:layout_scrollFlags="scroll|enterAlways" />
+		<android.support.design.widget.TabLayout
+			android:id="@+id/tabs"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:paddingLeft="16dp"
+			local:tabGravity="center"
+			local:tabMode="scrollable" />
+	</android.support.design.widget.AppBarLayout>
+	<android.support.v4.view.ViewPager
+		android:id="@+id/viewpager"
+		android:layout_width="match_parent"
+		android:layout_height="fill_parent"
+		local:layout_behavior="@string/appbar_scrolling_view_behavior" />
 </android.support.design.widget.CoordinatorLayout>

--- a/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/fragment_example_viewpager_state.axml
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/fragment_example_viewpager_state.axml
@@ -3,34 +3,31 @@
     xmlns:local="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_content"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-  <LinearLayout android:orientation="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
     <android.support.design.widget.AppBarLayout
         android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
-      <android.support.v7.widget.Toolbar
-          android:id="@+id/toolbar"
-          android:layout_width="match_parent"
-          android:layout_height="?attr/actionBarSize"
-          android:background="?attr/colorPrimary"
-          local:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-          local:layout_scrollFlags="scroll|enterAlways" />
-      <android.support.design.widget.TabLayout
-          android:id="@+id/tabs"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:paddingLeft="16dp"
-          local:tabGravity="center"
-          local:tabMode="scrollable" />
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            local:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+            local:layout_scrollFlags="scroll|enterAlways" />
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tabs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="16dp"
+            local:tabGravity="center"
+            local:tabMode="scrollable" />
     </android.support.design.widget.AppBarLayout>
     <android.support.v4.view.ViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="fill_parent"
         local:layout_behavior="@string/appbar_scrolling_view_behavior" />
-  </LinearLayout>
 </android.support.design.widget.CoordinatorLayout>

--- a/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/fragment_recyclerview_multiitemtemplate.axml
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/fragment_recyclerview_multiitemtemplate.axml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:local="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
-        <include
-            layout="@layout/toolbar_actionbar" />
-        <MvxRecyclerView
-            android:id="@+id/my_recycler_view"
-            android:scrollbars="vertical"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            local:MvxTemplateSelector="@string/recyclerview_multiitem_templateselector"
-            local:MvxBind="ItemsSource Items; ItemClick ItemSelected" />
-    </LinearLayout>
+<android.support.design.widget.CoordinatorLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:local="http://schemas.android.com/apk/res-auto"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+	<include
+		layout="@layout/toolbar_actionbar" />
+	<MvxRecyclerView
+		android:id="@+id/my_recycler_view"
+		android:scrollbars="vertical"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		local:MvxTemplateSelector="@string/recyclerview_multiitem_templateselector"
+		local:MvxBind="ItemsSource Items; ItemClick ItemSelected" />
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

## :arrow_heading_down: What is the current behavior?
Currently in the AndroidSupport test project there are some fragments where the `AppBarLayout` control is not a direct child of the `CoordinatedLayout` control. 

## :new: What is the new behavior (if this is a feature change)?
The `AppBarLayout` control is now a direct child of the `CoordinatedLayout` control

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing
Run the AndroidSupport test project

## :memo: Links to relevant issues/docs
Link to Google documentation:
- https://developer.android.com/reference/android/support/design/widget/AppBarLayout.html

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [N/A] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [N/A] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop