### PR TITLE
Droid Presenter: Support for BottomSheetDialogFragment

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
@@ -68,7 +68,6 @@ namespace MvvmCross.Droid.Support.Design
     {
         public MvxBottomSheetDialogFragment()
         {
-
         }
 
         protected MvxBottomSheetDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
@@ -18,58 +18,68 @@ namespace MvvmCross.Droid.Support.Design
 {
     [Register("mvvmcross.droid.support.design.MvxBottomSheetDialogFragment")]
     public abstract class MvxBottomSheetDialogFragment
-		: MvxEventSourceBottomSheetDialogFragment, IMvxFragmentView
-	{
-		protected MvxBottomSheetDialogFragment()
-		{
-			this.AddEventListeners();
-		}
+        : MvxEventSourceBottomSheetDialogFragment, IMvxFragmentView
+    {
+        protected MvxBottomSheetDialogFragment()
+        {
+            this.AddEventListeners();
+        }
 
-	    protected MvxBottomSheetDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
-	        : base(javaReference, transfer)
-	    {
-	    }
+        protected MvxBottomSheetDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
 
-		public IMvxBindingContext BindingContext { get; set; }
+        public IMvxBindingContext BindingContext { get; set; }
 
-		private object _dataContext;
+        private object _dataContext;
 
-		public object DataContext
-		{
-			get
+        public object DataContext
+        {
+            get
             {
                 return _dataContext;
             }
-			set
-			{
-				_dataContext = value;
-				if (BindingContext != null)
-					BindingContext.DataContext = value;
-			}
-		}
+            set
+            {
+                _dataContext = value;
+                if (BindingContext != null)
+                    BindingContext.DataContext = value;
+            }
+        }
 
-		public virtual IMvxViewModel ViewModel
-		{
-			get { return DataContext as IMvxViewModel; }
-			set { DataContext = value; }
-		}
+        public virtual IMvxViewModel ViewModel
+        {
+            get { return DataContext as IMvxViewModel; }
+            set { DataContext = value; }
+        }
 
-		protected void EnsureBindingContextSet(Bundle b0)
-		{
-			this.EnsureBindingContextIsSet(b0);
-		}
+        protected void EnsureBindingContextSet(Bundle b0)
+        {
+            this.EnsureBindingContextIsSet(b0);
+        }
 
-		public virtual string UniqueImmutableCacheTag => Tag;
-	}
+        public virtual string UniqueImmutableCacheTag => Tag;
+    }
 
-	public abstract class MvxBottomSheetDialogFragment<TViewModel>
-		: MvxBottomSheetDialogFragment
-		, IMvxFragmentView<TViewModel> where TViewModel : class, IMvxViewModel
-	{
-		public new TViewModel ViewModel
-		{
-			get { return (TViewModel)base.ViewModel; }
-			set { base.ViewModel = value; }
-		}
-	}
+    public abstract class MvxBottomSheetDialogFragment<TViewModel>
+        : MvxBottomSheetDialogFragment
+        , IMvxFragmentView<TViewModel> where TViewModel : class, IMvxViewModel
+    {
+        public MvxBottomSheetDialogFragment()
+        {
+
+        }
+
+        protected MvxBottomSheetDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+
+        public new TViewModel ViewModel
+        {
+            get { return (TViewModel)base.ViewModel; }
+            set { base.ViewModel = value; }
+        }
+    }
 }

--- a/TestProjects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/TestProjects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -137,6 +137,7 @@
     <AndroidResource Include="Resources\layout\SecondChildView.axml" />
     <AndroidResource Include="Resources\layout\ModalNavView.axml" />
     <AndroidResource Include="Resources\layout\NestedChildView.axml" />
+    <AndroidResource Include="Resources\layout\SheetView.axml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\drawable\" />

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
@@ -30,6 +30,11 @@
 		android:layout_marginTop="10dp"
 		android:text="Show Master/Detail"
 		local:MvxBind="Click ShowSplitCommand;" />
+	<Button android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_marginTop="10dp"
+		android:text="Show BottomSheet"
+		local:MvxBind="Click ShowSheetCommand" />
 	<FrameLayout android:id="@+id/content_frame"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent" />

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/SheetView.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/SheetView.axml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:local="http://schemas.android.com/apk/res-auto"
+	android:orientation="vertical"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:background="#FFD454"
+	android:padding="@dimen/margin_medium">
+	<Button android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:text="Close"
+		local:MvxBind="Click CloseCommand" />
+</LinearLayout>

--- a/TestProjects/Playground/Playground.Droid/Views/SheetView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/SheetView.cs
@@ -23,7 +23,6 @@ namespace Playground.Droid.Views
         {
         }
 
-
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             base.OnCreateView(inflater, container, savedInstanceState);

--- a/TestProjects/Playground/Playground.Droid/Views/SheetView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/SheetView.cs
@@ -3,22 +3,32 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross.Binding.Droid.BindingContext;
+using MvvmCross.Droid.Support.Design;
 using MvvmCross.Droid.Support.V4;
 using MvvmCross.Droid.Views.Attributes;
 using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Views
 {
-    [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame)]
-    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
+    [MvxDialogFragmentPresentation]
     [Register(nameof(SheetView))]
-    public class SheetView : MvxFragment<SheetViewModel>
+    public class SheetView : MvxBottomSheetDialogFragment<SheetViewModel>
     {
+        public SheetView()
+        {
+        }
+
+        protected SheetView(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+
+
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.ChildView, null);
+            var view = this.BindingInflate(Resource.Layout.SheetView, null);
 
             return view;
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
`MvxBottomSheetDialogFragment<TViewModel>` is missing a ctor that makes an app crash. Also it isn't verified that the new ViewPresenter for Droid supports this kind of dialogs.

### :new: What is the new behavior (if this is a feature change)?
I've added the missing ctors for `MvxBottomSheetDialogFragment<TViewModel>` and also added a test case to Playground.Droid project, to ensure it works.

__Note: Sorry for the crazy diffs, but there was a file using tabs instead of spaces.__

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Playground.Droid and tap on "Show BottomSheet" button.

### :memo: Links to relevant issues/docs
Issue: #1934 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
