### PR TITLE
Fix hang in Initialize when called from Navigation app start

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
@@ -31,7 +31,7 @@ namespace MvvmCross.Core.ViewModels
             }
             try
             {
-                NavigationService.Navigate<TViewModel>().GetAwaiter().GetResult();
+                NavigationService.Navigate<TViewModel>();
             }
             catch (System.Exception exception)
             {

--- a/TestProjects/Forms/Example001CSharp/Example/App.cs
+++ b/TestProjects/Forms/Example001CSharp/Example/App.cs
@@ -13,7 +13,7 @@ namespace Example
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 				
-            RegisterAppStart<FirstViewModel>();
+            RegisterNavigationServiceAppStart<FirstViewModel>();
         }
     }
 }

--- a/TestProjects/Forms/Example001CSharp/Example/ViewModels/FirstViewModel.cs
+++ b/TestProjects/Forms/Example001CSharp/Example/ViewModels/FirstViewModel.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using MvvmCross.Core.ViewModels;
+using System.Threading.Tasks;
 
 namespace Example.ViewModels
 {
@@ -19,6 +20,11 @@ namespace Example.ViewModels
                 RaisePropertyChanged(() => Hello);
             }
 		}
+
+        public override async Task Initialize()
+        {
+            await Task.Delay(1);
+        }
 
         public string Hello
         {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This is a reproduction and possible fix for https://github.com/MvvmCross/MvvmCross/issues/2182

### :arrow_heading_down: What is the current behavior?
The navigation service app start causes a hang if the start view model overrides Initialize

### :new: What is the new behavior (if this is a feature change)?
The hang stops

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
The example 1 app is updated to reproduce the issue (first commit)

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2182

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop