### PR TITLE
Fix Setup iOS wrong ctor

### DIFF
--- a/nuspec/iOSContent/Setup.cs.pp
+++ b/nuspec/iOSContent/Setup.cs.pp
@@ -13,8 +13,8 @@ namespace $rootnamespace$
         {
         }
         
-        public Setup(IMvxApplicationDelegate applicationDelegate, UIWindow window, IMvxIosViewPresenter presenter)
-            : base(applicationDelegate, window, presenter)
+        public Setup(IMvxApplicationDelegate applicationDelegate, IMvxIosViewPresenter presenter)
+            : base(applicationDelegate, presenter)
         {
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
In the starterpack a wrong ctor is added on iOS

### :new: What is the new behavior (if this is a feature change)?
Fix for this.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
