### PR TITLE
Extract parse method to inside MvxColor

### DIFF
--- a/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color/MvxARGBValueConverter.cs
+++ b/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color/MvxARGBValueConverter.cs
@@ -11,13 +11,9 @@ using MvvmCross.Platform.UI;
 namespace MvvmCross.Plugins.Color
 {
     [Preserve(AllMembers = true)]
-	public class MvxARGBValueConverter : MvxRGBValueConverter
+    public class MvxARGBValueConverter : MvxColorValueConverter<string>
     {
-        protected override MvxColor Parse8DigitColor(string value)
-        {
-            var a = int.Parse(value.Substring(0, 2), NumberStyles.HexNumber);
-            var rgb = int.Parse(value.Substring(2, 6), NumberStyles.HexNumber);
-            return new MvxColor(rgb, a);
-        }
+        protected override MvxColor Convert(string value, object parameter, CultureInfo culture)
+            => MvxColor.ParseHexString(value, assumeArgb: true);
     }
 }

--- a/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color/MvxRGBValueConverter.cs
+++ b/MvvmCross-Plugins/Color/MvvmCross.Plugins.Color/MvxRGBValueConverter.cs
@@ -14,58 +14,6 @@ namespace MvvmCross.Plugins.Color
 	public class MvxRGBValueConverter : MvxColorValueConverter<string>
     {
         protected override MvxColor Convert(string value, object parameter, CultureInfo culture)
-        {
-            if (string.IsNullOrEmpty(value))
-                return new MvxColor(0);
-
-            value = value.TrimStart('#');
-            if (value.Length == 0)
-                return new MvxColor(0);
-
-            switch (value.Length)
-            {
-                case 3:
-                    return Parse3DigitColor(value);
-
-                case 6:
-                    return Parse6DigitColor(value);
-
-                case 8:
-                    return Parse8DigitColor(value);
-
-                default:
-                    return new MvxColor(0);
-            }
-        }
-
-        private MvxColor Parse3DigitColor(string value)
-        {
-            var red = int.Parse(value.Substring(0, 1), NumberStyles.HexNumber);
-            var green = int.Parse(value.Substring(1, 1), NumberStyles.HexNumber);
-            var blue = int.Parse(value.Substring(2, 1), NumberStyles.HexNumber);
-            return new MvxColor(UpByte(red), UpByte(green), UpByte(blue));
-        }
-
-        private int UpByte(int input)
-        {
-            var fourBit = input & 0xF;
-            var output = fourBit << 4;
-            output |= fourBit;
-            return output;
-        }
-
-        private MvxColor Parse6DigitColor(string value)
-        {
-            var rgb = int.Parse(value, NumberStyles.HexNumber);
-            return new MvxColor(rgb, 255);
-        }
-
-        protected virtual MvxColor Parse8DigitColor(string value)
-        {
-            // assume RGBA
-            var rgb = int.Parse(value.Substring(0, 6), NumberStyles.HexNumber);
-            var a = int.Parse(value.Substring(6, 2), NumberStyles.HexNumber);
-            return new MvxColor(rgb, a);
-        }
+            => MvxColor.ParseHexString(value);
     }
 }

--- a/MvvmCross/Platform/Platform/UI/MvxColor.cs
+++ b/MvvmCross/Platform/Platform/UI/MvxColor.cs
@@ -5,6 +5,8 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System.Globalization;
+
 namespace MvvmCross.Platform.UI
 {
     public class MvxColor
@@ -79,6 +81,91 @@ namespace MvvmCross.Platform.UI
         public override string ToString()
         {
             return $"argb: #{A:X2}{R:X2}{G:X2}{B:X2}";
+        }
+
+        public static MvxColor ParseHexString(string value)
+            => ParseHexString(value, assumeArgb: false);
+
+        public static MvxColor ParseHexString(string value, bool assumeArgb)
+        {
+            if (string.IsNullOrEmpty(value))
+                return new MvxColor(0);
+
+            value = value.TrimStart('#');
+            if (value.Length == 0)
+                return new MvxColor(0);
+
+            switch (value.Length)
+            {
+                case 3:
+                    return Parse3DigitColor(value);
+
+                case 4:
+                    return assumeArgb ? Parse4DigitARBGColor(value) : Parse4DigitRBGAColor(value);
+
+                case 6:
+                    return Parse6DigitColor(value);
+
+                case 8:
+                    return assumeArgb ? Parse8DigitARGBColor(value) : Parse8DigitRGBAColor(value);
+
+                default:
+                    return new MvxColor(0);
+            }
+        }
+
+        private static int UpByte(int input)
+        {
+            var fourBit = input & 0xF;
+            var output = fourBit << 4;
+            output |= fourBit;
+            return output;
+        }
+
+        private static MvxColor Parse3DigitColor(string value)
+        {
+            var red = int.Parse(value.Substring(0, 1), NumberStyles.HexNumber);
+            var green = int.Parse(value.Substring(1, 1), NumberStyles.HexNumber);
+            var blue = int.Parse(value.Substring(2, 1), NumberStyles.HexNumber);
+            return new MvxColor(UpByte(red), UpByte(green), UpByte(blue));
+        }
+
+        private static MvxColor Parse6DigitColor(string value)
+        {
+            var rgb = int.Parse(value, NumberStyles.HexNumber);
+            return new MvxColor(rgb, 255);
+        }
+
+        private static MvxColor Parse4DigitARBGColor(string value)
+        {
+            var alpha = int.Parse(value.Substring(0, 1), NumberStyles.HexNumber);
+            var red = int.Parse(value.Substring(1, 1), NumberStyles.HexNumber);
+            var green = int.Parse(value.Substring(2, 1), NumberStyles.HexNumber);
+            var blue = int.Parse(value.Substring(3, 1), NumberStyles.HexNumber);
+            return new MvxColor(UpByte(red), UpByte(green), UpByte(blue), UpByte(alpha));
+        }
+
+        private static MvxColor Parse4DigitRBGAColor(string value)
+        {
+            var red = int.Parse(value.Substring(0, 1), NumberStyles.HexNumber);
+            var green = int.Parse(value.Substring(1, 1), NumberStyles.HexNumber);
+            var blue = int.Parse(value.Substring(2, 1), NumberStyles.HexNumber);
+            var alpha = int.Parse(value.Substring(3, 1), NumberStyles.HexNumber);
+            return new MvxColor(UpByte(red), UpByte(green), UpByte(blue), UpByte(alpha));
+        }
+
+        private static MvxColor Parse8DigitARGBColor(string value)
+        {
+            var a = int.Parse(value.Substring(0, 2), NumberStyles.HexNumber);
+            var rgb = int.Parse(value.Substring(2, 6), NumberStyles.HexNumber);
+            return new MvxColor(rgb, a);
+        }
+
+        private static MvxColor Parse8DigitRGBAColor(string value)
+        {
+            var rgb = int.Parse(value.Substring(0, 6), NumberStyles.HexNumber);
+            var a = int.Parse(value.Substring(6, 2), NumberStyles.HexNumber);
+            return new MvxColor(rgb, a);
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
There's no out-of-the-box way of creating colors from string, other than instantiating `MvxRGBValueConverter`s

### :new: What is the new behavior (if this is a feature change)?
You can now simply call `MvxColor.ParseHexString` instead

### :boom: Does this PR introduce a breaking change?
Sort of. It removes some methods from `MvxRGBValueConverter`, but that this is probs not a problem, since there isn't much reason to override those methods

### :bug: Recommendations for testing
Unit tests already cover this, but using projects that use converters is a way of ensuring this works

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
