### PR TITLE
Add ability to set fragment content by name rather than id

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentActivity.cs
@@ -461,7 +461,7 @@ namespace MvvmCross.Droid.Support.V4
 			var fragmentTag = GetFragmentTag(request, bundle, fragmentType);
 			FragmentCacheConfiguration.RegisterFragmentToCache(fragmentTag, fragmentType, request.ViewModelType, fragmentAttribute.AddToBackStack);
 
-			ShowFragment(fragmentTag, fragmentAttribute.FragmentContentId, bundle);
+			ShowFragment(fragmentTag, fragmentAttribute.GetFragmentContentId(this), bundle);
 			return true;
 		}
 

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -1,4 +1,4 @@
-﻿// MvxCachingFragmentActivityCompat.cs
+// MvxCachingFragmentActivityCompat.cs
 // (c) Copyright Cirrious Ltd. http://www.cirrious.com
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -457,7 +457,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 			var fragmentTag = GetFragmentTag(request, bundle, fragmentType);
 			FragmentCacheConfiguration.RegisterFragmentToCache(fragmentTag, fragmentType, request.ViewModelType, fragmentAttribute.AddToBackStack);
 
-			ShowFragment(fragmentTag, fragmentAttribute.FragmentContentId, bundle);
+			ShowFragment(fragmentTag, fragmentAttribute.GetFragmentContentId(this), bundle);
 			return true;
 		}
 

--- a/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
+++ b/MvvmCross/Droid/FullFragging/Caching/MvxCachingFragmentActivity.cs
@@ -1,4 +1,4 @@
-﻿// MvxCachingFragmentActivity.cs
+// MvxCachingFragmentActivity.cs
 // (c) Copyright Cirrious Ltd. http://www.cirrious.com
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -449,7 +449,7 @@ namespace MvvmCross.Droid.FullFragging.Caching
 			var fragmentTag = GetFragmentTag(request, bundle, fragmentType);
 			FragmentCacheConfiguration.RegisterFragmentToCache(fragmentTag, fragmentType, request.ViewModelType, fragmentAttribute.AddToBackStack);
 
-			ShowFragment(fragmentTag, fragmentAttribute.FragmentContentId, bundle);
+			ShowFragment(fragmentTag, fragmentAttribute.GetFragmentContentId(this), bundle);
 			return true;
 		}
 

--- a/MvvmCross/Droid/Shared/Attributes/MvxFragmentAttribute.cs
+++ b/MvvmCross/Droid/Shared/Attributes/MvxFragmentAttribute.cs
@@ -5,17 +5,28 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using Android.App;
 using System;
+using System.Collections.Concurrent;
 
 namespace MvvmCross.Droid.Shared.Attributes
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class MvxFragmentAttribute : Attribute
     {
+
+        private static readonly ConcurrentDictionary<string, int> FragmentNameMappings = new ConcurrentDictionary<string, int>();
         public MvxFragmentAttribute(Type parentActivityViewModelType, int fragmentContentId, bool addToBackStack = false)
         {
             ParentActivityViewModelType = parentActivityViewModelType;
             FragmentContentId = fragmentContentId;
+            AddToBackStack = addToBackStack;
+        }
+
+        public MvxFragmentAttribute(Type parentActivityViewModelType, string fragmentContentName, bool addToBackStack = false)
+        {
+            ParentActivityViewModelType = parentActivityViewModelType;
+            FragmentContentName = fragmentContentName;
             AddToBackStack = addToBackStack;
         }
 
@@ -37,11 +48,39 @@ namespace MvvmCross.Droid.Shared.Attributes
         /// <summary>
         /// Content id - place where to show fragment.
         /// </summary>
-        public int FragmentContentId { get; private set; }
+        public int? FragmentContentId { get; private set; }
+
+        /// <summary>
+        /// Content name - place where to show fragment.
+        /// </summary>
+        public string FragmentContentName { get; private set; }
 
         /// <summary>
         /// Indicates if the fragment can be cached. False by default.
         /// </summary>
         public bool AddToBackStack { get; set; } = false;
+
+        /// <summary>
+        /// Determines the content id according to whether the name or id has been specified.
+        /// </summary>
+        /// <param name="activity">The activity to use to retrieve the id</param>
+        /// <returns>The content id</returns>
+        public int GetFragmentContentId(Activity activity)
+        {
+            int contentId;
+            if (this.FragmentContentId != null)
+            {
+                contentId = this.FragmentContentId.Value;
+            }
+            else
+            {
+                if (!FragmentNameMappings.TryGetValue(this.FragmentContentName, out contentId))
+                {
+                    contentId = activity.Resources.GetIdentifier(this.FragmentContentName, "id", activity.PackageName);
+                    FragmentNameMappings.TryAdd(this.FragmentContentName, contentId);
+                }
+            }
+            return contentId;
+        }
     }
 }

--- a/MvvmCross/Droid/Shared/Presenter/FragmentHostRegistrationSettings.cs
+++ b/MvvmCross/Droid/Shared/Presenter/FragmentHostRegistrationSettings.cs
@@ -132,7 +132,7 @@ namespace MvvmCross.Droid.Shared.Presenter
             {
                 foreach (var item in fragmentAttributes)
                 {
-                    if (currentActivity.FindViewById(item.FragmentContentId) != null)
+                    if (currentActivity.FindViewById(item.GetFragmentContentId(currentActivity)) != null)
                     {
                         attribute = item;
                         break;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
To use the MvxFragment attribute, you have to supply a Resource ID.  Due to the way Android UI shared projects work, you cannot use resource IDs in an attribute because they are defined as `static int` rather than `const int`.

See https://bugzilla.xamarin.com/show_bug.cgi?id=39185

### :new: What is the new behavior (if this is a feature change)?
This pull request adds the ability to define the content ID using the resource name, i.e.
`[MvxFragment(typeof(ViewModel), "content_id")]`

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
