### PR TITLE
navigation service in default app start

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxAppStart.cs
@@ -5,6 +5,8 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using MvvmCross.Core.Navigation;
+using MvvmCross.Platform;
 using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Core.ViewModels
@@ -19,7 +21,8 @@ namespace MvvmCross.Core.ViewModels
             {
                 MvxTrace.Trace("Hint ignored in default MvxAppStart");
             }
-            ShowViewModel<TViewModel>();
+            var navigationService = Mvx.Resolve<IMvxNavigationService>();
+            navigationService?.Navigate<TViewModel>();
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix?

### :arrow_heading_down: What is the current behavior?
Default MvxAppStart use legacy navigation (ShowViewModel), therefore eg. Initialize method of first ViewModel isn't fired.

### :new: What is the new behavior (if this is a feature change)?
Initialize method of first ViewModel is fired :)

### :boom: Does this PR introduce a breaking change?
For someone who use default MvxAppStart - Yes :)

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
