### PR TITLE
MvxSimpleWpfViewPresenter supports MvxClosePresentationHint

### DIFF
--- a/MvvmCross/Windows/Wpf/Views/MvxSimpleWpfViewPresenter.cs
+++ b/MvvmCross/Windows/Wpf/Views/MvxSimpleWpfViewPresenter.cs
@@ -1,4 +1,4 @@
-// MvxSimpleWpfViewPresenter.cs
+﻿// MvxSimpleWpfViewPresenter.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -8,6 +8,9 @@
 using System.Windows;
 using System.Windows.Controls;
 using MvvmCross.Core.ViewModels;
+using MvvmCross.Platform.Platform;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MvvmCross.Wpf.Views
 {
@@ -15,19 +18,50 @@ namespace MvvmCross.Wpf.Views
         : MvxWpfViewPresenter
     {
         private readonly ContentControl _contentControl;
+        private Stack<FrameworkElement> _frameworkElements = new Stack<FrameworkElement>();
 
         public MvxSimpleWpfViewPresenter(ContentControl contentControl)
         {
             _contentControl = contentControl;
         }
 
+        public override void ChangePresentation(MvxPresentationHint hint)
+        {
+            base.ChangePresentation(hint);
+
+            if (hint is MvxClosePresentationHint)
+            {
+                Close((hint as MvxClosePresentationHint).ViewModelToClose);
+            }
+        }
+
         public override void Present(FrameworkElement frameworkElement)
         {
+            _frameworkElements.Push(frameworkElement);
             _contentControl.Content = frameworkElement;
         }
 
         public override void Close(IMvxViewModel toClose)
         {
+            if (_frameworkElements.Any() && CloseFrameworkElement(toClose))
+                return;
+
+            MvxTrace.Warning($"Could not close ViewModel type {toClose.GetType().Name}");
+        }
+
+        protected virtual bool CloseFrameworkElement(IMvxViewModel toClose)
+        {
+            var view = _frameworkElements.Peek() as IMvxWpfView;
+            if (toClose == view?.ViewModel)
+            {
+                _frameworkElements.Pop(); // Pop closing view
+                if (_frameworkElements.Any())
+                {
+                    Present(_frameworkElements.Pop());
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Can't close viewmodel in WPF app using default presenter.

### :new: What is the new behavior (if this is a feature change)?
Can close viewmodel in WPF app using default presenter and NavigationService

### :boom: Does this PR introduce a breaking change?
Yes. Changed default WPF presenter behavior.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
