### PR TITLE
Fix CollectionViewSourceAnimated Move Action

### DIFF
--- a/MvvmCross/Binding/iOS/Views/MvxCollectionViewSourceAnimated.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxCollectionViewSourceAnimated.cs
@@ -80,18 +80,16 @@ namespace MvvmCross.Binding.iOS.Views
             {
                 await CollectionView.PerformBatchUpdatesAsync(() =>
                 {
-                    var oldCount = args.OldItems.Count;
-                    var newCount = args.NewItems.Count;
-                    var indexes = new NSIndexPath[oldCount + newCount];
+                    if (args.NewItems.Count != 1 && args.OldItems.Count != 1)
+                    {
+                        Mvx.Trace($"CollectionChanged {args.Action} action called with more than one movement. All data will be reloaded");
+                        CollectionView.ReloadData();
+                        return;
+                    }
 
-                    var startIndex = args.OldStartingIndex;
-                    for (var i = 0; i < oldCount; i++)
-                        indexes[i] = NSIndexPath.FromRowSection(startIndex + i, 0);
-                    startIndex = args.NewStartingIndex;
-                    for (var i = oldCount; i < oldCount + newCount; i++)
-                        indexes[i] = NSIndexPath.FromRowSection(startIndex + i, 0);
-
-                    CollectionView.ReloadItems(indexes);
+                    var oldIndexPath = NSIndexPath.FromRowSection(args.OldStartingIndex, 0);
+                    var newIndexPath = NSIndexPath.FromRowSection(args.NewStartingIndex, 0);
+                    CollectionView.MoveItem(oldIndexPath, newIndexPath);
                 });
             }
             else if (args.Action == NotifyCollectionChangedAction.Remove)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
Move action doesn't work on `MvxCollectionViewSourceAnimated`

### :new: What is the new behavior (if this is a feature change)?
Move action works for `MvxCollectionViewSourceAnimated`

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run the sample project provided by @kenkosmowski: https://github.com/kenkosmowski/MvvmCross-MvxCollectionViewSourceAnimated. It will fail to move items with the current implementation, but it will work when the changes he suggested are applied.

### :memo: Links to relevant issues/docs
Closes issue #2061

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
