### PR TITLE
Android ViewPresenter: Copy PresentationValues when Showing a new Activity Host

### DIFF
--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -447,42 +447,42 @@ namespace MvvmCross.Droid.Views
             OnFragmentChanged(ft, fragmentView, attribute);
         }
 
-		protected virtual void OnBeforeFragmentChanging(FragmentTransaction ft, MvxFragmentPresentationAttribute attribute)
-		{
-			if (attribute.SharedElements != null)
-			{
-				foreach (var item in attribute.SharedElements)
-				{
-					ft.AddSharedElement(item.Value, item.Key);
-				}
-			}
+        protected virtual void OnBeforeFragmentChanging(FragmentTransaction ft, MvxFragmentPresentationAttribute attribute)
+        {
+            if (attribute.SharedElements != null)
+            {
+                foreach (var item in attribute.SharedElements)
+                {
+                    ft.AddSharedElement(item.Value, item.Key);
+                }
+            }
 
-			if (!attribute.EnterAnimation.Equals(int.MinValue) && !attribute.ExitAnimation.Equals(int.MinValue))
-			{
-				if (!attribute.PopEnterAnimation.Equals(int.MinValue) && !attribute.PopExitAnimation.Equals(int.MinValue))
-					ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation, attribute.PopEnterAnimation, attribute.PopExitAnimation);
-				else
-					ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation);
-			}
+            if (!attribute.EnterAnimation.Equals(int.MinValue) && !attribute.ExitAnimation.Equals(int.MinValue))
+            {
+                if (!attribute.PopEnterAnimation.Equals(int.MinValue) && !attribute.PopExitAnimation.Equals(int.MinValue))
+                    ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation, attribute.PopEnterAnimation, attribute.PopExitAnimation);
+                else
+                    ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation);
+            }
 
-			if (attribute.TransitionStyle != int.MinValue)
-				ft.SetTransitionStyle(attribute.TransitionStyle);
-		}
+            if (attribute.TransitionStyle != int.MinValue)
+                ft.SetTransitionStyle(attribute.TransitionStyle);
+        }
 
-		protected virtual void OnFragmentChanged(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
-		{
+        protected virtual void OnFragmentChanged(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
+        {
 
-		}
+        }
 
-		protected virtual void OnFragmentChanging(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
-		{
+        protected virtual void OnFragmentChanging(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
+        {
 
-		}
+        }
 
-		protected virtual void OnFragmentPopped(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
-		{
+        protected virtual void OnFragmentPopped(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
+        {
 
-		}
+        }
 
         protected virtual void ShowDialogFragment(
             Type view,

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -333,9 +333,10 @@ namespace MvvmCross.Droid.Views
         {
             var viewType = ViewsContainer.GetViewType(attribute.ActivityHostViewModelType);
             if (!viewType.IsSubclassOf(typeof(Activity)))
-                throw new MvxException("The host activity doesnt inherit Activity");
+                throw new MvxException("The host activity doesn't inherit Activity");
 
             var hostViewModelRequest = MvxViewModelRequest.GetDefaultRequest(attribute.ActivityHostViewModelType);
+            hostViewModelRequest.PresentationValues = _pendingRequest.PresentationValues;
             Show(hostViewModelRequest);
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
PresentationValues are not copied to the host's ViewModelRequest, breaking an existing feature.

### :new: What is the new behavior (if this is a feature change)?
PresentationValues are copied as they were before.

### :boom: Does this PR introduce a breaking change?
No.
### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Closes #2237 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
