### PR TITLE
Allowing MvxNavigationFacades to set parameters

### DIFF
--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -133,6 +133,12 @@ namespace MvvmCross.Core.Navigation
                 {
                     var facadeRequest = await facade.BuildViewModelRequest(path, paramDict).ConfigureAwait(false);
                     request.ViewModelType = facadeRequest.ViewModelType;
+
+                    if (facadeRequest.ParameterValues != null)
+                    {
+                        request.ParameterValues = facadeRequest.ParameterValues;
+                    }
+
                     request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, null);
 
                     if (facadeRequest == null)

--- a/TestProjects/Navigation/RoutingExample.Core/RoutingExample.Core.csproj
+++ b/TestProjects/Navigation/RoutingExample.Core/RoutingExample.Core.csproj
@@ -48,6 +48,8 @@
     <Compile Include="ViewModels\ViewModelA.cs" />
     <Compile Include="ViewModels\ViewModelB.cs" />
     <Compile Include="ViewModels\ViewModelC.cs" />
+    <Compile Include="ViewModels\TestCViewModel.cs" />
+    <Compile Include="RoutingFacades\PrePopulateRoutingFacade.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross\Platform\Platform\MvvmCross.Platform.csproj">

--- a/TestProjects/Navigation/RoutingExample.Core/RoutingFacades/PrePopulateRoutingFacade.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/RoutingFacades/PrePopulateRoutingFacade.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+using RoutingExample.Core.RoutingFacades;
+using RoutingExample.Core.ViewModels;
+
+[assembly: MvxNavigation(typeof(PrePopulateRoutingFacade), @"mvx://prepop")]
+
+namespace RoutingExample.Core.RoutingFacades
+{
+    public class PrePopulateRoutingFacade
+        : IMvxNavigationFacade
+    {
+        public Task<MvxViewModelRequest> BuildViewModelRequest(string url, IDictionary<string, string> currentParameters)
+        {
+            var viewModelType = typeof(TestCViewModel);
+
+            var testKey = "viewmodelcparameter";
+            if (currentParameters.ContainsKey(testKey))
+            {
+                currentParameters.Remove(testKey);
+            }
+            currentParameters.Add(testKey, "this is set from the navigation facade");
+
+            return Task.FromResult(new MvxViewModelRequest(viewModelType, new MvxBundle(currentParameters), null));
+        }
+    }
+}

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
@@ -66,5 +66,18 @@ namespace RoutingExample.Core.ViewModels
                 }));
             }
         }
+
+        private IMvxCommand _showPrePopCommand;
+
+        public IMvxCommand ShowPrePopCommand
+        {
+            get
+            {
+                return _showPrePopCommand ?? (_showPrePopCommand = new MvxAsyncCommand(async () =>
+                {
+                    await _navigationService.Navigate("mvx://prepop");
+                }));
+            }
+        }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestCViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestCViewModel.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Platform;
+using RoutingExample.Core.ViewModels;
+
+namespace RoutingExample.Core.ViewModels
+{
+    public class TestCViewModel
+        : MvxViewModel<User, User>
+    {
+        private readonly IMvxNavigationService _navigationService;
+        public TestCViewModel(IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService;
+        }
+
+        private string _parameter;
+        public string Parameter
+        {
+            get { return _parameter; }
+            set { SetProperty(ref _parameter, value); }
+        }
+
+        public void Init(string viewmodelcparameter)
+        {
+            Parameter = viewmodelcparameter;
+            _user = new User($"Initial view {GetHashCode()}", "Test");
+        }
+
+        private User _user;
+
+        public IMvxAsyncCommand CloseViewModelCommand => new MvxAsyncCommand(
+            () => _navigationService.Close(this, new User("Return result", "Something")));
+
+        public override void Prepare(User parameter)
+        {
+            _user = parameter;
+        }
+    }
+}

--- a/TestProjects/Navigation/RoutingExample.iOS/Main.storyboard
+++ b/TestProjects/Navigation/RoutingExample.iOS/Main.storyboard
@@ -187,9 +187,6 @@
                                 <state key="normal" title="Close with Result">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
-                                <connections>
-                                    <action selector="CloseButton:" destination="Yyt-ZP-EJU" eventType="touchUpInside" id="dNe-3y-uYV"/>
-                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parameter" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylb-DU-MoP">
                                 <rect key="frame" x="16" y="84" width="171.5" height="21"/>

--- a/TestProjects/Navigation/RoutingExample.iOS/Main.storyboard
+++ b/TestProjects/Navigation/RoutingExample.iOS/Main.storyboard
@@ -1,7 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,24 +20,30 @@
                         <viewControllerLayoutGuide type="bottom" id="3"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="6">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                <rect key="frame" x="15" y="74" width="570" height="30"/>
+                                <rect key="frame" x="15" y="74" width="345" height="30"/>
                                 <state key="normal" title="mvx://test/a">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                <rect key="frame" x="15" y="134" width="570" height="30"/>
+                                <rect key="frame" x="15" y="134" width="345" height="30"/>
                                 <state key="normal" title="mvx://test/b">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                <rect key="frame" x="15" y="194" width="570" height="30"/>
+                                <rect key="frame" x="15" y="194" width="345" height="30"/>
                                 <state key="normal" title="mvx://random">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4CL-wn-i6a">
+                                <rect key="frame" x="15" y="254" width="345" height="30"/>
+                                <state key="normal" title="mvx://prepop">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
@@ -47,10 +59,14 @@
                             <constraint firstItem="11" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="15" id="18"/>
                             <constraint firstAttribute="trailing" secondItem="11" secondAttribute="trailing" constant="15" id="20"/>
                             <constraint firstItem="9" firstAttribute="top" secondItem="2" secondAttribute="bottom" constant="54" id="21"/>
+                            <constraint firstItem="4CL-wn-i6a" firstAttribute="trailing" secondItem="11" secondAttribute="trailing" id="TGw-3F-9ZG"/>
+                            <constraint firstItem="4CL-wn-i6a" firstAttribute="top" secondItem="11" secondAttribute="bottom" constant="30" id="qNS-gg-Fs8"/>
+                            <constraint firstItem="4CL-wn-i6a" firstAttribute="leading" secondItem="11" secondAttribute="leading" id="yPH-Um-2Z8"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Example" id="201"/>
                     <connections>
+                        <outlet property="BtnPrePop" destination="4CL-wn-i6a" id="lG0-59-5en"/>
                         <outlet property="BtnRandom" destination="11" id="name-outlet-11"/>
                         <outlet property="BtnTestA" destination="9" id="name-outlet-9"/>
                         <outlet property="BtnTestB" destination="10" id="name-outlet-10"/>
@@ -69,7 +85,7 @@
                         <viewControllerLayoutGuide type="bottom" id="27"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="30">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="A" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="33">
@@ -105,7 +121,7 @@
                         <viewControllerLayoutGuide type="bottom" id="55"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="48">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="B" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="49">
@@ -119,7 +135,7 @@
                                 <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="207" translatesAutoresizingMaskIntoConstraints="NO" fixedFrame="YES">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="207">
                                 <rect key="frame" x="170" y="285" width="259" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Close with Result">
@@ -141,6 +157,74 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="56" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="238" y="603"/>
+        </scene>
+        <!--Example C-->
+        <scene sceneID="zgi-gS-Z0L">
+            <objects>
+                <viewController storyboardIdentifier="TestCViewController" title="Example C" id="Yyt-ZP-EJU" customClass="TestCViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="9th-Se-wdV"/>
+                        <viewControllerLayoutGuide type="bottom" id="Ew0-Yf-v0h"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="c5L-db-Fbi">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="C" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="rgV-oF-Hux">
+                                <rect key="frame" x="208" y="192" width="132" height="125"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="150" id="46h-Ar-j2N"/>
+                                    <constraint firstAttribute="width" constant="150" id="eGA-pJ-mpW"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="150"/>
+                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v6C-GC-KuY">
+                                <rect key="frame" x="170" y="285" width="259" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Close with Result">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="CloseButton:" destination="Yyt-ZP-EJU" eventType="touchUpInside" id="dNe-3y-uYV"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parameter" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylb-DU-MoP">
+                                <rect key="frame" x="16" y="84" width="171.5" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Value" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OZO-OP-O3P">
+                                <rect key="frame" x="187.5" y="84" width="171.5" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="0.40000000600000002" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="centerX" secondItem="rgV-oF-Hux" secondAttribute="centerX" id="2r8-S1-bPj"/>
+                            <constraint firstItem="ylb-DU-MoP" firstAttribute="leading" secondItem="c5L-db-Fbi" secondAttribute="leadingMargin" id="OuK-HN-SaX"/>
+                            <constraint firstAttribute="centerX" secondItem="ylb-DU-MoP" secondAttribute="trailing" id="PPF-T6-P2J"/>
+                            <constraint firstItem="rgV-oF-Hux" firstAttribute="centerY" secondItem="c5L-db-Fbi" secondAttribute="centerY" id="Wy6-Id-Oht"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="OZO-OP-O3P" secondAttribute="trailing" id="XSf-Yz-gO1"/>
+                            <constraint firstItem="OZO-OP-O3P" firstAttribute="leading" secondItem="ylb-DU-MoP" secondAttribute="trailing" id="bbz-cv-LLA"/>
+                            <constraint firstItem="ylb-DU-MoP" firstAttribute="top" secondItem="9th-Se-wdV" secondAttribute="bottom" constant="20" id="csg-TM-oHK"/>
+                            <constraint firstItem="OZO-OP-O3P" firstAttribute="top" secondItem="ylb-DU-MoP" secondAttribute="top" id="xTt-om-NdD"/>
+                        </constraints>
+                    </view>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="CloseButton" destination="v6C-GC-KuY" id="tL5-hc-IxQ"/>
+                        <outlet property="ValueLabel" destination="OZO-OP-O3P" id="9Gl-q7-RwC"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="DzS-qQ-uwv" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="983" y="600"/>
         </scene>
     </scenes>
 </document>

--- a/TestProjects/Navigation/RoutingExample.iOS/MainViewController.cs
+++ b/TestProjects/Navigation/RoutingExample.iOS/MainViewController.cs
@@ -23,6 +23,7 @@ namespace RoutingExample.iOS
             set.Bind(BtnTestA).To(vm => vm.ShowACommand);
             set.Bind(BtnTestB).To(vm => vm.ShowBCommand);
             set.Bind(BtnRandom).To(vm => vm.ShowRandomCommand);
+            set.Bind(BtnPrePop).To(vm => vm.ShowPrePopCommand);
 
             set.Apply();
 

--- a/TestProjects/Navigation/RoutingExample.iOS/MainViewController.designer.cs
+++ b/TestProjects/Navigation/RoutingExample.iOS/MainViewController.designer.cs
@@ -1,46 +1,56 @@
 // WARNING
 //
-// This file has been generated automatically by Xamarin Studio from the outlets and
-// actions declared in your storyboard file.
-// Manual changes to this file will not be maintained.
+// This file has been generated automatically by Visual Studio to store outlets and
+// actions made in the UI designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
 //
 using Foundation;
-using System;
 using System.CodeDom.Compiler;
-using UIKit;
 
 namespace RoutingExample.iOS
 {
-    [Register ("MainViewController")]
+    [Register("MainViewController")]
     partial class MainViewController
     {
         [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
+        UIKit.UIButton BtnPrePop { get; set; }
+
+        [Outlet]
+        [GeneratedCode("iOS Designer", "1.0")]
         UIKit.UIButton BtnRandom { get; set; }
 
         [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
+        [GeneratedCode("iOS Designer", "1.0")]
         UIKit.UIButton BtnTestA { get; set; }
 
         [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
+        [GeneratedCode("iOS Designer", "1.0")]
         UIKit.UIButton BtnTestB { get; set; }
 
-        void ReleaseDesignerOutlets ()
+        void ReleaseDesignerOutlets()
         {
-            if (BtnRandom != null) {
-                BtnRandom.Dispose ();
+            if (BtnRandom != null)
+            {
+                BtnRandom.Dispose();
                 BtnRandom = null;
             }
 
-            if (BtnTestA != null) {
-                BtnTestA.Dispose ();
+            if (BtnTestA != null)
+            {
+                BtnTestA.Dispose();
                 BtnTestA = null;
             }
 
-            if (BtnTestB != null) {
-                BtnTestB.Dispose ();
+            if (BtnTestB != null)
+            {
+                BtnTestB.Dispose();
                 BtnTestB = null;
+            }
+
+            if (BtnPrePop != null)
+            {
+                BtnPrePop.Dispose();
+                BtnPrePop = null;
             }
         }
     }

--- a/TestProjects/Navigation/RoutingExample.iOS/RoutingExample.iOS.csproj
+++ b/TestProjects/Navigation/RoutingExample.iOS/RoutingExample.iOS.csproj
@@ -110,6 +110,10 @@
       <SubType>Designer</SubType>
     </Content>
     <InterfaceDefinition Include="Main.storyboard" />
+    <Compile Include="TestCViewController.cs" />
+    <Compile Include="TestCViewController.designer.cs">
+      <DependentUpon>TestCViewController.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/TestProjects/Navigation/RoutingExample.iOS/TestCViewController.cs
+++ b/TestProjects/Navigation/RoutingExample.iOS/TestCViewController.cs
@@ -25,4 +25,3 @@ namespace RoutingExample.iOS
         }
     }
 }
-

--- a/TestProjects/Navigation/RoutingExample.iOS/TestCViewController.cs
+++ b/TestProjects/Navigation/RoutingExample.iOS/TestCViewController.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.iOS.Views;
+using MvvmCross.iOS.Views.Presenters.Attributes;
+using RoutingExample.Core.ViewModels;
+using UIKit;
+
+namespace RoutingExample.iOS
+{
+    [MvxFromStoryboard("Main")]
+    [MvxChildPresentation]
+    public partial class TestCViewController : MvxViewController<TestCViewModel>
+    {
+        public TestCViewController(IntPtr handle) : base(handle)
+        {
+        }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            var set = this.CreateBindingSet<TestCViewController, TestCViewModel>();
+            set.Bind(CloseButton).To(vm => vm.CloseViewModelCommand);
+            set.Bind(ValueLabel).To(vm => vm.Parameter);
+            set.Apply();
+        }
+    }
+}
+

--- a/TestProjects/Navigation/RoutingExample.iOS/TestCViewController.designer.cs
+++ b/TestProjects/Navigation/RoutingExample.iOS/TestCViewController.designer.cs
@@ -1,0 +1,34 @@
+// WARNING
+//
+// This file has been generated automatically by Visual Studio to store outlets and
+// actions made in the UI designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+using System.CodeDom.Compiler;
+
+namespace RoutingExample.iOS
+{
+	[Register ("TestCViewController")]
+	partial class TestCViewController
+	{
+		[Outlet]
+		UIKit.UIButton CloseButton { get; set; }
+
+		[Outlet]
+		UIKit.UILabel ValueLabel { get; set; }
+		
+		void ReleaseDesignerOutlets ()
+		{
+			if (CloseButton != null) {
+				CloseButton.Dispose ();
+				CloseButton = null;
+			}
+
+			if (ValueLabel != null) {
+				ValueLabel.Dispose ();
+				ValueLabel = null;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
When changing the parameters in a navigation facade they are ignored.

### :new: What is the new behavior (if this is a feature change)?
This PR allows for parameter to be set in the navigation facade when deeplinking.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Open the Navigation Test Project and look at how the PrePopulateRoutingFacade adds the parameter to TestCViewModel

### :memo: Links to relevant issues/docs
https://stackoverflow.com/questions/45436119/sending-new-parameters-in-mvxviewmodelrequest-from-a-imvxnavigationfacade-when-d

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
