### PR TITLE
Add MvxTableViewHeaderFooterView

### DIFF
--- a/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
+++ b/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Views\MvxView.cs" />
     <Compile Include="Target\MvxUISegmentedControlSelectedSegmentTargetBinding.cs" />
     <Compile Include="Target\MvxUIControlTargetBinding.cs" />
+    <Compile Include="Views\MvxTableViewHeaderFooterView.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Platform\iOS\MvvmCross.Platform.iOS.csproj">

--- a/MvvmCross/Binding/iOS/Views/MvxTableViewHeaderFooterView.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxTableViewHeaderFooterView.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using CoreGraphics;
+using Foundation;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Binding.Bindings;
+using UIKit;
+
+namespace MvvmCross.Binding.iOS.Views
+{
+    public class MvxTableViewHeaderFooterView
+        : UITableViewHeaderFooterView, IMvxBindable
+    {
+        public IMvxBindingContext BindingContext { get; set; }
+
+        public MvxTableViewHeaderFooterView()
+            : this(string.Empty)
+        {
+        }
+
+        public MvxTableViewHeaderFooterView(string bindingText)
+        {
+            this.CreateBindingContext(bindingText);
+        }
+
+        public MvxTableViewHeaderFooterView(IEnumerable<MvxBindingDescription> bindingDescriptions)
+        {
+            this.CreateBindingContext(bindingDescriptions);
+        }
+
+        public MvxTableViewHeaderFooterView(string bindingText, CGRect frame)
+            : base(frame)
+        {
+            this.CreateBindingContext(bindingText);
+        }
+
+        public MvxTableViewHeaderFooterView(IEnumerable<MvxBindingDescription> bindingDescriptions, CGRect frame)
+            : base(frame)
+        {
+            this.CreateBindingContext(bindingDescriptions);
+        }
+
+        public MvxTableViewHeaderFooterView(IntPtr handle)
+            : this(string.Empty, handle)
+        {
+        }
+
+        public MvxTableViewHeaderFooterView(string bindingText, IntPtr handle)
+            : base(handle)
+        {
+            this.CreateBindingContext(bindingText);
+        }
+
+        public MvxTableViewHeaderFooterView(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+            : base(handle)
+        {
+            this.CreateBindingContext(bindingDescriptions);
+        }
+
+        public MvxTableViewHeaderFooterView(NSString reuseIdentifier)
+            : this(string.Empty, reuseIdentifier)
+        {
+        }
+
+        public MvxTableViewHeaderFooterView(string bindingText, NSString reuseIdentifier)
+            : base(reuseIdentifier)
+        {
+            this.CreateBindingContext(bindingText);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                BindingContext.ClearAllBindings();
+            }
+            base.Dispose(disposing);
+        }
+
+        public object DataContext
+        {
+            get { return BindingContext.DataContext; }
+            set { BindingContext.DataContext = value; }
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This adds an `IMvxBindable` subclass of `UITableViewHeaderFooterView`. No reason not to have it, since we already provide `MvxTableViewCell`.

### :boom: Does this PR introduce a breaking change?

Nope

### :bug: Recommendations for testing

Fiddle around with it in TableViews

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop