### PR TITLE
WrapInNavigationController for TabBarViewController/SplitViewController

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using CoreGraphics;
@@ -111,62 +111,46 @@ namespace MvvmCross.iOS.Views.Presenters
             MvxRootPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
+            // first set the new RootViewController
+            if (attribute.WrapInNavigationController)
+            { 
+				// viewController is initializing a navigation stack
+
+                var navigationController = CreateNavigationController(viewController);
+                MasterNavigationController = navigationController as MvxNavigationController;
+                SetWindowRootViewController(navigationController);
+            }
+            else
+            {
+				// set plain ViewController as root
+
+                SetWindowRootViewController(viewController);
+
+                CloseMasterNavigationController();
+            }
+
             // check if viewController is a TabBarController
             if (viewController is IMvxTabBarViewController tabBarController)
             {
                 TabBarViewController = tabBarController;
-                if (!attribute.WrapInNavigationController)
-                    SetWindowRootViewController(viewController);
-                else
-                {
-                    viewController = CreateNavigationController(viewController);
-                    MasterNavigationController = viewController as MvxNavigationController;
-                    SetWindowRootViewController(viewController);
-                }
 
-                CloseMasterNavigationController();
-                CleanupModalViewControllers();
                 CloseSplitViewController();
-
-                return;
             }
             // check if viewController is a SplitViewController
             else if (viewController is IMvxSplitViewController splitController)
             {
                 SplitViewController = splitController;
 
-                if (!attribute.WrapInNavigationController)
-                    SetWindowRootViewController(viewController);
-                else
-                {
-                    viewController = CreateNavigationController(viewController);
-                    MasterNavigationController = viewController as MvxNavigationController;
-                    SetWindowRootViewController(viewController);
-                }
-
-                CloseMasterNavigationController();
-                CleanupModalViewControllers();
                 CloseTabBarViewController();
-
-                return;
             }
-
-            // check if viewController is trying to initialize a navigation stack
-            if (attribute.WrapInNavigationController)
+            else
             {
-                viewController = CreateNavigationController(viewController);
-                MasterNavigationController = viewController as MvxNavigationController;
-                SetWindowRootViewController(viewController);
-
-                CleanupModalViewControllers();
                 CloseTabBarViewController();
                 CloseSplitViewController();
-
-                return;
             }
 
-            // last scenario: display the plain viewController as root
-            SetWindowRootViewController(viewController);
+            // always clean ModalViewControllers when setting a new root
+            CleanupModalViewControllers();
         }
 
         protected virtual void ShowChildViewController(
@@ -198,8 +182,7 @@ namespace MvvmCross.iOS.Views.Presenters
 
             if (MasterNavigationController != null)
             {
-                PushViewControllerIntoStack(MasterNavigationController, viewController, attribute.Animated);
-
+				PushViewControllerIntoStack(MasterNavigationController, viewController, attribute.Animated);
                 return;
             }
 

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -115,11 +115,40 @@ namespace MvvmCross.iOS.Views.Presenters
             if (viewController is IMvxTabBarViewController tabBarController)
             {
                 TabBarViewController = tabBarController;
+                if (!attribute.WrapInNavigationController)
+                    SetWindowRootViewController(viewController);
+                else
+                {
+                    viewController = CreateNavigationController(viewController);
+                    MasterNavigationController = viewController as MvxNavigationController;
+                    SetWindowRootViewController(viewController);
+                }
+
+                CloseMasterNavigationController();
+                CleanupModalViewControllers();
+                CloseSplitViewController();
+
+                return;
             }
             // check if viewController is a SplitViewController
             else if (viewController is IMvxSplitViewController splitController)
             {
                 SplitViewController = splitController;
+
+                if (!attribute.WrapInNavigationController)
+                    SetWindowRootViewController(viewController);
+                else
+                {
+                    viewController = CreateNavigationController(viewController);
+                    MasterNavigationController = viewController as MvxNavigationController;
+                    SetWindowRootViewController(viewController);
+                }
+
+                CloseMasterNavigationController();
+                CleanupModalViewControllers();
+                CloseTabBarViewController();
+
+                return;
             }
 
             // check if viewController is trying to initialize a navigation stack

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -115,26 +115,11 @@ namespace MvvmCross.iOS.Views.Presenters
             if (viewController is IMvxTabBarViewController tabBarController)
             {
                 TabBarViewController = tabBarController;
-                SetWindowRootViewController(viewController);
-
-                CloseMasterNavigationController();
-                CleanupModalViewControllers();
-                CloseSplitViewController();
-
-                return;
             }
-
             // check if viewController is a SplitViewController
-            if (viewController is IMvxSplitViewController splitController)
+            else if (viewController is IMvxSplitViewController splitController)
             {
                 SplitViewController = splitController;
-                SetWindowRootViewController(viewController);
-
-                CloseMasterNavigationController();
-                CleanupModalViewControllers();
-                CloseTabBarViewController();
-
-                return;
             }
 
             // check if viewController is trying to initialize a navigation stack

--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
 using Playground.Core.ViewModels;
@@ -7,7 +7,7 @@ using UIKit;
 namespace Playground.iOS.Views
 {
     [MvxFromStoryboard("Main")]
-    //[MvxRootPresentation]
+    [MvxRootPresentation(WrapInNavigationController = true)]
     public partial class TabsRootView : MvxTabBarViewController<TabsRootViewModel>
     {
         private bool _isPresentedFirstTime = true;
@@ -36,6 +36,15 @@ namespace Playground.iOS.Views
                 iconName = "ic_tabbar_menu";
 
             base.SetTitleAndTabBarItem(viewController, title, iconName);
+        }
+
+        public override bool ShowChildView(UIViewController viewController)
+        {
+            var type = viewController.GetType();
+
+            return type == typeof(ChildView)
+                ? false
+                : base.ShowChildView(viewController);
         }
     }
 }

--- a/docs/_documentation/platform/ios-view-presenter.md
+++ b/docs/_documentation/platform/ios-view-presenter.md
@@ -27,9 +27,11 @@ The presenter uses a set of `PresentationAttributes` to define how a view will b
 Used to set a view as _Root_. You should use this attribute over the view class that will be the root of your application (your app can have several root views, one at a time).
 The view root can be one of the following types:
 
-- To use stack navigation, your view can just be a `MvxViewController`, but it needs to set the attribute member `WrapInNavigationController` to true.
-- To use Tabs, your view needs to implement `IMvxTabBarViewController` or simply extend `MvxTabBarViewController`, which has all the needed behavior built in.
-- To use a SplitView, your view needs to implement `IMvxSplitViewController` or simply extend `MvxSplitViewController`, which has all the needed behavior built in.
+- `MvxViewController`
+- `MvxTabBarViewController` (actually implementing `IMvxTabBarViewController` is enough)
+- `MvxSplitViewController` (actually implementing `IMvxSplitViewController` is enough)
+
+If you want to initiate a stack navigation, just set the attribute member `WrapInNavigationController` to true.
 
 
 ### MvxChildPresentationAttribute
@@ -79,8 +81,11 @@ There is an attribute member that can be used to customize the presentation:
 - If the initial view class of your app has no attribute over it, the presenter will assume stack navigation and will wrap your initial view in a `MvxNavigationController`.
 - If a view class has no attribute over it, the presenter will assume _animated_ child presentation and will display the view in the current navigation stack (could be modal or not).
 
+
 ## Override a presentation attribute at runtime
+
 To override a presentation attribute at runtime you can implement the `IMvxOverridePresentationAttribute` in your view controller and determine the presentation attribute in the `PresentationAttribute` method like this:
+
 ```c#
 public MvxBasePresentationAttribute PresentationAttribute()
 {
@@ -93,6 +98,8 @@ public MvxBasePresentationAttribute PresentationAttribute()
 ```
 
 If you return `null` from the `PresentationAttribute` the iOS View Presenter will fallback to the attribute used to decorate the view controller. If the view controller is not decorated with a presentation attribute it will use the default presentation attribute (a _animated_ child presentation).
+
+__Note:__ Be aware that your ViewModel will be null during `PresentationAttribute`, so the logic you can perform there is limited here. Reason to this limitation is MvvmCross Presenters are stateless, you can't connect an already instantiated ViewModel with a new View.
 
 ## Extensibility
 The presenter is completely extensible! You can override any attribute and customize attribute members.

--- a/docs/_documentation/platform/mac-view-presenter.md
+++ b/docs/_documentation/platform/mac-view-presenter.md
@@ -80,6 +80,8 @@ public MvxBasePresentationAttribute PresentationAttribute()
 
 If you return `null` from the `PresentationAttribute` the Mac View Presenter will fallback to the attribute used to decorate the view controller. If the view controller is not decorated with a presentation attribute it will use the default presentation attribute (a new window).
 
+__Note:__ Be aware that your ViewModel will be null during `PresentationAttribute`, so the logic you can perform there is limited here. Reason to this limitation is MvvmCross Presenters are stateless, you can't connect an already instantiated ViewModel with a new View.
+
 ## Extensibility
 The presenter is completely extensible! You can override any attribute and customize attribute members.
 


### PR DESCRIPTION
This PR is a clean version of #2050. I've squashed commits, added a new one and rebased onto develop.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR makes WrapInNavigationController property work with TabBarViewController and SplitViewController.

### :arrow_heading_down: What is the current behavior?
If you use `[MvxRootPresentation(WrapInNavigationController = true)]` in a TabBarController or a SplitViewController, the property is just ignored.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run TestProject/Playground.iOS and navigate to Tabs. Also navigate to Child. Introduced some logic in ChildView to test navigation there.

### :memo: Links to relevant issues/docs
Previous PR: #2050 
### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
