### PR TITLE
MvxFragmentAttribute that can be used in Android Library

### DIFF
--- a/MvvmCross/Droid/Shared/Attributes/MvxFragmentAttribute.cs
+++ b/MvvmCross/Droid/Shared/Attributes/MvxFragmentAttribute.cs
@@ -6,6 +6,9 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Droid;
+using MvvmCross.Platform.Droid.Platform;
 
 namespace MvvmCross.Droid.Shared.Attributes
 {
@@ -16,6 +19,15 @@ namespace MvvmCross.Droid.Shared.Attributes
         {
             ParentActivityViewModelType = parentActivityViewModelType;
             FragmentContentId = fragmentContentId;
+            AddToBackStack = addToBackStack;
+        }
+
+        public MvxFragmentAttribute(Type parentActivityViewModelType, string fragmentContentResourceName, bool addToBackStack = false)
+        {
+            var context = Mvx.Resolve<IMvxAndroidGlobals>().ApplicationContext;
+
+            ParentActivityViewModelType = parentActivityViewModelType;
+            FragmentContentId = context?.Resources.GetIdentifier(fragmentContentResourceName, "id", context.PackageName) ?? 0;
             AddToBackStack = addToBackStack;
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It is a feature

### :arrow_heading_down: What is the current behavior?
Now it is impossible to use MvxFragmentAttribure in Android library class. In Android projects Resource ids are constant but in Android Library they are static therefore it is impossible to use it in Attributes.  

### :new: What is the new behavior (if this is a feature change)?
This PR introduces additional Attribute constructor with string which is converted to int.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Version for Android projects:
`[MvxFragment(typeof(MainViewModel), Resource.Id.content_frame, true)]`
Version for Android libraries:
`[MvxFragment(typeof(MainViewModel), "content_frame", true)]`

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
