### PR TITLE
Code Behind Binding for Forms

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Core/IMvxContentPage.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Core/IMvxContentPage.cs
@@ -1,9 +1,10 @@
-﻿using MvvmCross.Core.ViewModels;
+﻿using MvvmCross.Binding.BindingContext;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 
 namespace MvvmCross.Forms.Core
 {
-    public interface IMvxContentPage : IMvxView
+    public interface IMvxContentPage : IMvxView, IMvxBindingContextOwner
     {
         MvxViewModelRequest Request { get; set; }
     }

--- a/MvvmCross-Forms/MvvmCross.Forms/Core/MvxContentPage.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Core/MvxContentPage.cs
@@ -1,4 +1,5 @@
-﻿using MvvmCross.Core.ViewModels;
+﻿using MvvmCross.Binding.BindingContext;
+using MvvmCross.Core.ViewModels;
 using Xamarin.Forms;
 
 namespace MvvmCross.Forms.Core
@@ -7,8 +8,30 @@ namespace MvvmCross.Forms.Core
     {
         public object DataContext
         {
-            get { return BindingContext; }
-            set { BindingContext = value; }
+            get
+            {
+                return BindingContext.DataContext;
+            }
+            set
+            {
+                base.BindingContext = value;
+                BindingContext.DataContext = value;
+            }
+        }
+
+        private IMvxBindingContext _bindingContext;
+        public new IMvxBindingContext BindingContext
+        {
+            get
+            {
+                if (_bindingContext == null)
+                    BindingContext = new MvxBindingContext(base.BindingContext);
+                return _bindingContext;
+            }
+            set
+            {
+                _bindingContext = value;
+            }
         }
 
         public IMvxViewModel ViewModel

--- a/TestProjects/Forms/MvxBindings/MvxBindingsExample/AppStart.cs
+++ b/TestProjects/Forms/MvxBindings/MvxBindingsExample/AppStart.cs
@@ -18,7 +18,11 @@ namespace MvxBindingsExample
         {
             try
             {
+                // Use this start to try the xaml bindings
                 _navigationService.Navigate<MainViewModel>().GetAwaiter().GetResult();
+
+                // Use this start to try the code behind View & ViewModel
+                //_navigationService.Navigate<CodeBehindViewModel>().GetAwaiter().GetResult();
             }
             catch (System.Exception e)
             {

--- a/TestProjects/Forms/MvxBindings/MvxBindingsExample/MvxBindingsExample.csproj
+++ b/TestProjects/Forms/MvxBindings/MvxBindingsExample/MvxBindingsExample.csproj
@@ -45,6 +45,8 @@
     <Compile Include="Services\TextProviderBuilder.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="AppStart.cs" />
+    <Compile Include="ViewModels\CodeBehindViewModel.cs" />
+    <Compile Include="Pages\CodeBehindPage.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Pages\MainPage.xaml">
@@ -80,6 +82,10 @@
     <ProjectReference Include="..\..\..\..\MvvmCross\Platform\Platform\MvvmCross.Platform.csproj">
       <Project>{CFF6F25A-3C3B-44EE-A54C-2ED4AAFF3ADB}</Project>
       <Name>MvvmCross.Platform</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\MvvmCross\Core\Binding\MvvmCross.Binding.csproj">
+      <Project>{64DCD397-9019-41E8-A928-E5F5C5DF185B}</Project>
+      <Name>MvvmCross.Binding</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/TestProjects/Forms/MvxBindings/MvxBindingsExample/Pages/CodeBehindPage.cs
+++ b/TestProjects/Forms/MvxBindings/MvxBindingsExample/Pages/CodeBehindPage.cs
@@ -1,0 +1,29 @@
+﻿using MvvmCross.Forms.Core;
+using Xamarin.Forms;
+using MvxBindingsExample.ViewModels;
+using MvvmCross.Binding.BindingContext;
+
+namespace MvxBindingsExample.Pages
+{
+    public class CodeBehindPage : MvxContentPage<CodeBehindViewModel>
+    {
+        private Label _label = new Label();
+        private Entry _entry = new Entry();
+        public CodeBehindPage()
+        {
+            Content = new StackLayout
+            {
+                Children = {
+                    _label,
+                    _entry
+                }
+            };
+
+            var set = this.CreateBindingSet<CodeBehindPage, CodeBehindViewModel>();
+            set.Bind(_label).For(l => l.Text).To(vm => vm.BindableText);
+            set.Bind(_entry).For(e => e.Text).To(vm => vm.BindableText);
+            set.Apply();
+        }
+    }
+}
+

--- a/TestProjects/Forms/MvxBindings/MvxBindingsExample/Pages/CodeBehindPage.cs
+++ b/TestProjects/Forms/MvxBindings/MvxBindingsExample/Pages/CodeBehindPage.cs
@@ -26,4 +26,3 @@ namespace MvxBindingsExample.Pages
         }
     }
 }
-

--- a/TestProjects/Forms/MvxBindings/MvxBindingsExample/ViewModels/CodeBehindViewModel.cs
+++ b/TestProjects/Forms/MvxBindings/MvxBindingsExample/ViewModels/CodeBehindViewModel.cs
@@ -1,0 +1,24 @@
+﻿using MvvmCross.Core.ViewModels;
+
+namespace MvxBindingsExample.ViewModels
+{
+    public class CodeBehindViewModel : MvxViewModel
+    {
+        private string _bindableText = "I'm bound!";
+        public string BindableText
+        {
+            get
+            {
+                return _bindableText;
+            }
+            set
+            {
+                if (BindableText != value)
+                {
+                    _bindableText = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
The ability to do code behind bindings from Xamarin Forms

### :arrow_heading_down: What is the current behavior?
MvxContentPage does not allow for code behind bindings, only Xaml bindings.

### :new: What is the new behavior (if this is a feature change)?
MvxContentPage (IMvxContentPage) now implements IMvxBindingContextOwner which allows for code behind bindings.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
