### PR TITLE
Add animated option to MvxSidebarPresentationAttribute

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresentationAttribute.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresentationAttribute.cs
@@ -1,5 +1,4 @@
-﻿using MvvmCross.Core.Views;
-using MvvmCross.iOS.Views.Presenters.Attributes;
+using MvvmCross.Core.Views;
 
 namespace MvvmCross.iOS.Support.XamarinSidebar
 {
@@ -26,18 +25,25 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
         public readonly bool ShowPanel;
 
         /// <summary>
+        /// Animate the View Controller
+        /// </summary>
+        public readonly bool Animated;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MvxSidebarPresentationAttribute"/> class.
         /// </summary>
         /// <param name="panel">The panel.</param>
         /// <param name="hintType">Type of the hint.</param>
         /// <param name="showPanel">if set to <c>true</c> [show panel].</param>
         /// <param name="behaviour">The splitview behaviour value</param>
-        public MvxSidebarPresentationAttribute(MvxPanelEnum panel, MvxPanelHintType hintType, bool showPanel, MvxSplitViewBehaviour behaviour = MvxSplitViewBehaviour.None)
+        /// <param name="animated">if set to <c>true</c> animate the View Controller.</param>
+        public MvxSidebarPresentationAttribute(MvxPanelEnum panel, MvxPanelHintType hintType, bool showPanel, MvxSplitViewBehaviour behaviour = MvxSplitViewBehaviour.None, bool animated = true)
         {
             Panel = panel;
             ShowPanel = showPanel;
             HintType = hintType;
             SplitViewBehaviour = behaviour;
+            Animated = animated;
         }
     }
 }

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -1,4 +1,4 @@
-﻿using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.iOS.Support.XamarinSidebar.Extensions;
 using MvvmCross.iOS.Support.XamarinSidebar.Views;
@@ -47,16 +47,16 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             switch (attribute.HintType)
             {
                 case MvxPanelHintType.PopToRoot:
-                    ShowPanelAndPopToRoot(attribute.Panel, viewController);
+                    ShowPanelAndPopToRoot(attribute, viewController);
                     break;
 
                 case MvxPanelHintType.ResetRoot:
-                    ShowPanelAndResetToRoot(attribute.Panel, viewController);
+                    ShowPanelAndResetToRoot(attribute, viewController);
                     break;
 
                 case MvxPanelHintType.PushPanel:
                 default:
-                    ShowPanel(attribute.Panel, viewController);
+                    ShowPanel(attribute, viewController);
                     break;
             }
 
@@ -67,7 +67,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             }
         }
 
-        protected virtual bool ShowPanelAndPopToRoot(MvxPanelEnum panel, UIViewController viewController)
+        protected virtual bool ShowPanelAndPopToRoot(MvxSidebarPresentationAttribute attribute, UIViewController viewController)
         {
             var navigationController = (SideBarViewController as MvxSidebarViewController).NavigationController;
 
@@ -80,7 +80,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             return true;
         }
 
-        protected virtual bool ShowPanelAndResetToRoot(MvxPanelEnum panel, UIViewController viewController)
+        protected virtual bool ShowPanelAndResetToRoot(MvxSidebarPresentationAttribute attribute, UIViewController viewController)
         {
             var navigationController = (SideBarViewController as MvxSidebarViewController).NavigationController;
 
@@ -89,7 +89,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
             navigationController.ViewControllers = new[] { viewController };
 
-            switch (panel)
+            switch (attribute.Panel)
             {
                 case MvxPanelEnum.Left:
                 case MvxPanelEnum.Right:
@@ -109,28 +109,28 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             return true;
         }
 
-        protected virtual bool ShowPanel(MvxPanelEnum panel, UIViewController viewController)
+        protected virtual bool ShowPanel(MvxSidebarPresentationAttribute attribute, UIViewController viewController)
         {
             var navigationController = (SideBarViewController as MvxSidebarViewController).NavigationController;
 
             if (navigationController == null)
                 return false;
 
-            switch (panel)
+            switch (attribute.Panel)
             {
                 case MvxPanelEnum.Left:
                 case MvxPanelEnum.Right:
                     break;
                 case MvxPanelEnum.Center:
                 default:
-                    navigationController.PushViewController(viewController, true);
+                    navigationController.PushViewController(viewController, attribute.Animated);
                     break;
                 case MvxPanelEnum.CenterWithLeft:
-                    navigationController.PushViewController(viewController, true);
+                    navigationController.PushViewController(viewController, attribute.Animated);
                     viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: true, showRight: false);
                     break;
                 case MvxPanelEnum.CenterWithRight:
-                    navigationController.PushViewController(viewController, true);
+                    navigationController.PushViewController(viewController, attribute.Animated);
                     viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: false, showRight: true);
                     break;
             }

--- a/docs/_documentation/platform/ios-support-library.md
+++ b/docs/_documentation/platform/ios-support-library.md
@@ -20,7 +20,7 @@ A view controller class can be decorated with the MvxSidebarPresentationAttribut
 ```c#
 public MvxSidebarPresentationAttribute(
     MvxPanelEnum panel, MvxPanelHintType hintType, bool showPanel,
-    MvxSplitViewBehaviour behaviour = MvxSplitViewBehaviour.None)
+    MvxSplitViewBehaviour behaviour = MvxSplitViewBehaviour.None, bool animated = true)
 {
 }
 ```


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature
### :arrow_heading_down: What is the current behavior?
MvvmCross iOS Support `MvxSidebarPresenter` currently forces new view controllers added with `MvxPanelHintType.PushPanel` to be added with animated of `True`.
### :new: What is the new behavior (if this is a feature change)?
The `MvxSidebarPresentationAttribute` now include a bool `Animated` with a default of `True`. Setting it to `False` will prevent the view controller being added with animations.
### :boom: Does this PR introduce a breaking change?
Yes, the signature for Show methods (`ShowPanel`, `ShowPanelAndResetToRoot` and `ShowPanelAndPopToRoot`) has been modified to make use the attribute instead of just the panel. This allows for easier overriding of the Show methods and having access to the attributes values.
### :bug: Recommendations for testing
[MvvmCross/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/](https://github.com/MvvmCross/MvvmCross/tree/develop/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar)
### :memo: Links to relevant issues/docs
[Docs](https://www.mvvmcross.com/documentation/platform/ios-support-library#mvxsidebarpresenter)

### _Side Note_
The documentation around the `MvvmCross.iOS.Support` will need some updating `MvxPanelPresentation` no longer exists. 

### :thinking: Checklist before submitting
- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
