### PR TITLE
"Close" button of ChildView is not working if it's open from tabs

### DIFF
--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -50,13 +50,13 @@ namespace Playground.iOS.Views
                 : base.ShowChildView(viewController);
         }
 
-		public override bool CloseChildViewModel(IMvxViewModel viewModel)
-		{
-			var type = viewModel.GetType();
+        public override bool CloseChildViewModel(IMvxViewModel viewModel)
+        {
+            var type = viewModel.GetType();
 
-			return type == typeof(ChildViewModel)
-				? false
-				: base.CloseChildViewModel(viewModel);
-		}
+            return type == typeof(ChildViewModel)
+                ? false
+                : base.CloseChildViewModel(viewModel);
+        }
     }
 }

--- a/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Threading.Tasks;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
 using Playground.Core.ViewModels;
@@ -48,5 +49,14 @@ namespace Playground.iOS.Views
                 ? false
                 : base.ShowChildView(viewController);
         }
+
+		public override bool CloseChildViewModel(IMvxViewModel viewModel)
+		{
+			var type = viewModel.GetType();
+
+			return type == typeof(ChildViewModel)
+				? false
+				: base.CloseChildViewModel(viewModel);
+		}
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
### :arrow_heading_down: What is the current behavior?
The "Close" button of ChildView is not working if it's open from tabs
### :new: What is the new behavior (if this is a feature change)?
The "Close" button should close the ChildView, same as by clicking the back button.
### :boom: Does this PR introduce a breaking change?
No.
### :bug: Recommendations for testing

1. Run the "Playground.iOS" sample;
2. Click the "Initiate Tabs navigation"
3. click the "Show child" button to display the ChildView, 
4. then click the "Close" button.
See the the ChildView is closed or not.
Before the PR, the ChildView is not closed.
After the PR, the ChildView can be closed.
### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
