### PR TITLE
fix missing OneWay on toggle

### DIFF
--- a/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
@@ -20,7 +20,7 @@ namespace Playground.Core.ViewModels
 
         public string Title => $"No.{Count} Window View";
 
-        private bool _isItem1 = false;
+        private bool _isItem1 = true;
         public bool IsItem1 {
             get { return _isItem1; }
             set { 
@@ -54,7 +54,7 @@ namespace Playground.Core.ViewModels
             }
         }
 
-        private bool _isItemSetting = false;
+        private bool _isItemSetting = true;
         public bool IsItemSetting
         {
             get { return _isItemSetting; }

--- a/TestProjects/Playground/Playground.Mac/WindowView.cs
+++ b/TestProjects/Playground/Playground.Mac/WindowView.cs
@@ -37,13 +37,15 @@ namespace Playground.Mac
         {
             base.ViewDidAppear();
 
+            //WindowController.MenuItemSetting.State = ViewModel.IsItemSetting ? NSCellStateValue.On : NSCellStateValue.Off;
+
             var set = this.CreateBindingSet<WindowView, WindowViewModel>();
             set.Bind(WindowController.TextTitle).For(v => v.StringValue).To(vm => vm.Title);
             set.Bind(WindowController.MenuItem1).For(v => v.State).To(vm => vm.IsItem1);
             set.Bind(WindowController.MenuItem2).For(v => v.State).To(vm => vm.IsItem2);
             set.Bind(WindowController.MenuItem3).For(v => v.State).To(vm => vm.IsItem3);
             set.Bind(WindowController.MenuItemSetting).To(vm => vm.ToggleSettingCommand);
-            set.Bind(WindowController.MenuItemSetting).For(v => v.State).To(vm => vm.IsItemSetting);
+            set.Bind(WindowController.MenuItemSetting).For(v => v.State).To(vm => vm.IsItemSetting).OneWay();
             set.Apply();
 
             GC.Collect();       // test to make sure WindowController does not get removed prematurely


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix on my sample

### :arrow_heading_down: What is the current behavior?
First try on changing toggle in sample fails because the connection from the ViewModel property to the State of the NSMenuItem should be OneWay not TwoWay.

### :new: What is the new behavior (if this is a feature change)?
Works now.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
