### PR TITLE
Add methods for using combiners with Fluent Bindings

### DIFF
--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -84,11 +84,14 @@ namespace MvvmCross.Binding.BindingContext
             => To($"{combinerName}({string.Join(", ", properties)})");
 
         public MvxFluentBindingDescription<TTarget, TSource> ByCombining(IMvxValueCombiner combiner, params Expression<Func<TSource, object>>[] properties)
-            => ByCombining(combiner, properties.Select(SourcePropertyPath).ToArray());
+        {
+            SetCombiner(combiner, properties.Select(SourcePropertyPath).ToArray(), useParser: false);
+            return this;
+        }
 
         public MvxFluentBindingDescription<TTarget, TSource> ByCombining(IMvxValueCombiner combiner, params string[] properties)
         {
-            SetCombiner(combiner, properties);
+            SetCombiner(combiner, properties, useParser: true);
             return this;
         }
 

--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.Bindings;
+using MvvmCross.Binding.Combiners;
 using MvvmCross.Binding.ValueConverters;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Converters;
@@ -73,6 +74,21 @@ namespace MvvmCross.Binding.BindingContext
         {
             var sourcePropertyPath = SourcePropertyPath(sourceProperty);
             SetKnownTextPropertyPath(sourcePropertyPath);
+            return this;
+        }
+
+        public MvxFluentBindingDescription<TTarget, TSource> ByCombining(string combinerName, params Expression<Func<TSource, object>>[] properties)
+            => ByCombining(combinerName, properties.Select(SourcePropertyPath).ToArray());
+
+        public MvxFluentBindingDescription<TTarget, TSource> ByCombining(string combinerName, params string[] properties)
+            => To($"{combinerName}({string.Join(", ", properties)})");
+
+        public MvxFluentBindingDescription<TTarget, TSource> ByCombining(IMvxValueCombiner combiner, params Expression<Func<TSource, object>>[] properties)
+            => ByCombining(combiner, properties.Select(SourcePropertyPath).ToArray());
+
+        public MvxFluentBindingDescription<TTarget, TSource> ByCombining(IMvxValueCombiner combiner, params string[] properties)
+        {
+            SetCombiner(combiner, properties);
             return this;
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This adds custom methods that make using Combiners nicer when using Fluent Bindings

### :arrow_heading_down: What is the current behavior?

Right now all you can do is use free text

### :new: What is the new behavior (if this is a feature change)?

You can now use Expressions, pass each property individually and even pass an instance of your combiner instead of relying on a string that will retrieve a registered combiner.

### :boom: Does this PR introduce a breaking change?

Nope

### :bug: Recommendations for testing

Fiddle around with the test projects or try using it to replace existing free text bindings that use combiners to see if behavior is correct.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))*
- [X] Rebased onto current develop

* There's a great lack of docs regarding combiners, so I could not even find a place that describes how to use them in first place. If anyone knows where such docs should be added, please link me so I can provide a full write up on both the new methods and the current way of using combiners :)