### PR TITLE
Operate with IMvxFragmentView in MvxCachingFragmentStatePagerAdapter

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentStatePagerAdapter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentStatePagerAdapter.cs
@@ -8,6 +8,7 @@ using Android.Support.V4.View;
 using Java.Lang;
 using MvvmCross.Core.Platform;
 using MvvmCross.Core.ViewModels;
+using MvvmCross.Droid.Views;
 using MvvmCross.Droid.Views.Attributes;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Droid.Platform;
@@ -47,7 +48,7 @@ namespace MvvmCross.Droid.Support.V4
             var fragInfo = FragmentsInfo.ElementAt(position);
             var fragment = Fragment.Instantiate(_context, FragmentJavaName(fragInfo.FragmentType));
 
-            var mvxFragment = fragment as MvxFragment;
+            var mvxFragment = fragment as IMvxFragmentView;
             if (mvxFragment == null)
                 return fragment;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Enhancement

### :arrow_heading_down: What is the current behavior?

`MvxCachingFragmentStatePagerAdapter` initalizes ViewModels only for `MvxFragment` inheritors, but there are other fragments can be used. For example `MvxAppCompatDialogFragment`.

### :new: What is the new behavior (if this is a feature change)?

`MvxCachingFragmentStatePagerAdapter` checks fragment for `IMvxFragmentView` now instead of `MvxFramgent` to setup ViewModel.

### :boom: Does this PR introduce a breaking change?

No breaking changes.

### :bug: Recommendations for testing

Just use `MvxAppCompatDialogFragment` as PageAdapter item and check for ViewModel instance: `((IMvxFragmentView)pageAdapater.GetItem(index)).ViewModel != null`

### :memo: Links to relevant issues/docs

No links.

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop

