### PR TITLE
Added ctor accepting an instance of 'NSCoder'

### DIFF
--- a/MvvmCross/Binding/iOS/Views/MvxView.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxView.cs
@@ -7,6 +7,7 @@
 
 using System;
 using CoreGraphics;
+using Foundation;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
 using UIKit;
@@ -19,19 +20,26 @@ namespace MvvmCross.Binding.iOS.Views
     {
         public IMvxBindingContext BindingContext { get; set; }
 
-        public MvxView()
-        {
-            this.CreateBindingContext();
-        }
+        // Constructor that will bind managed object to its unmanaged counterpart. This constructor 
+        // should not have any implementation and is only used for types that can be created by the
+        // interface builder (or Xamarin iOS designer). More documentation can be found:
+        // - here: https://developer.xamarin.com/guides/ios/user_interface/designer/ios_designable_controls_overview/
+        // - and here: https://developer.xamarin.com/guides/ios/under_the_hood/api_design/#Types_and_Interface_Builder
+        public MvxView(IntPtr handle) : base(handle) { }
 
-        public MvxView(IntPtr handle)
-            : base(handle)
+        public MvxView()
         {
             this.CreateBindingContext();
         }
 
         public MvxView(CGRect frame)
             : base(frame)
+        {
+            this.CreateBindingContext();
+        }
+
+        public MvxView(NSCoder coder) 
+            : base(coder)
         {
             this.CreateBindingContext();
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix (issue #2156)

### :arrow_heading_down: What is the current behavior?
The `MvxView` class is missing a constructor accepting an instance of the `NSCoder` class. This means custom views deriving from `MvxView` will not function properly when used with the Interface Builder or Xamarin iOS Designer.

### :new: What is the new behavior (if this is a feature change)?
Added implementation for a ctor accepting an instance of the `NSCoder` class. Now custom views deriving from the `MvxView` class can be used in the Interface Builder or Xamarin iOS Designer.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See reproduction steps in issue #2156 

### :memo: Links to relevant issues/docs
Solves #2156 

More information is available in the Xamarin articles [Custom Controls in the Xamarin Designer for iOS](https://developer.xamarin.com/guides/ios/user_interface/designer/ios_designable_controls_overview/) and [API Design - Types and Interface Builder](https://developer.xamarin.com/guides/ios/under_the_hood/api_design/#Types_and_Interface_Builder)

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [N/A] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [N/A] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
