### PR TITLE
bug fix for UWP compilation

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Uwp/MvxFormsWindowsSetup.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Uwp/MvxFormsWindowsSetup.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Forms.Uwp
         {
             get
             {
-                if (!Xamarin.Forms.Forms.IsInitialized)
+                if (_formsApplication == null)
                     Xamarin.Forms.Forms.Init(_launchActivatedEventArgs);
                 _formsApplication = _formsApplication ?? CreateFormsApplication();
             }

--- a/MvvmCross-Forms/MvvmCross.Forms.Uwp/MvxFormsWindowsSetup.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Uwp/MvxFormsWindowsSetup.cs
@@ -46,8 +46,11 @@ namespace MvvmCross.Forms.Uwp
             get
             {
                 if (_formsApplication == null)
+                {
                     Xamarin.Forms.Forms.Init(_launchActivatedEventArgs);
-                _formsApplication = _formsApplication ?? CreateFormsApplication();
+                    _formsApplication = _formsApplication ?? CreateFormsApplication();
+                }
+                return _formsApplication;
             }
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for UWP compilation problem.

### :arrow_heading_down: What is the current behavior?
UWP can't compile because there is no IsInitialized method on the Forms class.

### :new: What is the new behavior (if this is a feature change)?
Changed to another guard.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
