### PR TITLE
add NSMenuItem command and state binding - Mac

### DIFF
--- a/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
+++ b/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Target\MvxMacTargetBinding.cs" />
     <Compile Include="Target\MvxNSSegmentedControlSelectedSegmentTargetBinding.cs" />
     <Compile Include="Target\MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs" />
+    <Compile Include="Target\MvxNSMenuItemOnTargetBinding.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup />

--- a/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
+++ b/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
@@ -76,6 +76,11 @@ namespace MvvmCross.Binding.Mac
                 MvxMacPropertyBinding.NSButton_State);
 
             registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxNSMenuItemOnTargetBinding),
+                typeof(NSMenuItem),
+                MvxMacPropertyBinding.NSMenuItem_State);
+
+            registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxNSSearchFieldTextTargetBinding),
                 typeof(NSSearchField),
                 MvxMacPropertyBinding.NSSearchField_Text);
@@ -116,6 +121,7 @@ namespace MvvmCross.Binding.Mac
 
             registry.AddOrOverwrite(typeof(NSButton), nameof(NSButton.Activated));
             registry.AddOrOverwrite(typeof(NSButtonCell), nameof(NSButtonCell.Activated));
+            registry.AddOrOverwrite(typeof(NSMenuItem), nameof(NSMenuItem.Activated));
             registry.AddOrOverwrite(typeof(NSSearchField), MvxMacPropertyBinding.NSSearchField_Text);
             registry.AddOrOverwrite(typeof(NSTextField), MvxMacPropertyBinding.NSTextField_StringValue);
             registry.AddOrOverwrite(typeof(NSTextView), MvxMacPropertyBinding.NSTextView_StringValue);

--- a/MvvmCross/Binding/Mac/MvxMacPropertyBinding.cs
+++ b/MvvmCross/Binding/Mac/MvxMacPropertyBinding.cs
@@ -18,6 +18,7 @@ namespace MvvmCross.Binding.Mac
         public const string NSTextField_StringValue = "StringValue";
         public const string NSTextView_StringValue = "StringValue";
         public const string NSButton_State = "State";
+        public const string NSMenuItem_State = "State";
         public const string NSSearchField_Text = "Text";
         public const string NSButton_Title = "Title";
         public const string NSTabViewController_SelectedTabViewItemIndex = "SelectedTabViewItemIndex";

--- a/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
@@ -38,6 +38,9 @@ namespace MvvmCross.Binding.Mac
         public static string BindState(this NSButton nsButton)
             => MvxMacPropertyBinding.NSButton_State;
 
+        public static string BindState(this NSMenuItem nsMenuItem)
+            => MvxMacPropertyBinding.NSMenuItem_State;
+
         public static string BindText(this NSSearchField nsSearchField)
             => MvxMacPropertyBinding.NSSearchField_Text;
 

--- a/MvvmCross/Binding/Mac/Target/MvxNSMenuItemOnTargetBinding.cs
+++ b/MvvmCross/Binding/Mac/Target/MvxNSMenuItemOnTargetBinding.cs
@@ -13,9 +13,9 @@ using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Mac.Target
 {
-    public class MvxNSSwitchOnTargetBinding : MvxPropertyInfoTargetBinding<NSButton>
+    public class MvxNSMenuItemOnTargetBinding : MvxPropertyInfoTargetBinding<NSMenuItem>
     {
-        public MvxNSSwitchOnTargetBinding(object target, PropertyInfo targetPropertyInfo)
+        public MvxNSMenuItemOnTargetBinding(object target, PropertyInfo targetPropertyInfo)
             : base(target, targetPropertyInfo)
         {
             var checkBox = View;
@@ -25,15 +25,16 @@ namespace MvvmCross.Binding.Mac.Target
             }
             else
             {
-                checkBox.Activated += HandleButtonCheckBoxAction;
+                checkBox.Activated += HandleMenuItemCheckBoxAction;
             }
         }
 
-        private void HandleButtonCheckBoxAction(object sender, EventArgs e)
+        private void HandleMenuItemCheckBoxAction(object sender, EventArgs e)
         {
             var view = View;
             if (view == null)
                 return;
+
             FireValueChanged(view.State == NSCellStateValue.On);
         }
 
@@ -66,7 +67,7 @@ namespace MvvmCross.Binding.Mac.Target
                 var view = View;
                 if (view != null)
                 {
-                    view.Activated -= HandleButtonCheckBoxAction;
+                    view.Activated -= HandleMenuItemCheckBoxAction;
                 }
             }
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows.Input;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
+using System.Threading.Tasks;
 
 namespace Playground.Core.ViewModels
 {
@@ -18,6 +19,52 @@ namespace Playground.Core.ViewModels
         private static int _count;
 
         public string Title => $"No.{Count} Window View";
+
+        private bool _isItem1 = false;
+        public bool IsItem1 {
+            get { return _isItem1; }
+            set { 
+                if (value == _isItem1) return;
+                _isItem1 = value;
+                RaisePropertyChanged(() => IsItem1);
+            }
+        }
+
+        private bool _isItem2 = false;
+        public bool IsItem2
+        {
+            get { return _isItem2; }
+            set
+            {
+                if (value == _isItem2) return;
+                _isItem2 = value;
+                RaisePropertyChanged(() => IsItem2);
+            }
+        }
+
+        private bool _isItem3 = false;
+        public bool IsItem3
+        {
+            get { return _isItem3; }
+            set
+            {
+                if (value == _isItem3) return;
+                _isItem3 = value;
+                RaisePropertyChanged(() => IsItem3);
+            }
+        }
+
+        private bool _isItemSetting = false;
+        public bool IsItemSetting
+        {
+            get { return _isItemSetting; }
+            set
+            {
+                if (value == _isItemSetting) return;
+                _isItemSetting = value;
+                RaisePropertyChanged(() => IsItemSetting);
+            }
+        }
 
         public int Count { get; set; }
 
@@ -38,9 +85,19 @@ namespace Playground.Core.ViewModels
             });
 
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+
+            ToggleSettingCommand = new MvxAsyncCommand(async () => 
+            {
+                await Task.Run(() =>
+                {
+                    IsItemSetting = !IsItemSetting;
+                });
+            });
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }
         public IMvxAsyncCommand<int> ShowWindowChildCommand { get; private set; }
+
+        public IMvxAsyncCommand ToggleSettingCommand { get; private set; }    
     }
 }

--- a/TestProjects/Playground/Playground.Mac/Main.storyboard
+++ b/TestProjects/Playground/Playground.Mac/Main.storyboard
@@ -715,7 +715,7 @@
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="75" y="655"/>
+            <point key="canvasLocation" x="-2" y="487"/>
         </scene>
         <!--Child View-->
         <scene sceneID="Z0v-PO-st2">
@@ -902,10 +902,51 @@
                                         </textFieldCell>
                                     </textField>
                                 </toolbarItem>
+                                <toolbarItem implicitItemIdentifier="815C7135-B362-45B7-92FA-0D86A805F646" label="Pulldown" paletteLabel="Pulldown" id="6ML-Um-2OT">
+                                    <nil key="toolTip"/>
+                                    <size key="minSize" width="100" height="28"/>
+                                    <size key="maxSize" width="100" height="28"/>
+                                    <popUpButton key="view" verticalHuggingPriority="750" id="IPA-ER-uD6" userLabel="Pulldown">
+                                        <rect key="frame" x="0.0" y="14" width="100" height="28"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <popUpButtonCell key="cell" type="roundTextured" title="Settings" bezelStyle="texturedRounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" id="Jf1-6c-g2z">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="menu"/>
+                                            <menu key="menu" id="89B-4R-kS8">
+                                                <items>
+                                                    <menuItem title="Settings" state="on" hidden="YES" id="3xr-j4-9vp"/>
+                                                    <menuItem title="A Toggle" keyEquivalent="s" id="hyv-8F-xQx"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                    </popUpButton>
+                                </toolbarItem>
+                                <toolbarItem implicitItemIdentifier="23C8C19A-3F97-465A-B9F1-30FE2A476C26" label="Popup" paletteLabel="Popup" id="6i0-qi-OoC">
+                                    <nil key="toolTip"/>
+                                    <size key="minSize" width="100" height="28"/>
+                                    <size key="maxSize" width="100" height="28"/>
+                                    <popUpButton key="view" verticalHuggingPriority="750" id="LQ6-rk-2lP" userLabel="Popup">
+                                        <rect key="frame" x="0.0" y="14" width="100" height="28"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <popUpButtonCell key="cell" type="roundTextured" title="Item 1" bezelStyle="texturedRounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="gsR-CX-7Ga" id="QIk-ut-Mpb">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="menu"/>
+                                            <menu key="menu" id="s0Z-qK-0jg">
+                                                <items>
+                                                    <menuItem title="Item 1" state="on" id="gsR-CX-7Ga"/>
+                                                    <menuItem title="Item 2" id="Wfx-q4-S4B"/>
+                                                    <menuItem title="Item 3" id="9w3-k0-j45"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                    </popUpButton>
+                                </toolbarItem>
                             </allowedToolbarItems>
                             <defaultToolbarItems>
                                 <toolbarItem reference="V11-Z1-YtT"/>
                                 <toolbarItem reference="a0v-0X-HyC"/>
+                                <toolbarItem reference="6ML-Um-2OT"/>
+                                <toolbarItem reference="6i0-qi-OoC"/>
                                 <toolbarItem reference="vn7-LH-rdg"/>
                                 <toolbarItem reference="leD-bj-Lg3"/>
                                 <toolbarItem reference="vn7-LH-rdg"/>
@@ -914,6 +955,10 @@
                         </toolbar>
                     </window>
                     <connections>
+                        <outlet property="menuItem1" destination="gsR-CX-7Ga" id="Srs-fE-LRv"/>
+                        <outlet property="menuItem2" destination="Wfx-q4-S4B" id="F69-bb-8od"/>
+                        <outlet property="menuItem3" destination="9w3-k0-j45" id="3QW-1H-ox5"/>
+                        <outlet property="menuItemSetting" destination="hyv-8F-xQx" id="ECK-RF-UOF"/>
                         <outlet property="textTitle" destination="GAa-jz-qCp" id="Eml-kM-92x"/>
                     </connections>
                 </windowController>

--- a/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
+++ b/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
@@ -10,21 +10,42 @@ namespace Playground.Mac
 {
     [MvxFromStoryboard("Main")]
     public partial class ToolbarWindow : MvxWindowController
-	{
+    {
         private static int _count;
 
-		public ToolbarWindow (IntPtr handle) : base (handle)
-		{
+        public ToolbarWindow(IntPtr handle) : base(handle)
+        {
             _count++;
-		}
+        }
 
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
         }
 
-        public NSTextField TextTitle {
+        public NSTextField TextTitle
+        {
             get { return textTitle; }
+        }
+
+        public NSMenuItem MenuItem1
+        {
+            get { return menuItem1; }
+        }
+
+        public NSMenuItem MenuItem2
+        {
+            get { return menuItem2; }
+        }
+
+        public NSMenuItem MenuItem3
+        {
+            get { return menuItem3; }
+        }
+
+        public NSMenuItem MenuItemSetting
+        {
+            get { return menuItemSetting; }
         }
     }
 }

--- a/TestProjects/Playground/Playground.Mac/ToolbarWindow.designer.cs
+++ b/TestProjects/Playground/Playground.Mac/ToolbarWindow.designer.cs
@@ -9,18 +9,53 @@ using System.CodeDom.Compiler;
 
 namespace Playground.Mac
 {
-    [Register ("ToolbarWindow")]
-    partial class ToolbarWindow
-    {
-        [Outlet]
-        AppKit.NSTextField textTitle { get; set; }
-        
-        void ReleaseDesignerOutlets ()
-        {
-            if (textTitle != null) {
-                textTitle.Dispose ();
-                textTitle = null;
-            }
-        }
-    }
+	[Register ("ToolbarWindow")]
+	partial class ToolbarWindow
+	{
+		[Outlet]
+		AppKit.NSMenuItem menuItem1 { get; set; }
+
+		[Outlet]
+		AppKit.NSMenuItem menuItem2 { get; set; }
+
+		[Outlet]
+		AppKit.NSMenuItem menuItem3 { get; set; }
+
+		[Outlet]
+		AppKit.NSMenuItem menuItemSetting { get; set; }
+
+		[Outlet]
+		AppKit.NSTextField textTitle { get; set; }
+
+		[Action ("ToggleSetting:")]
+		partial void ToggleSetting (Foundation.NSObject sender);
+		
+		void ReleaseDesignerOutlets ()
+		{
+			if (menuItem1 != null) {
+				menuItem1.Dispose ();
+				menuItem1 = null;
+			}
+
+			if (menuItem2 != null) {
+				menuItem2.Dispose ();
+				menuItem2 = null;
+			}
+
+			if (menuItem3 != null) {
+				menuItem3.Dispose ();
+				menuItem3 = null;
+			}
+
+			if (menuItemSetting != null) {
+				menuItemSetting.Dispose ();
+				menuItemSetting = null;
+			}
+
+			if (textTitle != null) {
+				textTitle.Dispose ();
+				textTitle = null;
+			}
+		}
+	}
 }

--- a/TestProjects/Playground/Playground.Mac/WindowView.cs
+++ b/TestProjects/Playground/Playground.Mac/WindowView.cs
@@ -12,7 +12,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Mac
 {
     [MvxFromStoryboard("Main")]
-    [MvxWindowPresentation("ToolbarWindow", "Main", Width = 200)]
+    [MvxWindowPresentation("ToolbarWindow", "Main", Width = 500)]
     public partial class WindowView : MvxViewController<WindowViewModel>
     {
         public WindowView(IntPtr handle) : base(handle)
@@ -39,6 +39,11 @@ namespace Playground.Mac
 
             var set = this.CreateBindingSet<WindowView, WindowViewModel>();
             set.Bind(WindowController.TextTitle).For(v => v.StringValue).To(vm => vm.Title);
+            set.Bind(WindowController.MenuItem1).For(v => v.State).To(vm => vm.IsItem1);
+            set.Bind(WindowController.MenuItem2).For(v => v.State).To(vm => vm.IsItem2);
+            set.Bind(WindowController.MenuItem3).For(v => v.State).To(vm => vm.IsItem3);
+            set.Bind(WindowController.MenuItemSetting).To(vm => vm.ToggleSettingCommand);
+            set.Bind(WindowController.MenuItemSetting).For(v => v.State).To(vm => vm.IsItemSetting);
             set.Apply();
 
             GC.Collect();       // test to make sure WindowController does not get removed prematurely

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -999,6 +999,7 @@ AppKit.NSTextView | StringValue
 AppKit.NSImageView | Image
 AppKit.NSDatePicker | Date
 AppKit.NSSlider | IntValue
+AppKit.NSMenuItem | Activated
 
 **tvOS**
 
@@ -1140,8 +1141,9 @@ AppKit.NSDatePicker | Time | BindTime()
 AppKit.NSDatePicker | Date | BindDate()
 AppKit.NSTextField | StringValue | BindStringValue()
 AppKit.NSTextView | StringValue | BindStringValue()
-AppKit.NSButton | Visibility | BindVisibility()
+AppKit.NSButton | State | BindState()
 AppKit.NSButton | Title | BindTitle()
+AppKit.NSMenuItem | State | BindState()
 AppKit.NSSearchField | Text | BindText()
 AppKit.NSTabViewController | SelectedTabViewItemIndex | BindSelectedTabViewItemIndex()
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
No binding on NSMenuItem

### :new: What is the new behavior (if this is a feature change)?
Add command and State binding on NSMenuItem, also example on toggling a menuitem

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See Playground.Mac, WindowView

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
