### PR TITLE
Extract MvxUIRefreshControl command execution logic into a method

### DIFF
--- a/MvvmCross/iOS/iOS/Views/MvxUIRefreshControl.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxUIRefreshControl.cs
@@ -18,14 +18,7 @@ namespace MvvmCross.iOS.Views
 		{
 			ValueChanged += (object sender, EventArgs e) =>
 			{
-				var command = RefreshCommand;
-				if (command == null)
-					return;
-
-				if (!command.CanExecute(null))
-					return;
-
-				command.Execute(null);
+				ExecuteRefreshCommand(RefreshCommand);
 			};
 		}
 
@@ -75,5 +68,16 @@ namespace MvvmCross.iOS.Views
 		/// </summary>
 		/// <value>The refresh command.</value>
 		public ICommand RefreshCommand { get; set; }
+
+		protected virtual void ExecuteRefreshCommand(ICommand command)
+        {
+            if (command == null)
+                return;
+
+            if (!command.CanExecute(null))
+                return;
+
+            command.Execute(null);
+        }
 	}
 }

--- a/MvvmCross/iOS/iOS/Views/MvxUIRefreshControl.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxUIRefreshControl.cs
@@ -16,10 +16,7 @@ namespace MvvmCross.iOS.Views
 		/// </summary>
 		public MvxUIRefreshControl()
 		{
-			ValueChanged += (object sender, EventArgs e) =>
-			{
-				ExecuteRefreshCommand(RefreshCommand);
-			};
+			ValueChanged += OnValueChanged;
 		}
 
 		private string _message;
@@ -69,6 +66,11 @@ namespace MvvmCross.iOS.Views
 		/// <value>The refresh command.</value>
 		public ICommand RefreshCommand { get; set; }
 
+		private void OnValueChanged(object sender, EventArgs args)
+		{
+			ExecuteRefreshCommand(RefreshCommand);
+		}
+
 		protected virtual void ExecuteRefreshCommand(ICommand command)
         {
             if (command == null)
@@ -79,5 +81,15 @@ namespace MvvmCross.iOS.Views
 
             command.Execute(null);
         }
+
+		protected override void Dispose(bool disposing)
+		{
+			if(disposing)
+			{
+				ValueChanged -= OnValueChanged;
+			}
+
+			base.Dispose(disposing);
+		}
 	}
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement

### :arrow_heading_down: What is the current behavior?
Logic is wrapped in a lambda expression, so it can't be easily overriden

### :new: What is the new behavior (if this is a feature change)?
Logic is located in a method, so it can be overriden. This makes MvxUIRefreshControl very similar to MvxSwipeRefreshLayout.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run any sample project that uses MvxUIRefreshControl. No behavior is changed.

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
