### PR TITLE
Stop using unsupported applicationDidFinishLaunching on iOS.

### DIFF
--- a/MvvmCross/iOS/iOS/Platform/MvxApplicationDelegate.cs
+++ b/MvvmCross/iOS/iOS/Platform/MvxApplicationDelegate.cs
@@ -1,4 +1,4 @@
-// MvxApplicationDelegate.cs
+﻿// MvxApplicationDelegate.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -6,13 +6,13 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using Foundation;
 using MvvmCross.Core.Platform;
 using UIKit;
 
 namespace MvvmCross.iOS.Platform
 {
-    public class MvxApplicationDelegate : UIApplicationDelegate
-                                          , IMvxApplicationDelegate
+    public class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplicationDelegate
     {
         public override void WillEnterForeground(UIApplication application)
         {
@@ -29,9 +29,10 @@ namespace MvvmCross.iOS.Platform
             FireLifetimeChanged(MvxLifetimeEvent.Closing);
         }
 
-        public override void FinishedLaunching(UIApplication application)
+        public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
+            return true;
         }
 
         private void FireLifetimeChanged(MvxLifetimeEvent which)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix/hygiene

### :arrow_heading_down: What is the current behavior?

`MvxApplicationDelegate` uses an overload of the AppDelegare.FinishedLaunching that is no longer supported. Applications which instead override the newer supported overload will cause the LifetimeChanged event to not fire.

### :new: What is the new behavior (if this is a feature change)?

`MvxApplicationDelegate` uses the correct, newer supported overload.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

Apple states:

> Important
> For app initialization, it is highly recommended that you use this method and the application:willFinishLaunchingWithOptions: method and do not use the applicationDidFinishLaunching: method, which is intended only for apps that run on older versions of iOS.

https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application?language=objc

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
