### PR TITLE
Add a constructor with a binding context

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
@@ -12,6 +12,7 @@ using Android.Content;
 using Android.Runtime;
 using Android.Widget;
 using Java.Lang;
+using MvvmCross.Binding.Droid.BindingContext;
 using MvvmCross.Platform.Droid;
 using MvvmCross.Platform.Platform;
 using Object = Java.Lang.Object;
@@ -116,6 +117,16 @@ namespace MvvmCross.Binding.Droid.Views
         }
 
         public MvxFilteringAdapter(Context context) : base(context)
+        {
+            CommonInitialize();
+        }
+
+        public MvxFilteringAdapter(Context context, IMvxAndroidBindingContext bindingContext) : base(context, bindingContext)
+        {
+            CommonInitialize();
+        }
+
+        private void CommonInitialize()
         {
             ReturnSingleObjectFromGetItem = true;
             Filter = new MyFilter(this);

--- a/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
@@ -116,22 +116,16 @@ namespace MvvmCross.Binding.Droid.Views
             base.NotifyDataSetChanged();
         }
 
-        public MvxFilteringAdapter(Context context) : base(context)
+        public MvxFilteringAdapter(Context context) : base(context, MvxAndroidBindingContextHelpers.Current())
         {
-            CommonInitialize();
         }
 
         public MvxFilteringAdapter(Context context, IMvxAndroidBindingContext bindingContext) : base(context, bindingContext)
         {
-            CommonInitialize();
-        }
-
-        private void CommonInitialize()
-        {
             ReturnSingleObjectFromGetItem = true;
             Filter = new MyFilter(this);
         }
-
+        
         protected MvxFilteringAdapter(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
         {

--- a/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
@@ -116,7 +116,7 @@ namespace MvvmCross.Binding.Droid.Views
             base.NotifyDataSetChanged();
         }
 
-        public MvxFilteringAdapter(Context context) : base(context, MvxAndroidBindingContextHelpers.Current())
+        public MvxFilteringAdapter(Context context) : this(context, MvxAndroidBindingContextHelpers.Current())
         {
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

I require an MvxFilteringAdapter that accepts an explicit Android binding context.

### :arrow_heading_down: What is the current behavior?

There is no such constructor. In my scenario, the adapter is created while there is still no context registration on the stack, and because the base constructor is invoked with a `Current` from the helper (which is `null`), it fails with exception.

### :new: What is the new behavior (if this is a feature change)?

The new behavior is simply another constructor with the same common initialization.

### :boom: Does this PR introduce a breaking change?

No breaking changes expected.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
