### PR TITLE
iOS ShowTabView: Pass MvxTabPresentationAttribute instead of atomic values

### DIFF
--- a/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/IMvxTabBarViewController.cs
@@ -1,13 +1,12 @@
 ﻿using MvvmCross.Core.ViewModels;
+using MvvmCross.iOS.Views.Presenters.Attributes;
 using UIKit;
 
 namespace MvvmCross.iOS.Views
 {
     public interface IMvxTabBarViewController
     {
-        void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabSelectedIconName = null, string tabAccessibilityIdentifier = null);
-
-        void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabAccessibilityIdentifier = null);
+        void ShowTabView(UIViewController viewController, MvxTabPresentationAttribute attribute);
 
         bool ShowChildView(UIViewController viewController);
 

--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.iOS.Views.Presenters;
+using MvvmCross.iOS.Views.Presenters.Attributes;
 using MvvmCross.Platform;
 using UIKit;
 
@@ -34,19 +35,13 @@ namespace MvvmCross.iOS.Views
             }
         }
 
-        //keep changes for selected icon from breaking current release
-        public virtual void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabAccessibilityIdentifier = null)
+        public virtual void ShowTabView(UIViewController viewController, MvxTabPresentationAttribute attribute)
         {
-            ShowTabView(viewController, tabTitle, tabIconName, null, tabAccessibilityIdentifier);
-        }
-
-        public virtual void ShowTabView(UIViewController viewController, string tabTitle, string tabIconName, string tabSelectedIconName = null, string tabAccessibilityIdentifier = null)
-        {
-            if (!string.IsNullOrEmpty(tabAccessibilityIdentifier))
-                viewController.View.AccessibilityIdentifier = tabAccessibilityIdentifier;
+            if (!string.IsNullOrEmpty(attribute.TabAccessibilityIdentifier))
+                viewController.View.AccessibilityIdentifier = attribute.TabAccessibilityIdentifier;
 
             // setup Tab
-            SetTitleAndTabBarItem(viewController, tabTitle, tabIconName, tabSelectedIconName);
+            SetTitleAndTabBarItem(viewController, attribute);
 
             // add Tab
             var currentTabs = new List<UIViewController>();
@@ -61,23 +56,17 @@ namespace MvvmCross.iOS.Views
             ViewControllers = currentTabs.ToArray();
         }
 
-        //keep changes for selected icon from breaking current release
-        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName)
+        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, MvxTabPresentationAttribute attribute)
         {
             _tabsCount++;
 
-            viewController.Title = title;
+            viewController.Title = attribute.TabName;
 
-            if (!string.IsNullOrEmpty(iconName))
-                viewController.TabBarItem = new UITabBarItem(title, UIImage.FromBundle(iconName), _tabsCount);
-        }
+            if (!string.IsNullOrEmpty(attribute.TabIconName))
+                viewController.TabBarItem = new UITabBarItem(attribute.TabName, UIImage.FromBundle(attribute.TabIconName), _tabsCount);
 
-        protected virtual void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName, string selectedIconName)
-        {
-            SetTitleAndTabBarItem(viewController, title, iconName);
-
-            if (!string.IsNullOrEmpty(selectedIconName))
-                viewController.TabBarItem.SelectedImage = UIImage.FromBundle(selectedIconName);
+            if (!string.IsNullOrEmpty(attribute.TabSelectedIconName))
+                viewController.TabBarItem.SelectedImage = UIImage.FromBundle(attribute.TabSelectedIconName);
         }
 
         public virtual bool ShowChildView(UIViewController viewController)

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -207,15 +207,11 @@ namespace MvvmCross.iOS.Views.Presenters
             if (TabBarViewController == null)
                 throw new MvxException("Trying to show a tab without a TabBarViewController, this is not possible!");
 
-            string tabName = attribute.TabName;
-            string tabIconName = attribute.TabIconName;
-            string tabSelectedIconName = attribute.TabSelectedIconName;
-
             if (viewController is IMvxTabBarItemViewController tabBarItem)
             {
-                tabName = tabBarItem.TabName;
-                tabIconName = tabBarItem.TabIconName;
-                tabSelectedIconName = tabBarItem.TabSelectedIconName;
+                attribute.TabName = tabBarItem.TabName;
+                attribute.TabIconName = tabBarItem.TabIconName;
+                attribute.TabSelectedIconName = tabBarItem.TabSelectedIconName;
             }
 
             if (attribute.WrapInNavigationController)
@@ -223,10 +219,7 @@ namespace MvvmCross.iOS.Views.Presenters
 
             TabBarViewController.ShowTabView(
                 viewController,
-                tabName,
-                tabIconName,
-                tabSelectedIconName,
-                attribute.TabAccessibilityIdentifier);
+                attribute);
         }
 
         protected virtual void ShowModalViewController(

--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -29,15 +29,15 @@ namespace Playground.iOS.Views
             }
         }
 
-        protected override void SetTitleAndTabBarItem(UIViewController viewController, string title, string iconName)
+        protected override void SetTitleAndTabBarItem(UIViewController viewController, MvxTabPresentationAttribute attribute)
         {
             // you can override this method to set title or iconName
-            if (string.IsNullOrEmpty(title))
-                title = "Tab 2";
-            if (string.IsNullOrEmpty(iconName))
-                iconName = "ic_tabbar_menu";
+            if (string.IsNullOrEmpty(attribute.TabName))
+                attribute.TabName = "Tab 2";
+            if (string.IsNullOrEmpty(attribute.TabIconName))
+                attribute.TabIconName = "ic_tabbar_menu";
 
-            base.SetTitleAndTabBarItem(viewController, title, iconName);
+            base.SetTitleAndTabBarItem(viewController, attribute);
         }
 
         public override bool ShowChildView(UIViewController viewController)

--- a/docs/_documentation/platform/ios-view-presenter.md
+++ b/docs/_documentation/platform/ios-view-presenter.md
@@ -58,6 +58,7 @@ The presentation can be highly customized through this attribute members:
 
 - TabName: Defines the title of the tab that will be displayed below the tab icon. It has to be a magic string, but it can be for example a key to a localized string that you can grab overriding the method `SetTitleAndTabBarItem` in your TabBarController.
 - TabIconName: Defines the name of the resource that will be used as icon for the tab. It also has to be a magic string, but same as before, your app can take control of what happens by overriding the method `SetTitleAndTabBarItem` in your TabBarController.
+- TabSelectedIconName: Defines the name of the resource that will be used as icon for the tab when it becomes selected. It also has to be a magic string, your app can take control of what happens by overriding the method `SetTitleAndTabBarItem` in your TabBarController.
 - WrapInNavigationController: If set to `true`, the view will be wrapped in a `MvxNavigationController`, which will allow the tab to have its own navigation stack. **Important note**: When the current _Root_ is a TabBarController and there is no current modal navigation stack, child presentations will be tried to be displayed in the current selected _Tab_.
 - TabAccessibilityIdentifier: Corresponds to the UIViewController.View `AccessibilityIdentifier` property.
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement.

### :arrow_heading_down: What is the current behavior?
MvxTabBarController.ShowTabView is hard to extend.

### :new: What is the new behavior (if this is a feature change)?
MvxTabBarController.ShowTabView is easier to extend.

### :boom: Does this PR introduce a breaking change?
YES. `IMvxTabBarController.ShowTabView` will break for everyone. Therefore this PR should be part of a major update.

### :bug: Recommendations for testing
Run Playground.iOS project.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
