### PR TITLE
Feature/mactabviewcontroller

### DIFF
--- a/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
+++ b/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Views\MvxTableColumn.cs" />
     <Compile Include="Target\MvxMacTargetBinding.cs" />
     <Compile Include="Target\MvxNSSegmentedControlSelectedSegmentTargetBinding.cs" />
+    <Compile Include="Target\MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup />

--- a/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
+++ b/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
@@ -90,5 +90,9 @@
       <Project>{64DCD397-9019-41E8-A928-E5F5C5DF185B}</Project>
       <Name>MvvmCross.Binding</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Platform\Mac\MvvmCross.Platform.Mac.csproj">
+      <Project>{EF426A55-0A10-4F13-BE4D-A96AC1C54706}</Project>
+      <Name>MvvmCross.Platform.Mac</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
+++ b/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
@@ -83,6 +83,11 @@ namespace MvvmCross.Binding.Mac
             registry.RegisterCustomBindingFactory<NSButton>(
                 MvxMacPropertyBinding.NSButton_Title,
                 button => new MvxNSButtonTitleTargetBinding(button));
+
+            registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding),
+                typeof(NSTabViewController),
+                MvxMacPropertyBinding.NSTabViewController_SelectedTabViewItemIndex);
             
             /* Todo: Address this for trackpad
             registry.RegisterCustomBindingFactory<NSView>("Tap", view => new MvxNSViewTapTargetBinding(view));

--- a/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
+++ b/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
@@ -123,6 +123,7 @@ namespace MvvmCross.Binding.Mac
             registry.AddOrOverwrite(typeof(NSDatePicker), MvxMacPropertyBinding.NSDatePicker_Date);
             registry.AddOrOverwrite(typeof(NSSlider), MvxMacPropertyBinding.NSSlider_IntValue);
             registry.AddOrOverwrite(typeof(NSSegmentedControl), MvxMacPropertyBinding.NSSegmentedControl_SelectedSegment);
+            registry.AddOrOverwrite(typeof(NSTabViewController), MvxMacPropertyBinding.NSTabViewController_SelectedTabViewItemIndex);
 
             //registry.AddOrOverwrite(typeof(MvxCollectionViewSource), "ItemsSource");
             //registry.AddOrOverwrite(typeof(MvxTableViewSource), "ItemsSource");

--- a/MvvmCross/Binding/Mac/MvxMacPropertyBinding.cs
+++ b/MvvmCross/Binding/Mac/MvxMacPropertyBinding.cs
@@ -20,5 +20,6 @@ namespace MvvmCross.Binding.Mac
         public const string NSButton_State = "State";
         public const string NSSearchField_Text = "Text";
         public const string NSButton_Title = "Title";
+        public const string NSTabViewController_SelectedTabViewItemIndex = "SelectedTabViewItemIndex";
     }
 }

--- a/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
@@ -43,5 +43,8 @@ namespace MvvmCross.Binding.Mac
 
         public static string BindTitle(this NSButton nsButton)
             => MvxMacPropertyBinding.NSButton_Title;
+
+        public static string BindSelectedTabViewItemIndex(this NSTabViewController nsTabViewController)
+            => MvxMacPropertyBinding.NSTabViewController_SelectedTabViewItemIndex;
     }
 }

--- a/MvvmCross/Binding/Mac/Target/MvxNSSegmentedControlSelectedSegmentTargetBinding.cs
+++ b/MvvmCross/Binding/Mac/Target/MvxNSSegmentedControlSelectedSegmentTargetBinding.cs
@@ -37,7 +37,7 @@ namespace MvvmCross.Binding.Mac.Target
                 return;
             }
 
-            this._subscribed = true;
+            _subscribed = true;
             segmentedControl.Activated += HandleValueChanged;
         }
 
@@ -56,10 +56,10 @@ namespace MvvmCross.Binding.Mac.Target
             if (isDisposing)
             {
                 var view = View;
-                if (view != null && this._subscribed)
+                if (view != null && _subscribed)
                 {
                     view.Activated -= HandleValueChanged;
-                    this._subscribed = false;
+                    _subscribed = false;
                 }
             }
         }

--- a/MvvmCross/Binding/Mac/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
+++ b/MvvmCross/Binding/Mac/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Reflection;
+using AppKit;
+using MvvmCross.Binding;
+using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.Platform;
+
+namespace MvvmCross.Binding.Mac.Target
+{
+    public class MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding : MvxPropertyInfoTargetBinding<NSTabViewController>
+    {
+        private bool _subscribed;
+        private NSTabViewController target;
+
+        public MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding(object target, PropertyInfo targetPropertyInfo)
+            : base(target, targetPropertyInfo)
+        {
+        }
+
+        private void HandleValueChanged(object sender, EventArgs e)
+        {
+            var view = View;
+            if (view == null)
+                return;
+            FireValueChanged((int)view.SelectedTabViewItemIndex);
+        }
+
+        public override MvxBindingMode DefaultMode
+        {
+            get { return MvxBindingMode.TwoWay; }
+        }
+
+        public override void SubscribeToEvents()
+        {
+            var tabViewController = View;
+            if (tabViewController == null)
+            {
+                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - NSTabViewController is null in MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding");
+                return;
+            }
+
+            this._subscribed = true;
+            tabViewController.TabView.DidSelect += HandleValueChanged;
+        }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            var view = target as NSTabViewController;
+            if (view == null)
+                return;
+
+            view.SelectedTabViewItemIndex = (int)value;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            if (isDisposing)
+            {
+                var view = View;
+                if (view != null && this._subscribed)
+                {
+                    view.TabView.DidSelect -= HandleValueChanged;
+                    this._subscribed = false;
+                }
+            }
+        }
+    }
+}

--- a/MvvmCross/Binding/Mac/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
+++ b/MvvmCross/Binding/Mac/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using AppKit;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.Mac.Views;
 using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Mac.Target
@@ -32,15 +33,27 @@ namespace MvvmCross.Binding.Mac.Target
 
         public override void SubscribeToEvents()
         {
-            var tabViewController = View;
-            if (tabViewController == null)
+            var view = View;
+            if (view == null)
             {
                 MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - NSTabViewController is null in MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding");
                 return;
             }
 
             this._subscribed = true;
-            tabViewController.TabView.DidSelect += HandleValueChanged;
+            if (view is MvxEventSourceTabViewController)
+            {
+                ((MvxEventSourceTabViewController)view).DidSelectCalled += HandleValueChanged;
+            }
+            else {
+                try {
+                    view.TabView.DidSelect += HandleValueChanged;
+                }
+                catch (Exception ex)
+                {
+                    MvxBindingTrace.Error(ex.Message);
+                }
+            }
         }
 
         protected override void SetValueImpl(object target, object value)
@@ -60,7 +73,21 @@ namespace MvvmCross.Binding.Mac.Target
                 var view = View;
                 if (view != null && this._subscribed)
                 {
-                    view.TabView.DidSelect -= HandleValueChanged;
+                    if (view is MvxEventSourceTabViewController)
+                    {
+                        ((MvxEventSourceTabViewController)view).DidSelectCalled -= HandleValueChanged;
+                    }
+                    else
+                    {
+                        try
+                        {
+                            view.TabView.DidSelect -= HandleValueChanged;
+                        }
+                        catch (Exception ex)
+                        {
+                            MvxBindingTrace.Error(ex.Message);
+                        }
+                    }
                     this._subscribed = false;
                 }
             }

--- a/MvvmCross/Binding/Mac/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
+++ b/MvvmCross/Binding/Mac/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
@@ -40,7 +40,7 @@ namespace MvvmCross.Binding.Mac.Target
                 return;
             }
 
-            this._subscribed = true;
+            _subscribed = true;
             if (view is MvxEventSourceTabViewController)
             {
                 ((MvxEventSourceTabViewController)view).DidSelectCalled += HandleValueChanged;
@@ -71,7 +71,7 @@ namespace MvvmCross.Binding.Mac.Target
             if (isDisposing)
             {
                 var view = View;
-                if (view != null && this._subscribed)
+                if (view != null && _subscribed)
                 {
                     if (view is MvxEventSourceTabViewController)
                     {
@@ -88,7 +88,7 @@ namespace MvvmCross.Binding.Mac.Target
                             MvxBindingTrace.Error(ex.Message);
                         }
                     }
-                    this._subscribed = false;
+                    _subscribed = false;
                 }
             }
         }

--- a/MvvmCross/Platform/Mac/Views/MvxEventSourceTabViewController.cs
+++ b/MvvmCross/Platform/Mac/Views/MvxEventSourceTabViewController.cs
@@ -77,6 +77,18 @@ namespace MvvmCross.Platform.Mac.Views
             ViewDidDisappearCalled?.Raise(this);
         }
 
+        public override void DidSelect(NSTabView tabView, NSTabViewItem item)
+        {
+            base.DidSelect(tabView, item);
+            DidSelectCalled?.Raise(this);
+        }
+
+        public override void WillSelect(NSTabView tabView, NSTabViewItem item)
+        {
+            base.WillSelect(tabView, item);
+            WillSelectCalled?.Raise(this);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -97,6 +109,10 @@ namespace MvvmCross.Platform.Mac.Views
         public event EventHandler ViewDidDisappearCalled;
 
         public event EventHandler ViewWillDisappearCalled;
+
+        public event EventHandler DidSelectCalled;
+
+        public event EventHandler WillSelectCalled;
 
         public event EventHandler DisposeCalled;
     }

--- a/TestProjects/Playground/Playground.Core/App.cs
+++ b/TestProjects/Playground/Playground.Core/App.cs
@@ -13,8 +13,7 @@ namespace Playground.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-//            RegisterNavigationServiceAppStart<RootViewModel>();
-            RegisterNavigationServiceAppStart<TabsRootViewModel>();
+            RegisterNavigationServiceAppStart<RootViewModel>();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Core/App.cs
+++ b/TestProjects/Playground/Playground.Core/App.cs
@@ -13,7 +13,8 @@ namespace Playground.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-            RegisterNavigationServiceAppStart<RootViewModel>();
+//            RegisterNavigationServiceAppStart<RootViewModel>();
+            RegisterNavigationServiceAppStart<TabsRootViewModel>();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using System.Collections.Generic;
+using MvvmCross.Platform.Platform;
 
 namespace Playground.Core.ViewModels
 {
@@ -28,7 +29,6 @@ namespace Playground.Core.ViewModels
             await Task.WhenAll(tasks);
         }
 
-        /*
         private int _itemIndex;
 
         public int ItemIndex {
@@ -37,9 +37,9 @@ namespace Playground.Core.ViewModels
             {
                 if (_itemIndex == value) return;
                 _itemIndex = value;
+                MvxTrace.Trace("Tab item changed to {0}", _itemIndex.ToString());
                 RaisePropertyChanged(() => ItemIndex);
             }
         }
-        */
     }
 }

--- a/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/TabsRootViewModel.cs
@@ -27,5 +27,19 @@ namespace Playground.Core.ViewModels
             tasks.Add(_navigationService.Navigate<Tab3ViewModel>());
             await Task.WhenAll(tasks);
         }
+
+        /*
+        private int _itemIndex;
+
+        public int ItemIndex {
+            get { return _itemIndex; }
+            set
+            {
+                if (_itemIndex == value) return;
+                _itemIndex = value;
+                RaisePropertyChanged(() => ItemIndex);
+            }
+        }
+        */
     }
 }

--- a/TestProjects/Playground/Playground.Mac/Main.storyboard
+++ b/TestProjects/Playground/Playground.Mac/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -841,7 +841,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Ic-19-5Df">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Ic-19-5Df">
                                 <rect key="frame" x="207" y="239" width="36" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Tab 1" id="nCp-Jv-1wh">
                                     <font key="font" metaFont="system"/>

--- a/TestProjects/Playground/Playground.Mac/Playground.Mac.csproj
+++ b/TestProjects/Playground/Playground.Mac/Playground.Mac.csproj
@@ -98,7 +98,6 @@
     <Compile Include="WindowView.designer.cs">
       <DependentUpon>WindowView.cs</DependentUpon>
     </Compile>
-    <Compile Include="TabsRootView.cs" />
     <Compile Include="Tab1View.cs" />
     <Compile Include="Tab1View.designer.cs">
       <DependentUpon>Tab1View.cs</DependentUpon>
@@ -108,6 +107,7 @@
     <Compile Include="..\..\..\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="TabsRootView.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />

--- a/TestProjects/Playground/Playground.Mac/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.Mac/TabsRootView.cs
@@ -1,16 +1,18 @@
-﻿using System;
+using System;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.Mac.Views;
 using MvvmCross.Mac.Views.Presenters.Attributes;
 using Playground.Core.ViewModels;
 
 namespace Playground.Mac
 {
+    //[MvxFromStoryboard("Main")]
     [MvxWindowPresentation(PositionX = 150)]
-    public class TabsRootView : MvxTabViewController<TabsRootViewModel>
+    public partial class TabsRootView : MvxTabViewController<TabsRootViewModel>
     {
         private bool _firstTime = true;
 
-        public TabsRootView()
+        public TabsRootView(IntPtr handle) : base(handle)
         {
         }
 
@@ -30,6 +32,20 @@ namespace Playground.Mac
                 ViewModel.ShowInitialViewModelsCommand.Execute(null);
                 _firstTime = false;
             }
+        }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+        }
+
+        public override void ViewDidAppear()
+        {
+            base.ViewDidAppear();
+
+            //var set = this.CreateBindingSet<TabsRootView, TabsRootViewModel>();
+            //set.Bind(this).For(v => v.SelectedTabViewItemIndex).To(vm => vm.ItemIndex);
+            //set.Apply();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Mac/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.Mac/TabsRootView.cs
@@ -16,8 +16,7 @@ namespace Playground.Mac
         }
 
         public TabsRootView()
-        {
-            
+        {            
         }
 
         public override void LoadView()

--- a/TestProjects/Playground/Playground.Mac/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.Mac/TabsRootView.cs
@@ -6,7 +6,6 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Mac
 {
-    //[MvxFromStoryboard("Main")]
     [MvxWindowPresentation(PositionX = 150)]
     public partial class TabsRootView : MvxTabViewController<TabsRootViewModel>
     {

--- a/TestProjects/Playground/Playground.Mac/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.Mac/TabsRootView.cs
@@ -16,6 +16,11 @@ namespace Playground.Mac
         {
         }
 
+        public TabsRootView()
+        {
+            
+        }
+
         public override void LoadView()
         {
             base.LoadView();
@@ -43,9 +48,9 @@ namespace Playground.Mac
         {
             base.ViewDidAppear();
 
-            //var set = this.CreateBindingSet<TabsRootView, TabsRootViewModel>();
-            //set.Bind(this).For(v => v.SelectedTabViewItemIndex).To(vm => vm.ItemIndex);
-            //set.Apply();
+            var set = this.CreateBindingSet<TabsRootView, TabsRootViewModel>();
+            set.Bind(this).For(v => v.SelectedTabViewItemIndex).To(vm => vm.ItemIndex);
+            set.Apply();
         }
     }
 }

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -1143,6 +1143,7 @@ AppKit.NSTextView | StringValue | BindStringValue()
 AppKit.NSButton | Visibility | BindVisibility()
 AppKit.NSButton | Title | BindTitle()
 AppKit.NSSearchField | Text | BindText()
+AppKit.NSTabViewController | SelectedTabViewItemIndex | BindSelectedTabViewItemIndex()
 
 **tvOS - `using MvvmCross.Binding.tvOS`**
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Allows binding the SelectedTabViewItemIndex in NSTabViewController

### :arrow_heading_down: What is the current behavior?
Can't do it, nothing happens

### :new: What is the new behavior (if this is a feature change)?
Can now bind SelectedTabViewItemIndex to ints and enums

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See Playground.Mac

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2191

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
