### PR TITLE
make WrapInNavigationController attribute working for tabBarControlle…

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -111,69 +111,38 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxRootPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            // check if viewController is a TabBarController
-            if (viewController is IMvxTabBarViewController tabBarController)
-            {
-                TabBarViewController = tabBarController;
-
-                if (!attribute.WrapInNavigationController)
-                {
-                    SetWindowRootViewController(viewController);
-
-                    CloseMasterNavigationController();
-                }
-                else
-                {
-                    viewController = CreateNavigationController(viewController);
-                    MasterNavigationController = viewController as MvxNavigationController;
-                    SetWindowRootViewController(viewController);
-                }
-
-                CleanupModalViewControllers();
-                CloseSplitViewController();
-
-                return;
-            }
-            // check if viewController is a SplitViewController
-            else if (viewController is IMvxSplitViewController splitController)
-            {
-                SplitViewController = splitController;
-
-                if (!attribute.WrapInNavigationController)
-                {
-                    SetWindowRootViewController(viewController);
-
-                    CloseMasterNavigationController();
-                }
-                else
-                {
-                    viewController = CreateNavigationController(viewController);
-                    MasterNavigationController = viewController as MvxNavigationController;
-                    SetWindowRootViewController(viewController);
-                }
-
-                CleanupModalViewControllers();
-                CloseTabBarViewController();
-
-                return;
-            }
-
             // check if viewController is trying to initialize a navigation stack
             if (attribute.WrapInNavigationController)
             {
                 viewController = CreateNavigationController(viewController);
                 MasterNavigationController = viewController as MvxNavigationController;
                 SetWindowRootViewController(viewController);
+            }
+            else
+            // display the plain viewController as root
+            {
+                SetWindowRootViewController(viewController);
 
-                CleanupModalViewControllers();
-                CloseTabBarViewController();
-                CloseSplitViewController();
-
-                return;
+                CloseMasterNavigationController();
             }
 
-            // last scenario: display the plain viewController as root
-            SetWindowRootViewController(viewController);
+            // check if viewController is a TabBarController
+            if (viewController is IMvxTabBarViewController tabBarController)
+            {
+                TabBarViewController = tabBarController;
+
+                CloseTabBarViewController();
+                CleanupModalViewControllers();
+            }
+            // check if viewController is a SplitViewController
+            else if (viewController is IMvxSplitViewController splitController)
+            {
+                SplitViewController = splitController;
+
+                CloseSplitViewController();
+                CleanupModalViewControllers();
+            }
+
         }
 
         protected virtual void ShowChildViewController(

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -131,23 +131,22 @@ namespace MvvmCross.iOS.Views.Presenters
             {
                 TabBarViewController = tabBarController;
 
-                CloseTabBarViewController();
-                CleanupModalViewControllers();
+                CloseSplitViewController();
             }
             // check if viewController is a SplitViewController
             else if (viewController is IMvxSplitViewController splitController)
             {
                 SplitViewController = splitController;
 
-                CloseSplitViewController();
-                CleanupModalViewControllers();
+                CloseTabBarViewController();
             }
             else
             {
                 CloseTabBarViewController();
                 CloseSplitViewController();
-                CleanupModalViewControllers();
             }
+
+            CleanupModalViewControllers();
         }
 
         protected virtual void ShowChildViewController(
@@ -172,15 +171,15 @@ namespace MvvmCross.iOS.Views.Presenters
                 }
             }
 
-            if (TabBarViewController != null && TabBarViewController.ShowChildView(viewController))
-            {
-                return;
-            }
-
             if (MasterNavigationController != null)
             {
                 PushViewControllerIntoStack(MasterNavigationController, viewController, attribute.Animated);
 
+                return;
+            }
+
+            if (TabBarViewController != null && TabBarViewController.ShowChildView(viewController))
+            {
                 return;
             }
 

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -115,11 +115,40 @@ namespace MvvmCross.iOS.Views.Presenters
             if (viewController is IMvxTabBarViewController tabBarController)
             {
                 TabBarViewController = tabBarController;
+                if (!attribute.WrapInNavigationController)
+                    SetWindowRootViewController(viewController);
+                else
+                {
+                    viewController = CreateNavigationController(viewController);
+                    MasterNavigationController = viewController as MvxNavigationController;
+                    SetWindowRootViewController(viewController);
+                }
+
+                CloseMasterNavigationController();
+                CleanupModalViewControllers();
+                CloseSplitViewController();
+
+                return;
             }
             // check if viewController is a SplitViewController
             else if (viewController is IMvxSplitViewController splitController)
             {
                 SplitViewController = splitController;
+
+                if (!attribute.WrapInNavigationController)
+                    SetWindowRootViewController(viewController);
+                else
+                {
+                    viewController = CreateNavigationController(viewController);
+                    MasterNavigationController = viewController as MvxNavigationController;
+                    SetWindowRootViewController(viewController);
+                }
+
+                CloseMasterNavigationController();
+                CleanupModalViewControllers();
+                CloseTabBarViewController();
+
+                return;
             }
 
             // check if viewController is trying to initialize a navigation stack

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -114,9 +114,9 @@ namespace MvvmCross.iOS.Views.Presenters
             // check if viewController is trying to initialize a navigation stack
             if (attribute.WrapInNavigationController)
             {
-                viewController = CreateNavigationController(viewController);
-                MasterNavigationController = viewController as MvxNavigationController;
-                SetWindowRootViewController(viewController);
+                var navigationController = CreateNavigationController(viewController);
+                MasterNavigationController = navigationController as MvxNavigationController;
+                SetWindowRootViewController(navigationController);
             }
             else
             // display the plain viewController as root
@@ -142,7 +142,6 @@ namespace MvvmCross.iOS.Views.Presenters
                 CloseSplitViewController();
                 CleanupModalViewControllers();
             }
-
         }
 
         protected virtual void ShowChildViewController(

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -115,26 +115,11 @@ namespace MvvmCross.iOS.Views.Presenters
             if (viewController is IMvxTabBarViewController tabBarController)
             {
                 TabBarViewController = tabBarController;
-                SetWindowRootViewController(viewController);
-
-                CloseMasterNavigationController();
-                CleanupModalViewControllers();
-                CloseSplitViewController();
-
-                return;
             }
-
             // check if viewController is a SplitViewController
-            if (viewController is IMvxSplitViewController splitController)
+            else if (viewController is IMvxSplitViewController splitController)
             {
                 SplitViewController = splitController;
-                SetWindowRootViewController(viewController);
-
-                CloseMasterNavigationController();
-                CleanupModalViewControllers();
-                CloseTabBarViewController();
-
-                return;
             }
 
             // check if viewController is trying to initialize a navigation stack

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -115,8 +115,13 @@ namespace MvvmCross.iOS.Views.Presenters
             if (viewController is IMvxTabBarViewController tabBarController)
             {
                 TabBarViewController = tabBarController;
+
                 if (!attribute.WrapInNavigationController)
+                {
                     SetWindowRootViewController(viewController);
+
+                    CloseMasterNavigationController();
+                }
                 else
                 {
                     viewController = CreateNavigationController(viewController);
@@ -124,7 +129,6 @@ namespace MvvmCross.iOS.Views.Presenters
                     SetWindowRootViewController(viewController);
                 }
 
-                CloseMasterNavigationController();
                 CleanupModalViewControllers();
                 CloseSplitViewController();
 
@@ -136,7 +140,11 @@ namespace MvvmCross.iOS.Views.Presenters
                 SplitViewController = splitController;
 
                 if (!attribute.WrapInNavigationController)
+                {
                     SetWindowRootViewController(viewController);
+
+                    CloseMasterNavigationController();
+                }
                 else
                 {
                     viewController = CreateNavigationController(viewController);
@@ -144,7 +152,6 @@ namespace MvvmCross.iOS.Views.Presenters
                     SetWindowRootViewController(viewController);
                 }
 
-                CloseMasterNavigationController();
                 CleanupModalViewControllers();
                 CloseTabBarViewController();
 

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -142,6 +142,12 @@ namespace MvvmCross.iOS.Views.Presenters
                 CloseSplitViewController();
                 CleanupModalViewControllers();
             }
+            else
+            {
+                CloseTabBarViewController();
+                CloseSplitViewController();
+                CleanupModalViewControllers();
+            }
         }
 
         protected virtual void ShowChildViewController(

--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -7,7 +7,7 @@ using UIKit;
 namespace Playground.iOS.Views
 {
     [MvxFromStoryboard("Main")]
-    [MvxRootPresentation(WrapInNavigationController =true)]
+    [MvxRootPresentation(WrapInNavigationController = true)]
     public partial class TabsRootView : MvxTabBarViewController<TabsRootViewModel>
     {
         private bool _isPresentedFirstTime = true;

--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
 using Playground.Core.ViewModels;
@@ -7,7 +7,7 @@ using UIKit;
 namespace Playground.iOS.Views
 {
     [MvxFromStoryboard("Main")]
-    //[MvxRootPresentation]
+    [MvxRootPresentation(WrapInNavigationController =true)]
     public partial class TabsRootView : MvxTabBarViewController<TabsRootViewModel>
     {
         private bool _isPresentedFirstTime = true;


### PR DESCRIPTION
make WrapInNavigationController attribute of MvxRootPresentationAttribute  working for tabBarController/ splitController

### :sparkles: What kind of change does this PR introduce? Bug fix

### :arrow_heading_down: What is the current behavior?

[MvxRootPresentation(WrapInNavigationController = true)], the WrapInNavigationController attribute is not working for MvxTabBarViewController and MvxSplitViewController

### :new: What is the new behavior (if this is a feature change)?

make the WrapInNavigationController  attrobute working

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

None

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
