### PR TITLE
Add .NET Standard documentation

### DIFF
--- a/docs/_documentation/getting-started/netstandard.md
+++ b/docs/_documentation/getting-started/netstandard.md
@@ -27,3 +27,5 @@ This line would normaly belong in the `PropertyGroup` which contains the `Target
   <!-- other entries -->
 </Project>
 ```
+
+From here you should be able to add MvvmCross and other PCL based NuGet packages to your .NET Standard project.

--- a/docs/_documentation/getting-started/netstandard.md
+++ b/docs/_documentation/getting-started/netstandard.md
@@ -1,0 +1,29 @@
+---
+layout: documentation
+title: .NET Standard & MvvmCross
+category: Getting-started
+order: 4
+---
+
+This document will briefly cover how you use .NET Standard in your core project, whilst still using the PCL based MvvmCross packages. This also works for other non-MvvmCross projects, where you want to have your core .NET Standard and still want to consume PCL projects in it.
+
+This document will asume that you are using the new `csproj` files and not using `project.json` to define your .NET Standard project.
+
+In order to consume PCL projects in any .NET Standard project you need to add a package target fallback for the PCL profile you want to consume. So let us assume you want to add `MvvmCross.Bindings` to your project. This library uses the PCL profile which has a signature that looks like `portable-net45+win+wpa81+wp80`. To add this as a target fallback you simply edit your `csproj` file and add the following line to it.
+
+```xml
+<PackageTargetFallback>portable-net45+win+wpa81+wp80</PackageTargetFallback>
+```
+
+This line would normaly belong in the `PropertyGroup` which contains the `TargetFramework`, so it would look like. You can have multiple `;`-separated fallbacks here, which helps you consume different profiles.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageTargetFallback>portable-net45+win+wpa81+wp80</PackageTargetFallback>
+  </PropertyGroup>
+
+  <!-- other entries -->
+</Project>
+```


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR adds documentation about how to add MvvmCross and other PCL based projects into your .NET Standard project.

### :arrow_heading_down: What is the current behavior?

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
