### PR TITLE
Android Presenter: Improve ViewModel loading method

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentExtensions.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentExtensions.cs
@@ -56,7 +56,7 @@ namespace MvvmCross.Droid.Support.V4
             view.OnViewCreate(() => cached ?? fragmentView.LoadViewModel(bundle, fragment.Activity.GetType(), request));
         }
 
-        private static Fragment ToFragment(this IMvxFragmentView fragmentView)
+        public static Fragment ToFragment(this IMvxFragmentView fragmentView)
         {
             return fragmentView as Fragment;
         }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Android.OS;
 using Android.Support.Design.Widget;
 using Android.Support.V4.App;
 using Android.Support.V4.Util;
@@ -177,14 +178,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             // if attribute has a Fragment Host, then show it as nested and return
             if (attribute.FragmentHostViewType != null)
             {
-                var fragmentHost = GetFragmentByViewType(attribute.FragmentHostViewType);
-                if (fragmentHost == null)
-                    throw new NullReferenceException($"Fragment host not found when trying to show View {view.Name} as Nested Fragment");
-
-                if (!fragmentHost.IsVisible)
-                    throw new InvalidOperationException($"Fragment host is not visible when trying to show View {view.Name} as Nested Fragment");
-
-                PerformShowFragmentTransaction(fragmentHost.ChildFragmentManager, attribute, request);
+                ShowNestedFragment(view, attribute, request);
 
                 return;
             }
@@ -210,6 +204,20 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             }
         }
 
+        protected override void ShowNestedFragment(Type view, MvxFragmentPresentationAttribute attribute, MvxViewModelRequest request)
+        {
+            // current implementation only supports one level of nesting 
+
+            var fragmentHost = GetFragmentByViewType(attribute.FragmentHostViewType);
+            if (fragmentHost == null)
+                throw new NullReferenceException($"Fragment host not found when trying to show View {view.Name} as Nested Fragment");
+
+            if (!fragmentHost.IsVisible)
+                throw new InvalidOperationException($"Fragment host is not visible when trying to show View {view.Name} as Nested Fragment");
+
+            PerformShowFragmentTransaction(fragmentHost.ChildFragmentManager, attribute, request);
+        }
+
         protected virtual void PerformShowFragmentTransaction(
             FragmentManager fragmentManager,
             MvxFragmentPresentationAttribute attribute,
@@ -218,12 +226,23 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             var fragmentName = FragmentJavaName(attribute.ViewType);
             var fragment = CreateFragment(attribute, fragmentName);
 
-            //TODO: Find a better way to set the ViewModel at the Fragment
+            // MvxNavigationService provides an already instantiated ViewModel here,
+            // therefore just assign it
             if (request is MvxViewModelInstanceRequest instanceRequest)
+            {
                 fragment.ViewModel = instanceRequest.ViewModelInstance;
+            }
             else
             {
-                fragment.ViewModel = (IMvxViewModel)Mvx.IocConstruct(request.ViewModelType);
+                var bundle = new Bundle();
+                var serializedRequest = NavigationSerializer.Serializer.SerializeObject(request);
+                bundle.PutString(ViewModelRequestBundleKey, serializedRequest);
+
+                var fragmentView = fragment.ToFragment();
+                if (fragmentView != null)
+                {
+                    fragmentView.Arguments = bundle;
+                }
             }
 
             var ft = fragmentManager.BeginTransaction();

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -280,18 +280,21 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             var fragmentName = FragmentJavaName(attribute.ViewType);
             var dialog = (DialogFragment)CreateFragment(attribute, fragmentName);
 
-            //TODO: Find a better way to set the ViewModel at the Fragment
-            IMvxViewModel viewModel;
+            var mvxFragmentView = (IMvxFragmentView)dialog;
+            // MvxNavigationService provides an already instantiated ViewModel here,
+            // therefore just assign it
             if (request is MvxViewModelInstanceRequest instanceRequest)
-                viewModel = instanceRequest.ViewModelInstance;
+            {
+                mvxFragmentView.ViewModel = instanceRequest.ViewModelInstance;
+            }
             else
             {
-                viewModel = (IMvxViewModel)Mvx.IocConstruct(request.ViewModelType);
+                mvxFragmentView.LoadViewModelFrom(request, null);
             }
-            ((IMvxFragmentView)dialog).ViewModel = viewModel;
+
             dialog.Cancelable = attribute.Cancelable;
 
-            Dialogs.Add(viewModel, dialog);
+            Dialogs.Add(mvxFragmentView.ViewModel, dialog);
 
             var ft = CurrentFragmentManager.BeginTransaction();
             if (attribute.SharedElements != null)

--- a/MvvmCross/Droid/Droid/MvvmCross.Droid.csproj
+++ b/MvvmCross/Droid/Droid/MvvmCross.Droid.csproj
@@ -95,7 +95,6 @@
     <Compile Include="Views\MvxFragmentExtensions.cs" />
     <Compile Include="Views\IMvxFragmentView.cs" />
     <Compile Include="Views\IMvxEventSourceFragment.cs" />
-    <Compile Include="Views\Caching\CachedFragmentManager.cs" />
     <Compile Include="Views\Caching\DefaultFragmentCacheConfiguration.cs" />
     <Compile Include="Views\Caching\FragmentCacheConfiguration.cs" />
     <Compile Include="Views\Caching\IFragmentCacheableActivity.cs" />

--- a/MvvmCross/Droid/Droid/Views/Caching/CachedFragmentManager.cs
+++ b/MvvmCross/Droid/Droid/Views/Caching/CachedFragmentManager.cs
@@ -1,6 +1,0 @@
-namespace MvvmCross.Droid.Views.Caching
-{
-    internal class FragmentPresenter
-    {
-    }
-}

--- a/MvvmCross/Droid/Droid/Views/MvxActivityViewExtensions.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxActivityViewExtensions.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Droid.Views
             var cache = Mvx.Resolve<IMvxSingleViewModelCache>();
             var cached = cache.GetAndClear(bundle);
 
-            var view = androidView as IMvxView;
+            var view = (IMvxView)androidView;
             var savedState = GetSavedStateFromBundle(bundle);
             view.OnViewCreate(() => cached ?? androidView.LoadViewModel(savedState));
         }

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -456,18 +456,21 @@ namespace MvvmCross.Droid.Views
             var fragmentName = FragmentJavaName(attribute.ViewType);
             var dialog = (DialogFragment)CreateFragment(attribute, fragmentName);
 
-            //TODO: Find a better way to set the ViewModel at the Fragment
-            IMvxViewModel viewModel;
+            var mvxFragmentView = (IMvxFragmentView)dialog;
+            // MvxNavigationService provides an already instantiated ViewModel here,
+            // therefore just assign it
             if (request is MvxViewModelInstanceRequest instanceRequest)
-                viewModel = instanceRequest.ViewModelInstance;
+            {
+                mvxFragmentView.ViewModel = instanceRequest.ViewModelInstance;
+            }
             else
             {
-                viewModel = (IMvxViewModel)Mvx.IocConstruct(request.ViewModelType);
+                mvxFragmentView.LoadViewModelFrom(request, null);
             }
-            ((IMvxFragmentView)dialog).ViewModel = viewModel;
+
             dialog.Cancelable = attribute.Cancelable;
 
-            Dialogs.Add(viewModel, dialog);
+            Dialogs.Add(mvxFragmentView.ViewModel, dialog);
 
             var ft = CurrentFragmentManager.BeginTransaction();
             if (attribute.SharedElements != null)

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -11,6 +11,7 @@ using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.Droid.Platform;
 using MvvmCross.Droid.Views.Attributes;
+using MvvmCross.Droid.Views.Fragments;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Droid.Platform;
 using MvvmCross.Platform.Exceptions;
@@ -70,6 +71,17 @@ namespace MvvmCross.Droid.Views
                 if (_viewsContainer == null)
                     _viewsContainer = Mvx.Resolve<IMvxViewsContainer>();
                 return _viewsContainer;
+            }
+        }
+
+        private IMvxNavigationSerializer _navigationSerializer;
+        protected IMvxNavigationSerializer NavigationSerializer
+        {
+            get
+            {
+                if (_navigationSerializer == null)
+                    _navigationSerializer = Mvx.Resolve<IMvxNavigationSerializer>();
+                return _navigationSerializer;
             }
         }
 
@@ -340,14 +352,7 @@ namespace MvvmCross.Droid.Views
             // if attribute has a Fragment Host, then show it as nested and return
             if (attribute.FragmentHostViewType != null)
             {
-                var fragmentHost = GetFragmentByViewType(attribute.FragmentHostViewType);
-                if (fragmentHost == null)
-                    throw new NullReferenceException($"Fragment host not found when trying to show View {view.Name} as Nested Fragment");
-
-                if (!fragmentHost.IsVisible)
-                    throw new InvalidOperationException($"Fragment host is not visible when trying to show View {view.Name} as Nested Fragment");
-
-                PerformShowFragmentTransaction(fragmentHost.ChildFragmentManager, attribute, request);
+                ShowNestedFragment(view, attribute, request);
 
                 return;
             }
@@ -373,6 +378,23 @@ namespace MvvmCross.Droid.Views
             }
         }
 
+        protected virtual void ShowNestedFragment(
+            Type view,
+            MvxFragmentPresentationAttribute attribute,
+            MvxViewModelRequest request)
+        {
+            // current implementation only supports one level of nesting 
+
+            var fragmentHost = GetFragmentByViewType(attribute.FragmentHostViewType);
+            if (fragmentHost == null)
+                throw new NullReferenceException($"Fragment host not found when trying to show View {view.Name} as Nested Fragment");
+
+            if (!fragmentHost.IsVisible)
+                throw new InvalidOperationException($"Fragment host is not visible when trying to show View {view.Name} as Nested Fragment");
+
+            PerformShowFragmentTransaction(fragmentHost.ChildFragmentManager, attribute, request);
+        }
+
         protected virtual void PerformShowFragmentTransaction(
             FragmentManager fragmentManager,
             MvxFragmentPresentationAttribute attribute,
@@ -381,12 +403,23 @@ namespace MvvmCross.Droid.Views
             var fragmentName = FragmentJavaName(attribute.ViewType);
             var fragment = CreateFragment(attribute, fragmentName);
 
-            //TODO: Find a better way to set the ViewModel at the Fragment
+            // MvxNavigationService provides an already instantiated ViewModel here,
+            // therefore just assign it
             if (request is MvxViewModelInstanceRequest instanceRequest)
+            {
                 fragment.ViewModel = instanceRequest.ViewModelInstance;
+            }
             else
             {
-                fragment.ViewModel = (IMvxViewModel)Mvx.IocConstruct(request.ViewModelType);
+                var bundle = new Bundle();
+                var serializedRequest = NavigationSerializer.Serializer.SerializeObject(request);
+                bundle.PutString(ViewModelRequestBundleKey, serializedRequest);
+
+                var fragmentView = fragment.ToFragment();
+                if (fragmentView != null)
+                {
+                    fragmentView.Arguments = bundle;
+                }
             }
 
             var ft = fragmentManager.BeginTransaction();

--- a/TestProjects/Playground/Playground.Core/ViewModels/ChildViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ChildViewModel.cs
@@ -19,6 +19,21 @@ namespace Playground.Core.ViewModels
             ShowRootCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
         }
 
+        public override System.Threading.Tasks.Task Initialize()
+        {
+            return base.Initialize();
+        }
+
+        public void Init()
+        {
+
+        }
+
+        public override void Start()
+        {
+            base.Start();
+        }
+
         public IMvxAsyncCommand CloseCommand { get; private set; }
 
         public IMvxAsyncCommand ShowSecondChildCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/ModalViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ModalViewModel.cs
@@ -19,6 +19,21 @@ namespace Playground.Core.ViewModels
             ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NestedModalViewModel>());
         }
 
+        public override System.Threading.Tasks.Task Initialize()
+        {
+            return base.Initialize();
+        }
+
+        public void Init()
+        {
+
+        }
+
+        public override void Start()
+        {
+            base.Start();
+        }
+
         public IMvxAsyncCommand ShowTabsCommand { get; private set; }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -15,11 +15,9 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            //ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
-
             ShowChildCommand = new MvxAsyncCommand(async () => ShowViewModel<ChildViewModel>());
 
-            ShowModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalViewModel>());
+            ShowModalCommand = new MvxAsyncCommand(async () => ShowViewModel<ModalViewModel>());
 
             ShowModalNavCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
 

--- a/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -9,11 +9,15 @@ namespace Playground.Core.ViewModels
     {
         private readonly IMvxNavigationService _navigationService;
 
+        private int _counter = 2;
+
         public RootViewModel(IMvxNavigationService navigationService)
         {
             _navigationService = navigationService;
 
-            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
+            //ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
+
+            ShowChildCommand = new MvxAsyncCommand(async () => ShowViewModel<ChildViewModel>());
 
             ShowModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalViewModel>());
 
@@ -28,20 +32,22 @@ namespace Playground.Core.ViewModels
             ShowSheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SheetViewModel>());
 
             ShowWindowCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<WindowViewModel>());
+
+            _counter = 3;
         }
 
-        private string _hello = "Hello MvvmCross";
-        public string Hello
+        protected override void SaveStateToBundle(IMvxBundle bundle)
         {
-            get { return _hello; }
-            set { SetProperty(ref _hello, value); }
+            base.SaveStateToBundle(bundle);
+
+            bundle.Data["MyKey"] = _counter.ToString();
         }
 
-        private int _counter = 2;
-        public int Counter
+        protected override void ReloadFromBundle(IMvxBundle state)
         {
-            get { return _counter; }
-            set { SetProperty(ref _counter, value); }
+            base.ReloadFromBundle(state);
+
+            _counter = int.Parse(state.Data["MyKey"]);
         }
 
         public IMvxAsyncCommand ShowChildCommand { get; private set; }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix and code improvement.

### :arrow_heading_down: What is the current behavior?
1) __Issue__: When showing a Fragment/DialogFragment by using `MvxViewModelRequest` instead of `MvxViewModelInstanceRequest` (the case of ShowViewModel), the new Android Presenter doesn't respect the ViewModel's lifecycle.

2) __Code improvement__: Logic to display nested fragments is placed inside a larger method, which makes it difficult to override.

### :new: What is the new behavior (if this is a feature change)?
1) Lifecycle methods are called in ViewModels when using `MvxViewModelRequest` instead of `MvxViewModelInstanceRequest`.

2) Extracted logic to show nested fragments to a new virtual method: `ShowNestedFragment`

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Playground.Droid. ModalViewModel and ChildViewModel are shown with `MvxViewModelRequest`. The rest use `MvxViewModelInstanceRequest`.

### :memo: Links to relevant issues/docs
Part of #1934.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
