### PR TITLE
MvxIosViewPresenter: Fix ShowRootViewController

### DIFF
--- a/TestProjects/Playground/Playground.Core/App.cs
+++ b/TestProjects/Playground/Playground.Core/App.cs
@@ -13,7 +13,7 @@ namespace Playground.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-            RegisterAppStart<RootViewModel>();
+            RegisterNavigationServiceAppStart<RootViewModel>();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-﻿using System;
+using System;
 using System.Windows.Input;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
@@ -20,9 +20,9 @@ namespace Playground.Core.ViewModels
 
         private async Task ShowInitialViewModels()
         {
-            await _navigationService.Navigate<Tab1ViewModel, string>("test").ConfigureAwait(false);
-            await _navigationService.Navigate<Tab2ViewModel>().ConfigureAwait(false);
-            await _navigationService.Navigate<Tab3ViewModel>().ConfigureAwait(false);
+            await _navigationService.Navigate<Tab1ViewModel, string>("test");
+            await _navigationService.Navigate<Tab2ViewModel>();
+            await _navigationService.Navigate<Tab3ViewModel>();
         }
     }
 }

--- a/docs/_documentation/platform/ios-view-presenter.md
+++ b/docs/_documentation/platform/ios-view-presenter.md
@@ -37,6 +37,7 @@ If you want to initiate a stack navigation, just set the attribute member `WrapI
 ### MvxChildPresentationAttribute
 Used to set a view as a _child_. You should use this attribute over a view class that will be displayed inside a navigation stack (modal or not).
 The view class can decide if wants to be displayed animated or not through the attribute member `Animated` (the default value is `true`).
+If your app uses a TabBarController as a child ViewController of a "master" NavigationController, you can decide whether to display a new child ViewController inside a Tab of the TabBarViewController (assuming that Tab  is a NavigationController) or to display it as a child of the "master" NavigationController. You can take control of this behavior by overriding `MvxTabBarController.ShowChildView`.
 
 
 ### MvxModalPresentationAttribute


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix & improvements

### :arrow_heading_down: What is the current behavior?
#2076 introduced a refactor of ShowRootViewController method that broke the logic in some scenarios. Reason for this is that some properties of the ViewPresenter were being assigned too late (like TabBarViewController property, which caused #2084).

### :new: What is the new behavior (if this is a feature change)?
The logic was reverted without loosing the feature introduced in #2076. Also improved some other parts:
- MvxTabBarController.CloseChildViewModel now closes Tabs that are NavigationControllers (previously only worked for Tabs that were plain ViewControllers)
- `MvxTabBarController.ShowChildView` now uses `as` operator instead of a direct cast (app could potentially crash because of that)
- Also improved doc for MvxIosViewPresenter

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Playground.iOS

### :memo: Links to relevant issues/docs
Related PR: #2076.
Related issue: #2084 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
