### PR TITLE
Remove virtual calls from constructor

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
         {
             base.RegisterAttributeTypes();
 
-            _attributeTypesToShowMethodDictionary.Add(
+            AttributeTypesToShowMethodDictionary.Add(
                 typeof(MvxSidebarPresentationAttribute),
                 (vc, attribute, request) => ShowSidebarViewController(vc, (MvxSidebarPresentationAttribute)attribute, request));
         }

--- a/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
@@ -96,7 +96,7 @@ namespace MvvmCross.Mac.Views.Presenters
             var attribute = GetPresentationAttributes(viewController);
 
             Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest> showAction;
-            if (!_attributeTypesToShowMethodDictionary.TryGetValue(attribute.GetType(), out showAction))
+            if (!AttributeTypesToShowMethodDictionary.TryGetValue(attribute.GetType(), out showAction))
                 throw new KeyNotFoundException($"The type {attribute.GetType().Name} is not configured in the presenter dictionary");
 
             showAction.Invoke(viewController, attribute, request);

--- a/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
@@ -23,7 +23,20 @@ namespace MvvmCross.Mac.Views.Presenters
     {
         private readonly INSApplicationDelegate _applicationDelegate;
         private List<NSWindow> _windows;
-        protected Dictionary<Type, Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> _attributeTypesToShowMethodDictionary;
+        private Dictionary<Type, Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> _attributeTypesToShowMethodDictionary;
+        protected Dictionary<Type, Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> AttributeTypesToShowMethodDictionary
+        {
+            get
+            {
+                if (_attributeTypesToShowMethodDictionary == null)
+                {
+                    _attributeTypesToShowMethodDictionary = new Dictionary<Type, Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest>>();
+                    RegisterAttributeTypes();
+                }
+                return _attributeTypesToShowMethodDictionary;
+            }
+        }
+
 
         protected virtual INSApplicationDelegate ApplicationDelegate => _applicationDelegate;
 
@@ -33,10 +46,6 @@ namespace MvvmCross.Mac.Views.Presenters
         {
             _applicationDelegate = applicationDelegate;
             _windows = new List<NSWindow>();
-
-            _attributeTypesToShowMethodDictionary = new Dictionary<Type, Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest>>();
-
-            RegisterAttributeTypes();
         }
 
         protected virtual void RegisterAttributeTypes()

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -96,7 +96,7 @@ namespace MvvmCross.iOS.Views.Presenters
             var attribute = GetPresentationAttributes(viewController);
             var attributeType = attribute.GetType();
 
-            if (_attributeTypesToShowMethodDictionary.TryGetValue(attributeType, 
+            if (AttributeTypesToShowMethodDictionary.TryGetValue(attributeType, 
                 out Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest> showAction))
             {
                 showAction.Invoke(viewController, attribute, request);

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -14,8 +14,19 @@ namespace MvvmCross.iOS.Views.Presenters
     {
         protected readonly IUIApplicationDelegate _applicationDelegate;
         protected readonly UIWindow _window;
-        protected Dictionary<Type, Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> 
-            _attributeTypesToShowMethodDictionary;
+        private Dictionary<Type, Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> _attributeTypesToShowMethodDictionary;
+        protected Dictionary<Type, Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> AttributeTypesToShowMethodDictionary
+        {
+            get
+            {
+                if(_attributeTypesToShowMethodDictionary == null)
+                {
+                    _attributeTypesToShowMethodDictionary = new Dictionary<Type, Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest>>();
+                    RegisterAttributeTypes();
+                }
+                return _attributeTypesToShowMethodDictionary;
+            }
+        }
 
         public UINavigationController MasterNavigationController { get; protected set; }
 
@@ -29,11 +40,6 @@ namespace MvvmCross.iOS.Views.Presenters
         {
             _applicationDelegate = applicationDelegate;
             _window = window;
-
-            _attributeTypesToShowMethodDictionary = 
-                new Dictionary<Type, Action<UIViewController, MvxBasePresentationAttribute, MvxViewModelRequest>>();
-
-            RegisterAttributeTypes();
         }
 
         protected virtual void RegisterAttributeTypes()


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes unrecommended code.

## :arrow_heading_down: What is the current behavior?
Currently there is a virtual call in the constructor.

## :new: What is the new behavior (if this is a feature change)?
Lazy init this.

## :boom: Does this PR introduce a breaking change?
No

## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs

## :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop