### PR TITLE
Now Forms MasterDetail can launch on iOS

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/MvxFormsAndroidSetup.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/MvxFormsAndroidSetup.cs
@@ -42,6 +42,8 @@ namespace MvvmCross.Forms.Droid
         {
             get
             {
+                if (!Xamarin.Forms.Forms.IsInitialized)
+                    Xamarin.Forms.Forms.Init(Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity, null);
                 if (_formsApplication == null)
                     _formsApplication = CreateFormsApplication();
                 return _formsApplication;
@@ -52,7 +54,6 @@ namespace MvvmCross.Forms.Droid
 
         protected override IMvxAndroidViewPresenter CreateViewPresenter()
         {
-            Xamarin.Forms.Forms.Init(Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity, null);
             return new MvxFormsDroidPagePresenter(FormsApplication);
         }
 

--- a/MvvmCross-Forms/MvvmCross.Forms.Uwp/MvxFormsWindowsSetup.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Uwp/MvxFormsWindowsSetup.cs
@@ -41,15 +41,20 @@ namespace MvvmCross.Forms.Uwp
         }
 
         private MvxFormsApplication _formsApplication;
-        public MvxFormsApplication FormsApplication =>
-            _formsApplication = _formsApplication ?? CreateFormsApplication();
+        public MvxFormsApplication FormsApplication
+        {
+            get
+            {
+                if (!Xamarin.Forms.Forms.IsInitialized)
+                    Xamarin.Forms.Forms.Init(_launchActivatedEventArgs);
+                _formsApplication = _formsApplication ?? CreateFormsApplication();
+            }
+        }
 
         protected virtual MvxFormsApplication CreateFormsApplication() => new MvxFormsApplication();
 
         protected override IMvxWindowsViewPresenter CreateViewPresenter(IMvxWindowsFrame rootFrame)
         {
-            Xamarin.Forms.Forms.Init(_launchActivatedEventArgs);
-
             var presenter = new MvxFormsUwpPagePresenter(rootFrame, FormsApplication);
             Mvx.RegisterSingleton<IMvxViewPresenter>(presenter);
 

--- a/MvvmCross-Forms/MvvmCross.Forms.iOS/MvxFormsIosSetup.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.iOS/MvxFormsIosSetup.cs
@@ -32,7 +32,7 @@ namespace MvvmCross.Forms.iOS
         {
             if (_viewAssemblies == null)
                 _viewAssemblies = new List<Assembly>(base.GetViewAssemblies());
-            
+
             return _viewAssemblies;
         }
 
@@ -45,6 +45,8 @@ namespace MvvmCross.Forms.iOS
         public MvxFormsApplication FormsApplication {
             get
             {
+                if (!Xamarin.Forms.Forms.IsInitialized)
+                    Xamarin.Forms.Forms.Init();
                 if(_formsApplication == null)
                     _formsApplication = CreateFormsApplication();
                 return _formsApplication;

--- a/MvvmCross-Forms/MvvmCross.Forms.iOS/MvxFormsIosSetup.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.iOS/MvxFormsIosSetup.cs
@@ -57,7 +57,6 @@ namespace MvvmCross.Forms.iOS
 
         protected override IMvxIosViewPresenter CreatePresenter()
         {
-            Xamarin.Forms.Forms.Init();
             return new MvxFormsIosPagePresenter(Window, FormsApplication);
         }
 

--- a/TestProjects/Forms/MasterDetail/MasterDetailExample.iOS/Setup.cs
+++ b/TestProjects/Forms/MasterDetail/MasterDetailExample.iOS/Setup.cs
@@ -15,7 +15,7 @@ namespace MasterDetailExample.iOS
         public Setup(IMvxApplicationDelegate applicationDelegate, UIWindow window)
             : base(applicationDelegate, window)
         {
-        }        
+        }
 
         protected override IMvxApplication CreateApp()
         {
@@ -24,6 +24,7 @@ namespace MasterDetailExample.iOS
 
         protected override IMvxIosViewPresenter CreatePresenter()
         {
+            Forms.Init();
             return new MvxFormsIosMasterDetailPagePresenter(Window, FormsApplication);
         }
     }

--- a/TestProjects/Forms/MasterDetail/MasterDetailExample.iOS/Setup.cs
+++ b/TestProjects/Forms/MasterDetail/MasterDetailExample.iOS/Setup.cs
@@ -24,7 +24,6 @@ namespace MasterDetailExample.iOS
 
         protected override IMvxIosViewPresenter CreatePresenter()
         {
-            Forms.Init();
             return new MvxFormsIosMasterDetailPagePresenter(Window, FormsApplication);
         }
     }


### PR DESCRIPTION
Now the Forms MasterDetail example can launch on iOS.
Still not working on Android though...

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The Forms MasterDetail Example can't launch because of a missing call to Forms.Init()

### :new: What is the new behavior (if this is a feature change)?
Now the example can launch on iOS - but still not Android though...

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
