### PR TITLE
Add support for one sidemenu at a time

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
@@ -6,11 +6,11 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
 {
     public static class ViewControllerExtensions
     {
-        public static void ShowMenuButton(this UIViewController viewController, MvxSidebarViewController sidebarPanelController)
+        public static void ShowMenuButton(this UIViewController viewController, MvxSidebarViewController sidebarPanelController, bool showLeft = true, bool showRight = true)
         {
             UIBarButtonItem barButtonItem;
 
-            if (sidebarPanelController.HasLeftMenu)
+            if (sidebarPanelController.HasLeftMenu && showLeft)
             {
                 var mvxSidebarMenu = sidebarPanelController.LeftSidebarController.MenuAreaController as IMvxSidebarMenu;
                 sidebarPanelController.LeftSidebarController.MenuLocation = MenuLocations.Left;
@@ -19,7 +19,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
                 viewController.NavigationItem.SetLeftBarButtonItem(barButtonItem, true);
             }
 
-            if (sidebarPanelController.HasRightMenu)
+            if (sidebarPanelController.HasRightMenu && showRight)
             {
                 var mvxSidebarMenu = sidebarPanelController.RightSidebarController.MenuAreaController as IMvxSidebarMenu;
                 sidebarPanelController.RightSidebarController.MenuLocation = MenuLocations.Right;

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxPanelEnum.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxPanelEnum.cs
@@ -5,6 +5,8 @@
         None,
         Center,
         Left,
-        Right
+        Right,
+        CenterWithLeft,
+        CenterWithRight
     }
 }

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -118,11 +118,11 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
                     break;
                 case MvxPanelEnum.CenterWithLeft:
                     navigationController.PushViewController(viewController, true);
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, true, false);
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: true, showRight: false);
                     break;
                 case MvxPanelEnum.CenterWithRight:
                     navigationController.PushViewController(viewController, true);
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, false, true);
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: false, showRight: true);
                     break;
             }
 

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -90,10 +90,10 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
                     viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController);
                     break;
                 case MvxPanelEnum.CenterWithLeft:
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, true, false);
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: true, showRight: false);
                     break;
                 case MvxPanelEnum.CenterWithRight:
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, false, true);
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: false, showRight: true);
                     break;
             }
 

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -80,8 +80,22 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
             navigationController.ViewControllers = new[] { viewController };
 
-            if (panel == MvxPanelEnum.Center)
-                viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController);
+            switch (panel)
+            {
+                case MvxPanelEnum.Left:
+                case MvxPanelEnum.Right:
+                    break;
+                case MvxPanelEnum.Center:
+                default:
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController);
+                    break;
+                case MvxPanelEnum.CenterWithLeft:
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, true, false);
+                    break;
+                case MvxPanelEnum.CenterWithRight:
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, false, true);
+                    break;
+            }
 
             return true;
         }
@@ -90,6 +104,9 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
         {
             var navigationController = (SideBarViewController as MvxSidebarViewController).NavigationController;
 
+            if (navigationController == null)
+                return false;
+
             switch (panel)
             {
                 case MvxPanelEnum.Left:
@@ -97,7 +114,15 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
                     break;
                 case MvxPanelEnum.Center:
                 default:
-                    navigationController?.PushViewController(viewController, true);
+                    navigationController.PushViewController(viewController, true);
+                    break;
+                case MvxPanelEnum.CenterWithLeft:
+                    navigationController.PushViewController(viewController, true);
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, true, false);
+                    break;
+                case MvxPanelEnum.CenterWithRight:
+                    navigationController.PushViewController(viewController, true);
+                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, false, true);
                     break;
             }
 

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/MvvmCross.iOS.Support.XamarinSidebarSample.Core.csproj
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/MvvmCross.iOS.Support.XamarinSidebarSample.Core.csproj
@@ -47,6 +47,7 @@
     <Compile Include="ViewModels\LeftPanelViewModel.cs" />
     <Compile Include="ViewModels\MasterViewModel.cs" />
     <Compile Include="ViewModels\RightPanelViewModel.cs" />
+    <Compile Include="ViewModels\DetailRightViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\MvvmCross\Core\Core\MvvmCross.Core.csproj">

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/DetailRightViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/DetailRightViewModel.cs
@@ -1,0 +1,10 @@
+namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
+{
+    public class DetailRightViewModel : BaseViewModel
+    {
+        public DetailRightViewModel()
+        {
+            ExampleValue = "Details Right menu";
+        }
+    }
+}

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
@@ -23,9 +23,22 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
             }
         }
 
+        public IMvxCommand ShowDetailRightCommand
+        {
+            get
+            {
+                return new MvxCommand(ShowDetailRightCommandExecuted);
+            }
+        }
+
         private void ShowDetailCommandExecuted()
         {
             _navigationService.Navigate<DetailViewModel>();
+        }
+
+        private void ShowDetailRightCommandExecuted()
+        {
+            _navigationService.Navigate<DetailRightViewModel>();
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/MvvmCross.iOS.Support.XamarinSidebarSample.iOS.csproj
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/MvvmCross.iOS.Support.XamarinSidebarSample.iOS.csproj
@@ -106,6 +106,7 @@
     <Compile Include="..\..\..\..\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Views\DetailRightView.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/DetailRightView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/DetailRightView.cs
@@ -1,0 +1,39 @@
+using Cirrious.FluentLayouts.Touch;
+using Foundation;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.iOS.Support.XamarinSidebar;
+using MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels;
+using UIKit;
+
+namespace MvvmCross.iOS.Support.XamarinSidebarSample.iOS.Views
+{
+    [Register("DetailRightView")]
+    [MvxSidebarPresentation(MvxPanelEnum.CenterWithRight, MvxPanelHintType.PushPanel, true, MvxSplitViewBehaviour.Detail)]
+    public class DetailRightView : BaseViewController<DetailRightViewModel>
+    {
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+
+            View.BackgroundColor = UIColor.Gray;
+
+            var label = new UILabel();
+
+            var bindingSet = this.CreateBindingSet<DetailRightView, DetailRightViewModel>();
+            bindingSet.Bind(label).To(vm => vm.ExampleValue);
+
+            bindingSet.Apply();
+
+            Add(label);
+
+            View.SubviewsDoNotTranslateAutoresizingMaskIntoConstraints();
+
+            View.AddConstraints(
+
+                label.WithSameCenterX(View),
+                label.WithSameCenterY(View)
+
+                );
+        }
+    }
+}

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
@@ -32,6 +32,9 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.iOS.Views
             var detailButton = new UIButton();
             detailButton.SetTitle("Show Detail", UIControlState.Normal);
 
+            var detailRightButton = new UIButton();
+            detailRightButton.SetTitle("Show Detail with right menu", UIControlState.Normal);
+
             var toggleMenuButton = new UIButton();
             toggleMenuButton.SetTitle("Open menu", UIControlState.Normal);
             toggleMenuButton.TouchUpInside += (s, e) =>
@@ -43,10 +46,12 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.iOS.Views
             var bindingSet = this.CreateBindingSet<MasterView, MasterViewModel>();
             bindingSet.Bind(label).To(vm => vm.ExampleValue);
             bindingSet.Bind(detailButton).To(vm => vm.ShowDetailCommand);
+            bindingSet.Bind(detailRightButton).To(vm => vm.ShowDetailRightCommand);
             bindingSet.Apply();
 
             Add(label);
             Add(detailButton);
+            Add(detailRightButton);
             Add(toggleMenuButton);
 
             View.SubviewsDoNotTranslateAutoresizingMaskIntoConstraints();
@@ -60,7 +65,10 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.iOS.Views
                 detailButton.WithSameCenterX(View),
 
                 toggleMenuButton.Below(detailButton, 10),
-                toggleMenuButton.WithSameCenterX(View)
+                toggleMenuButton.WithSameCenterX(View),
+
+                detailRightButton.Below(toggleMenuButton, 10),
+                detailRightButton.WithSameCenterX(View)
 
                 );
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
If you use a left and right sidemenu both will always be shown.

### :new: What is the new behavior (if this is a feature change)?
With the new enums you can shown either a menu on the right or just one on the left.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
