### PR TITLE
Add Transitioning sample to ModalView in Playground iOS

### DIFF
--- a/TestProjects/Playground/Playground.iOS/Views/ModalView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/ModalView.cs
@@ -1,4 +1,5 @@
 using System;
+using CoreGraphics;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
@@ -19,6 +20,8 @@ namespace Playground.iOS.Views
         {
             base.ViewDidLoad();
 
+            TransitioningDelegate = new TransitioningDelegate();
+
             View.BackgroundColor = UIColor.Orange;
 
             var set = this.CreateBindingSet<ModalView, ModalViewModel>();
@@ -28,6 +31,42 @@ namespace Playground.iOS.Views
             set.Bind(btnNestedModal).To(vm => vm.ShowNestedModalCommand);
 
             set.Apply();
+        }
+    }
+
+    public class TransitioningDelegate : UIViewControllerTransitioningDelegate
+    {
+        public override IUIViewControllerAnimatedTransitioning GetAnimationControllerForPresentedController(UIViewController presented, UIViewController presenting, UIViewController source)
+        {
+            return new CustomTransitionAnimator();
+        }
+    }
+
+    public class CustomTransitionAnimator : UIViewControllerAnimatedTransitioning
+    {
+        public override double TransitionDuration(IUIViewControllerContextTransitioning transitionContext)
+        {
+            return 1.0f;
+        }
+
+        public override void AnimateTransition(IUIViewControllerContextTransitioning transitionContext)
+        {
+            var inView = transitionContext.ContainerView;
+            var toVC = transitionContext.GetViewControllerForKey(UITransitionContext.ToViewControllerKey);
+            var toView = toVC.View;
+
+            inView.AddSubview(toView);
+
+            var frame = toView.Frame;
+            toView.Frame = CGRect.Empty;
+
+            UIView.Animate(TransitionDuration(transitionContext), () =>
+            {
+                toView.Frame = new CGRect(10, 10, frame.Width - 20, frame.Height - 20);
+            }, () =>
+            {
+                transitionContext.CompleteTransition(true);
+            });
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Sample update

### :arrow_heading_down: What is the current behavior?
No iOS UIViewControllerTransitioningDelegate sample (it isn't verified whether this work or not with MvxIosViewPresenter).

### :new: What is the new behavior (if this is a feature change)?
There is a UIViewControllerTransitioningDelegate sample, and it is verified to work with MvxIosViewPresenter.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run TestProjects/Playground.iOS and show ModalView

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop