### PR TITLE
Uwp handling BackRequestedEventArgs.Handled

### DIFF
--- a/MvvmCross/Binding/UWP/MvvmCross.Binding.Uwp.csproj
+++ b/MvvmCross/Binding/UWP/MvvmCross.Binding.Uwp.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/MvvmCross/Platform/UWP/MvvmCross.Platform.Uwp.csproj
+++ b/MvvmCross/Platform/UWP/MvvmCross.Platform.Uwp.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -28,8 +28,11 @@ namespace MvvmCross.Uwp.Views
             SystemNavigationManager.GetForCurrentView().BackRequested += BackButtonOnBackRequested;
         }
 
-        protected virtual void BackButtonOnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)
+        protected virtual async void BackButtonOnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)
         {
+            if (backRequestedEventArgs.Handled)
+                return;
+
             var currentView = _rootFrame.Content as IMvxView;
             if (currentView == null)
             {
@@ -38,7 +41,7 @@ namespace MvvmCross.Uwp.Views
             }
 
             var navigationService = Mvx.Resolve<IMvxNavigationService>();
-            navigationService.Close(currentView.ViewModel);
+            backRequestedEventArgs.Handled = await navigationService.Close(currentView.ViewModel);
         }
 
         public override void Show(MvxViewModelRequest request)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
MvvmCross.Uwp didn't compile, because  MvvmCross.Binding.Uwp and MvvmCross.Platform.Uwp had TargetPlatformMinVersion 10.0.10586.0.

Added handling for BackRequestedEventArgs.Handled.

### :arrow_heading_down: What is the current behavior?
MvvmCross.Uwp doesn't compile.

BackRequestedEventArgs.Handled wasn't checked, so Close was always called.
Also it wasn't set.

### :new: What is the new behavior (if this is a feature change)?
MvvmCross.Uwp compiles.

When BackRequestedEventArgs.Handled is true, Close doesn't get called.
When Close is called its result is set to BackRequestedEventArgs.Handled.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
