### PR TITLE
[WIP]Apply async suffix on IMvxNavigationService

### DIFF
--- a/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
@@ -20,15 +20,15 @@ namespace MvvmCross.Core.Navigation
         event BeforeCloseEventHandler BeforeClose;
         event AfterCloseEventHandler AfterClose;
 
-        Task Navigate<TViewModel>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel;
-        Task Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel<TParameter>;
-        Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult>;
-        Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult>;
+        Task NavigateAsync<TViewModel>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel;
+        Task NavigateAsync<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel<TParameter>;
+        Task<TResult> NavigateAsync<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult>;
+        Task<TResult> NavigateAsync<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult>;
 
-        Task Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null);
-        Task Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null);
-        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
-        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task NavigateAsync(IMvxViewModel viewModel, IMvxBundle presentationBundle = null);
+        Task NavigateAsync<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null);
+        Task<TResult> NavigateAsync<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> NavigateAsync<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -48,7 +48,7 @@ namespace MvvmCross.Core.Navigation
         Task<bool> CanNavigate(string path);
 
         Task<bool> Close(IMvxViewModel viewModel);
-        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result);
+        Task<bool> CloseAsync<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result);
 
         bool ChangePresentation(MvxPresentationHint hint);
     }

--- a/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
@@ -45,9 +45,9 @@ namespace MvvmCross.Core.Navigation
         /// </summary>
         /// <param name="path">URI to route</param>
         /// <returns>True if the uri can be routed or false if it cannot.</returns>
-        Task<bool> CanNavigate(string path);
+        Task<bool> CanNavigateAsync(string path);
 
-        Task<bool> Close(IMvxViewModel viewModel);
+        Task<bool> CloseAsync(IMvxViewModel viewModel);
         Task<bool> CloseAsync<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result);
 
         bool ChangePresentation(MvxPresentationHint hint);

--- a/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
@@ -35,10 +35,10 @@ namespace MvvmCross.Core.Navigation
         /// </summary>
         /// <param name="path">URI to route</param>
         /// <returns>A task to await upon</returns>
-        Task Navigate(string path, IMvxBundle presentationBundle = null);
-        Task Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null);
-        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
-        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task NavigateAsync(string path, IMvxBundle presentationBundle = null);
+        Task NavigateAsync<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null);
+        Task<TResult> NavigateAsync<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> NavigateAsync<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Verifies if the provided Uri can be routed to a ViewModel request.

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationExtensions.cs
@@ -25,22 +25,22 @@ namespace MvvmCross.Core.Navigation
         /// <returns>A task to await upon</returns>
         public static Task Navigate(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null)
         {
-            return navigationService.Navigate(path.ToString(), presentationBundle);
+            return navigationService.NavigateAsync(path.ToString(), presentationBundle);
         }
 
         public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class
         {
-            return navigationService.Navigate<TParameter>(path.ToString(), param, presentationBundle);
+            return navigationService.NavigateAsync<TParameter>(path.ToString(), param, presentationBundle);
         }
 
         public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
-            return navigationService.Navigate<TResult>(path.ToString(), presentationBundle, cancellationToken);
+            return navigationService.NavigateAsync<TResult>(path.ToString(), presentationBundle, cancellationToken);
         }
 
         public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
         {
-            return navigationService.Navigate<TParameter, TResult>(path.ToString(), param, presentationBundle, cancellationToken);
+            return navigationService.NavigateAsync<TParameter, TResult>(path.ToString(), param, presentationBundle, cancellationToken);
         }
     }
 }

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationExtensions.cs
@@ -15,7 +15,7 @@ namespace MvvmCross.Core.Navigation
         /// <returns>True if the uri can be routed or false if it cannot.</returns>
         public static Task<bool> CanNavigate(this IMvxNavigationService navigationService, Uri path)
         {
-            return navigationService.CanNavigate(path.ToString());
+            return navigationService.CanNavigateAsync(path.ToString());
         }
 
         /// <summary>

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -19,7 +19,7 @@ namespace MvvmCross.Core.Navigation
     public class MvxNavigationService : IMvxNavigationService
     {
         private IMvxViewDispatcher _viewDispatcher;
-        public IMvxViewDispatcher ViewDispatcher 
+        public IMvxViewDispatcher ViewDispatcher
         {
             get => _viewDispatcher ?? (IMvxViewDispatcher)MvxMainThreadDispatcher.Instance;
             set => _viewDispatcher = value;
@@ -199,10 +199,11 @@ namespace MvvmCross.Core.Navigation
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
-            if(cancellationToken != default(CancellationToken))
+            if (cancellationToken != default(CancellationToken))
             {
-                cancellationToken.Register(async () => {
-                    await Close(viewModel, default(TResult));
+                cancellationToken.Register(async () =>
+                {
+                    await CloseAsync(viewModel, default(TResult));
                 });
             }
 
@@ -226,15 +227,16 @@ namespace MvvmCross.Core.Navigation
             }
         }
 
-        protected virtual async Task<TResult> Navigate<TParameter, TResult> (MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
 
             if (cancellationToken != default(CancellationToken))
             {
-                cancellationToken.Register(async () => {
-                    await Close(viewModel, default(TResult));
+                cancellationToken.Register(async () =>
+                {
+                    await CloseAsync(viewModel, default(TResult));
                 });
             }
 
@@ -259,40 +261,41 @@ namespace MvvmCross.Core.Navigation
             }
         }
 
-        public virtual async Task Navigate(string path, IMvxBundle presentationBundle = null)
+        public virtual async Task NavigateAsync(string path, IMvxBundle presentationBundle = null)
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
             await Navigate(request, request.ViewModelInstance, presentationBundle).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null)
+        public virtual async Task NavigateAsync<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null)
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
             await Navigate<TParameter>(request, (IMvxViewModel<TParameter>)request.ViewModelInstance, param, presentationBundle).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> NavigateAsync<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> NavigateAsync<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
             return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate<TViewModel>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel
+        public virtual async Task NavigateAsync<TViewModel>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel
         {
-            var request = new MvxViewModelInstanceRequest(typeof(TViewModel)){
+            var request = new MvxViewModelInstanceRequest(typeof(TViewModel))
+            {
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, null);
             await Navigate(request, request.ViewModelInstance, presentationBundle).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null)
+        public virtual async Task NavigateAsync<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null)
             where TViewModel : IMvxViewModel<TParameter>
         {
             var request = new MvxViewModelInstanceRequest(typeof(TViewModel))
@@ -303,7 +306,7 @@ namespace MvvmCross.Core.Navigation
             await Navigate<TParameter>(request, (IMvxViewModel<TParameter>)request.ViewModelInstance, param, presentationBundle).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> NavigateAsync<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModelResult<TResult>
         {
             var request = new MvxViewModelInstanceRequest(typeof(TViewModel))
@@ -314,7 +317,7 @@ namespace MvvmCross.Core.Navigation
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> NavigateAsync<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModel<TParameter, TResult>
         {
             var request = new MvxViewModelInstanceRequest(typeof(TViewModel))
@@ -325,30 +328,30 @@ namespace MvvmCross.Core.Navigation
             return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null)
+        public virtual async Task NavigateAsync(IMvxViewModel viewModel, IMvxBundle presentationBundle = null)
         {
-            var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
+            var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
             await Navigate(request, viewModel, presentationBundle).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null)
+        public virtual async Task NavigateAsync<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null)
         {
-            var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
+            var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
             await Navigate<TParameter>(request, viewModel, param, presentationBundle).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> NavigateAsync<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
+            var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
             return await Navigate<TResult>(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> NavigateAsync<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var request = new MvxViewModelInstanceRequest(viewModel){ PresentationValues = presentationBundle?.SafeGetData() };
+            var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
             return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
@@ -369,7 +372,7 @@ namespace MvvmCross.Core.Navigation
             return Task.FromResult(close);
         }
 
-        public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result)
+        public virtual async Task<bool> CloseAsync<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result)
         {
             _tcsResults.TryGetValue(viewModel, out TaskCompletionSource<object> _tcs);
 

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -163,7 +163,7 @@ namespace MvvmCross.Core.Navigation
             return request;
         }
 
-        public virtual Task<bool> CanNavigate(string path)
+        public virtual Task<bool> CanNavigateAsync(string path)
         {
             KeyValuePair<Regex, Type> entry;
 
@@ -362,7 +362,7 @@ namespace MvvmCross.Core.Navigation
             return ViewDispatcher.ChangePresentation(hint);
         }
 
-        public virtual Task<bool> Close(IMvxViewModel viewModel)
+        public virtual Task<bool> CloseAsync(IMvxViewModel viewModel)
         {
             var args = new NavigateEventArgs(viewModel);
             OnBeforeClose(this, args);
@@ -381,7 +381,7 @@ namespace MvvmCross.Core.Navigation
 
             try
             {
-                var closeResult = await Close(viewModel);
+                var closeResult = await CloseAsync(viewModel);
                 if (closeResult)
                 {
                     _tcs?.TrySetResult(result);

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -170,7 +170,7 @@ namespace MvvmCross.Core.Navigation
             return Task.FromResult(TryGetRoute(path, out entry));
         }
 
-        protected virtual async Task Navigate(MvxViewModelRequest request, IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task NavigateAsync(MvxViewModelRequest request, IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
@@ -182,7 +182,7 @@ namespace MvvmCross.Core.Navigation
             OnAfterNavigate(this, args);
         }
 
-        protected virtual async Task Navigate<TParameter>(MvxViewModelRequest request, IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task NavigateAsync<TParameter>(MvxViewModelRequest request, IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
@@ -194,7 +194,7 @@ namespace MvvmCross.Core.Navigation
             OnAfterNavigate(this, args);
         }
 
-        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task<TResult> NavigateAsync<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
@@ -227,7 +227,7 @@ namespace MvvmCross.Core.Navigation
             }
         }
 
-        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task<TResult> NavigateAsync<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var args = new NavigateEventArgs(viewModel);
             OnBeforeNavigate(this, args);
@@ -264,25 +264,25 @@ namespace MvvmCross.Core.Navigation
         public virtual async Task NavigateAsync(string path, IMvxBundle presentationBundle = null)
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
-            await Navigate(request, request.ViewModelInstance, presentationBundle).ConfigureAwait(false);
+            await NavigateAsync(request, request.ViewModelInstance, presentationBundle).ConfigureAwait(false);
         }
 
         public virtual async Task NavigateAsync<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null)
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
-            await Navigate<TParameter>(request, (IMvxViewModel<TParameter>)request.ViewModelInstance, param, presentationBundle).ConfigureAwait(false);
+            await NavigateAsync(request, (IMvxViewModel<TParameter>)request.ViewModelInstance, param, presentationBundle).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> NavigateAsync<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
-            return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await NavigateAsync(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> NavigateAsync<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
-            return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await NavigateAsync(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task NavigateAsync<TViewModel>(IMvxBundle presentationBundle = null) where TViewModel : IMvxViewModel
@@ -292,7 +292,7 @@ namespace MvvmCross.Core.Navigation
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, null);
-            await Navigate(request, request.ViewModelInstance, presentationBundle).ConfigureAwait(false);
+            await NavigateAsync(request, request.ViewModelInstance, presentationBundle).ConfigureAwait(false);
         }
 
         public virtual async Task NavigateAsync<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null)
@@ -303,7 +303,7 @@ namespace MvvmCross.Core.Navigation
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = (IMvxViewModel<TParameter>)ViewModelLoader.LoadViewModel(request, null);
-            await Navigate<TParameter>(request, (IMvxViewModel<TParameter>)request.ViewModelInstance, param, presentationBundle).ConfigureAwait(false);
+            await NavigateAsync(request, (IMvxViewModel<TParameter>)request.ViewModelInstance, param, presentationBundle).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> NavigateAsync<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -314,7 +314,7 @@ namespace MvvmCross.Core.Navigation
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = (IMvxViewModelResult<TResult>)ViewModelLoader.LoadViewModel(request, null);
-            return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await NavigateAsync(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> NavigateAsync<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -325,35 +325,35 @@ namespace MvvmCross.Core.Navigation
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = (IMvxViewModel<TParameter, TResult>)ViewModelLoader.LoadViewModel(request, null);
-            return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await NavigateAsync(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task NavigateAsync(IMvxViewModel viewModel, IMvxBundle presentationBundle = null)
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
-            await Navigate(request, viewModel, presentationBundle).ConfigureAwait(false);
+            await NavigateAsync(request, viewModel, presentationBundle).ConfigureAwait(false);
         }
 
         public virtual async Task NavigateAsync<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null)
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
-            await Navigate<TParameter>(request, viewModel, param, presentationBundle).ConfigureAwait(false);
+            await NavigateAsync(request, viewModel, param, presentationBundle).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> NavigateAsync<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
-            return await Navigate<TResult>(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await NavigateAsync(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> NavigateAsync<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
-            return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await NavigateAsync(request, viewModel, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public bool ChangePresentation(MvxPresentationHint hint)

--- a/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
@@ -31,7 +31,7 @@ namespace MvvmCross.Core.ViewModels
             }
             try
             {
-                NavigationService.Navigate<TViewModel>().GetAwaiter().GetResult();
+                NavigationService.NavigateAsync<TViewModel>().GetAwaiter().GetResult();
             }
             catch (System.Exception exception)
             {

--- a/MvvmCross/Test/Test/Navigation/NavigationServiceTests.cs
+++ b/MvvmCross/Test/Test/Navigation/NavigationServiceTests.cs
@@ -55,7 +55,7 @@ namespace MvvmCross.Test.Navigation
         {
             var navigationService = Ioc.Resolve<IMvxNavigationService>();
 
-            await navigationService.Navigate<SimpleTestViewModel>();
+            await navigationService.NavigateAsync<SimpleTestViewModel>();
 
             MockDispatcher.Verify(
                 x => x.ShowViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleTestViewModel))),
@@ -72,7 +72,7 @@ namespace MvvmCross.Test.Navigation
             var bundle = new MvxBundle();
             bundle.Write(new { hello = "world" });
 
-            await navigationService.Navigate(mockVm.Object, bundle);
+            await navigationService.NavigateAsync(mockVm.Object, bundle);
 
             mockVm.Verify(vm => vm.Initialize(), Times.Once);
             //mockVm.Verify(vm => vm.Init(), Times.Once);
@@ -88,7 +88,7 @@ namespace MvvmCross.Test.Navigation
 
             var mockVm = new Mock<SimpleTestViewModel>();
 
-            await navigationService.Navigate(mockVm.Object);
+            await navigationService.NavigateAsync(mockVm.Object);
 
             mockVm.Verify(vm => vm.Initialize(), Times.Once);
             //mockVm.Verify(vm => vm.Init(), Times.Once);

--- a/MvvmCross/Test/Test/Navigation/RoutingServiceTests.cs
+++ b/MvvmCross/Test/Test/Navigation/RoutingServiceTests.cs
@@ -83,7 +83,7 @@ namespace MvvmCross.Test.Navigation
 
             Assert.CatchAsync(async () =>
             {
-                await RoutingService.Navigate(url);
+                await RoutingService.NavigateAsync(url);
             });
 
             MockDispatcher.Verify(x => x.ShowViewModel(It.IsAny<MvxViewModelRequest>()), Times.Never);
@@ -92,7 +92,7 @@ namespace MvvmCross.Test.Navigation
         [Test]
         public async Task TestDirectMatchRegexAsync()
         {
-            await RoutingService.Navigate("mvx://test/?id=" + Guid.Empty.ToString("N"));
+            await RoutingService.NavigateAsync("mvx://test/?id=" + Guid.Empty.ToString("N"));
 
             MockDispatcher.Verify(
                 x => x.ShowViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(ViewModelB))),
@@ -102,7 +102,7 @@ namespace MvvmCross.Test.Navigation
         [Test]
         public async Task TestRegexWithParametersAsync()
         {
-            await RoutingService.Navigate("mvx://test/?id=" + Guid.NewGuid().ToString("N"));
+            await RoutingService.NavigateAsync("mvx://test/?id=" + Guid.NewGuid().ToString("N"));
 
             MockDispatcher.Verify(
                 x => x.ShowViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(ViewModelC))),
@@ -112,7 +112,7 @@ namespace MvvmCross.Test.Navigation
         [Test]
         public async Task TestFacadeAsync()
         {
-            await RoutingService.Navigate("mvx://facade/?id=a");
+            await RoutingService.NavigateAsync("mvx://facade/?id=a");
 
             MockDispatcher.Verify(
                 x => x.ShowViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(ViewModelA))),

--- a/MvvmCross/Test/Test/Navigation/RoutingServiceTests.cs
+++ b/MvvmCross/Test/Test/Navigation/RoutingServiceTests.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Test.Navigation
         {
             var url = "mvx://fail/?id=" + Guid.NewGuid();
 
-            var canNavigate = await RoutingService.CanNavigate(url);
+            var canNavigate = await RoutingService.CanNavigateAsync(url);
             Assert.That(canNavigate, Is.False);
 
             Assert.CatchAsync(async () =>

--- a/TestProjects/Android-Support/Fragments/Example.Core/AppStart.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/AppStart.cs
@@ -13,7 +13,7 @@ namespace Example.Core
         /// </summary>
         public void Start(object hint = null)
         {
-            Mvx.Resolve<IMvxNavigationService>().Navigate<LoginViewModel>();
+            Mvx.Resolve<IMvxNavigationService>().NavigateAsync<LoginViewModel>();
 			//ShowViewModel<LoginViewModel>();
         }
     }

--- a/TestProjects/Forms/MvxBindings/MvxBindingsExample/AppStart.cs
+++ b/TestProjects/Forms/MvxBindings/MvxBindingsExample/AppStart.cs
@@ -19,7 +19,7 @@ namespace MvxBindingsExample
             try
             {
                 // Use this start to try the xaml bindings
-                _navigationService.Navigate<MainViewModel>().GetAwaiter().GetResult();
+                _navigationService.NavigateAsync<MainViewModel>().GetAwaiter().GetResult();
 
                 // Use this start to try the code behind View & ViewModel
                 //_navigationService.Navigate<CodeBehindViewModel>().GetAwaiter().GetResult();

--- a/TestProjects/Navigation/RoutingExample.Core/AppStart.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/AppStart.cs
@@ -18,7 +18,7 @@ namespace RoutingExample.Core
         {
             try
             {
-                _navigationService.Navigate<MainViewModel>().GetAwaiter().GetResult();
+                _navigationService.NavigateAsync<MainViewModel>().GetAwaiter().GetResult();
             }
             catch (System.Exception e)
             {

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/MainViewModel.cs
@@ -31,7 +31,7 @@ namespace RoutingExample.Core.ViewModels
             {
                 return _showACommand ?? (_showACommand = new MvxAsyncCommand(async () =>
                 {
-                    await _navigationService.Navigate<ViewModelA, string, string>("test");
+                    await _navigationService.NavigateAsync<ViewModelA, string, string>("test");
                     //await _navigationService.Navigate<TestAViewModel, User>(new User("MvvmCross", "Test"));
 
                     //await _navigationService.Navigate("mvx://test/a");
@@ -48,7 +48,7 @@ namespace RoutingExample.Core.ViewModels
                 return _showBCommand ?? (_showBCommand = new MvxAsyncCommand(async () =>
                 {
                     //var result = await _navigationService.Navigate<User, User>("mvx://test/?id=" + Guid.NewGuid().ToString("N"), new User("MvvmCross2", "Test2"));
-                    var result = await _navigationService.Navigate<TestBViewModel, User, User>(new User("MvvmCross", "Test"));
+                    var result = await _navigationService.NavigateAsync<TestBViewModel, User, User>(new User("MvvmCross", "Test"));
                     var test = result?.FirstName;
                     //await _navigationService.Close(this, new User("Close parent", "Test"));
                 }));
@@ -63,7 +63,7 @@ namespace RoutingExample.Core.ViewModels
             {
                 return _showDialogACommand ?? (_showDialogACommand = new MvxAsyncCommand(async () =>
                 {
-                    var result = await _navigationService.Navigate<ViewModelDialogA, IMvxViewModel, string>(this);
+                    var result = await _navigationService.NavigateAsync<ViewModelDialogA, IMvxViewModel, string>(this);
                 }));
             }
         }
@@ -76,7 +76,7 @@ namespace RoutingExample.Core.ViewModels
             {
                 return _showRandomCommand ?? (_showRandomCommand = new MvxAsyncCommand(async () =>
                 {
-                    await _navigationService.Navigate("mvx://random");
+                    await _navigationService.NavigateAsync("mvx://random");
                 }));
             }
         }
@@ -89,7 +89,7 @@ namespace RoutingExample.Core.ViewModels
             {
                 return _showPrePopCommand ?? (_showPrePopCommand = new MvxAsyncCommand(async () =>
                 {
-                    await _navigationService.Navigate("mvx://prepop");
+                    await _navigationService.NavigateAsync("mvx://prepop");
                 }));
             }
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/SecondHostViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/SecondHostViewModel.cs
@@ -20,7 +20,7 @@ namespace RoutingExample.Core.ViewModels
             {
                 return _showACommand ?? (_showACommand = new MvxAsyncCommand(async () =>
                 {
-                    await _routingService.Navigate<TestAViewModel, User>(new User("MvvmCross", "Test"));
+                    await _routingService.NavigateAsync<TestAViewModel, User>(new User("MvvmCross", "Test"));
 
                     //await _routingService.Navigate("mvx://test/a");
                 }));
@@ -36,7 +36,7 @@ namespace RoutingExample.Core.ViewModels
                 return _showBCommand ?? (_showBCommand = new MvxAsyncCommand(async () =>
                 {
                     //var result = await _routingService.Navigate<User, User>("mvx://test/?id=" + Guid.NewGuid().ToString("N"), new User("MvvmCross2", "Test2"));
-                    var result = await _routingService.Navigate<TestBViewModel, User, User>(new User("MvvmCross", "Test"));
+                    var result = await _routingService.NavAsyncigate<TestBViewModel, User, User>(new User("MvvmCross", "Test"));
                     var test = result?.FirstName;
                 }));
             }
@@ -50,7 +50,7 @@ namespace RoutingExample.Core.ViewModels
             {
                 return _showRandomCommand ?? (_showRandomCommand = new MvxAsyncCommand(async () =>
                 {
-                    await _routingService.Navigate("mvx://random");
+                    await _routingService.NavigateAsync("mvx://random");
                 }));
             }
         }

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestAViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestAViewModel.cs
@@ -17,7 +17,7 @@ namespace RoutingExample.Core.ViewModels
         }
 
         public IMvxAsyncCommand OpenViewModelBCommand => new MvxAsyncCommand(
-            async () => await Mvx.Resolve<IMvxNavigationService>().Navigate<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
+            async () => await Mvx.Resolve<IMvxNavigationService>().NavigateAsync<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
 
         public void Init()
         {

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestBViewModel.cs
@@ -31,13 +31,13 @@ namespace RoutingExample.Core.ViewModels
         private User _user;
 
         public IMvxAsyncCommand CloseViewModelCommand => new MvxAsyncCommand(
-            () => _navigationService.Close(this, new User("Return result", "Something")));
+            () => _navigationService.CloseAsync(this, new User("Return result", "Something")));
         public IMvxAsyncCommand OpenViewModelMainCommand => new MvxAsyncCommand(
-            () => _navigationService.Navigate<MainViewModel>());
+            () => _navigationService.NavigateAsync<MainViewModel>());
         public IMvxAsyncCommand OpenViewModelACommand => new MvxAsyncCommand(
-            () =>  _navigationService.Navigate<TestAViewModel, User>(new User($"To A from {GetHashCode()}", "Something")));
+            () =>  _navigationService.NavigateAsync<TestAViewModel, User>(new User($"To A from {GetHashCode()}", "Something")));
         public IMvxAsyncCommand OpenViewModelBCommand => new MvxAsyncCommand(
-            () =>  _navigationService.Navigate<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
+            () =>  _navigationService.NavigateAsync<TestBViewModel, User, User>(new User($"To B from {GetHashCode()}", "Something")));
 
         public override void Prepare(User parameter)
         {

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestCViewModel.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/TestCViewModel.cs
@@ -24,7 +24,7 @@ namespace RoutingExample.Core.ViewModels
         }
 
         public IMvxAsyncCommand CloseViewModelCommand => new MvxAsyncCommand(
-                () => _navigationService.Close(this, UserId));
+                () => _navigationService.CloseAsync(this, UserId));
 
         public override void Prepare(int parameter)
         {

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelA.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelA.cs
@@ -32,7 +32,7 @@ namespace RoutingExample.Core.ViewModels
             _navigatedAwayFromCount++;
             NavigatedAwayFrom = $"Navigated to View B {_navigatedAwayFromCount} times";
 
-            var result = await _navigationService.Navigate<ViewModelB, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
+            var result = await _navigationService.NavigateAsync<ViewModelB, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
 
             _returnedFromCount++;
 
@@ -41,7 +41,7 @@ namespace RoutingExample.Core.ViewModels
 
         public MvxCommand GoToNestedCommand => new MvxCommand(async () =>
         {
-            await _navigationService.Navigate<ViewModelNested>();
+            await _navigationService.NavigateAsync<ViewModelNested>();
         });
 
         public ViewModelA(IMvxNavigationService navigationService)

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelB.cs
@@ -40,7 +40,7 @@ namespace RoutingExample.Core.ViewModels
 
             NavigatedAwayFrom = $"Navigated to View C {_navigatedAwayFromCount} times";
 
-            var result = await _navigationService.Navigate<ViewModelC, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
+            var result = await _navigationService.NavigateAsync<ViewModelC, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
 
             _returnedFromCount++;
 
@@ -49,7 +49,7 @@ namespace RoutingExample.Core.ViewModels
 
         public MvxCommand CloseCommand => new MvxCommand(async () =>
         {
-            await _navigationService.Close(this, Title);
+            await _navigationService.CloseAsync(this, Title);
         });
 
         public ViewModelB(IMvxNavigationService navigationService)

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelC.cs
@@ -25,7 +25,7 @@ namespace RoutingExample.Core.ViewModels
 
         public MvxCommand CloseCommand => new MvxCommand(async () =>
         {
-            await _navigationService.Close(this, Title);
+            await _navigationService.CloseAsync(this, Title);
         });
 
         public override void Prepare(Tuple<string, int> parameter)

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelDialogA.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelDialogA.cs
@@ -32,7 +32,7 @@ namespace RoutingExample.Core.ViewModels
             _navigatedAwayFromCount++;
             NavigatedAwayFrom = $"Navigated to View B {_navigatedAwayFromCount} times";
 
-            var result = await _navigationService.Navigate<ViewModelB, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
+            var result = await _navigationService.NavigateAsync<ViewModelB, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
 
             _returnedFromCount++;
 
@@ -41,7 +41,7 @@ namespace RoutingExample.Core.ViewModels
 
         public MvxCommand CloseCommand => new MvxCommand(async () =>
         {
-            await _navigationService.Close(this, Title);
+            await _navigationService.CloseAsync(this, Title);
         });
 
         public MvxCommand CloseHostCommand => new MvxCommand(async () =>

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelDialogA.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelDialogA.cs
@@ -46,7 +46,7 @@ namespace RoutingExample.Core.ViewModels
 
         public MvxCommand CloseHostCommand => new MvxCommand(async () =>
         {
-            await _navigationService.Close(viewmodel);
+            await _navigationService.CloseAsync(viewmodel);
         });
 
         public ViewModelDialogA(IMvxNavigationService navigationService)

--- a/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelNested.cs
+++ b/TestProjects/Navigation/RoutingExample.Core/ViewModels/ViewModelNested.cs
@@ -32,7 +32,7 @@ namespace RoutingExample.Core.ViewModels
             _navigatedAwayFromCount++;
             NavigatedAwayFrom = $"Navigated to View B {_navigatedAwayFromCount} times";
 
-            var result = await _navigationService.Navigate<ViewModelB, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
+            var result = await _navigationService.NavigateAsync<ViewModelB, Tuple<string, int>, string>(new Tuple<string, int>(Title, _navigatedAwayFromCount));
 
             _returnedFromCount++;
 

--- a/TestProjects/Navigation/RoutingExample.Droid/MainView.cs
+++ b/TestProjects/Navigation/RoutingExample.Droid/MainView.cs
@@ -34,7 +34,7 @@ namespace RoutingExample.Droid
 
             var url = WebUtility.UrlDecode(intent.DataString);
 
-            Mvx.Resolve<IMvxNavigationService>().Navigate(url);
+            Mvx.Resolve<IMvxNavigationService>().NavigateAsync(url);
         }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.Droid/SecondHostView.cs
+++ b/TestProjects/Navigation/RoutingExample.Droid/SecondHostView.cs
@@ -36,7 +36,7 @@ namespace RoutingExample.Droid
 
             var url = WebUtility.UrlDecode(intent.DataString);
 
-            Mvx.Resolve<IMvxNavigationService>().Navigate(url);
+            Mvx.Resolve<IMvxNavigationService>().NavigateAsync(url);
         }
     }
 }

--- a/TestProjects/Navigation/RoutingExample.iOS/AppDelegate.cs
+++ b/TestProjects/Navigation/RoutingExample.iOS/AppDelegate.cs
@@ -44,7 +44,7 @@ namespace RoutingExample.iOS
             var navigationService = Mvx.Resolve<IMvxNavigationService>();
 
             if (navigationService.CanNavigate(normalized).Result)
-                navigationService.Navigate(normalized);
+                navigationService.NavigateAsync(normalized);
 
             return true;
         }

--- a/TestProjects/Navigation/RoutingExample.iOS/AppDelegate.cs
+++ b/TestProjects/Navigation/RoutingExample.iOS/AppDelegate.cs
@@ -43,7 +43,7 @@ namespace RoutingExample.iOS
 
             var navigationService = Mvx.Resolve<IMvxNavigationService>();
 
-            if (navigationService.CanNavigate(normalized).Result)
+            if (navigationService.CanNavigateAsync(normalized).Result)
                 navigationService.NavigateAsync(normalized);
 
             return true;

--- a/TestProjects/Playground/Playground.Core/ViewModels/ChildViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ChildViewModel.cs
@@ -14,9 +14,9 @@ namespace Playground.Core.ViewModels
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
 
-            ShowSecondChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SecondChildViewModel>());
+            ShowSecondChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<SecondChildViewModel>());
 
-            ShowRootCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
+            ShowRootCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<RootViewModel>());
         }
 
         public override System.Threading.Tasks.Task Initialize()

--- a/TestProjects/Playground/Playground.Core/ViewModels/ChildViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ChildViewModel.cs
@@ -12,7 +12,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
 
             ShowSecondChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<SecondChildViewModel>());
 

--- a/TestProjects/Playground/Playground.Core/ViewModels/ModalNavViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ModalNavViewModel.cs
@@ -12,7 +12,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
 
             ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ChildViewModel>());
 

--- a/TestProjects/Playground/Playground.Core/ViewModels/ModalNavViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ModalNavViewModel.cs
@@ -14,9 +14,9 @@ namespace Playground.Core.ViewModels
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
 
-            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
+            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ChildViewModel>());
 
-            ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NestedModalViewModel>());
+            ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<NestedModalViewModel>());
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/ModalViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ModalViewModel.cs
@@ -12,11 +12,11 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<TabsRootViewModel>());
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
 
-            ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NestedModalViewModel>());
+            ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<NestedModalViewModel>());
         }
 
         public override System.Threading.Tasks.Task Initialize()

--- a/TestProjects/Playground/Playground.Core/ViewModels/ModalViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/ModalViewModel.cs
@@ -14,7 +14,7 @@ namespace Playground.Core.ViewModels
 
             ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<TabsRootViewModel>());
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
 
             ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<NestedModalViewModel>());
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/NestedChildViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/NestedChildViewModel.cs
@@ -12,7 +12,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/NestedModalViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/NestedModalViewModel.cs
@@ -15,7 +15,7 @@ namespace Playground.Core.ViewModels
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<TabsRootViewModel>());
         }
 
         public IMvxAsyncCommand ShowTabsCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/NestedModalViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/NestedModalViewModel.cs
@@ -13,7 +13,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
 
             ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<TabsRootViewModel>());
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/OverrideAttributeViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/OverrideAttributeViewModel.cs
@@ -14,7 +14,7 @@ namespace Playground.Core.ViewModels
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<TabsRootViewModel>());
         }
 
         public IMvxAsyncCommand ShowTabsCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/OverrideAttributeViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/OverrideAttributeViewModel.cs
@@ -12,7 +12,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
 
             ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<TabsRootViewModel>());
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -19,17 +19,17 @@ namespace Playground.Core.ViewModels
 
             ShowModalCommand = new MvxAsyncCommand(async () => ShowViewModel<ModalViewModel>());
 
-            ShowModalNavCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
+            ShowModalNavCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ModalNavViewModel>());
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<TabsRootViewModel>());
 
-            ShowSplitCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitRootViewModel>());
+            ShowSplitCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<SplitRootViewModel>());
 
-            ShowOverrideAttributeCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<OverrideAttributeViewModel>());
+            ShowOverrideAttributeCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<OverrideAttributeViewModel>());
 
-            ShowSheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SheetViewModel>());
+            ShowSheetCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<SheetViewModel>());
 
-            ShowWindowCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<WindowViewModel>());
+            ShowWindowCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<WindowViewModel>());
 
             _counter = 3;
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/SecondChildViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SecondChildViewModel.cs
@@ -14,7 +14,7 @@ namespace Playground.Core.ViewModels
 
             ShowNestedChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<NestedChildViewModel>());
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
         }
 
         public IMvxAsyncCommand ShowNestedChildCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/SecondChildViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SecondChildViewModel.cs
@@ -12,7 +12,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            ShowNestedChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NestedChildViewModel>());
+            ShowNestedChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<NestedChildViewModel>());
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/SheetViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SheetViewModel.cs
@@ -13,7 +13,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/SplitDetailViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SplitDetailViewModel.cs
@@ -11,7 +11,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
+            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ChildViewModel>());
         }
 
         public IMvxAsyncCommand ShowChildCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/SplitMasterViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SplitMasterViewModel.cs
@@ -12,11 +12,11 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            OpenDetailCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitDetailViewModel>());
+            OpenDetailCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<SplitDetailViewModel>());
 
-            OpenDetailNavCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitDetailNavViewModel>());
+            OpenDetailNavCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<SplitDetailNavViewModel>());
 
-            ShowRootViewModel = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
+            ShowRootViewModel = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<RootViewModel>());
         }
 
         public IMvxAsyncCommand OpenDetailCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/SplitRootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SplitRootViewModel.cs
@@ -23,12 +23,12 @@ namespace Playground.Core.ViewModels
 
         private async Task ShowInitialViewModels()
         {
-            await _navigationService.Navigate<SplitMasterViewModel>();
+            await _navigationService.NavigateAsync<SplitMasterViewModel>();
         }
 
         private async Task ShowDetailViewModel()
         {
-            await _navigationService.Navigate<SplitDetailViewModel>();
+            await _navigationService.NavigateAsync<SplitDetailViewModel>();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
@@ -20,7 +20,7 @@ namespace Playground.Core.ViewModels
 
             OpenNavModalCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ModalNavViewModel>());
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
         }
 
         public override async Task Initialize()

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab1ViewModel.cs
@@ -14,11 +14,11 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            OpenChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
+            OpenChildCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ChildViewModel>());
 
-            OpenModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalViewModel>());
+            OpenModalCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ModalViewModel>());
 
-            OpenNavModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
+            OpenNavModalCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<ModalNavViewModel>());
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab2ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab2ViewModel.cs
@@ -14,7 +14,7 @@ namespace Playground.Core.ViewModels
 
             ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<RootViewModel>());
 
-            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
         }
 
         public IMvxAsyncCommand ShowRootViewModelCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab2ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab2ViewModel.cs
@@ -12,7 +12,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
+            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<RootViewModel>());
 
             CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab3ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab3ViewModel.cs
@@ -14,7 +14,7 @@ namespace Playground.Core.ViewModels
 
             ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<RootViewModel>());
 
-            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
         }
 
         public IMvxAsyncCommand ShowRootViewModelCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab3ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab3ViewModel.cs
@@ -12,7 +12,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
+            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.NavigateAsync<RootViewModel>());
 
             CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
@@ -22,9 +22,9 @@ namespace Playground.Core.ViewModels
         private async Task ShowInitialViewModels()
         {
             var tasks = new List<Task>();
-            tasks.Add(_navigationService.Navigate<Tab1ViewModel, string>("test"));
-            tasks.Add(_navigationService.Navigate<Tab2ViewModel>());
-            tasks.Add(_navigationService.Navigate<Tab3ViewModel>());
+            tasks.Add(_navigationService.NavigateAsync<Tab1ViewModel, string>("test"));
+            tasks.Add(_navigationService.NavigateAsync<Tab2ViewModel>());
+            tasks.Add(_navigationService.NavigateAsync<Tab3ViewModel>());
             await Task.WhenAll(tasks);
         }
     }

--- a/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
@@ -13,7 +13,7 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.CloseAsync(this));
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/AppStart.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/AppStart.cs
@@ -20,7 +20,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
         /// </summary>
         public void Start(object hint = null)
         {
-            _navigationService.Navigate<CenterPanelViewModel>();
+            _navigationService.NavigateAsync<CenterPanelViewModel>();
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/CenterPanelViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/CenterPanelViewModel.cs
@@ -37,7 +37,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
         /// </remarks>
         private void ShowMasterCommandExecuted()
         {
-            _navigationService.Navigate<MasterViewModel>();
+            _navigationService.NavigateAsync<MasterViewModel>();
         }
 
         public IMvxCommand ShowKeyboardHandlingCommand
@@ -53,7 +53,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
         /// </summary>
         private void ShowKeyboardHandlingCommandExecuted()
         {
-            _navigationService.Navigate<KeyboardHandlingViewModel>();
+            _navigationService.NavigateAsync<KeyboardHandlingViewModel>();
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/LeftPanelViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/LeftPanelViewModel.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 
         private void DoShowExampleMenuItem()
         {
-            _navigationService.Navigate<ExampleMenuItemViewModel>();
+            _navigationService.NavigateAsync<ExampleMenuItemViewModel>();
         }
 
         public MvxCommand ShowMasterViewCommand
@@ -41,7 +41,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 
         private void ShowMasterView()
         {
-            _navigationService.Navigate<MasterViewModel>();
+            _navigationService.NavigateAsync<MasterViewModel>();
         }
     }
 }

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
@@ -33,12 +33,12 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core.ViewModels
 
         private void ShowDetailCommandExecuted()
         {
-            _navigationService.Navigate<DetailViewModel>();
+            _navigationService.NavigateAsync<DetailViewModel>();
         }
 
         private void ShowDetailRightCommandExecuted()
         {
-            _navigationService.Navigate<DetailRightViewModel>();
+            _navigationService.NavigateAsync<DetailRightViewModel>();
         }
     }
 }


### PR DESCRIPTION
Still WIP, haven't checked on UWP, documentation etc.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Applies the Async suffix to methods which return Task in the IMvxNavigationService. It has also been done to methods not using the async modifier as the MvxNavigationService is usually used as a baseclass and its good practice to suffix it Async then.

### :arrow_heading_down: What is the current behavior?

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?
If implementing the IMvxNavigationService, you would need to update your code.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
