### PR TITLE
Calls CloseTabBarViewController() only for actual MvxIosViewPresenter

### DIFF
--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -30,8 +30,10 @@ namespace MvvmCross.iOS.Views
 
             if (IsMovingFromParentViewController)
             {
-                var presenter = Mvx.Resolve<IMvxIosViewPresenter>() as MvxIosViewPresenter;
-                presenter.CloseTabBarViewController();
+                if (Mvx.Resolve<IMvxIosViewPresenter>() is MvxIosViewPresenter presenter)
+                {
+                    presenter.CloseTabBarViewController();
+                };
             }
         }
 


### PR DESCRIPTION

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

It's crashing.

### :new: What is the new behavior (if this is a feature change)?

It's not crashing anymore.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

See issue: https://github.com/MvvmCross/MvvmCross/issues/2112

### :memo: Links to relevant issues/docs

Issue: https://github.com/MvvmCross/MvvmCross/issues/2112

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
