### PR TITLE
Add MvxNavigationService to LinkerPleaseInclude

### DIFF
--- a/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
@@ -101,5 +101,10 @@ namespace $rootnamespace$
             var context2 = new MvxTaskBasedBindingContext();
             context2.Dispose();
         }
+
+        public void Include(MvvmCross.Core.Navigation.MvxNavigationService navigationService)
+        {
+            navigationService = new MvvmCross.Core.Navigation.MvxNavigationService()
+        }
     }
 }

--- a/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
@@ -113,5 +113,10 @@ namespace $rootnamespace$
         {
             changed.PropertyChanged += (sender, e) => { var test = e.PropertyName; };
         }
+        
+        public void Include(MvvmCross.Core.Navigation.MvxNavigationService navigationService)
+        {
+            navigationService = new MvvmCross.Core.Navigation.MvxNavigationService()
+        }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix (sort of)

### :arrow_heading_down: What is the current behavior?
MvxNavigationService gets stripped away by the linker, since there are no static usages of it or its constructor.

### :new: What is the new behavior (if this is a feature change)?
The navigation service gets preserved

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Check if the navigation service gets stripped when using Link All

### :memo: Links to relevant issues/docs
Closes #2025

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
