### PR TITLE
Make sure the binding context is created when loading from nib

### DIFF
--- a/MvvmCross/Binding/iOS/Views/MvxView.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxView.cs
@@ -18,8 +18,6 @@ namespace MvvmCross.Binding.iOS.Views
         : UIView
         , IMvxBindable
     {
-        private bool _isInitialized;
-
         public IMvxBindingContext BindingContext { get; set; }
 
         // Constructor that will bind managed object to its unmanaged counterpart. This constructor 
@@ -31,33 +29,29 @@ namespace MvvmCross.Binding.iOS.Views
 
         public MvxView()
         {
-            Initialize();
+            this.CreateBindingContext();
         }
 
         public MvxView(CGRect frame)
             : base(frame)
         {
-            Initialize();
+            this.CreateBindingContext();
         }
 
         public MvxView(NSCoder coder)
             : base(coder)
         {
-            Initialize();
+            this.CreateBindingContext();
         }
 
         public override void AwakeFromNib()
         {
-            if (!_isInitialized)
-            {
-                Initialize();
-            }
-        }
+            base.AwakeFromNib();
 
-        private void Initialize()
-        {
-            this.CreateBindingContext();
-            _isInitialized = true;
+            if (BindingContext == null)
+            {
+                this.CreateBindingContext();
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/MvvmCross/Binding/iOS/Views/MvxView.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxView.cs
@@ -18,6 +18,8 @@ namespace MvvmCross.Binding.iOS.Views
         : UIView
         , IMvxBindable
     {
+        private bool _isInitialized;
+
         public IMvxBindingContext BindingContext { get; set; }
 
         // Constructor that will bind managed object to its unmanaged counterpart. This constructor 
@@ -29,19 +31,33 @@ namespace MvvmCross.Binding.iOS.Views
 
         public MvxView()
         {
-            this.CreateBindingContext();
+            Initialize();
         }
 
         public MvxView(CGRect frame)
             : base(frame)
         {
-            this.CreateBindingContext();
+            Initialize();
         }
 
-        public MvxView(NSCoder coder) 
+        public MvxView(NSCoder coder)
             : base(coder)
         {
+            Initialize();
+        }
+
+        public override void AwakeFromNib()
+        {
+            if (!_isInitialized)
+            {
+                Initialize();
+            }
+        }
+
+        private void Initialize()
+        {
             this.CreateBindingContext();
+            _isInitialized = true;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The binding context is currently not created when you create a custom implementation of the `MvxView`, load the design from a nib file and construct the view programmatically (as demonstrated here: https://developer.xamarin.com/recipes/ios/general/templates/using_the_ios_view_xib_template/). 

### :new: What is the new behavior (if this is a feature change)?
Binding context will be created when the `AwakeFromNib` method is called.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Steps to reproduce:
1. Create a custom view and derive from `MvxView` (instead of `UIView`)
2. Load the design from a Nib
3. Programmatically create an instance of the custom view and notice the binding context is not created by the base class.

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [n/a] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [n/a] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
