### PR TITLE
Added documentation to IoC Open-Generic registration

### DIFF
--- a/docs/_documentation/fundamentals/inversion-of-control-ioc.md
+++ b/docs/_documentation/fundamentals/inversion-of-control-ioc.md
@@ -82,6 +82,22 @@ One final option, is that you can register the `IFoo` and `Foo` pair as:
 
 In this case, every call to `Mvx.Resolve<IFoo>()` will create a new `Foo` - every call will return a different `Foo`.
 
+### Open-Generic registration
+
+There are situations where you have an interface with a generic type parameter `IFoo<T>` and you have to register it in the IoC with different T types. One way to do this is to register it as many times as T types you have:
+
+    Mvx.RegisterType<IFoo<Bar1>, Foo<Bar1>>();
+    Mvx.RegisterType<IFoo<Bar2>, Foo<Bar2>>();
+    Mvx.RegisterType<IFoo<Bar3>, Foo<Bar3>>();
+    Mvx.RegisterType<IFoo<Bar4>, Foo<Bar4>>();
+
+but this creates boilerplate code and in case you need another instance with a different T type, you have to register it as well. To solve this you can register this interface as *open-generic*, i.e. you don't specify the generic type parameter in neither the interface nor the implementation:
+    
+    Mvx.RegisterType<IFoo<>, Foo<>>();
+    
+Then at the moment of resolving the interface the implementation takes the same generic type parameter that the interface, e.g. if you resolve `var foo = Mvx.Resolve<IFoo<Bar1>>();` then `foo` will be of type `Foo<Bar1>`.
+As you can see this give us more flexibility and scalability because we can effortlessly change the generic type parameters at the moment of resolving the interface and we don't need to add anything to register the interface with a new generic type parameter.
+
 ### Last-registered wins
 
 If you create several implementations of an interface and register them all:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
IoC Open-generic registration was added to the documentation.
### :arrow_heading_down: What is the current behavior?

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?
No
### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
PR: #2242 
### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
