### PR TITLE
Remove unnecessary additions to AndroidViewAssemblies

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatSetup.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatSetup.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using Android.Content;
-using Android.Support.V4.View;
 using Android.Support.V4.Widget;
 using Android.Support.V7.Widget;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
-using MvvmCross.Core.ViewModels;
 using MvvmCross.Droid.Platform;
+using MvvmCross.Droid.Support.V4;
 using MvvmCross.Droid.Views;
 
 namespace MvvmCross.Droid.Support.V7.AppCompat
@@ -19,15 +18,13 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         {
         }
 
-        protected override IEnumerable<Assembly> AndroidViewAssemblies => new List<Assembly>(base.AndroidViewAssemblies)
-        {
-            typeof(Toolbar).Assembly,
-            typeof(DrawerLayout).Assembly,
-            typeof(NestedScrollView).Assembly,
-            typeof(SlidingPaneLayout).Assembly,
-            typeof(ViewPager).Assembly,
-            typeof(Support.V4.MvxSwipeRefreshLayout).Assembly
-        };
+        protected override IEnumerable<Assembly> AndroidViewAssemblies => 
+            new List<Assembly>(base.AndroidViewAssemblies)
+            {
+                typeof(Toolbar).Assembly,
+                typeof(DrawerLayout).Assembly,
+                typeof(MvxSwipeRefreshLayout).Assembly
+            };
 
         /// <summary>
         /// This is very important to override. The default view presenter does not know how to show fragments!


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
DrawerLayout, NestedScrollView, SlidingPaneLayout and ViewPager all come from the same assembly.

### :new: What is the new behavior (if this is a feature change)?
Only one is used to register the Assembly they come from

### :boom: Does this PR introduce a breaking change?

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
#2169 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
