### PR TITLE
Added OpenGenerics feature to the IoC

### DIFF
--- a/MvvmCross/Platform/Platform/IoC/MvxSimpleIoCContainer.cs
+++ b/MvvmCross/Platform/Platform/IoC/MvxSimpleIoCContainer.cs
@@ -59,6 +59,8 @@ namespace MvvmCross.Platform.IoC
             object Resolve();
 
             ResolverType ResolveType { get; }
+
+            void SetGenericTypeParameters(Type[] genericTypeParameters);
         }
 
         public class ConstructingResolver : IResolver
@@ -75,6 +77,11 @@ namespace MvvmCross.Platform.IoC
             public object Resolve()
             {
                 return _parent.IoCConstruct(_type);
+            }
+
+            public void SetGenericTypeParameters(Type[] genericTypeParameters)
+            {
+                throw new InvalidOperationException("This Resolver does not set generic type parameters");
             }
 
             public ResolverType ResolveType => ResolverType.DynamicPerResolve;
@@ -94,6 +101,11 @@ namespace MvvmCross.Platform.IoC
                 return _constructor();
             }
 
+            public void SetGenericTypeParameters(Type[] genericTypeParameters)
+            {
+                throw new InvalidOperationException("This Resolver does not set generic type parameters");
+            }
+
             public ResolverType ResolveType => ResolverType.DynamicPerResolve;
         }
 
@@ -109,6 +121,11 @@ namespace MvvmCross.Platform.IoC
             public object Resolve()
             {
                 return _theObject;
+            }
+
+            public void SetGenericTypeParameters(Type[] genericTypeParameters)
+            {
+                throw new InvalidOperationException("This Resolver does not set generic type parameters");
             }
 
             public ResolverType ResolveType => ResolverType.Singleton;
@@ -137,6 +154,11 @@ namespace MvvmCross.Platform.IoC
                 }
 
                 return _theObject;
+            }
+
+            public void SetGenericTypeParameters(Type[] genericTypeParameters)
+            {
+                throw new InvalidOperationException("This Resolver does not set generic type parameters");
             }
 
             public ResolverType ResolveType => ResolverType.Singleton;
@@ -499,10 +521,9 @@ namespace MvvmCross.Platform.IoC
 
             try
             {
-                var openGenericResolver = resolver as ConstructingOpenGenericResolver;
-                if (openGenericResolver != null)
+                if(resolver is ConstructingOpenGenericResolver)
                 {
-                    openGenericResolver.SetGenericTypeParameters(type.GetTypeInfo().GenericTypeArguments);
+                    resolver.SetGenericTypeParameters(type.GetTypeInfo().GenericTypeArguments);
                 }
 
                 var raw = resolver.Resolve();
@@ -531,7 +552,9 @@ namespace MvvmCross.Platform.IoC
             {
                 _resolvers[interfaceType] = resolver;
                 if (_waiters.TryGetValue(interfaceType, out actions))
+                {
                     _waiters.Remove(interfaceType);
+                }
             }
 
             if (actions != null)

--- a/MvvmCross/Platform/Platform/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/Platform/Platform/IoC/MvxTypeExtensions.cs
@@ -1,4 +1,4 @@
-// MvxTypeExtensions.cs
+﻿// MvxTypeExtensions.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -104,6 +104,11 @@ namespace MvvmCross.Platform.IoC
                 return types.Where(x => !except.Contains(x));
             }
         }
+
+        public static bool IsGenericPartiallyClosed(this Type type) =>
+            type.GetTypeInfo().IsGenericType
+            && type.GetTypeInfo().ContainsGenericParameters
+            && type.GetGenericTypeDefinition() != type;
 
         public class ServiceTypeAndImplementationTypePair
         {

--- a/MvvmCross/Platform/Test/MvxIoCTest.cs
+++ b/MvvmCross/Platform/Test/MvxIoCTest.cs
@@ -329,7 +329,7 @@ namespace MvvmCross.Platform.Test
         #region Open-Generics
 
         [Test]
-        public void Resolves_successfully_when_registered_open_generic_with_one_generic_type_parameter()
+        public static void Resolves_successfully_when_registered_open_generic_with_one_generic_type_parameter()
         {
             var instance = MvxSimpleIoCContainer.Initialize();
             ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
@@ -345,7 +345,7 @@ namespace MvvmCross.Platform.Test
         }
 
         [Test]
-        public void Resolves_successfully_when_registered_closed_generic_with_one_generic_type_parameter()
+        public static void Resolves_successfully_when_registered_closed_generic_with_one_generic_type_parameter()
         {
             var instance = MvxSimpleIoCContainer.Initialize();
             ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
@@ -361,7 +361,7 @@ namespace MvvmCross.Platform.Test
         }
 
         [Test]
-        public void Resolves_successfully_when_registered_open_generic_with_two_generic_type_parameter()
+        public static void Resolves_successfully_when_registered_open_generic_with_two_generic_type_parameter()
         {
             var instance = MvxSimpleIoCContainer.Initialize();
             ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
@@ -377,7 +377,7 @@ namespace MvvmCross.Platform.Test
         }
 
         [Test]
-        public void Resolves_successfully_when_registered_closed_generic_with_two_generic_type_parameter()
+        public static void Resolves_successfully_when_registered_closed_generic_with_two_generic_type_parameter()
         {
             var instance = MvxSimpleIoCContainer.Initialize();
             ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
@@ -393,7 +393,7 @@ namespace MvvmCross.Platform.Test
         }
 
         [Test]
-        public void Resolves_unsuccessfully_when_registered_open_generic_with_one_generic_parameter_that_was_not_registered()
+        public static void Resolves_unsuccessfully_when_registered_open_generic_with_one_generic_parameter_that_was_not_registered()
         {
             var instance = MvxSimpleIoCContainer.Initialize();
             ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
@@ -407,7 +407,7 @@ namespace MvvmCross.Platform.Test
         }
 
         [Test]
-        public void Resolves_successfully_when_resolving_entity_that_has_injected_an_open_generic_parameter()
+        public static void Resolves_successfully_when_resolving_entity_that_has_injected_an_open_generic_parameter()
         {
             var instance = MvxSimpleIoCContainer.Initialize();
             ((MvxSimpleIoCContainer)instance).CleanAllResolvers();

--- a/MvvmCross/Platform/Test/MvxIoCTest.cs
+++ b/MvvmCross/Platform/Test/MvxIoCTest.cs
@@ -329,7 +329,7 @@ namespace MvvmCross.Platform.Test
         #region Open-Generics
 
         [Test]
-        public void Resolves_successfully_when_registered_open_generic_with_one_generic_type_parameter_()
+        public void Resolves_successfully_when_registered_open_generic_with_one_generic_type_parameter()
         {
             var instance = MvxSimpleIoCContainer.Initialize();
             ((MvxSimpleIoCContainer)instance).CleanAllResolvers();

--- a/MvvmCross/Platform/Test/MvxIoCTest.cs
+++ b/MvvmCross/Platform/Test/MvxIoCTest.cs
@@ -10,6 +10,8 @@ using MvvmCross.Platform.Core;
 using MvvmCross.Platform.Exceptions;
 using MvvmCross.Platform.IoC;
 using NUnit.Framework;
+using System.Reflection;
+using System.Linq;
 
 namespace MvvmCross.Platform.Test
 {
@@ -27,6 +29,19 @@ namespace MvvmCross.Platform.Test
 
         public interface IC
         {
+        }
+
+        public interface IOG<T>
+        {
+        }
+
+        public interface IOG2<T, T2>
+        {
+        }
+
+        public interface IHasOGParameter
+        {
+            IOG<C> OpenGeneric { get; }
         }
 
         public class A : IA
@@ -72,6 +87,24 @@ namespace MvvmCross.Platform.Test
                     var a = Mvx.Resolve<IA>();
                 }
             }
+        }
+
+        public class OG<T> : IOG<T>
+        {
+        }
+
+        public class OG2<T, T2> : IOG2<T, T2>
+        {
+        }
+
+        public class HasOGParameter : IHasOGParameter
+        {
+            public HasOGParameter(IOG<C> openGeneric)
+            {
+                this.OpenGeneric = openGeneric;
+            }
+
+            public IOG<C> OpenGeneric { get; }
         }
 
         [Test]
@@ -292,6 +325,107 @@ namespace MvvmCross.Platform.Test
                 var c1 = Mvx.Resolve<IC>();
             });
         }
+
+        #region Open-Generics
+
+        [Test]
+        public void Resolves_successfully_when_registered_open_generic_with_one_generic_type_parameter_()
+        {
+            var instance = MvxSimpleIoCContainer.Initialize();
+            ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
+
+            instance.RegisterType(typeof(IOG<>), typeof(OG<>));
+
+            IOG<C2> toResolve = null;
+            Mvx.TryResolve<IOG<C2>>(out toResolve);
+
+            Assert.IsNotNull(toResolve);
+            Assert.IsTrue(toResolve.GetType().GetTypeInfo().ImplementedInterfaces.Any(i => i == typeof(IOG<C2>)));
+            Assert.IsTrue(toResolve.GetType() == typeof(OG<C2>));
+        }
+
+        [Test]
+        public void Resolves_successfully_when_registered_closed_generic_with_one_generic_type_parameter()
+        {
+            var instance = MvxSimpleIoCContainer.Initialize();
+            ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
+
+            instance.RegisterType(typeof(IOG<C2>), typeof(OG<C2>));
+            
+            IOG<C2> toResolve = null;
+            Mvx.TryResolve<IOG<C2>>(out toResolve);
+
+            Assert.IsNotNull(toResolve);
+            Assert.IsTrue(toResolve.GetType().GetTypeInfo().ImplementedInterfaces.Any(i => i == typeof(IOG<C2>)));
+            Assert.IsTrue(toResolve.GetType() == typeof(OG<C2>));
+        }
+
+        [Test]
+        public void Resolves_successfully_when_registered_open_generic_with_two_generic_type_parameter()
+        {
+            var instance = MvxSimpleIoCContainer.Initialize();
+            ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
+
+            instance.RegisterType(typeof(IOG2<,>), typeof(OG2<,>));
+
+            IOG2<C2, C> toResolve = null;
+            Mvx.TryResolve<IOG2<C2,C>>(out toResolve);
+
+            Assert.IsNotNull(toResolve);
+            Assert.IsTrue(toResolve.GetType().GetTypeInfo().ImplementedInterfaces.Any(i => i == typeof(IOG2<C2, C>)));
+            Assert.IsTrue(toResolve.GetType() == typeof(OG2<C2, C>));
+        }
+
+        [Test]
+        public void Resolves_successfully_when_registered_closed_generic_with_two_generic_type_parameter()
+        {
+            var instance = MvxSimpleIoCContainer.Initialize();
+            ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
+
+            instance.RegisterType(typeof(IOG2<C2,C>), typeof(OG2<C2,C>));
+
+            IOG2<C2, C> toResolve = null;
+            Mvx.TryResolve<IOG2<C2, C>>(out toResolve);
+
+            Assert.IsNotNull(toResolve);
+            Assert.IsTrue(toResolve.GetType().GetTypeInfo().ImplementedInterfaces.Any(i => i == typeof(IOG2<C2, C>)));
+            Assert.IsTrue(toResolve.GetType() == typeof(OG2<C2, C>));
+        }
+
+        [Test]
+        public void Resolves_unsuccessfully_when_registered_open_generic_with_one_generic_parameter_that_was_not_registered()
+        {
+            var instance = MvxSimpleIoCContainer.Initialize();
+            ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
+
+            IOG<C2> toResolve = null;
+
+            var isResolved = Mvx.TryResolve<IOG<C2>>(out toResolve);
+
+            Assert.IsFalse(isResolved);
+            Assert.IsNull(toResolve);
+        }
+
+        [Test]
+        public void Resolves_successfully_when_resolving_entity_that_has_injected_an_open_generic_parameter()
+        {
+            var instance = MvxSimpleIoCContainer.Initialize();
+            ((MvxSimpleIoCContainer)instance).CleanAllResolvers();
+
+            instance.RegisterType<IHasOGParameter, HasOGParameter>();
+            instance.RegisterType(typeof(IOG<>), typeof(OG<>));
+
+            IHasOGParameter toResolve = null;
+            Mvx.TryResolve<IHasOGParameter>(out toResolve);
+
+            Assert.IsNotNull(toResolve);
+            Assert.IsTrue(toResolve.GetType().GetTypeInfo().ImplementedInterfaces.Any(i => i == typeof(IHasOGParameter)));
+            Assert.IsTrue(toResolve.GetType() == typeof(HasOGParameter));
+            Assert.IsTrue(toResolve.OpenGeneric.GetType().GetTypeInfo().ImplementedInterfaces.Any(i => i == typeof(IOG<C>)));
+            Assert.IsTrue(toResolve.OpenGeneric.GetType() == typeof(OG<C>));
+        }
+
+        #endregion
 
         // TODO - there are so many tests we could and should do here!
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This introduces OpenGenerics feature to the IoC. Now we can register things like IMyInterface<> without specifying the generic type parameter that will be set at the moment of resolving it.
### :arrow_heading_down: What is the current behavior?
It does not allow to use open generics in the IoC.
### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?
No.
### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
One of the improvements to do in [#2069](https://github.com/MvvmCross/MvvmCross/issues/2069)
### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
