### PR TITLE
nspopup goodies

### DIFF
--- a/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
+++ b/MvvmCross/Binding/Mac/MvvmCross.Binding.Mac.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Target\MvxNSSegmentedControlSelectedSegmentTargetBinding.cs" />
     <Compile Include="Target\MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs" />
     <Compile Include="Target\MvxNSMenuItemOnTargetBinding.cs" />
+    <Compile Include="Target\MvxNSPopUpButtonSelectedTagTargetBinding.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup />

--- a/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
+++ b/MvvmCross/Binding/Mac/MvxMacBindingBuilder.cs
@@ -52,6 +52,11 @@ namespace MvvmCross.Binding.Mac
                 typeof(NSSegmentedControl),
                 MvxMacPropertyBinding.NSSegmentedControl_SelectedSegment);
 
+            registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxNSPopUpButtonSelectedTagTargetBinding),
+                typeof(NSPopUpButton),
+                MvxMacPropertyBinding.NSPopUpButton_SelectedTag);
+            
             registry.RegisterCustomBindingFactory<NSDatePicker>(
                 MvxMacPropertyBinding.NSDatePicker_Time,
                 view => new MvxNSDatePickerTimeTargetBinding(view));
@@ -129,6 +134,7 @@ namespace MvvmCross.Binding.Mac
             registry.AddOrOverwrite(typeof(NSDatePicker), MvxMacPropertyBinding.NSDatePicker_Date);
             registry.AddOrOverwrite(typeof(NSSlider), MvxMacPropertyBinding.NSSlider_IntValue);
             registry.AddOrOverwrite(typeof(NSSegmentedControl), MvxMacPropertyBinding.NSSegmentedControl_SelectedSegment);
+            registry.AddOrOverwrite(typeof(NSPopUpButton), MvxMacPropertyBinding.NSPopUpButton_SelectedTag);
             registry.AddOrOverwrite(typeof(NSTabViewController), MvxMacPropertyBinding.NSTabViewController_SelectedTabViewItemIndex);
 
             //registry.AddOrOverwrite(typeof(MvxCollectionViewSource), "ItemsSource");

--- a/MvvmCross/Binding/Mac/MvxMacPropertyBinding.cs
+++ b/MvvmCross/Binding/Mac/MvxMacPropertyBinding.cs
@@ -13,6 +13,7 @@ namespace MvvmCross.Binding.Mac
         public const string NSView_Visible = "Visible";
         public const string NSSlider_IntValue = "IntValue";
         public const string NSSegmentedControl_SelectedSegment = "SelectedSegment";
+        public const string NSPopUpButton_SelectedTag = "SelectedTag";
         public const string NSDatePicker_Time = "Time";
         public const string NSDatePicker_Date = "Date";
         public const string NSTextField_StringValue = "StringValue";

--- a/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Binding.Mac
             => MvxMacPropertyBinding.NSSegmentedControl_SelectedSegment;
 
         public static string BindSelectedTag(this NSPopUpButton nsPopUpButton)
-        => MvxMacPropertyBinding.NSPopUpButton_SelectedTag;
+            => MvxMacPropertyBinding.NSPopUpButton_SelectedTag;
 
         public static string BindTime(this NSDatePicker nsDatePicker)
             => MvxMacPropertyBinding.NSDatePicker_Time;

--- a/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/Mac/MvxMacPropertyBindingExtensions.cs
@@ -23,6 +23,9 @@ namespace MvvmCross.Binding.Mac
         public static string BindSelectedSegment(this NSSegmentedControl nsSegmentedControl)
             => MvxMacPropertyBinding.NSSegmentedControl_SelectedSegment;
 
+        public static string BindSelectedTag(this NSPopUpButton nsPopUpButton)
+        => MvxMacPropertyBinding.NSPopUpButton_SelectedTag;
+
         public static string BindTime(this NSDatePicker nsDatePicker)
             => MvxMacPropertyBinding.NSDatePicker_Time;
 

--- a/MvvmCross/Binding/Mac/Target/MvxNSPopUpButtonSelectedTagTargetBinding.cs
+++ b/MvvmCross/Binding/Mac/Target/MvxNSPopUpButtonSelectedTagTargetBinding.cs
@@ -6,11 +6,11 @@ using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Binding.Mac.Target
 {
-    public class MvxNSSegmentedControlSelectedSegmentTargetBinding : MvxPropertyInfoTargetBinding<NSSegmentedControl>
+    public class MvxNSPopUpButtonSelectedTagTargetBinding : MvxPropertyInfoTargetBinding<NSPopUpButton>
     {
         private bool _subscribed;
 
-        public MvxNSSegmentedControlSelectedSegmentTargetBinding(object target, PropertyInfo targetPropertyInfo)
+        public MvxNSPopUpButtonSelectedTagTargetBinding(object target, PropertyInfo targetPropertyInfo)
             : base(target, targetPropertyInfo)
         {
         }
@@ -20,7 +20,7 @@ namespace MvvmCross.Binding.Mac.Target
             var view = View;
             if (view == null)
                 return;
-            FireValueChanged((int)view.SelectedSegment);
+            FireValueChanged((int)view.SelectedTag);
         }
 
         public override MvxBindingMode DefaultMode
@@ -30,24 +30,24 @@ namespace MvvmCross.Binding.Mac.Target
 
         public override void SubscribeToEvents()
         {
-            var segmentedControl = View;
-            if (segmentedControl == null)
+            var popupButton = View;
+            if (popupButton == null)
             {
-                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - NSSegmentedControl is null in MvxNSSegmentedControlSelectedSegmentTargetBinding");
+                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - NSPopUpButton is null in MvxNSPopUpButtonSelectedTagTargetBinding");
                 return;
             }
 
             _subscribed = true;
-            segmentedControl.Activated += HandleValueChanged;
+            popupButton.Activated += HandleValueChanged;
         }
 
         protected override void SetValueImpl(object target, object value)
         {
-            var view = target as NSSegmentedControl;
+            var view = target as NSPopUpButton;
             if (view == null)
                 return;
             
-            view.SelectSegment((int)value);
+            view.SelectItemWithTag((int)value);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/TestProjects/Playground/Playground.Core/Models/Modes.cs
+++ b/TestProjects/Playground/Playground.Core/Models/Modes.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Playground.Core.Models
+{
+    public enum Modes
+    {
+        Red,
+        Green,
+        Blue
+    }
+}

--- a/TestProjects/Playground/Playground.Core/Playground.Core.csproj
+++ b/TestProjects/Playground/Playground.Core/Playground.Core.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ViewModels\WindowViewModel.cs" />
     <Compile Include="ViewModels\NestedModalViewModel.cs" />
     <Compile Include="ViewModels\NestedChildViewModel.cs" />
+    <Compile Include="Models\Modes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross\Core\Core\MvvmCross.Core.csproj">
@@ -63,5 +64,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Models\" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/WindowViewModel.cs
@@ -3,6 +3,7 @@ using System.Windows.Input;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using System.Threading.Tasks;
+using Playground.Core.Models;
 
 namespace Playground.Core.ViewModels
 {
@@ -19,6 +20,16 @@ namespace Playground.Core.ViewModels
         private static int _count;
 
         public string Title => $"No.{Count} Window View";
+
+        private Modes _mode = Modes.Blue;
+        public Modes Mode {
+            get { return _mode; }
+            set {
+                if (value == _mode) return;
+                _mode = value;
+                RaisePropertyChanged(() => Mode);
+            }
+        }
 
         private bool _isItem1 = true;
         public bool IsItem1 {

--- a/TestProjects/Playground/Playground.Mac/Main.storyboard
+++ b/TestProjects/Playground/Playground.Mac/Main.storyboard
@@ -921,21 +921,21 @@
                                         </popUpButtonCell>
                                     </popUpButton>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="23C8C19A-3F97-465A-B9F1-30FE2A476C26" label="Popup" paletteLabel="Popup" id="6i0-qi-OoC">
+                                <toolbarItem implicitItemIdentifier="98E5F37E-CA5A-4A58-A927-28DADD0D36E2" label="Popup" paletteLabel="Popup" id="6i0-qi-OoC">
                                     <nil key="toolTip"/>
                                     <size key="minSize" width="100" height="28"/>
                                     <size key="maxSize" width="100" height="28"/>
                                     <popUpButton key="view" verticalHuggingPriority="750" id="LQ6-rk-2lP" userLabel="Popup">
                                         <rect key="frame" x="0.0" y="14" width="100" height="28"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <popUpButtonCell key="cell" type="roundTextured" title="Item 1" bezelStyle="texturedRounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="gsR-CX-7Ga" id="QIk-ut-Mpb">
+                                        <popUpButtonCell key="cell" type="roundTextured" title="Red" bezelStyle="texturedRounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="gsR-CX-7Ga" id="QIk-ut-Mpb">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="menu"/>
                                             <menu key="menu" id="s0Z-qK-0jg">
                                                 <items>
-                                                    <menuItem title="Item 1" state="on" id="gsR-CX-7Ga"/>
-                                                    <menuItem title="Item 2" id="Wfx-q4-S4B"/>
-                                                    <menuItem title="Item 3" id="9w3-k0-j45"/>
+                                                    <menuItem title="Red" state="on" id="gsR-CX-7Ga"/>
+                                                    <menuItem title="Green" tag="1" id="Wfx-q4-S4B"/>
+                                                    <menuItem title="Blue" tag="2" id="9w3-k0-j45"/>
                                                 </items>
                                             </menu>
                                         </popUpButtonCell>
@@ -959,6 +959,7 @@
                         <outlet property="menuItem2" destination="Wfx-q4-S4B" id="F69-bb-8od"/>
                         <outlet property="menuItem3" destination="9w3-k0-j45" id="3QW-1H-ox5"/>
                         <outlet property="menuItemSetting" destination="hyv-8F-xQx" id="ECK-RF-UOF"/>
+                        <outlet property="popupModes" destination="LQ6-rk-2lP" id="fxP-u2-atz"/>
                         <outlet property="textTitle" destination="GAa-jz-qCp" id="Eml-kM-92x"/>
                     </connections>
                 </windowController>

--- a/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
+++ b/TestProjects/Playground/Playground.Mac/ToolbarWindow.cs
@@ -23,29 +23,16 @@ namespace Playground.Mac
             base.Dispose(disposing);
         }
 
-        public NSTextField TextTitle
-        {
-            get { return textTitle; }
-        }
+        public NSTextField TextTitle => textTitle;
 
-        public NSMenuItem MenuItem1
-        {
-            get { return menuItem1; }
-        }
+        public NSMenuItem MenuItem1 => menuItem1;
 
-        public NSMenuItem MenuItem2
-        {
-            get { return menuItem2; }
-        }
+        public NSMenuItem MenuItem2 => menuItem2;
 
-        public NSMenuItem MenuItem3
-        {
-            get { return menuItem3; }
-        }
+        public NSMenuItem MenuItem3 => menuItem3;
 
-        public NSMenuItem MenuItemSetting
-        {
-            get { return menuItemSetting; }
-        }
+        public NSMenuItem MenuItemSetting => menuItemSetting;
+
+        public NSPopUpButton PopupModes => popupModes;
     }
 }

--- a/TestProjects/Playground/Playground.Mac/ToolbarWindow.designer.cs
+++ b/TestProjects/Playground/Playground.Mac/ToolbarWindow.designer.cs
@@ -25,6 +25,9 @@ namespace Playground.Mac
 		AppKit.NSMenuItem menuItemSetting { get; set; }
 
 		[Outlet]
+		AppKit.NSPopUpButton popupModes { get; set; }
+
+		[Outlet]
 		AppKit.NSTextField textTitle { get; set; }
 
 		[Action ("ToggleSetting:")]
@@ -55,6 +58,11 @@ namespace Playground.Mac
 			if (textTitle != null) {
 				textTitle.Dispose ();
 				textTitle = null;
+			}
+
+			if (popupModes != null) {
+				popupModes.Dispose ();
+				popupModes = null;
 			}
 		}
 	}

--- a/TestProjects/Playground/Playground.Mac/WindowView.cs
+++ b/TestProjects/Playground/Playground.Mac/WindowView.cs
@@ -41,9 +41,7 @@ namespace Playground.Mac
 
             var set = this.CreateBindingSet<WindowView, WindowViewModel>();
             set.Bind(WindowController.TextTitle).For(v => v.StringValue).To(vm => vm.Title);
-            set.Bind(WindowController.MenuItem1).For(v => v.State).To(vm => vm.IsItem1);
-            set.Bind(WindowController.MenuItem2).For(v => v.State).To(vm => vm.IsItem2);
-            set.Bind(WindowController.MenuItem3).For(v => v.State).To(vm => vm.IsItem3);
+            set.Bind(WindowController.PopupModes).To(vm => vm.Mode);
             set.Bind(WindowController.MenuItemSetting).To(vm => vm.ToggleSettingCommand);
             set.Bind(WindowController.MenuItemSetting).For(v => v.State).To(vm => vm.IsItemSetting).OneWay();
             set.Apply();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds binding support for NSPopUpButton - a similar kind of control as NSSegmentedControl for selecting items.

![image](https://user-images.githubusercontent.com/157766/30626889-d228d72a-9d81-11e7-8e04-3921401e856f.png)


### :arrow_heading_down: What is the current behavior?
Not supported

### :new: What is the new behavior (if this is a feature change)?
Supported.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
See Playground.Mac, WindowsView.

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
