### PR TITLE
Add weak table to tie NSWindow and NSWindowController

### DIFF
--- a/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
@@ -24,6 +24,8 @@ namespace MvvmCross.Mac.Views.Presenters
     {
         private readonly INSApplicationDelegate _applicationDelegate;
         private List<NSWindow> _windows;
+        private ConditionalWeakTable<NSWindow, NSWindowController> _windowsToWindowControllers = new ConditionalWeakTable<NSWindow, NSWindowController>();
+
         private Dictionary<Type, Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> _attributeTypesToShowMethodDictionary;
         protected Dictionary<Type, Action<NSViewController, MvxBasePresentationAttribute, MvxViewModelRequest>> AttributeTypesToShowMethodDictionary
         {
@@ -37,7 +39,6 @@ namespace MvvmCross.Mac.Views.Presenters
                 return _attributeTypesToShowMethodDictionary;
             }
         }
-
 
         protected virtual INSApplicationDelegate ApplicationDelegate => _applicationDelegate;
 
@@ -103,8 +104,6 @@ namespace MvvmCross.Mac.Views.Presenters
             showAction.Invoke(viewController, attribute, request);
         }
 
-        private ConditionalWeakTable<NSWindow, NSWindowController> weakTable = new ConditionalWeakTable<NSWindow, NSWindowController>();
-
         protected virtual void ShowWindowViewController(
             NSViewController viewController,
             MvxWindowPresentationAttribute attribute,
@@ -145,7 +144,7 @@ namespace MvvmCross.Mac.Views.Presenters
             window.ContentViewController = viewController;
             windowController.ShowWindow(null);  
 
-            weakTable.Add(window, windowController);
+            _windowsToWindowControllers.Add(window, windowController);
         }
 
         protected virtual void UpdateWindow(MvxWindowPresentationAttribute attribute, NSWindow window)

--- a/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using AppKit;
 using CoreGraphics;
 using MvvmCross.Core.ViewModels;
@@ -102,6 +103,8 @@ namespace MvvmCross.Mac.Views.Presenters
             showAction.Invoke(viewController, attribute, request);
         }
 
+        private ConditionalWeakTable<NSWindow, NSWindowController> weakTable = new ConditionalWeakTable<NSWindow, NSWindowController>();
+
         protected virtual void ShowWindowViewController(
             NSViewController viewController,
             MvxWindowPresentationAttribute attribute,
@@ -140,7 +143,9 @@ namespace MvvmCross.Mac.Views.Presenters
             Windows.Add(window);
             window.ContentView = viewController.View;
             window.ContentViewController = viewController;
-            windowController.ShowWindow(null);                
+            windowController.ShowWindow(null);  
+
+            weakTable.Add(window, windowController);
         }
 
         protected virtual void UpdateWindow(MvxWindowPresentationAttribute attribute, NSWindow window)

--- a/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
+++ b/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
@@ -26,6 +26,5 @@ namespace Playground.Mac
         public NSTextField TextTitle {
             get { return textTitle; }
         }
-
     }
 }

--- a/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
+++ b/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
@@ -11,12 +11,21 @@ namespace Playground.Mac
     [MvxFromStoryboard("Main")]
     public partial class ToolbarWindow : MvxWindowController
 	{
+        private static int _count;
+
 		public ToolbarWindow (IntPtr handle) : base (handle)
 		{
+            _count++;
 		}
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+        }
 
         public NSTextField TextTitle {
             get { return textTitle; }
         }
+
     }
 }

--- a/TestProjects/Playground/Playground.Mac/WindowView.cs
+++ b/TestProjects/Playground/Playground.Mac/WindowView.cs
@@ -40,6 +40,8 @@ namespace Playground.Mac
             var set = this.CreateBindingSet<WindowView, WindowViewModel>();
             set.Bind(WindowController.TextTitle).For(v => v.StringValue).To(vm => vm.Title);
             set.Apply();
+
+            GC.Collect();       // test to make sure WindowController does not get removed prematurely
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix - fixes problem where NSWindowController created by Storyboard gets disposed with garbage collection.

### :arrow_heading_down: What is the current behavior?
After GC.Collect or other garbage collection, NSWindowController can get disposed even though the NSWindow corresponding to it is still alive. This is problematic because the View can no longer access WindowController items, like toolbar.

### :new: What is the new behavior (if this is a feature change)?
Add a weak ref between Window and WindowController. This prevents the WindowController from getting collected as garbage until the Window is closed.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Playground.Mac has ToolbarWindow (MvxWindowController). Break point can be placed on Dispose to verify that disposal doesn't happen.

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2198

### :thinking: Checklist before submitting

- [X] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
