### PR TITLE
Move result close to the navigation service

### DIFF
--- a/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
@@ -48,6 +48,7 @@ namespace MvvmCross.Core.Navigation
         Task<bool> CanNavigate(string path);
 
         Task<bool> Close(IMvxViewModel viewModel);
+        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result) where TResult : class;
 
         bool ChangePresentation(MvxPresentationHint hint);
     }

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationExtensions.cs
@@ -42,10 +42,5 @@ namespace MvvmCross.Core.Navigation
         {
             return navigationService.Navigate<TParameter, TResult>(path.ToString(), param, presentationBundle, cancellationToken);
         }
-
-        public static Task<bool> Close<TViewModel>(this IMvxNavigationService navigationService)
-        {
-            return navigationService.Close((IMvxViewModel)Mvx.IocConstruct<TViewModel>());
-        }
     }
 }

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -169,9 +169,9 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
+            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
-            ViewDispatcher.ShowViewModel(request);
             OnAfterNavigate(this, args);
         }
 
@@ -180,10 +180,10 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            await viewModel.Initialize(param).ConfigureAwait(false);
+            viewModel.Declare(param);
+            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
-            ViewDispatcher.ShowViewModel(request);
             OnAfterNavigate(this, args);
         }
 
@@ -200,12 +200,12 @@ namespace MvvmCross.Core.Navigation
             }
 
             var tcs = new TaskCompletionSource<object>();
-            viewModel.SetClose(tcs);
+            viewModel.CloseCompletionSource = tcs;
             _tcsResults.Add(viewModel, tcs);
 
+            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
-            ViewDispatcher.ShowViewModel(request);
             OnAfterNavigate(this, args);
 
             try
@@ -231,13 +231,14 @@ namespace MvvmCross.Core.Navigation
             }
 
             var tcs = new TaskCompletionSource<object>();
-            viewModel.SetClose(tcs);
+            viewModel.CloseCompletionSource = tcs;
             _tcsResults.Add(viewModel, tcs);
 
-            await viewModel.Initialize(param).ConfigureAwait(false);
+            viewModel.Declare(param);
+            ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
-            ViewDispatcher.ShowViewModel(request);
+
             OnAfterNavigate(this, args);
 
             try
@@ -371,7 +372,7 @@ namespace MvvmCross.Core.Navigation
             _tcsResults.TryGetValue(viewModel, out TaskCompletionSource<object> _tcs);
 
             //Disable cancelation of the Task when closing ViewModel through the service
-            viewModel.SetClose(null);
+            viewModel.CloseCompletionSource = null;
 
             try
             {
@@ -379,7 +380,7 @@ namespace MvvmCross.Core.Navigation
                 if (closeResult)
                     _tcs?.TrySetResult(result);
                 else
-                    viewModel.SetClose(_tcs);
+                    viewModel.CloseCompletionSource = _tcs;
                 return closeResult;
             }
             catch (Exception ex)

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -378,7 +378,10 @@ namespace MvvmCross.Core.Navigation
             {
                 var closeResult = await Close(viewModel);
                 if (closeResult)
+                {
                     _tcs?.TrySetResult(result);
+                    _tcsResults.Remove(viewModel);
+                }
                 else
                     viewModel.CloseCompletionSource = _tcs;
                 return closeResult;

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -169,6 +169,7 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
+            viewModel.Declare();
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
@@ -203,6 +204,7 @@ namespace MvvmCross.Core.Navigation
             viewModel.CloseCompletionSource = tcs;
             _tcsResults.Add(viewModel, tcs);
 
+            viewModel.Declare();
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -169,7 +169,7 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            viewModel.Declare();
+            viewModel.Prepare();
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
@@ -181,7 +181,7 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            viewModel.Declare(param);
+            viewModel.Prepare(param);
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
@@ -204,7 +204,7 @@ namespace MvvmCross.Core.Navigation
             viewModel.CloseCompletionSource = tcs;
             _tcsResults.Add(viewModel, tcs);
 
-            viewModel.Declare();
+            viewModel.Prepare();
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 
@@ -236,7 +236,7 @@ namespace MvvmCross.Core.Navigation
             viewModel.CloseCompletionSource = tcs;
             _tcsResults.Add(viewModel, tcs);
 
-            viewModel.Declare(param);
+            viewModel.Prepare(param);
             ViewDispatcher.ShowViewModel(request);
             await viewModel.Initialize().ConfigureAwait(false);
 

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -43,8 +43,7 @@ namespace MvvmCross.Core.ViewModels
     //TODO: Can we keep the IMvxViewModel syntax here? Compiler complains
     public interface IMvxViewModelResult<TResult> : IMvxViewModel where TResult : class
     {
-        void SetClose(TaskCompletionSource<TResult> tcs, CancellationToken cancellationToken);
-        Task<bool> Close(TResult result);
+        void SetClose(TaskCompletionSource<object> tcs);
     }
 
     public interface IMvxViewModel<TParameter, TResult> : IMvxViewModel<TParameter>, IMvxViewModelResult<TResult> where TParameter : class where TResult : class

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -32,6 +32,8 @@ namespace MvvmCross.Core.ViewModels
 
         void SaveState(IMvxBundle state);
 
+        void Declare();
+
         Task Initialize();
     }
 

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -37,13 +37,13 @@ namespace MvvmCross.Core.ViewModels
 
     public interface IMvxViewModel<TParameter> : IMvxViewModel where TParameter : class
     {
-        Task Initialize(TParameter parameter);
+        void Declare(TParameter parameter);
     }
 
     //TODO: Can we keep the IMvxViewModel syntax here? Compiler complains
     public interface IMvxViewModelResult<TResult> : IMvxViewModel where TResult : class
     {
-        void SetClose(TaskCompletionSource<object> tcs);
+        TaskCompletionSource<object> CloseCompletionSource { get; set; }
     }
 
     public interface IMvxViewModel<TParameter, TResult> : IMvxViewModel<TParameter>, IMvxViewModelResult<TResult> where TParameter : class where TResult : class

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -32,14 +32,14 @@ namespace MvvmCross.Core.ViewModels
 
         void SaveState(IMvxBundle state);
 
-        void Declare();
+        void Prepare();
 
         Task Initialize();
     }
 
     public interface IMvxViewModel<TParameter> : IMvxViewModel where TParameter : class
     {
-        void Declare(TParameter parameter);
+        void Prepare(TParameter parameter);
     }
 
     //TODO: Can we keep the IMvxViewModel syntax here? Compiler complains

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -76,7 +76,7 @@ namespace MvvmCross.Core.ViewModels
         {
         }
 
-        public virtual void Declare()
+        public virtual void Prepare()
         {
             
         }
@@ -100,12 +100,12 @@ namespace MvvmCross.Core.ViewModels
                 }
 
                 var deserialized = serializer.DeserializeObject<TParameter>(parameter);
-                Declare(deserialized);
+                Prepare(deserialized);
                 await Initialize();
             }
         }
 
-        public abstract void Declare(TParameter parameter);
+        public abstract void Prepare(TParameter parameter);
     }
 
     //TODO: Not possible to name MvxViewModel, name is MvxViewModelResult for now
@@ -123,6 +123,6 @@ namespace MvvmCross.Core.ViewModels
 
     public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class
     {
-        public abstract void Declare(TParameter parameter);
+        public abstract void Prepare(TParameter parameter);
     }
 }

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -95,33 +95,29 @@ namespace MvvmCross.Core.ViewModels
                 }
 
                 var deserialized = serializer.DeserializeObject<TParameter>(parameter);
-                await Initialize(deserialized);
+                Declare(deserialized);
+                await Initialize();
             }
         }
 
-        public abstract Task Initialize(TParameter parameter);
+        public abstract void Declare(TParameter parameter);
     }
 
     //TODO: Not possible to name MvxViewModel, name is MvxViewModelResult for now
     public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult> where TResult : class
     {
-        private TaskCompletionSource<object> _tcs;
-
-        public void SetClose(TaskCompletionSource<object> tcs)
-        {
-            _tcs = tcs;
-        }
+        public TaskCompletionSource<object> CloseCompletionSource { get; set; }
 
         public override void ViewDestroy()
         {
-            if (_tcs != null && !_tcs.Task.IsCompleted && !_tcs.Task.IsFaulted)
-                _tcs?.TrySetCanceled();
+            if (CloseCompletionSource != null && !CloseCompletionSource.Task.IsCompleted && !CloseCompletionSource.Task.IsFaulted)
+                CloseCompletionSource?.TrySetCanceled();
             base.ViewDestroy();
         }
     }
 
     public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class
     {
-        public abstract Task Initialize(TParameter parameter);
+        public abstract void Declare(TParameter parameter);
     }
 }

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -76,6 +76,11 @@ namespace MvvmCross.Core.ViewModels
         {
         }
 
+        public virtual void Declare()
+        {
+            
+        }
+
         public virtual Task Initialize()
         {
             return Task.FromResult(true);

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
@@ -4,7 +4,7 @@ using MvvmCross.Core.ViewModels;
 
 namespace RoutingExample.Core.ViewModels
 {
-    public class MainViewModel : MvxViewModel
+    public class MainViewModel : MvxViewModelResult<User>
     {
         private readonly IMvxNavigationService _navigationService;
 
@@ -49,6 +49,7 @@ namespace RoutingExample.Core.ViewModels
                     //var result = await _navigationService.Navigate<User, User>("mvx://test/?id=" + Guid.NewGuid().ToString("N"), new User("MvvmCross2", "Test2"));
                     var result = await _navigationService.Navigate<TestBViewModel, User, User>(new User("MvvmCross", "Test"));
                     var test = result?.FirstName;
+                    await _navigationService.Close(this, new User("Close parent", "Test"));
                 }));
             }
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestAViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestAViewModel.cs
@@ -24,10 +24,9 @@ namespace RoutingExample.Core.ViewModels
             
         }
 
-        public override async Task Initialize(User parameter)
+        public override void Declare(User parameter)
         {
             var test = parameter;
-            await Task.FromResult(true);
         }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestAViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestAViewModel.cs
@@ -24,7 +24,7 @@ namespace RoutingExample.Core.ViewModels
             
         }
 
-        public override void Declare(User parameter)
+        public override void Prepare(User parameter)
         {
             var test = parameter;
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
@@ -39,7 +39,7 @@ namespace RoutingExample.Core.ViewModels
         public IMvxAsyncCommand OpenViewModelBCommand => new MvxAsyncCommand(
             () =>  _navigationService.Navigate<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
 
-        public override async Task Initialize(User parameter)
+        public override void Declare(User parameter)
         {
             _user = parameter;
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
@@ -39,7 +39,7 @@ namespace RoutingExample.Core.ViewModels
         public IMvxAsyncCommand OpenViewModelBCommand => new MvxAsyncCommand(
             () =>  _navigationService.Navigate<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
 
-        public override void Declare(User parameter)
+        public override void Prepare(User parameter)
         {
             _user = parameter;
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
@@ -10,8 +10,10 @@ namespace RoutingExample.Core.ViewModels
     public class TestBViewModel
         : MvxViewModel<User, User>
     {
-        public TestBViewModel()
+        private readonly IMvxNavigationService _navigationService;
+        public TestBViewModel(IMvxNavigationService navigationService)
         {
+            _navigationService = navigationService;
         }
 
         private string _id;
@@ -29,13 +31,13 @@ namespace RoutingExample.Core.ViewModels
         private User _user;
 
         public IMvxAsyncCommand CloseViewModelCommand => new MvxAsyncCommand(
-            () => Close(new User("Return result", "Something")));
+            () => _navigationService.Close(this, new User("Return result", "Something")));
         public IMvxAsyncCommand OpenViewModelMainCommand => new MvxAsyncCommand(
-            () => Mvx.Resolve<IMvxNavigationService>().Navigate<MainViewModel>());
+            () => _navigationService.Navigate<MainViewModel>());
         public IMvxAsyncCommand OpenViewModelACommand => new MvxAsyncCommand(
-            () =>  Mvx.Resolve<IMvxNavigationService>().Navigate<TestAViewModel, User>(new User($"To A from {GetHashCode()}", "Something")));
+            () =>  _navigationService.Navigate<TestAViewModel, User>(new User($"To A from {GetHashCode()}", "Something")));
         public IMvxAsyncCommand OpenViewModelBCommand => new MvxAsyncCommand(
-            () =>  Mvx.Resolve<IMvxNavigationService>().Navigate<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
+            () =>  _navigationService.Navigate<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
 
         public override async Task Initialize(User parameter)
         {

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelA.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelA.cs
@@ -47,7 +47,7 @@ namespace RoutingExample.Core.ViewModels
             ReturnedFrom = $"Returned from View B {_returnedFromCount} times";
         }
 
-        public override void Declare(string parameter)
+        public override void Prepare(string parameter)
         {
             
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelA.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelA.cs
@@ -47,9 +47,9 @@ namespace RoutingExample.Core.ViewModels
             ReturnedFrom = $"Returned from View B {_returnedFromCount} times";
         }
 
-        public override Task Initialize(string parameter)
+        public override void Declare(string parameter)
         {
-            return Task.FromResult(true);
+            
         }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
@@ -61,11 +61,9 @@ namespace RoutingExample.Core.ViewModels
             ReturnedFrom = $"Returned from View C {_returnedFromCount} times";
         }
 
-        public override Task Initialize(Tuple<string, int> parameter)
+        public override void Declare(Tuple<string, int> parameter)
         {
             NavigatedTo = $"Navigated to from {parameter.Item1} {parameter.Item2} times";
-
-            return Task.FromResult(true);
         }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
@@ -61,7 +61,7 @@ namespace RoutingExample.Core.ViewModels
             ReturnedFrom = $"Returned from View C {_returnedFromCount} times";
         }
 
-        public override void Declare(Tuple<string, int> parameter)
+        public override void Prepare(Tuple<string, int> parameter)
         {
             NavigatedTo = $"Navigated to from {parameter.Item1} {parameter.Item2} times";
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
@@ -49,7 +49,7 @@ namespace RoutingExample.Core.ViewModels
 
         public MvxCommand CloseCommand => new MvxCommand(async () =>
         {
-            await Close(Title);
+            await _navigationService.Close(this, Title);
         });
 
         public ViewModelB(IMvxNavigationService navigationService)

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
@@ -28,11 +28,9 @@ namespace RoutingExample.Core.ViewModels
             await _navigationService.Close(this, Title);
         });
 
-        public override Task Initialize(Tuple<string, int> parameter)
+        public override void Declare(Tuple<string, int> parameter)
         {
             NavigatedTo = $"Navigated to from {parameter.Item1} {parameter.Item2} times";
-
-            return Task.FromResult(true);
         }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
@@ -1,12 +1,19 @@
 ﻿using System;
 using System.Threading.Tasks;
+using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 
 namespace RoutingExample.Core.ViewModels
 {
-    public class ViewModelC : MvxViewModel<Tuple<string, int>,string>
+    public class ViewModelC : MvxViewModel<Tuple<string, int>, string>
     {
+        private readonly IMvxNavigationService _navigationService;
         private string _navigatedTo;
+
+        public ViewModelC(IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService;
+        }
 
         public string Title => "View C";
 
@@ -18,7 +25,7 @@ namespace RoutingExample.Core.ViewModels
 
         public MvxCommand CloseCommand => new MvxCommand(async () =>
         {
-            await Close(Title);
+            await _navigationService.Close(this, Title);
         });
 
         public override Task Initialize(Tuple<string, int> parameter)

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
@@ -28,7 +28,7 @@ namespace RoutingExample.Core.ViewModels
             await _navigationService.Close(this, Title);
         });
 
-        public override void Declare(Tuple<string, int> parameter)
+        public override void Prepare(Tuple<string, int> parameter)
         {
             NavigatedTo = $"Navigated to from {parameter.Item1} {parameter.Item2} times";
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
@@ -29,10 +29,9 @@ namespace Playground.Core.ViewModels
         }
 
         string para;
-        public override async Task Initialize(string parameter)
+        public override void Declare(string parameter)
         {
             para = parameter;
-            await Task.Delay(3000);
         }
 
         public override void ViewAppeared()

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
@@ -29,7 +29,7 @@ namespace Playground.Core.ViewModels
         }
 
         string para;
-        public override void Declare(string parameter)
+        public override void Prepare(string parameter)
         {
             para = parameter;
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
@@ -1,10 +1,12 @@
 ﻿using System.Windows.Input;
 using MvvmCross.Core.Navigation;
+﻿using System;
+using System.Threading.Tasks;
 using MvvmCross.Core.ViewModels;
 
 namespace Playground.Core.ViewModels
 {
-    public class Tab1ViewModel : MvxViewModel
+    public class Tab1ViewModel : MvxViewModel<string>
     {
         private readonly IMvxNavigationService _navigationService;
 
@@ -19,6 +21,23 @@ namespace Playground.Core.ViewModels
             OpenNavModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+        }
+
+        public override async Task Initialize()
+        {
+            await Task.Delay(3000);
+        }
+
+        string para;
+        public override async Task Initialize(string parameter)
+        {
+            para = parameter;
+            await Task.Delay(3000);
+        }
+
+        public override void ViewAppeared()
+        {
+            base.ViewAppeared();
         }
 
         public IMvxAsyncCommand OpenChildCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+﻿using System;
 using System.Windows.Input;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
@@ -11,8 +12,7 @@ namespace Playground.Core.ViewModels
 
         public TabsRootViewModel(IMvxNavigationService navigationService)
         {
-            _navigationService = navigationService;
-
+            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
             ShowInitialViewModelsCommand = new MvxAsyncCommand(ShowInitialViewModels);
         }
 
@@ -20,9 +20,9 @@ namespace Playground.Core.ViewModels
 
         private async Task ShowInitialViewModels()
         {
-            await _navigationService.Navigate<Tab1ViewModel>();
-            await _navigationService.Navigate<Tab2ViewModel>();
-            await _navigationService.Navigate<Tab3ViewModel>();
+            await _navigationService.Navigate<Tab1ViewModel, string>("test").ConfigureAwait(false);
+            await _navigationService.Navigate<Tab2ViewModel>().ConfigureAwait(false);
+            await _navigationService.Navigate<Tab3ViewModel>().ConfigureAwait(false);
         }
     }
 }

--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -1,4 +1,6 @@
-﻿using System;
+
+using System;
+using System.Threading.Tasks;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
 using Playground.Core.ViewModels;

--- a/docs/_documentation/fundamentals/navigation.md
+++ b/docs/_documentation/fundamentals/navigation.md
@@ -68,7 +68,7 @@ public class MyViewModel : MvxViewModel
         _navigationService = navigationService;
     }
     
-    public override void Declare()
+    public override void Prepare()
     {
         //Do anything before navigating to the view
     }
@@ -81,7 +81,7 @@ public class MyViewModel : MvxViewModel
 
 public class NextViewModel : MvxViewModel<MyObject>
 {
-    public override void Declare(MyObject parameter)
+    public override void Prepare(MyObject parameter)
     {
         //Do anything before navigating to the view
         //Save the parameter to a property if you want to use it later
@@ -125,7 +125,7 @@ public class NextViewModel : MvxViewModel<MyObject, MyReturnObject>
         _navigationService = navigationService;
     }
     
-    public override void Declare(MyObject parameter)
+    public override void Prepare(MyObject parameter)
     {
         //Do anything before navigating to the view
         //Save the parameter to a property if you want to use it later

--- a/docs/_documentation/fundamentals/navigation.md
+++ b/docs/_documentation/fundamentals/navigation.md
@@ -38,6 +38,9 @@ public interface IMvxNavigationService
 
     Task<bool> CanNavigate(string path);
     Task<bool> Close(IMvxViewModel viewModel);
+    Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result) where TResult : class;
+
+    bool ChangePresentation(MvxPresentationHint hint);
 }
 ```
 
@@ -51,7 +54,6 @@ public static class MvxNavigationExtensions
     public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class
     public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
     public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
-    public static Task<bool> Close<TViewModel>(this IMvxNavigationService navigationService)
 }
 ```
 
@@ -65,6 +67,11 @@ public class MyViewModel : MvxViewModel
     {
         _navigationService = navigationService;
     }
+    
+    public override void Declare()
+    {
+        //Do anything before navigating to the view
+    }
 
     public async Task SomeMethod()
     {
@@ -74,9 +81,15 @@ public class MyViewModel : MvxViewModel
 
 public class NextViewModel : MvxViewModel<MyObject>
 {
-    public async Task Initialize(MyObject parameter)
+    public override void Declare(MyObject parameter)
     {
-        //Do something with parameter
+        //Do anything before navigating to the view
+        //Save the parameter to a property if you want to use it later
+    }
+    
+    public override async Task Initialize()
+    {
+        //Do heavy work and data loading here
     }
 }
 ```
@@ -91,6 +104,11 @@ public class MyViewModel : MvxViewModel
     {
         _navigationService = navigationService;
     }
+    
+    public override async Task Initialize()
+    {
+        //Do heavy work and data loading here
+    }
 
     public async Task SomeMethod()
     {
@@ -101,14 +119,26 @@ public class MyViewModel : MvxViewModel
 
 public class NextViewModel : MvxViewModel<MyObject, MyReturnObject>
 {
-    public async Task Initialize(MyObject parameter)
+    private readonly IMvxNavigationService _navigationService;
+    public MyViewModel(IMvxNavigationService navigation)
     {
-        //Do something with parameter
+        _navigationService = navigationService;
     }
     
-    public async Task SomeMethod()
+    public override void Declare(MyObject parameter)
     {
-        await Close(new MyReturnObject());
+        //Do anything before navigating to the view
+        //Save the parameter to a property if you want to use it later
+    }
+    
+    public override async Task Initialize()
+    {
+        //Do heavy work and data loading here
+    }
+    
+    public async Task SomeMethodToClose()
+    {
+        await _navigationService.Close(this, new MyReturnObject());
     }
 }
 ```
@@ -118,6 +148,19 @@ You can provide a CancellationToken to abort waiting for a Result. This will clo
 If you have a BaseViewModel you might not be able to inherit `MvxViewModel<TParameter>` or `MvxViewModel<TParameter, TResult>` because you already have the BaseViewModel as base class. In this case you can implement the following interface:
 
 `IMvxViewModel<TParameter>`, `IMvxViewModelResult<TResult>` or `IMvxViewModel<TParameter, TResult>`
+
+To implement returning your own result add the following to your (Base)ViewModel:
+
+```c#
+public override TaskCompletionSource<object> CloseCompletionSource { get; set; }
+
+public override void ViewDestroy()
+{
+    if (CloseCompletionSource != null && !CloseCompletionSource.Task.IsCompleted && !CloseCompletionSource.Task.IsFaulted)
+        CloseCompletionSource?.TrySetCanceled();
+    base.ViewDestroy();
+}
+```
 
 To check if you are able to navigate to a certain ViewModel you can use the `CanNavigate` method.
 
@@ -170,7 +213,7 @@ namespace *.ViewModels
     public class ViewModelA
         : MvxViewModel
     {
-    	public void Initialize(string id) // you can use captured groups defined in the regex as parameters here
+    	public void Init(string id) // you can use captured groups defined in the regex as parameters here
         {
 
         }
@@ -304,7 +347,7 @@ public class MyViewModel : MvxViewModel<TParameter>
 If you have a BaseViewModel you might not be able to inherit `MvxViewModel<TParameter>` because you already have the BaseViewModel as base class. In this case you can implement the following interface:
 
 ```c#
-IMvxViewModelInitializer<TInit>
+IMvxViewModel<TParameter>
 ```
 
 MvvmCross uses JSON to serialize the object and to use complex parameters you should have the MvvmCross Json plugin installed or register your own IMvxJsonConverter.


### PR DESCRIPTION
Because it can only be used with that.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This fixes unwanted behaviour

### :arrow_heading_down: What is the current behavior?
Close with result will just close if the NavigationService was used. But since it is in the base class you could use it anywhere.

### :new: What is the new behavior (if this is a feature change)?
You need to use it through the NavigationService. This also makes it easier to implement the interface for it.

### :boom: Does this PR introduce a breaking change?
Yes, but it would not have worked before if you used ShowViewModel.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
Fixes https://github.com/MvvmCross/MvvmCross/issues/2071
Fixes https://github.com/MvvmCross/MvvmCross/issues/2046
Fixes https://github.com/MvvmCross/MvvmCross/issues/2009

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
