### PR TITLE
Move creating of attributes to method

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -111,23 +111,26 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 return attribute;
             }
 
+            return CreateAttributeForViewModel(viewModelType);
+        }
+
+        protected override MvxBasePresentationAttribute CreateAttributeForViewModel(Type viewModelType)
+        {
             var viewType = ViewsContainer.GetViewType(viewModelType);
             if (viewType.IsSubclassOf(typeof(DialogFragment)))
             {
                 MvxTrace.Trace($"PresentationAttribute not found for {viewModelType.Name}. " +
                     $"Assuming DialogFragment presentation");
-                return new MvxDialogFragmentPresentationAttribute();
+                return new MvxDialogFragmentPresentationAttribute() { ViewType = viewType, ViewModelType = viewModelType };
             }
             if (viewType.IsSubclassOf(typeof(Fragment)))
             {
                 MvxTrace.Trace($"PresentationAttribute not found for {viewModelType.Name}. " +
                     $"Assuming Fragment presentation");
-                return new MvxFragmentPresentationAttribute(GetCurrentActivityViewModelType(), Android.Resource.Id.Content);
+                return new MvxFragmentPresentationAttribute(GetCurrentActivityViewModelType(), Android.Resource.Id.Content) { ViewType = viewType, ViewModelType = viewModelType };
             }
 
-            MvxTrace.Trace($"PresentationAttribute not found for {viewModelType.Name}. " +
-                    $"Assuming Activity presentation");
-            return new MvxActivityPresentationAttribute() { ViewModelType = viewModelType };
+            return base.CreateAttributeForViewModel(viewModelType);
         }
 
         protected override void ShowActivity(Type view,

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -250,24 +250,29 @@ namespace MvvmCross.Droid.Views
                 return attribute;
             }
 
+            return CreateAttributeForViewModel(viewModelType);
+        }
+
+        protected virtual MvxBasePresentationAttribute CreateAttributeForViewModel(Type viewModelType)
+        {
             var viewType = ViewsContainer.GetViewType(viewModelType);
 
             if (viewType.IsSubclassOf(typeof(DialogFragment)))
             {
                 MvxTrace.Trace($"PresentationAttribute not found for {viewModelType.Name}. " +
                     $"Assuming DialogFragment presentation");
-                return new MvxDialogFragmentPresentationAttribute();
+                return new MvxDialogFragmentPresentationAttribute() { ViewType = viewType, ViewModelType = viewModelType };
             }
             if (viewType.IsSubclassOf(typeof(Fragment)))
             {
                 MvxTrace.Trace($"PresentationAttribute not found for {viewModelType.Name}. " +
                     $"Assuming Fragment presentation");
-                return new MvxFragmentPresentationAttribute(GetCurrentActivityViewModelType(), Android.Resource.Id.Content);
+                return new MvxFragmentPresentationAttribute(GetCurrentActivityViewModelType(), Android.Resource.Id.Content) { ViewType = viewType, ViewModelType = viewModelType };
             }
 
             MvxTrace.Trace($"PresentationAttribute not found for {viewModelType.Name}. " +
                     $"Assuming Activity presentation");
-            return new MvxActivityPresentationAttribute() { ViewModelType = viewModelType };
+            return new MvxActivityPresentationAttribute() { ViewType = viewType, ViewModelType = viewModelType };
         }
 
         protected Type GetCurrentActivityViewModelType()


### PR DESCRIPTION
Move creating of attributes when none is set on view to virtual method to support calling base.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature, needed for Forms support.

### :arrow_heading_down: What is the current behavior?
Only possible to either have AppCompat or native views.

### :new: What is the new behavior (if this is a feature change)?
When no AppCompat view is found, try native view.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
