### PR TITLE
Update pp file for WPF StarterPack nuspec. Update doc.

### DIFF
--- a/nuspec/WpfContent/App.Xaml.Mvx.cs.pp
+++ b/nuspec/WpfContent/App.Xaml.Mvx.cs.pp
@@ -14,9 +14,7 @@ namespace $rootnamespace$
         {
             LoadMvxAssemblyResources();
             
-            var presenter = new MvxSimpleWpfViewPresenter(MainWindow);
-
-            var setup = new Setup(Dispatcher, presenter);
+            var setup = new Setup(Dispatcher, MainWindow);
             setup.Initialize();
 
             var start = Mvx.Resolve<IMvxAppStart>();

--- a/nuspec/WpfContent/Setup.cs.pp
+++ b/nuspec/WpfContent/Setup.cs.pp
@@ -1,3 +1,4 @@
+using System.Windows.Controls;
 using System.Windows.Threading;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Platform.Platform;
@@ -9,8 +10,8 @@ namespace $rootnamespace$
     public class Setup
         : MvxWpfSetup
     {
-        public Setup(Dispatcher dispatcher, IMvxWpfViewPresenter presenter)
-            : base(dispatcher, presenter)
+        public Setup(Dispatcher uiThreadDispatcher, ContentControl root)
+            : base(uiThreadDispatcher, root)
         {
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
pp files update
doc update

### :arrow_heading_down: What is the current behavior?
* Used simple WPF presenter in pp files
* Written old StarterPack codes in MvvmCross Overview doc

### :new: What is the new behavior (if this is a feature change)?
* Use new WPF presenter in pp files
* Update MvvmCross Overview doc
    * Use latest StarterPack codes.
    * But this doc is too old. Old descriptions are remain.

### :boom: Does this PR introduce a breaking change?
Yes. pp files are for 5.2

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
