### PR TITLE
Fix #2116 Incorrect ViewModel Init() params serialization/deserialization

### DIFF
--- a/MvvmCross/Core/Core/Platform/MvxSimplePropertyDictionaryExtensionMethods.cs
+++ b/MvvmCross/Core/Core/Platform/MvxSimplePropertyDictionaryExtensionMethods.cs
@@ -13,6 +13,7 @@ using MvvmCross.Core.ViewModels;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Exceptions;
 using MvvmCross.Platform.Platform;
+using System.Globalization;
 
 namespace MvvmCross.Core.Platform
 {
@@ -24,7 +25,7 @@ namespace MvvmCross.Core.Platform
             if (input == null)
                 return new Dictionary<string, string>();
 
-            return input.ToDictionary(x => x.Key, x => x.Value?.ToString());
+            return input.ToDictionary(x => x.Key, x => x.Value?.ToStringInvariant());
         }
 
         public static IDictionary<string, string> SafeGetData(this IMvxBundle bundle)
@@ -148,13 +149,24 @@ namespace MvvmCross.Core.Platform
             try
             {
                 var value = propertyInfo.GetValue(input, new object[] { });
-
-                return value?.ToString();
+                return value?.ToStringInvariant();
             }
             catch (Exception suspectedMethodAccessException)
             {
                 throw suspectedMethodAccessException.MvxWrap(
                     "Problem accessing object - most likely this is caused by an anonymous object being generated as Internal - please see http://stackoverflow.com/questions/8273399/anonymous-types-and-get-accessors-on-wp7-1");
+            }
+        }
+
+        private static string ToStringInvariant(this object value)
+        {
+            switch (value)
+            {
+                case DateTime dateTime: return dateTime.ToString("o", CultureInfo.InvariantCulture);
+                case double doubleValue: return doubleValue.ToString("r", CultureInfo.InvariantCulture);
+                case float floatValue: return floatValue.ToString("r", CultureInfo.InvariantCulture);
+                case IFormattable formattableValue: return formattableValue.ToString(null, CultureInfo.InvariantCulture);
+                default: return value.ToString();
             }
         }
     }

--- a/MvvmCross/Core/Core/Platform/MvxStringToTypeParser.cs
+++ b/MvvmCross/Core/Core/Platform/MvxStringToTypeParser.cs
@@ -106,7 +106,7 @@ namespace MvvmCross.Core.Platform
             protected override bool TryParse(string input, out object result)
             {
                 short value;
-                var toReturn = short.TryParse(input, out value);
+                var toReturn = short.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
                 result = value;
                 return toReturn;
             }
@@ -117,7 +117,7 @@ namespace MvvmCross.Core.Platform
             protected override bool TryParse(string input, out object result)
             {
                 int value;
-                var toReturn = int.TryParse(input, out value);
+                var toReturn = int.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
                 result = value;
                 return toReturn;
             }
@@ -128,7 +128,7 @@ namespace MvvmCross.Core.Platform
             protected override bool TryParse(string input, out object result)
             {
                 long value;
-                var toReturn = long.TryParse(input, out value);
+                var toReturn = long.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
                 result = value;
                 return toReturn;
             }
@@ -139,7 +139,7 @@ namespace MvvmCross.Core.Platform
             protected override bool TryParse(string input, out object result)
             {
                 ushort value;
-                var toReturn = ushort.TryParse(input, out value);
+                var toReturn = ushort.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
                 result = value;
                 return toReturn;
             }
@@ -150,7 +150,7 @@ namespace MvvmCross.Core.Platform
             protected override bool TryParse(string input, out object result)
             {
                 uint value;
-                var toReturn = uint.TryParse(input, out value);
+                var toReturn = uint.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
                 result = value;
                 return toReturn;
             }
@@ -161,7 +161,7 @@ namespace MvvmCross.Core.Platform
             protected override bool TryParse(string input, out object result)
             {
                 ulong value;
-                var toReturn = ulong.TryParse(input, out value);
+                var toReturn = ulong.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
                 result = value;
                 return toReturn;
             }
@@ -228,7 +228,7 @@ namespace MvvmCross.Core.Platform
             protected override bool TryParse(string input, out object result)
             {
                 DateTime value;
-                var toReturn = DateTime.TryParse(input, out value);
+                var toReturn = DateTime.TryParse(input, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out value);
                 result = value;
                 return toReturn;
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The passed values in navigation are different from original values.

Reasons:
* Serialization with CurrentCulture,  Deserialization with InvariantCulture (#2116)
* The precision is dropped (float, double, DateTime)

### :new: What is the new behavior (if this is a feature change)?
The passed values in navigation are equal to original values.

Modified:
* Serialization/Deserialization with InvariantCulture 
* Round-trip Serialization/Deserialization

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
#2116 

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
