### PR TITLE
Change size of headers in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,16 @@
-## :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
+### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
 
-## :arrow_heading_down: What is the current behavior?
+### :arrow_heading_down: What is the current behavior?
 
-## :new: What is the new behavior (if this is a feature change)?
+### :new: What is the new behavior (if this is a feature change)?
 
-## :boom: Does this PR introduce a breaking change?
+### :boom: Does this PR introduce a breaking change?
 
-## :bug: Recommendations for testing
+### :bug: Recommendations for testing
 
-## :memo: Links to relevant issues/docs
+### :memo: Links to relevant issues/docs
 
-## :thinking: Checklist before submitting
+### :thinking: Checklist before submitting
 
 - [ ] All projects build
 - [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))


### PR DESCRIPTION
### :arrow_heading_down: What is the current behavior?
Headers are too big, making it hard to quickly scan the template

### :new: What is the new behavior (if this is a feature change)?
Properly sized headers :)

### :boom: Does this PR introduce a breaking change?
No

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop