### PR TITLE
Don't try to use deprecated init when using navigationservice

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -82,14 +82,17 @@ namespace MvvmCross.Core.ViewModels
     {
         public async Task Init(string parameter)
         {
-            IMvxJsonConverter serializer;
-            if (!Mvx.TryResolve(out serializer))
+            if(!string.IsNullOrEmpty(parameter))
             {
-                throw new MvxIoCResolveException("There is no implementation of IMvxJsonConverter registered. You need to use the MvvmCross Json plugin or create your own implementation of IMvxJsonConverter.");
-            }
+                IMvxJsonConverter serializer;
+                if (!Mvx.TryResolve(out serializer))
+                {
+                    throw new MvxIoCResolveException("There is no implementation of IMvxJsonConverter registered. You need to use the MvvmCross Json plugin or create your own implementation of IMvxJsonConverter.");
+                }
 
-            var deserialized = serializer.DeserializeObject<TParameter>(parameter);
-            await Initialize(deserialized);
+                var deserialized = serializer.DeserializeObject<TParameter>(parameter);
+                await Initialize(deserialized);
+            }
         }
 
         public abstract Task Initialize(TParameter parameter);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Throws when using new navigation

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
#2028

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
