### PR TITLE
Update WPF presenter

### DIFF
--- a/MvvmCross/Windows/Wpf/Platform/MvxWpfSetup.cs
+++ b/MvvmCross/Windows/Wpf/Platform/MvxWpfSetup.cs
@@ -14,6 +14,7 @@ using MvvmCross.Platform.Platform;
 using MvvmCross.Platform.Plugins;
 using MvvmCross.Wpf.Views;
 using MvvmCross.Wpf.Views.Presenters;
+using System.Windows.Controls;
 
 namespace MvvmCross.Wpf.Platform
 {
@@ -27,6 +28,12 @@ namespace MvvmCross.Wpf.Platform
         {
             _uiThreadDispatcher = uiThreadDispatcher;
             _presenter = presenter;
+        }
+
+        protected MvxWpfSetup(Dispatcher uiThreadDispatcher, ContentControl root)
+        {
+            _uiThreadDispatcher = uiThreadDispatcher;
+            _presenter = CreateViewPresenter(root);
         }
 
         protected override IMvxTrace CreateDebugTrace()
@@ -44,6 +51,11 @@ namespace MvvmCross.Wpf.Platform
         protected virtual IMvxWpfViewsContainer CreateWpfViewsContainer()
         {
             return new MvxWpfViewsContainer();
+        }
+
+        protected virtual IMvxWpfViewPresenter CreateViewPresenter(ContentControl root)
+        {
+            return new MvxWpfViewPresenter(root);
         }
 
         protected override IMvxViewDispatcher CreateViewDispatcher()

--- a/MvvmCross/Windows/Wpf/Views/Presenters/Attributes/MvxContentPresentationAttribute.cs
+++ b/MvvmCross/Windows/Wpf/Views/Presenters/Attributes/MvxContentPresentationAttribute.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using MvvmCross.Core.Views;
+﻿using MvvmCross.Core.Views;
 
 namespace MvvmCross.Wpf.Views.Presenters.Attributes
 {
     public class MvxContentPresentationAttribute : MvxBasePresentationAttribute
     {
         public string WindowIdentifier { get; set; }
+        public bool StackNavigation { get; set; } = true;
     }
 }

--- a/MvvmCross/Windows/Wpf/Views/Presenters/Attributes/MvxWindowPresentationAttribute.cs
+++ b/MvvmCross/Windows/Wpf/Views/Presenters/Attributes/MvxWindowPresentationAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using MvvmCross.Core.Views;
-using System.Windows;
+﻿using MvvmCross.Core.Views;
 
 namespace MvvmCross.Wpf.Views.Presenters.Attributes
 {

--- a/TestProjects/Playground/Playground.Core/Playground.Core.csproj
+++ b/TestProjects/Playground/Playground.Core/Playground.Core.csproj
@@ -32,6 +32,7 @@
     <Compile Include="..\..\..\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ViewModels\WindowChildViewModel.cs" />
     <Compile Include="ViewModels\RootViewModel.cs" />
     <Compile Include="ViewModels\ChildViewModel.cs" />
     <Compile Include="ViewModels\ModalNavViewModel.cs" />

--- a/TestProjects/Playground/Playground.Core/ViewModels/WindowChildViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/WindowChildViewModel.cs
@@ -1,0 +1,21 @@
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class WindowChildViewModel : MvxViewModel<WindowChildParam>
+    {
+        private readonly IMvxNavigationService _navigationService;
+
+        private WindowChildParam _param;
+
+        public int ParentNo => _param.ParentNo;
+        public string Text => $"I'm No.{_param.ChildNo}. My parent is No.{_param.ParentNo}";
+
+        public IMvxAsyncCommand CloseCommand => new MvxAsyncCommand(async () => await _navigationService.Close(this));
+
+        public WindowChildViewModel(IMvxNavigationService navigationService) => _navigationService = navigationService;
+
+        public override void Prepare(WindowChildParam param) => _param = param;
+    }
+}

--- a/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
@@ -1,21 +1,46 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 
 namespace Playground.Core.ViewModels
 {
+    public class WindowChildParam
+    {
+        public int ParentNo { get; set; }
+        public int ChildNo { get; set; }
+    }
+
     public class WindowViewModel : MvxViewModel
     {
         private readonly IMvxNavigationService _navigationService;
+
+        private static int _count;
+
+        public string Title => $"No.{Count} Window View";
+
+        public int Count { get; set; }
 
         public WindowViewModel(IMvxNavigationService navigationService)
         {
             _navigationService = navigationService;
 
+            _count++;
+            Count = _count;
+
+            ShowWindowChildCommand = new MvxAsyncCommand<int>(async no =>
+            {
+                await _navigationService.Navigate<WindowChildViewModel, WindowChildParam>(new WindowChildParam
+                {
+                    ParentNo = Count,
+                    ChildNo = no
+                });
+            });
+
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }
+        public IMvxAsyncCommand<int> ShowWindowChildCommand { get; private set; }
     }
 }

--- a/TestProjects/Playground/Playground.Wpf/App.xaml.cs
+++ b/TestProjects/Playground/Playground.Wpf/App.xaml.cs
@@ -16,11 +16,9 @@ namespace Playground.Wpf
 
         void DoSetup()
         {
-            var presenter = new MvxWpfViewPresenter(MainWindow);
             // Hint: You can also set a ContentControl of the Window.
-            // var presenter = new MvxWpfViewPresenter(MainWindow.FindName("FooContentControl") as ContentControl);
-
-            var setup = new Setup(Dispatcher, presenter);
+            // var setup = new Setup(Dispatcher, MainWindow.FindName("FooContentControl") as ContentControl);
+            var setup = new Setup(Dispatcher, MainWindow);
             setup.Initialize();
 
             var start = Mvx.Resolve<IMvxAppStart>();

--- a/TestProjects/Playground/Playground.Wpf/App.xaml.cs
+++ b/TestProjects/Playground/Playground.Wpf/App.xaml.cs
@@ -1,8 +1,9 @@
-﻿using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Platform;
 using MvvmCross.Wpf.Views.Presenters;
 using System;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace Playground.Wpf
 {
@@ -16,6 +17,8 @@ namespace Playground.Wpf
         void DoSetup()
         {
             var presenter = new MvxWpfViewPresenter(MainWindow);
+            // Hint: You can also set a ContentControl of the Window.
+            // var presenter = new MvxWpfViewPresenter(MainWindow.FindName("FooContentControl") as ContentControl);
 
             var setup = new Setup(Dispatcher, presenter);
             setup.Initialize();

--- a/TestProjects/Playground/Playground.Wpf/Playground.Wpf.csproj
+++ b/TestProjects/Playground/Playground.Wpf/Playground.Wpf.csproj
@@ -59,6 +59,9 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Setup.cs" />
+    <Compile Include="Views\WindowChildView.xaml.cs">
+      <DependentUpon>WindowChildView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\NestedModalView.xaml.cs">
       <DependentUpon>NestedModalView.xaml</DependentUpon>
     </Compile>
@@ -89,6 +92,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="Views\WindowChildView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\NestedModalView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/TestProjects/Playground/Playground.Wpf/Setup.cs
+++ b/TestProjects/Playground/Playground.Wpf/Setup.cs
@@ -1,13 +1,13 @@
-﻿using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Wpf.Platform;
-using MvvmCross.Wpf.Views.Presenters;
+using System.Windows.Controls;
 using System.Windows.Threading;
 
 namespace Playground.Wpf
 {
     public class Setup : MvxWpfSetup
     {
-        public Setup(Dispatcher uiThreadDispatcher, IMvxWpfViewPresenter presenter) : base(uiThreadDispatcher, presenter)
+        public Setup(Dispatcher uiThreadDispatcher, ContentControl root) : base(uiThreadDispatcher, root)
         {
         }
 

--- a/TestProjects/Playground/Playground.Wpf/Views/ChildView.xaml
+++ b/TestProjects/Playground/Playground.Wpf/Views/ChildView.xaml
@@ -1,20 +1,17 @@
-﻿<views:MvxWpfView  x:Class="Playground.Wpf.Views.ChildView"
+﻿<views:MvxWpfView x:Class="Playground.Wpf.Views.ChildView"
+                  x:TypeArguments="vm:ChildViewModel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Playground.Wpf.Views"
+             xmlns:vm="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-        </Grid.RowDefinitions>
+    <StackPanel>
         <TextBlock Text="Child View" Margin="5" />
-        <Button Content="Show Second Child" Command="{Binding ShowSecondChildCommand}" Margin="5" Grid.Row="1" />
-        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Grid.Row="2" />
-    </Grid>
+        <Button Content="Show Second Child" Command="{Binding ShowSecondChildCommand}" Margin="5" Padding="5" />
+        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Padding="5" />
+    </StackPanel>
 </views:MvxWpfView>

--- a/TestProjects/Playground/Playground.Wpf/Views/ChildView.xaml.cs
+++ b/TestProjects/Playground/Playground.Wpf/Views/ChildView.xaml.cs
@@ -1,5 +1,5 @@
-﻿using MvvmCross.Core.ViewModels;
-using MvvmCross.Wpf.Views;
+﻿using MvvmCross.Wpf.Views;
+using MvvmCross.Wpf.Views.Presenters.Attributes;
 using Playground.Core.ViewModels;
 
 namespace Playground.Wpf.Views
@@ -7,8 +7,8 @@ namespace Playground.Wpf.Views
     /// <summary>
     /// Interaction logic for ChildView.xaml
     /// </summary>
-    [MvxViewFor(typeof(ChildViewModel))]
-    public partial class ChildView : MvxWpfView
+    [MvxContentPresentation]
+    public partial class ChildView : MvxWpfView<ChildViewModel>
     {
         public ChildView()
         {

--- a/TestProjects/Playground/Playground.Wpf/Views/ModalView.xaml
+++ b/TestProjects/Playground/Playground.Wpf/Views/ModalView.xaml
@@ -1,20 +1,17 @@
-﻿<views:MvxWpfView  x:Class="Playground.Wpf.Views.ModalView"
+﻿<views:MvxWpfView x:Class="Playground.Wpf.Views.ModalView"
+                  x:TypeArguments="vm:ModalViewModel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Playground.Wpf.Views"
+             xmlns:vm="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-        </Grid.RowDefinitions>
+    <StackPanel>
         <TextBlock Text="Modal View" Margin="5" />
-        <Button Content="Show Nested Modal" Command="{Binding ShowNestedModalCommand}" Margin="5" Grid.Row="1" />
-        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Grid.Row="2" />
-    </Grid>
+        <Button Content="Show Nested Modal" Command="{Binding ShowNestedModalCommand}" Margin="5" Padding="5" />
+        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Padding="5" />
+    </StackPanel>
 </views:MvxWpfView>

--- a/TestProjects/Playground/Playground.Wpf/Views/ModalView.xaml.cs
+++ b/TestProjects/Playground/Playground.Wpf/Views/ModalView.xaml.cs
@@ -7,8 +7,8 @@ namespace Playground.Wpf.Views
     /// <summary>
     /// Interaction logic for ModalView.xaml
     /// </summary>
-    [MvxWindowPresentation(ViewModelType = typeof(ModalViewModel), Identifier = nameof(ModalView), Modal = true)]
-    public partial class ModalView : MvxWpfView
+    [MvxWindowPresentation(Identifier = nameof(ModalView), Modal = true)]
+    public partial class ModalView : MvxWpfView<ModalViewModel>
     {
         public ModalView()
         {

--- a/TestProjects/Playground/Playground.Wpf/Views/NestedModalView.xaml
+++ b/TestProjects/Playground/Playground.Wpf/Views/NestedModalView.xaml
@@ -1,18 +1,16 @@
-﻿<views:MvxWpfView  x:Class="Playground.Wpf.Views.NestedModalView"
+﻿<views:MvxWpfView x:Class="Playground.Wpf.Views.NestedModalView"
+                  x:TypeArguments="vm:NestedModalViewModel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Playground.Wpf.Views"
+             xmlns:vm="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-        </Grid.RowDefinitions>
+    <StackPanel>
         <TextBlock Text="Nested Modal" Margin="5" />
-        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Grid.Row="1" />
-    </Grid>
+        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Padding="5" />
+    </StackPanel>
 </views:MvxWpfView>

--- a/TestProjects/Playground/Playground.Wpf/Views/NestedModalView.xaml.cs
+++ b/TestProjects/Playground/Playground.Wpf/Views/NestedModalView.xaml.cs
@@ -7,8 +7,8 @@ namespace Playground.Wpf.Views
     /// <summary>
     /// Interaction logic for NestedModalView.xaml
     /// </summary>
-    [MvxContentPresentation(ViewModelType = typeof(NestedModalViewModel), WindowIdentifier = nameof(ModalView))]
-    public partial class NestedModalView : MvxWpfView
+    [MvxContentPresentation(WindowIdentifier = nameof(ModalView))]
+    public partial class NestedModalView : MvxWpfView<NestedModalViewModel>
     {
         public NestedModalView()
         {

--- a/TestProjects/Playground/Playground.Wpf/Views/RootView.xaml
+++ b/TestProjects/Playground/Playground.Wpf/Views/RootView.xaml
@@ -1,4 +1,4 @@
-﻿<views:MvxWpfView  x:Class="Playground.Wpf.Views.RootView"
+<views:MvxWpfView  x:Class="Playground.Wpf.Views.RootView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,14 +7,9 @@
              xmlns:local="clr-namespace:Playground.Wpf.Views"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-        </Grid.RowDefinitions>
-        <Button Content="Show Child" Command="{Binding ShowChildCommand}" Margin="5" />
-        <Button Content="Show Window" Command="{Binding ShowWindowCommand}" Margin="5" Grid.Row="1" />
-        <Button Content="Show Modal" Command="{Binding ShowModalCommand}" Margin="5" Grid.Row="2" />
-    </Grid>
+    <StackPanel>
+        <Button Content="Show Child (Stack Navigation)" Command="{Binding ShowChildCommand}" Margin="5" Padding="5" />
+        <Button Content="Show New Window (Multiple Windows and Non-stack Navigation)" Command="{Binding ShowWindowCommand}" Margin="5" Padding="5" />
+        <Button Content="Show Modal" Command="{Binding ShowModalCommand}" Margin="5" Padding="5" />
+    </StackPanel>
 </views:MvxWpfView>

--- a/TestProjects/Playground/Playground.Wpf/Views/SecondChildView.xaml.cs
+++ b/TestProjects/Playground/Playground.Wpf/Views/SecondChildView.xaml.cs
@@ -1,14 +1,14 @@
-﻿using MvvmCross.Core.ViewModels;
-using MvvmCross.Wpf.Views;
+﻿using MvvmCross.Wpf.Views;
+using MvvmCross.Wpf.Views.Presenters.Attributes;
 using Playground.Core.ViewModels;
 
 namespace Playground.Wpf.Views
 {
     /// <summary>
     /// Interaction logic for SecondChildView.xaml
-    /// </summary>
-    [MvxViewFor(typeof(SecondChildViewModel))]
-    public partial class SecondChildView : MvxWpfView
+    /// </summary>    
+    [MvxContentPresentation]
+    public partial class SecondChildView : MvxWpfView<SecondChildViewModel>
     {
         public SecondChildView()
         {

--- a/TestProjects/Playground/Playground.Wpf/Views/WindowChildView.xaml
+++ b/TestProjects/Playground/Playground.Wpf/Views/WindowChildView.xaml
@@ -1,16 +1,15 @@
-﻿<views:MvxWpfView x:Class="Playground.Wpf.Views.SecondChildView"
-                  x:TypeArguments="vm:SecondChildViewModel"
+<views:MvxWpfView x:Class="Playground.Wpf.Views.WindowChildView"
+                  x:TypeArguments="vm:WindowChildViewModel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Playground.Wpf.Views"
-             xmlns:vm="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"                   
+             xmlns:vm="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <StackPanel>
-        <TextBlock Text="Second Child" Margin="5" />
-        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Padding="5" />
+    <StackPanel Background="LightGray">
+        <TextBlock Text="{Binding Text}" Margin="5" />
     </StackPanel>
 </views:MvxWpfView>

--- a/TestProjects/Playground/Playground.Wpf/Views/WindowChildView.xaml.cs
+++ b/TestProjects/Playground/Playground.Wpf/Views/WindowChildView.xaml.cs
@@ -1,4 +1,3 @@
-using System;
 using MvvmCross.Core.Views;
 using MvvmCross.Wpf.Views;
 using MvvmCross.Wpf.Views.Presenters.Attributes;
@@ -7,20 +6,21 @@ using Playground.Core.ViewModels;
 namespace Playground.Wpf.Views
 {
     /// <summary>
-    /// Interaction logic for WindowView.xaml
+    /// Interaction logic for WindowChildView.xaml
     /// </summary>
-    public partial class WindowView : MvxWindow<WindowViewModel>, IMvxOverridePresentationAttribute
+    public partial class WindowChildView : MvxWpfView<WindowChildViewModel>, IMvxOverridePresentationAttribute
     {
-        public WindowView()
+        public WindowChildView()
         {
             InitializeComponent();
         }
 
         public MvxBasePresentationAttribute PresentationAttribute()
         {
-            return new MvxWindowPresentationAttribute
+            return new MvxContentPresentationAttribute
             {
-                Identifier = $"{nameof(WindowView)}.{ViewModel.Count}"
+                WindowIdentifier = $"{nameof(WindowView)}.{ViewModel.ParentNo}",
+                StackNavigation = false
             };
         }
     }

--- a/TestProjects/Playground/Playground.Wpf/Views/WindowView.xaml
+++ b/TestProjects/Playground/Playground.Wpf/Views/WindowView.xaml
@@ -1,20 +1,37 @@
-﻿<views:MvxWindow  x:Class="Playground.Wpf.Views.WindowView"
+<views:MvxWindow x:Class="Playground.Wpf.Views.WindowView"
+                 x:TypeArguments="vm:WindowViewModel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Playground.Wpf.Views"
+             xmlns:vm="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
              Height="300" Width="300"
-             Title="Window View">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-        </Grid.RowDefinitions>
-        <TextBlock Text="Window View" Margin="5" />
-        <Button Content="Close" Command="{Binding CloseCommand}" Margin="5" Grid.Row="1" />
-    </Grid>
+             Title="{Binding Title}">
+    <views:MvxWindow.ContentTemplate>
+        <DataTemplate>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <Button Content="Show 1st Child" 
+                        Command="{Binding ShowWindowChildCommand}" CommandParameter="1"
+                        Margin="5" Padding="5" />
+                    <Button Content="Show 2st Child" Grid.Column="1"
+                        Command="{Binding ShowWindowChildCommand}" CommandParameter="2"
+                        Margin="5" Padding="5" />
+                </Grid>
+                <ContentPresenter Content="{Binding}" Grid.Row="1" />
+            </Grid>
+        </DataTemplate>
+    </views:MvxWindow.ContentTemplate>
 </views:MvxWindow>

--- a/docs/_documentation/platform/wpf-view-presenter.md
+++ b/docs/_documentation/platform/wpf-view-presenter.md
@@ -1,0 +1,152 @@
+---
+layout: documentation
+title: WPF View Presenter
+category: Platform specifics
+---
+
+Starting with MvvmCross 5.2, there is a new default Presenter for Views, namely `MvxWpfViewPresenter`.
+
+## View Presenter Overview
+
+The default presenter that comes with MvvmCross offers out of the box support for the following navigation patterns / strategies:
+
+- Single window and Multiple windows app
+- Content inside window with stack/non-stack navigation
+- Modal and modal-less window
+
+Also if your app needs another kind of presentation mode, you can easily extend it!
+
+## Presentation Attributes
+
+The presenter uses a set of `MvxBasePresentationAttribute` to define how a view will be displayed. The existing attributes are:
+
+### MvxWindowPresentationAttribute
+
+Used to a _Window_. 
+
+The view can be one of the following types:
+
+- `MvxWindowView` (that inherits `Window` and implements `IMvxWindowView`)
+- `MvxWpfView` (that inherits `UserControl` and implements `IMvxWpfView`)
+
+
+If the view class isn't `Window`, wrap in a window by the presenter. 
+
+You can customize how the window will look through the following properties:
+
+- `Identifier`: Window identifier, used to identify the window for other attributes. If an identifier is not provided by the developer, it will be set to the name of the view class.
+- `Modal`: How to show window, if true the window will show by `ShowDialog` method. If false the window will show by `Show` method.
+
+This view with this attribute like this:
+```c#
+[MvxWindowPresentation(Identifier = nameof(MainWindow), Modal = false)]
+public partial class MainWindow : MvxWindow<MainWindow>
+{
+    public MainWindow() => InitializeComponent();
+}
+```
+
+### MvxContentPresentationAttribute
+
+Used to set a view as a _content_. The view that will be displayed as a `Content` object in a `Window`. The view class that will be displayed with stack navigation by default.
+
+The view can be one of the following types:
+
+- `MvxWpfView` (that inherits `UserControl` and implements `IMvxWpfView`)
+
+You can customize how the content will look through the following properties:
+
+- `WindowIdentifier`: You can choose in which window should this view be displayed by using this property.If the identifier is not provided, the view will be displayed in the last opened window.
+- `StackNavigation`: The view class can decide if wants to be displayed with stack navigation or non-stack navigation. The default is true.
+
+
+The view with this attribute like this:
+```c#
+[MvxContentPresentation(WindowIdentifier = nameof(MainWindow), StackNavigation = false)]
+public partial class ChildView : MvxWpfView<ChildViewModel>
+{
+    public ChildView() => InitializeComponent();
+}
+```
+
+
+## Views without attributes: Default values
+
+If a `Window` class has no attribute over it, the presenter will assume _Window_ presentation.  Other classes are assumed _Content_ presentation.
+
+
+## Override a presentation attribute at runtime
+
+To override a presentation attribute at runtime you can implement the `IMvxOverridePresentationAttribute` in your view and determine the presentation attribute in the `PresentationAttribute` method like this:
+
+```c#
+public partial class WindowView :
+    MvxWindow<WindowViewModel>,
+    IMvxOverridePresentationAttribute
+{
+    public WindowView() => InitializeComponent();
+
+    // Override a presentation attribute at runtime
+    public MvxBasePresentationAttribute PresentationAttribute() =>
+        new MvxWindowPresentationAttribute
+        {
+            Identifier = $"{nameof(WindowView)}.{ViewModel.Count}"
+        };
+}
+```
+
+If you return `null` from the `PresentationAttribute`, the presenter will assume presentation the same way as views without attributes.
+
+
+## Extensibility
+The presenter is completely extensible! You can override any attribute and customize attribute members.
+
+You can also define new attributes to satisfy your needs. The steps to do so are:
+
+1. Add a new attribute that extends `MvxBasePresentationAttribute`
+    ```c#
+    public class MyCustomModePresentationAttribute : MvxBasePresentationAttribute
+    {
+        public int MyProperty { get; set; }
+    }
+    ```
+2. Subclass `MvxWpfViewPresenter` and make it the presenter of your application in Setup.cs (by overriding the method `CreateViewPresenter`).
+    ```c#
+    public class Setup : MvxWpfSetup
+    {
+        public Setup(Dispatcher uiThreadDispatcher, ContentControl root) : base(uiThreadDispatcher, root)
+        {
+        }
+
+        protected override IMvxApplication CreateApp()
+        {
+            return new Core.App();
+        }
+
+        protected override IMvxWpfViewPresenter CreateViewPresenter(ContentControl root)
+        {
+            return new MyCustomViewPresenter(root);
+        }
+    }
+    ```
+3. Override the method `RegisterAttributeTypes` and add a registry to the dictionary like this:
+    ```c#
+    public class MyCustomViewPresenter
+            : MvxWpfViewPresenter
+    {
+        protected virtual void RegisterAttributeTypes()
+        {
+            _attributeTypesToShowMethodDictionary.Add(
+                typeof(MyCustomModePresentationAttribute),
+                (element, attribute, request) =>
+                    ShowMyCustomModeView(element, (MyCustomPresentationAttribute)attribute, request));
+        }
+    }
+    ```
+4. Implement a method that takes care of the presentation mode (in the example above, `ShowMyCustomModeView`).
+5. Use your attribute over a view class. Ready!
+
+
+
+## Sample please!
+You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/TestProjects/Playground) WPF project to see this presenter in action.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature and doc

### :arrow_heading_down: What is the current behavior?

### :new: What is the new behavior (if this is a feature change)?
Compare to previous 'new preseter'
* Support IMvxOverridePresentationAttribute
    * This enables easily that multiple window view can show view from same child view class. See WindowView/WindowChildView in plyaground.
* Support non-stack navigation (default behavior is stack navigation)
    * This enables easily tab like navigation. See WindowView/WindowChildView in playground
* Accept ContentControl only for the first host view 
    * This enables flexible host view. See the followings.

```c#
var presenter = new MvxWpfViewPresenter(MainWindow);
// or
var presenter = new MvxWpfViewPresenter(MainWindow.FindName("FooContentControl") as ContentControl);
```

* Add overload constructor to MvxWpfSetup (This is not a breaking change)
    * This enables that custom presenter creation in Setup.cs
* Add doc

### :boom: Does this PR introduce a breaking change?
* Yes: For not released 5.2 presenter (presenter of #2124)
    * protected function signature changed: ```GetAttributeForViewModel(Type viewModelType)
``` to ```GetPresentationAttributes(FrameworkElement element)``` for IMvxOverridePresentationAttribute support
* Yes: For released 5.1 presenter. (See #2124)

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
#2124 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
