### PR TITLE
2236 - updated nuspec with Xamarin.Android.Support.Exif dependency

### DIFF
--- a/nuspec/MvvmCross.Plugin.PictureChooser.nuspec
+++ b/nuspec/MvvmCross.Plugin.PictureChooser.nuspec
@@ -10,6 +10,7 @@ This package contains the 'PictureChooser' plugin for MvvmCross</description>
 		<tags>mvvm mvvmcross cross xamarin android ios forms monodroid monotouch xamarin.android xamarin.ios xamarin.forms wpf windows8 winrt net net45 netcore wp wpdev windowsphone windowsstore uwp plugin</tags>
 		<dependencies>
 			<dependency id="MvvmCross.Platform" version="[$version$]" />
+			<dependency id="Xamarin.Android.Support.Exif" version="25.3.1" />
 		</dependencies>
 	</metadata>
 	<files>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix to nuspec PictureChooser plugin - added missing nuspec dependency.

### :arrow_heading_down: What is the current behavior?

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?
/

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
fixes issue #2236 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
