### PR TITLE
Add obsolete attribute

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxApplication.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxApplication.cs
@@ -60,6 +60,7 @@ namespace MvvmCross.Core.ViewModels
             Mvx.ConstructAndRegisterSingleton<IMvxAppStart, TMvxAppStart>();
         }
 
+        [Obsolete("Please use RegisterNavigationServiceAppStart instead")]
         protected void RegisterAppStart<TViewModel>()
             where TViewModel : IMvxViewModel
         {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement

### :arrow_heading_down: What is the current behavior?
Instance `MvxAppStart` class in `RegisterAppStart<TViewModel>()`.
`MvxAppStart` is marked obsolete class. `MvxAppStart` is instanced only in this method.

```c#
protected void RegisterAppStart<TViewModel>()
    where TViewModel : IMvxViewModel
{
    Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<TViewModel>());
}
```

### :new: What is the new behavior (if this is a feature change)?
Add `Obsolete` attribute to `RegisterAppStart<TViewModel>()`.

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
