### PR TITLE
Fix close for DialogFragments when using MvxNavigationService

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using Android.Content;
 using Android.OS;
 using Android.Runtime;
 using MvvmCross.Binding.BindingContext;
@@ -71,9 +72,9 @@ namespace MvvmCross.Droid.Support.V4
 
         public virtual string UniqueImmutableCacheTag => Tag;
 
-        public override void OnCreate(Bundle bundle)
+        public override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
             ViewModel?.ViewCreated();
         }
 
@@ -105,6 +106,24 @@ namespace MvvmCross.Droid.Support.V4
         {
             base.OnStop();
             ViewModel?.ViewDisappeared();
+        }
+
+        public override void OnCancel(IDialogInterface dialog)
+        {
+            base.OnCancel(dialog);
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void DismissAllowingStateLoss()
+        {
+            base.DismissAllowingStateLoss();
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void Dismiss()
+        {
+            base.Dismiss();
+            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using Android.Content;
 using Android.OS;
 using Android.Runtime;
 using MvvmCross.Binding.BindingContext;
@@ -50,8 +51,19 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         public virtual IMvxViewModel ViewModel
         {
-            get { return DataContext as IMvxViewModel; }
-            set { DataContext = value; }
+            get
+            {
+                return DataContext as IMvxViewModel;
+            }
+            set
+            {
+                DataContext = value;
+                OnViewModelSet();
+            }
+        }
+
+        public virtual void OnViewModelSet()
+        {
         }
 
         protected void EnsureBindingContextSet(Bundle b0)
@@ -60,6 +72,60 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         }
 
         public virtual string UniqueImmutableCacheTag => Tag;
+
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            ViewModel?.ViewCreated();
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void OnStart()
+        {
+            base.OnStart();
+            ViewModel?.ViewAppearing();
+        }
+
+        public override void OnResume()
+        {
+            base.OnResume();
+            ViewModel?.ViewAppeared();
+        }
+
+        public override void OnPause()
+        {
+            base.OnPause();
+            ViewModel?.ViewDisappearing();
+        }
+
+        public override void OnStop()
+        {
+            base.OnStop();
+            ViewModel?.ViewDisappeared();
+        }
+
+        public override void OnCancel(IDialogInterface dialog)
+        {
+            base.OnCancel(dialog);
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void DismissAllowingStateLoss()
+        {
+            base.DismissAllowingStateLoss();
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void Dismiss()
+        {
+            base.Dismiss();
+            ViewModel?.ViewDestroy();
+        }
     }
 
     public abstract class MvxAppCompatDialogFragment<TViewModel>

--- a/TestProjects/Android-Support/Fragments/Example.Core/Example.Core.csproj
+++ b/TestProjects/Android-Support/Fragments/Example.Core/Example.Core.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ViewModels\ExampleViewPagerViewModel.cs" />
     <Compile Include="ViewModels\ExampleRecyclerViewModel.cs" />
     <Compile Include="ViewModels\SecondHostViewModel.cs" />
+    <Compile Include="ViewModels\ConfirmationViewModel.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/TestProjects/Android-Support/Fragments/Example.Core/Example.Core.csproj
+++ b/TestProjects/Android-Support/Fragments/Example.Core/Example.Core.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ViewModels\ExampleRecyclerViewModel.cs" />
     <Compile Include="ViewModels\SecondHostViewModel.cs" />
     <Compile Include="ViewModels\ConfirmationViewModel.cs" />
+    <Compile Include="Model\ConfirmationConfiguration.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/TestProjects/Android-Support/Fragments/Example.Core/Model/ConfirmationConfiguration.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/Model/ConfirmationConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Example.Core.Model
+{
+    public class ConfirmationConfiguration
+    {
+        public string Title { get; set; }
+        public string Body { get; set; }
+        public string PositiveCommandText { get; set; }
+        public string NegativeCommandText { get; set; }
+    }
+}

--- a/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/ConfirmationViewModel.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/ConfirmationViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Example.Core.Model;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 
@@ -17,7 +18,9 @@ namespace Example.Core.ViewModels
         public override void Prepare(ConfirmationConfiguration parameter)
         {
             if (parameter == null)
+            {
                 throw new ArgumentNullException(nameof(parameter));
+            }
 
             Title = parameter.Title;
             Body = parameter.Body;
@@ -69,14 +72,4 @@ namespace Example.Core.ViewModels
             return _mvxNavigationService.Close(this, false);
         }
     }
-
-    public class ConfirmationConfiguration
-    {
-        public string Title { get; set; }
-        public string Body { get; set; }
-        public string PositiveCommandText { get; set; }
-        public string NegativeCommandText { get; set; }
-    }
-
-
 }

--- a/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/ConfirmationViewModel.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/ConfirmationViewModel.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Threading.Tasks;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+
+namespace Example.Core.ViewModels
+{
+    public class ConfirmationViewModel : MvxViewModel<ConfirmationConfiguration, bool?>
+    {
+        private readonly IMvxNavigationService _mvxNavigationService;
+
+        public ConfirmationViewModel(IMvxNavigationService mvxNavigationService)
+        {
+            _mvxNavigationService = mvxNavigationService;
+        }
+
+        public override void Prepare(ConfirmationConfiguration parameter)
+        {
+            if (parameter == null)
+                throw new ArgumentNullException(nameof(parameter));
+
+            Title = parameter.Title;
+            Body = parameter.Body;
+            PositiveCommandText = parameter.PositiveCommandText;
+            NegativeCommandText = parameter.NegativeCommandText;
+        }
+
+        private string _title;
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        private string _body;
+        public string Body
+        {
+            get => _body;
+            set => SetProperty(ref _body, value);
+        }
+
+        private string _positiveCommandText;
+        public string PositiveCommandText
+        {
+            get => _positiveCommandText;
+            set => SetProperty(ref _positiveCommandText, value);
+        }
+
+        private string _negativeCommandText;
+        public string NegativeCommandText
+        {
+            get => _negativeCommandText;
+            set => SetProperty(ref _negativeCommandText, value);
+        }
+
+        private IMvxAsyncCommand _yesCommand;
+        public IMvxAsyncCommand PositiveCommand => _yesCommand ?? (_yesCommand = new MvxAsyncCommand(OnPositiveCommandAsync));
+
+        private Task OnPositiveCommandAsync()
+        {
+            return _mvxNavigationService.Close(this, true);
+        }
+
+        private IMvxAsyncCommand _noCommand;
+        public IMvxAsyncCommand NegativeCommand => _noCommand ?? (_noCommand = new MvxAsyncCommand(OnNegativeCommandAsync));
+
+        private Task OnNegativeCommandAsync()
+        {
+            return _mvxNavigationService.Close(this, false);
+        }
+    }
+
+    public class ConfirmationConfiguration
+    {
+        public string Title { get; set; }
+        public string Body { get; set; }
+        public string PositiveCommandText { get; set; }
+        public string NegativeCommandText { get; set; }
+    }
+
+
+}

--- a/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/LoginViewModel.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/LoginViewModel.cs
@@ -1,11 +1,18 @@
-﻿using MvvmCross.Core.ViewModels;
+﻿using System.Threading.Tasks;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Platform;
 
 namespace Example.Core.ViewModels
 {
     public class LoginViewModel : MvxViewModel
     {
-        public LoginViewModel()
+        private readonly IMvxNavigationService _mvxNavigationService;
+
+        public LoginViewModel(IMvxNavigationService mvxNavigationService)
         {
+            _mvxNavigationService = mvxNavigationService;
+
             Username = "TestUser";
             Password = "YouCantSeeMe";
             IsLoading = false;
@@ -39,12 +46,34 @@ namespace Example.Core.ViewModels
         {
             get
             {
-				return new MvxCommand(() =>
-				{
-					IsLoading = !IsLoading; //Toggle for testing
-					ShowViewModel<HomeViewModel>();
-				});
+                return new MvxCommand(() =>
+                {
+                    IsLoading = !IsLoading; //Toggle for testing
+                    ShowViewModel<HomeViewModel>();
+                });
             }
+        }
+
+        public virtual IMvxAsyncCommand ShowDialogCommand
+        {
+            get
+            {
+                return new MvxAsyncCommand(ExecuteShowDialogCommandAsync);
+            }
+        }
+
+        private async Task ExecuteShowDialogCommandAsync()
+        {
+            var confirmationResult = await _mvxNavigationService.Navigate<ConfirmationViewModel, ConfirmationConfiguration, bool?>(
+                 new ConfirmationConfiguration
+                 {
+                     Body = "Confirm this message",
+                     Title = "Example App",
+                     PositiveCommandText = "Yes",
+                     NegativeCommandText = "No"
+                 });
+
+            Mvx.Trace($"ConfirmationViewModel navigation returned {confirmationResult}.");
         }
     }
 }

--- a/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/LoginViewModel.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/LoginViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Example.Core.Model;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Platform;

--- a/TestProjects/Android-Support/Fragments/Example.Droid/Example.Droid.csproj
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Example.Droid.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Fragments\ExampleRecyclerViewFragment.cs" />
     <Compile Include="Activities\SecondHostActivity.cs" />
     <Compile Include="Activities\INavigationActivity.cs" />
+    <Compile Include="Fragments\ConfirmationFragment.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/TestProjects/Android-Support/Fragments/Example.Droid/Fragments/ConfirmationFragment.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Fragments/ConfirmationFragment.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Example.Core.ViewModels;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Droid.Views.Attributes;
+
+namespace Example.Droid.Fragments
+{
+    [MvxDialogFragmentPresentation(Cancelable = true)]
+    [Register(nameof(ConfirmationFragment))]
+    public class ConfirmationFragment : MvxAppCompatDialogFragment<ConfirmationViewModel>
+    {
+        public ConfirmationFragment()
+        {
+            RetainInstance = true;
+        }
+
+        public ConfirmationFragment(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+            RetainInstance = true;
+        }
+
+        public override Dialog OnCreateDialog(Bundle savedInstanceState)
+        {
+            var builder = new AlertDialog.Builder(Activity)
+                .SetTitle(ViewModel.Title)
+                .SetMessage(ViewModel.Body)
+                .SetPositiveButton(ViewModel.PositiveCommandText, OnPositiveButton)
+                .SetNegativeButton(ViewModel.NegativeCommandText, OnNegativeButton);
+            return builder.Create();
+        }
+
+        private async void OnNegativeButton(object sender, DialogClickEventArgs e)
+        {
+            if (ViewModel.NegativeCommand.CanExecute())
+            {
+                await ViewModel.NegativeCommand.ExecuteAsync();
+            }
+        }
+
+        private async void OnPositiveButton(object sender, DialogClickEventArgs e)
+        {
+            if (ViewModel.PositiveCommand.CanExecute())
+            {
+                await ViewModel.PositiveCommand.ExecuteAsync();
+            }
+        }
+    }
+
+}

--- a/TestProjects/Android-Support/Fragments/Example.Droid/Fragments/ConfirmationFragment.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Fragments/ConfirmationFragment.cs
@@ -49,5 +49,4 @@ namespace Example.Droid.Fragments
             }
         }
     }
-
 }

--- a/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/activity_login.axml
+++ b/TestProjects/Android-Support/Fragments/Example.Droid/Resources/layout/activity_login.axml
@@ -84,6 +84,11 @@
         android:layout_width="fill_parent"
         android:layout_height="0dp"
         android:layout_weight="2" />
+	<Button
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:text="Show Dialog" 
+		local:MvxBind="Click ShowDialogCommand;"/>
     <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
When using `MvxNavigationService` and a Cancelable dialog, if the user cancels the dialog pressing the back button, the `CloseCompletionSource` hangs and the task never returns to the caller.
Also `MvxAppCompatDialogFragment` doesn't have any ViewModel lifecycle method implemented.

### :new: What is the new behavior (if this is a feature change)?
Cancel is correctly managed by dialogs when using `MvxNavigationService`.
Also ViewModel lifecycle methods are implemented on `MvxAppCompatDialogFragment`.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Android-Support example and play with the dialog on Login screen.

### :memo: Links to relevant issues/docs

Issue: #2246 (should be fixed).

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
