### PR TITLE
added ability to initialize converter inline in xaml

### DIFF
--- a/MvvmCross/Platform/Wpf/Converters/MvxNativeValueConverter.cs
+++ b/MvvmCross/Platform/Wpf/Converters/MvxNativeValueConverter.cs
@@ -9,6 +9,7 @@ using System;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
+using System.Windows.Markup;
 using MvvmCross.Platform.Converters;
 
 namespace MvvmCross.Platform.Wpf.Converters

--- a/MvvmCross/Platform/Wpf/Converters/MvxNativeValueConverter.cs
+++ b/MvvmCross/Platform/Wpf/Converters/MvxNativeValueConverter.cs
@@ -14,7 +14,7 @@ using MvvmCross.Platform.Converters;
 namespace MvvmCross.Platform.Wpf.Converters
 {
     public class MvxNativeValueConverter
-        : IValueConverter
+        : MarkupExtension, IValueConverter
     {
         private readonly IMvxValueConverter _wrapped;
 
@@ -50,6 +50,11 @@ namespace MvvmCross.Platform.Wpf.Converters
             }
 
             return toReturn;
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider) 
+        { 
+            return this; 
         }
     }
 


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature request: https://github.com/MvvmCross/MvvmCross/issues/2000
This will allow inline creation of converters in XAML (WPF)

## :arrow_heading_down: What is the current behavior?
Currently this is not possible

## :new: What is the new behavior (if this is a feature change)?
Converters can be created in XAML as shown below:
```xaml
<Some Property="{Binding Tags, Converter={local:TokenConverter}}"/>
```

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2000

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop