### PR TITLE
Introduced new lifecycle event "Created" in MvxViewModel

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentActivity.cs
@@ -29,7 +29,7 @@ using MvvmCross.Platform.Platform;
 namespace MvvmCross.Droid.Support.V4
 {
     [Register("mvvmcross.droid.support.v4.MvxCachingFragmentActivity")]
-    public class MvxCachingFragmentActivity 
+    public class MvxCachingFragmentActivity
         : MvxFragmentActivity, IFragmentCacheableActivity, IMvxFragmentHost
     {
 		public const string ViewModelRequestBundleKey = "__mvxViewModelRequest";
@@ -54,7 +54,7 @@ namespace MvvmCross.Droid.Support.V4
 
 		protected override void OnCreate(Bundle bundle)
 		{
-			// Prevents crash when activity in background with history enable is reopened after 
+			// Prevents crash when activity in background with history enable is reopened after
 			// Android does some auto memory management.
 			var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(this);
 			setup.EnsureInitialized();
@@ -478,6 +478,12 @@ namespace MvvmCross.Droid.Support.V4
 			return true;
 		}
 
+        public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
+        {
+            base.OnCreate(savedInstanceState, persistentState);
+            ViewModel?.Created();
+        }
+
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
@@ -493,8 +499,8 @@ namespace MvvmCross.Droid.Support.V4
     }
 
     public abstract class MvxCachingFragmentActivity<TViewModel>
-        : MvxCachingFragmentActivity, 
-        IMvxAndroidView<TViewModel> 
+        : MvxCachingFragmentActivity,
+        IMvxAndroidView<TViewModel>
         where TViewModel : class, IMvxViewModel
     {
         public new TViewModel ViewModel

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentActivity.cs
@@ -481,20 +481,20 @@ namespace MvvmCross.Droid.Support.V4
         public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
         {
             base.OnCreate(savedInstanceState, persistentState);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
     }
 

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
@@ -64,37 +64,37 @@ namespace MvvmCross.Droid.Support.V4
         public override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.Destroy();
+            ViewModel?.ViewDestroy();
         }
 
         public override void OnStart()
         {
             base.OnStart();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnResume()
         {
             base.OnResume();
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void OnPause()
         {
             base.OnPause();
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void OnStop()
         {
             base.OnStop();
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
     }
 

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
@@ -60,6 +60,13 @@ namespace MvvmCross.Droid.Support.V4
 
         public virtual string UniqueImmutableCacheTag => Tag;
 
+
+        public override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+            ViewModel?.Created();
+        }
+
         public override void OnDestroy()
         {
             base.OnDestroy();
@@ -92,7 +99,7 @@ namespace MvvmCross.Droid.Support.V4
     }
 
     public abstract class MvxDialogFragment<TViewModel>
-        : MvxDialogFragment, IMvxFragmentView<TViewModel> 
+        : MvxDialogFragment, IMvxFragmentView<TViewModel>
         where TViewModel : class, IMvxViewModel
     {
         public new TViewModel ViewModel

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragment.cs
@@ -83,37 +83,37 @@ namespace MvvmCross.Droid.Support.V4
         public override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.Destroy();
+            ViewModel?.ViewDestroy();
         }
 
         public override void OnStart()
         {
             base.OnStart();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnResume()
         {
             base.OnResume();
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void OnPause()
         {
             base.OnPause();
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void OnStop()
         {
             base.OnStop();
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
     }
 

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragment.cs
@@ -80,6 +80,12 @@ namespace MvvmCross.Droid.Support.V4
 
         public virtual string UniqueImmutableCacheTag => Tag;
 
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            ViewModel?.Created();
+        }
+
         public override void OnDestroy()
         {
             base.OnDestroy();
@@ -112,7 +118,7 @@ namespace MvvmCross.Droid.Support.V4
     }
 
     public abstract class MvxFragment<TViewModel>
-        : MvxFragment, IMvxFragmentView<TViewModel> 
+        : MvxFragment, IMvxFragmentView<TViewModel>
         where TViewModel : class, IMvxViewModel
     {
         protected MvxFragment()

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
@@ -80,6 +80,12 @@ namespace MvvmCross.Droid.Support.V4
             base.AttachBaseContext(MvxContextWrapper.Wrap(@base, this));
         }
 
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+            ViewModel?.Created();
+        }
+
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
@@ -117,7 +123,7 @@ namespace MvvmCross.Droid.Support.V4
     }
 
     public abstract class MvxFragmentActivity<TViewModel>
-        : MvxFragmentActivity, IMvxAndroidView<TViewModel> 
+        : MvxFragmentActivity, IMvxAndroidView<TViewModel>
         where TViewModel : class, IMvxViewModel
     {
         public new TViewModel ViewModel

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
@@ -83,20 +83,20 @@ namespace MvvmCross.Droid.Support.V4
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
 
         public void OnGlobalLayout()
@@ -117,7 +117,7 @@ namespace MvvmCross.Droid.Support.V4
                     }
                 }
                 _view = null;
-                ViewModel?.Appeared();
+                ViewModel?.ViewAppeared();
             }
         }
     }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxTabsFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxTabsFragmentActivity.cs
@@ -220,6 +220,12 @@ namespace MvvmCross.Droid.Support.V4
         {
         }
 
+        public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
+        {
+            base.OnCreate(savedInstanceState, persistentState);
+            ViewModel?.Created();
+        }
+
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxTabsFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxTabsFragmentActivity.cs
@@ -223,20 +223,20 @@ namespace MvvmCross.Droid.Support.V4
         public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
         {
             base.OnCreate(savedInstanceState, persistentState);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
     }
 }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
@@ -90,20 +90,20 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnAttachedToWindow()
 		{
 			base.OnAttachedToWindow();
-			ViewModel?.Appearing();
+			ViewModel?.ViewAppearing();
 		}
 
 		public override void OnDetachedFromWindow()
 		{
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
 		}
 
         public override View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
@@ -130,7 +130,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                     }
                 }
                 _view = null;
-                ViewModel?.Appeared();
+                ViewModel?.ViewAppeared();
             }
         }
     }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 {
     [Register("mvvmcross.droid.support.v7.appcompat.MvxAppCompatActivity")]
     public class MvxAppCompatActivity
-        : MvxEventSourceAppCompatActivity, IMvxAndroidView, ViewTreeObserver.IOnGlobalLayoutListener 
+        : MvxEventSourceAppCompatActivity, IMvxAndroidView, ViewTreeObserver.IOnGlobalLayoutListener
     {
         private View _view;
 
@@ -87,7 +87,13 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             base.AttachBaseContext(MvxContextWrapper.Wrap(@base, this));
         }
 
-		public override void OnAttachedToWindow()
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+            ViewModel?.Created();
+        }
+
+        public override void OnAttachedToWindow()
 		{
 			base.OnAttachedToWindow();
 			ViewModel?.Appearing();
@@ -133,7 +139,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         : MvxAppCompatActivity, IMvxAndroidView<TViewModel>
         where TViewModel : class, IMvxViewModel
     {
-        protected MvxAppCompatActivity(IntPtr ptr, JniHandleOwnership ownership) 
+        protected MvxAppCompatActivity(IntPtr ptr, JniHandleOwnership ownership)
             : base(ptr, ownership)
         {
         }

--- a/MvvmCross-Forms/MvvmCross.Forms/Core/MvxContentPage.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Core/MvxContentPage.cs
@@ -20,15 +20,15 @@ namespace MvvmCross.Forms.Core
         protected override void OnAppearing()
         {
             base.OnAppearing();
-            ViewModel?.Appearing();
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppearing();
+            ViewModel?.ViewAppeared();
         }
 
         protected override void OnDisappearing()
         {
             base.OnDisappearing();
-            ViewModel?.Disappearing();
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing();
+            ViewModel?.ViewDisappeared();
         }
 
         public MvxViewModelRequest Request { get; set; }

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -12,23 +12,23 @@ namespace MvvmCross.Core.ViewModels
 {
     public interface IMvxViewModel
     {
-        void Created();
+        void ViewCreated();
 
-        void Appearing();
+        void ViewAppearing();
 
-        void Appeared();
+        void ViewAppeared();
 
-        void Disappearing();
+        void ViewDisappearing();
 
-        void Disappeared();
+        void ViewDisappeared();
+
+        void ViewDestroy();
 
         void Init(IMvxBundle parameters);
 
         void ReloadState(IMvxBundle state);
 
         void Start();
-
-        void Destroy ();
 
         void SaveState(IMvxBundle state);
 

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -12,6 +12,8 @@ namespace MvvmCross.Core.ViewModels
 {
     public interface IMvxViewModel
     {
+        void Created();
+
         void Appearing();
 
         void Appeared();

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -21,6 +21,10 @@ namespace MvvmCross.Core.ViewModels
         {
         }
 
+        public virtual void Created()
+        {
+        }
+
         public virtual void Appearing()
         {
         }

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -21,23 +21,27 @@ namespace MvvmCross.Core.ViewModels
         {
         }
 
-        public virtual void Created()
+        public virtual void ViewCreated()
         {
         }
 
-        public virtual void Appearing()
+        public virtual void ViewAppearing()
         {
         }
 
-        public virtual void Appeared()
+        public virtual void ViewAppeared()
         {
         }
 
-        public virtual void Disappearing()
+        public virtual void ViewDisappearing()
         {
         }
 
-        public virtual void Disappeared()
+        public virtual void ViewDisappeared()
+        {
+        }
+
+        public virtual void ViewDestroy()
         {
         }
 
@@ -52,10 +56,6 @@ namespace MvvmCross.Core.ViewModels
         }
 
         public virtual void Start()
-        {
-        }
-
-        public virtual void Destroy()
         {
         }
 
@@ -138,11 +138,11 @@ namespace MvvmCross.Core.ViewModels
             }
         }
 
-        public override void Destroy()
+        public override void ViewDestroy()
         {
             if (!_isClosing)
                 _tcs?.TrySetCanceled();
-            base.Destroy();
+            base.ViewDestroy();
         }
     }
 

--- a/MvvmCross/Droid/Droid/Views/MvxActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxActivity.cs
@@ -90,26 +90,26 @@ namespace MvvmCross.Droid.Views
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         protected override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.Destroy();
+            ViewModel?.ViewDestroy();
         }
 
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
 
         public void OnGlobalLayout()
@@ -130,7 +130,7 @@ namespace MvvmCross.Droid.Views
                     }
                 }
                 _view = null;
-                ViewModel?.Appeared();
+                ViewModel?.ViewAppeared();
             }
         }
     }

--- a/MvvmCross/Droid/Droid/Views/MvxActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxActivity.cs
@@ -45,9 +45,9 @@ namespace MvvmCross.Droid.Views
 
         public IMvxViewModel ViewModel
         {
-            get 
-            { 
-                return DataContext as IMvxViewModel; 
+            get
+            {
+                return DataContext as IMvxViewModel;
             }
             set
             {
@@ -85,6 +85,18 @@ namespace MvvmCross.Droid.Views
                 return;
             }
             base.AttachBaseContext(MvxContextWrapper.Wrap(@base, this));
+        }
+
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+            ViewModel?.Created();
+        }
+
+        protected override void OnDestroy()
+        {
+            base.OnDestroy();
+            ViewModel?.Destroy();
         }
 
         public override void OnAttachedToWindow()

--- a/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
@@ -84,20 +84,20 @@ namespace MvvmCross.Droid.Views
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
 
         public void OnGlobalLayout()
@@ -118,7 +118,7 @@ namespace MvvmCross.Droid.Views
                     }
                 }
                 _view = null;
-                ViewModel?.Appeared();
+                ViewModel?.ViewAppeared();
             }
         }
     }

--- a/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
@@ -81,6 +81,12 @@ namespace MvvmCross.Droid.Views
             base.AttachBaseContext(MvxContextWrapper.Wrap(@base, this));
         }
 
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+            ViewModel?.Created();
+        }
+
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();

--- a/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
+++ b/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
@@ -476,20 +476,20 @@ namespace MvvmCross.Droid.FullFragging.Caching
 	    public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
 	    {
 	        base.OnCreate(savedInstanceState, persistentState);
-	        ViewModel?.Created();
+	        ViewModel?.ViewCreated();
 	    }
 
 	    public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
     }
 

--- a/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
+++ b/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
@@ -29,7 +29,7 @@ using MvxActivity = MvvmCross.Droid.FullFragging.Views.MvxActivity;
 namespace MvvmCross.Droid.FullFragging.Caching
 {
     [Register("mvvmcross.droid.fullfragging.caching.MvxCachingFragmentActivity")]
-    public class MvxCachingFragmentActivity 
+    public class MvxCachingFragmentActivity
         : MvxActivity, IFragmentCacheableActivity, IMvxFragmentHost
 	{
 		public const string ViewModelRequestBundleKey = "__mvxViewModelRequest";
@@ -473,7 +473,13 @@ namespace MvvmCross.Droid.FullFragging.Caching
 			return true;
 		}
 
-        public override void OnAttachedToWindow()
+	    public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
+	    {
+	        base.OnCreate(savedInstanceState, persistentState);
+	        ViewModel?.Created();
+	    }
+
+	    public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
             ViewModel?.Appearing();
@@ -488,7 +494,7 @@ namespace MvvmCross.Droid.FullFragging.Caching
     }
 
     public abstract class MvxCachingFragmentActivity<TViewModel>
-        : MvxCachingFragmentActivity, IMvxAndroidView<TViewModel> 
+        : MvxCachingFragmentActivity, IMvxAndroidView<TViewModel>
         where TViewModel : class, IMvxViewModel
     {
         public new TViewModel ViewModel

--- a/MvvmCross/Droid/FullFragging/Fragments/MvxDialogFragment.cs
+++ b/MvvmCross/Droid/FullFragging/Fragments/MvxDialogFragment.cs
@@ -60,6 +60,12 @@ namespace MvvmCross.Droid.FullFragging.Fragments
 
         public string UniqueImmutableCacheTag => Tag;
 
+        public override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+            ViewModel?.Created();
+        }
+
         public override void OnDestroy ()
         {
             base.OnDestroy ();

--- a/MvvmCross/Droid/FullFragging/Fragments/MvxDialogFragment.cs
+++ b/MvvmCross/Droid/FullFragging/Fragments/MvxDialogFragment.cs
@@ -63,37 +63,37 @@ namespace MvvmCross.Droid.FullFragging.Fragments
         public override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnDestroy ()
         {
             base.OnDestroy ();
-            ViewModel?.Destroy ();
+            ViewModel?.ViewDestroy ();
         }
 
         public override void OnStart()
         {
             base.OnStart();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnResume()
         {
             base.OnResume();
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void OnPause()
         {
             base.OnPause();
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void OnStop()
         {
             base.OnStop();
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
     }
 

--- a/MvvmCross/Droid/FullFragging/Fragments/MvxFragment.cs
+++ b/MvvmCross/Droid/FullFragging/Fragments/MvxFragment.cs
@@ -81,6 +81,12 @@ namespace MvvmCross.Droid.FullFragging.Fragments
 
         public string UniqueImmutableCacheTag => Tag;
 
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            ViewModel?.Created();
+        }
+
         public override void OnDestroy()
         {
             base.OnDestroy();

--- a/MvvmCross/Droid/FullFragging/Fragments/MvxFragment.cs
+++ b/MvvmCross/Droid/FullFragging/Fragments/MvxFragment.cs
@@ -84,37 +84,37 @@ namespace MvvmCross.Droid.FullFragging.Fragments
         public override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.Destroy();
+            ViewModel?.ViewDestroy();
         }
 
         public override void OnStart()
         {
             base.OnStart();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnResume()
         {
             base.OnResume();
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void OnPause()
         {
             base.OnPause();
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void OnStop()
         {
             base.OnStop();
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
     }
 

--- a/MvvmCross/Droid/FullFragging/Fragments/MvxPreferenceFragment.cs
+++ b/MvvmCross/Droid/FullFragging/Fragments/MvxPreferenceFragment.cs
@@ -61,37 +61,37 @@ namespace MvvmCross.Droid.FullFragging.Fragments
         public override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnDestroy ()
         {
             base.OnDestroy ();
-            ViewModel?.Destroy ();
+            ViewModel?.ViewDestroy ();
         }
 
         public override void OnStart()
         {
             base.OnStart();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnResume()
         {
             base.OnResume();
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void OnPause()
         {
             base.OnPause();
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void OnStop()
         {
             base.OnStop();
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
     }
 

--- a/MvvmCross/Droid/FullFragging/Fragments/MvxPreferenceFragment.cs
+++ b/MvvmCross/Droid/FullFragging/Fragments/MvxPreferenceFragment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Android.OS;
 using Android.Runtime;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Core.ViewModels;
@@ -56,6 +57,12 @@ namespace MvvmCross.Droid.FullFragging.Fragments
         }
 
         public string UniqueImmutableCacheTag => Tag;
+
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            ViewModel?.Created();
+        }
 
         public override void OnDestroy ()
         {

--- a/MvvmCross/Droid/FullFragging/MvxTabsFragmentActivity.cs
+++ b/MvvmCross/Droid/FullFragging/MvxTabsFragmentActivity.cs
@@ -103,6 +103,12 @@ namespace MvvmCross.Droid.FullFragging
             SetContentView(view);
         }
 
+        public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
+        {
+            base.OnCreate(savedInstanceState, persistentState);
+            ViewModel?.Created();
+        }
+
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();

--- a/MvvmCross/Droid/FullFragging/MvxTabsFragmentActivity.cs
+++ b/MvvmCross/Droid/FullFragging/MvxTabsFragmentActivity.cs
@@ -106,20 +106,20 @@ namespace MvvmCross.Droid.FullFragging
         public override void OnCreate(Bundle savedInstanceState, PersistableBundle persistentState)
         {
             base.OnCreate(savedInstanceState, persistentState);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
 
         protected override void OnSaveInstanceState(Bundle outState)

--- a/MvvmCross/Droid/FullFragging/Views/MvxActivity.cs
+++ b/MvvmCross/Droid/FullFragging/Views/MvxActivity.cs
@@ -48,9 +48,9 @@ namespace MvvmCross.Droid.FullFragging.Views
 
         public IMvxViewModel ViewModel
         {
-            get 
-            { 
-                return DataContext as IMvxViewModel; 
+            get
+            {
+                return DataContext as IMvxViewModel;
             }
             set
             {
@@ -107,6 +107,12 @@ namespace MvvmCross.Droid.FullFragging.Views
 
                 return ret;
             }
+        }
+
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+            ViewModel?.Created();
         }
 
         protected override void OnDestroy()

--- a/MvvmCross/Droid/FullFragging/Views/MvxActivity.cs
+++ b/MvvmCross/Droid/FullFragging/Views/MvxActivity.cs
@@ -112,26 +112,26 @@ namespace MvvmCross.Droid.FullFragging.Views
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         protected override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.Destroy();
+            ViewModel?.ViewDestroy();
         }
 
         public override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void OnDetachedFromWindow()
         {
             base.OnDetachedFromWindow();
-            ViewModel?.Disappearing(); // we don't have anywhere to get this info
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing(); // we don't have anywhere to get this info
+            ViewModel?.ViewDisappeared();
         }
 
         public void OnGlobalLayout()
@@ -151,7 +151,7 @@ namespace MvvmCross.Droid.FullFragging.Views
                     }
                 }
                 _view = null;
-                ViewModel?.Appeared();
+                ViewModel?.ViewAppeared();
             }
         }
     }

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsPage.cs
@@ -31,22 +31,22 @@ namespace MvvmCross.Uwp.Views
 
         private void MvxWindowsPage_Loading(FrameworkElement sender, object args)
         {
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         private void MvxWindowsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         private void MvxWindowsPage_Unloaded(object sender, RoutedEventArgs e)
         {
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
             base.OnNavigatingFrom(e);
         }
 
@@ -85,7 +85,7 @@ namespace MvvmCross.Uwp.Views
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
 
             if (_reqData != string.Empty)
             {

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsPage.cs
@@ -85,6 +85,7 @@ namespace MvvmCross.Uwp.Views
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
+            ViewModel?.Created();
 
             if (_reqData != string.Empty)
             {

--- a/MvvmCross/Windows/Wpf/Views/MvxWpfView.cs
+++ b/MvvmCross/Windows/Wpf/Views/MvxWpfView.cs
@@ -37,14 +37,14 @@ namespace MvvmCross.Wpf.Views
 
         private void MvxWpfView_Unloaded(object sender, RoutedEventArgs e)
         {
-            ViewModel?.Disappearing();
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappearing();
+            ViewModel?.ViewDisappeared();
         }
 
         private void MvxWpfView_Loaded(object sender, RoutedEventArgs e)
         {
-            ViewModel?.Appearing();
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppearing();
+            ViewModel?.ViewAppeared();
         }
 
         public void Dispose()

--- a/MvvmCross/iOS/iOS/Views/MvxBaseSplitViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxBaseSplitViewController.cs
@@ -41,6 +41,12 @@ namespace MvvmCross.iOS.Views
 
         public IMvxBindingContext BindingContext { get; set; }
 
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            ViewModel?.Created();
+        }
+
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);

--- a/MvvmCross/iOS/iOS/Views/MvxBaseSplitViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxBaseSplitViewController.cs
@@ -44,31 +44,31 @@ namespace MvvmCross.iOS.Views
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
 
         public override void DidMoveToParentViewController(UIViewController parent)
@@ -76,7 +76,7 @@ namespace MvvmCross.iOS.Views
             base.DidMoveToParentViewController(parent);
             if (parent == null)
             {
-                ViewModel?.Destroy();
+                ViewModel?.ViewDestroy();
             }
         }
 

--- a/MvvmCross/iOS/iOS/Views/MvxBaseTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxBaseTabBarViewController.cs
@@ -50,6 +50,12 @@ namespace MvvmCross.iOS.Views
 
         public IMvxBindingContext BindingContext { get; set; }
 
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            ViewModel?.Created();
+        }
+
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);

--- a/MvvmCross/iOS/iOS/Views/MvxBaseTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxBaseTabBarViewController.cs
@@ -53,38 +53,38 @@ namespace MvvmCross.iOS.Views
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
 
         public override void DidMoveToParentViewController(UIViewController parent)
         {
             base.DidMoveToParentViewController(parent);
             if (parent == null)
-                ViewModel?.Destroy();
+                ViewModel?.ViewDestroy();
         }
 
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)

--- a/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
@@ -51,6 +51,12 @@ namespace MvvmCross.iOS.Views
 
         public IMvxBindingContext BindingContext { get; set; }
 
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            ViewModel?.Created();
+        }
+
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
@@ -108,6 +114,6 @@ namespace MvvmCross.iOS.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
-        }   
+        }
     }
 }

--- a/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxCollectionViewController.cs
@@ -54,38 +54,38 @@ namespace MvvmCross.iOS.Views
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
 
         public override void DidMoveToParentViewController(UIViewController parent)
         {
             base.DidMoveToParentViewController(parent);
             if (parent == null)
-                ViewModel?.Destroy();
+                ViewModel?.ViewDestroy();
         }
 
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)

--- a/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
@@ -121,6 +121,7 @@ namespace MvvmCross.iOS.Views
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
+            ViewModel?.Created();
             InitializePaging();
         }
 

--- a/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxPageViewController.cs
@@ -31,32 +31,32 @@ namespace MvvmCross.iOS.Views
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
 
         public override void DidMoveToParentViewController(UIViewController parent)
         {
             base.DidMoveToParentViewController(parent);
             if (parent == null)
-                ViewModel?.Destroy();
+                ViewModel?.ViewDestroy();
         }
 
         public IMvxViewModel ViewModel
@@ -121,7 +121,7 @@ namespace MvvmCross.iOS.Views
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
             InitializePaging();
         }
 

--- a/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
@@ -76,6 +76,12 @@ namespace MvvmCross.iOS.Views
 
         public IMvxBindingContext BindingContext { get; set; }
 
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            ViewModel?.Created();
+        }
+
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);

--- a/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTableViewController.cs
@@ -79,38 +79,38 @@ namespace MvvmCross.iOS.Views
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewModel?.Appearing();
+            ViewModel?.ViewAppearing();
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewModel?.Appeared();
+            ViewModel?.ViewAppeared();
         }
 
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewModel?.Disappearing();
+            ViewModel?.ViewDisappearing();
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewModel?.Disappeared();
+            ViewModel?.ViewDisappeared();
         }
 
         public override void DidMoveToParentViewController(UIViewController parent)
         {
             base.DidMoveToParentViewController(parent);
             if (parent == null)
-                ViewModel?.Destroy();
+                ViewModel?.ViewDestroy();
         }
 
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)

--- a/MvvmCross/iOS/iOS/Views/MvxViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxViewController.cs
@@ -53,38 +53,38 @@ namespace MvvmCross.iOS.Views
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewModel?.Created();
+            ViewModel?.ViewCreated();
         }
 
         public override void ViewWillAppear(bool animated)
 		{
 			base.ViewWillAppear(animated);
-			ViewModel?.Appearing();
+			ViewModel?.ViewAppearing();
 		}
 
 		public override void ViewDidAppear(bool animated)
 		{
 			base.ViewDidAppear(animated);
-			ViewModel?.Appeared();
+			ViewModel?.ViewAppeared();
 		}
 
 		public override void ViewWillDisappear(bool animated)
 		{
 			base.ViewWillDisappear(animated);
-			ViewModel?.Disappearing();
+			ViewModel?.ViewDisappearing();
 		}
 
 		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
-			ViewModel?.Disappeared();
+			ViewModel?.ViewDisappeared();
 		}
 
         public override void DidMoveToParentViewController (UIViewController parent)
         {
             base.DidMoveToParentViewController (parent);
             if (parent == null) {
-                ViewModel?.Destroy ();
+                ViewModel?.ViewDestroy ();
             }
         }
 

--- a/MvvmCross/iOS/iOS/Views/MvxViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxViewController.cs
@@ -50,7 +50,13 @@ namespace MvvmCross.iOS.Views
 
         public IMvxBindingContext BindingContext { get; set; }
 
-		public override void ViewWillAppear(bool animated)
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            ViewModel?.Created();
+        }
+
+        public override void ViewWillAppear(bool animated)
 		{
 			base.ViewWillAppear(animated);
 			ViewModel?.Appearing();

--- a/TestProjects/Eventhooks/Eventhooks.Core/ViewModels/FirstViewModel.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Core/ViewModels/FirstViewModel.cs
@@ -6,29 +6,39 @@ namespace Eventhooks.Core.ViewModels
 	public class FirstViewModel
 		: MvxViewModel
 	{
-		public override void Appearing()
+	    public override void ViewCreated()
+	    {
+	        MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is created");
+	    }
+
+	    public override void ViewDestroy()
+	    {
+	        MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is destroyed");
+	    }
+
+	    public override void ViewAppearing()
 		{
 			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is appearing");
 		}
 
-		public override void Appeared()
+		public override void ViewAppeared()
 		{
 			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View appeared");
 		}
 
-		public override void Disappearing()
+		public override void ViewDisappearing()
 		{
 			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is disappearing");
 		}
 
-		public override void Disappeared()
+		public override void ViewDisappeared()
 		{
 			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View has disappeared");
 		}
 
-		public IMvxCommand ShowSecondView 
-		{ 
-			get { return new MvxCommand(ExecuteSecondViewCommand); } 
+		public IMvxCommand ShowSecondView
+		{
+			get { return new MvxCommand(ExecuteSecondViewCommand); }
 		}
 
 		private void ExecuteSecondViewCommand()


### PR DESCRIPTION
## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature (solves #2018)

New lifecycle event Created for MvxViewModel. On Android this maps to OnCreate, on iOS ViewDidLoad and UWP OnNavigatedTo.

Renamed existing View events with prefix View. ViewAppearing, ViewAppeared, ViewDisappearing, ViewDisappeared.

## :arrow_heading_down: What is the current behavior?

Event does not exist.

## :new: What is the new behavior (if this is a feature change)?

New lifecycle event Created for MvxViewModel.

## :boom: Does this PR introduce a breaking change?

Yes. Renamed existing View events with prefix View. ViewAppearing, ViewAppeared, ViewDisappearing, ViewDisappeared.

## :bug: Recommendations for testing

## :memo: Links to relevant issues/docs

Feature (solves #2018)

## :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop