### PR TITLE
Support all primitive types (except IntPtr/UIntPtr) and decimal type in navigation with parameters

### DIFF
--- a/MvvmCross/Core/Core/Platform/MvxStringToTypeParser.cs
+++ b/MvvmCross/Core/Core/Platform/MvxStringToTypeParser.cs
@@ -90,100 +90,39 @@ namespace MvvmCross.Core.Platform
             }
         }
 
+        public class NumberParser<T> : ValueParser where T : struct
+        {
+            // See also https://stackoverflow.com/questions/2961656/generic-tryparse/6553694
+            // Piers Myers(https://stackoverflow.com/users/275751/piers-myers)'s question and
+            // Charlie Brown(https://stackoverflow.com/users/825578/charlie-brown)'s answer
+            public delegate bool TryParseHandler(string input, NumberStyles style, IFormatProvider provider, out T result);
+            private TryParseHandler _tryParseHandler;
+
+            public NumberParser(TryParseHandler handler) => _tryParseHandler = handler;
+
+            protected override bool TryParse(string input, out object result)
+            {
+                var toReturn = _tryParseHandler(input, NumberStyles.Any, CultureInfo.InvariantCulture, out T value);
+                result = value;
+                return toReturn;
+            }
+        }
+
+        public class CharParser : ValueParser
+        {
+            protected override bool TryParse(string input, out object result)
+            {
+                var toReturn = char.TryParse(input, out var value);
+                result = value;
+                return toReturn;
+            }
+        }
+
         public class BoolParser : ValueParser
         {
             protected override bool TryParse(string input, out object result)
             {
-                bool value;
-                var toReturn = bool.TryParse(input, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class ShortParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                short value;
-                var toReturn = short.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class IntParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                int value;
-                var toReturn = int.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class LongParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                long value;
-                var toReturn = long.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class UshortParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                ushort value;
-                var toReturn = ushort.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class UintParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                uint value;
-                var toReturn = uint.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class UlongParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                ulong value;
-                var toReturn = ulong.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class FloatParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                float value;
-                var toReturn = float.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-                result = value;
-                return toReturn;
-            }
-        }
-
-        public class DoubleParser : ValueParser
-        {
-            protected override bool TryParse(string input, out object result)
-            {
-                double value;
-                var toReturn = double.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
+                var toReturn = bool.TryParse(input, out var value);
                 result = value;
                 return toReturn;
             }
@@ -241,15 +180,19 @@ namespace MvvmCross.Core.Platform
         {
             TypeParsers = new Dictionary<Type, IParser>
             {
+                { typeof(char), new CharParser() },
                 { typeof(string), new StringParser() },
-                { typeof(short), new ShortParser() },
-                { typeof(int), new IntParser() },
-                { typeof(long), new LongParser() },
-                { typeof(ushort), new UshortParser() },
-                { typeof(uint), new UintParser() },
-                { typeof(ulong), new UlongParser() },
-                { typeof(double), new DoubleParser() },
-                { typeof(float), new FloatParser() },
+                { typeof(sbyte), new NumberParser<sbyte>(sbyte.TryParse) },
+                { typeof(short), new NumberParser<short>(short.TryParse) },
+                { typeof(int), new NumberParser<int>(int.TryParse) },
+                { typeof(long), new NumberParser<long>(long.TryParse) },
+                { typeof(byte), new NumberParser<byte>(byte.TryParse) },
+                { typeof(ushort), new NumberParser<ushort>(ushort.TryParse) },
+                { typeof(uint), new NumberParser<uint>(uint.TryParse) },
+                { typeof(ulong), new NumberParser<ulong>(ulong.TryParse) },
+                { typeof(double), new NumberParser<double>(double.TryParse) },
+                { typeof(float), new NumberParser<float>(float.TryParse) },
+                { typeof(decimal), new NumberParser<decimal>(decimal.TryParse) },
                 { typeof(bool), new BoolParser() },
                 { typeof(Guid), new GuidParser() },
                 { typeof(DateTime), new DateTimeParser() }

--- a/docs/_documentation/fundamentals/navigation.md
+++ b/docs/_documentation/fundamentals/navigation.md
@@ -401,12 +401,15 @@ public void Init(DetailParameters parameters)
 - it must contain a parameterless constructor
 - it should contain only public properties with both `get` and `set` access
 - these properties should be only of types:
-- `int`
-- `long`
-- `double`
-- `string`
-- `Guid`
-- enumeration values
+    - `bool`
+    - Integral types: `sbyte`, `short`, `int`, `long`, `byte`, `ushort`, `uint`, `ulong`
+    - Floating-point types: `float`, `double`
+    - `decimal`
+    - `char`
+    - `string`
+    - `DateTime`
+    - `Guid`
+    - Enumeration values
 
 ## Navigation with parameters - using an anonymous parameter object
 
@@ -425,15 +428,18 @@ For example, you can:
 ```c#
 public void Init(int index)
 {
-// use the index here
+    // use the index here
 }
 ```
 
 **Note** that due to serialization requirements, the only available parameter types used within this technique are only:
 
-- `int`
-- `long`
-- `double`
+- `bool`
+- Integral types: `sbyte`, `short`, `int`, `long`, `byte`, `ushort`, `uint`, `ulong`
+- Floating-point types: `float`, `double`
+- `decimal`
+- `char`
 - `string`
+- `DateTime`
 - `Guid`
-- enumeration values
+- Enumeration values


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature, doc update

### :arrow_heading_down: What is the current behavior?
Not supported char, sbyte, byte and decimal types in navigation with parameters. (ShowViewModel/Init navigation)

### :new: What is the new behavior (if this is a feature change)?
Support char, sbyte, byte and decimal.

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
