### PR TITLE
change FillBindingNames argument to 'registry' to be consistent

### DIFF
--- a/MvvmCross/Mac/Mac/Platform/MvxMacSetup.cs
+++ b/MvvmCross/Mac/Mac/Platform/MvxMacSetup.cs
@@ -151,7 +151,7 @@ namespace MvvmCross.Mac.Platform
             return bindingBuilder;
         }
 
-        protected virtual void FillBindingNames(IMvxBindingNameRegistry obj)
+        protected virtual void FillBindingNames(IMvxBindingNameRegistry registry)
         {
             // this base class does nothing
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
FillBindingNames argument should be registry instead of 'obj'

### :arrow_heading_down: What is the current behavior?
When you override the function the registry is named obj.

### :new: What is the new behavior (if this is a feature change)?
To be consistent with FillTargetFactories, etc., should be registry.

### :boom: Does this PR introduce a breaking change?
Folks that override FillBindingNames may have to use 'registry' instead of 'obj'. Existing code should be ok.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
