### PR TITLE
Fix for android only dependency in PictureChooser Plugin

### DIFF
--- a/nuspec/MvvmCross.Plugin.PictureChooser.nuspec
+++ b/nuspec/MvvmCross.Plugin.PictureChooser.nuspec
@@ -9,8 +9,16 @@
 This package contains the 'PictureChooser' plugin for MvvmCross</description>
 		<tags>mvvm mvvmcross cross xamarin android ios forms monodroid monotouch xamarin.android xamarin.ios xamarin.forms wpf windows8 winrt net net45 netcore wp wpdev windowsphone windowsstore uwp plugin</tags>
 		<dependencies>
-			<dependency id="MvvmCross.Platform" version="[$version$]" />
-			<dependency id="Xamarin.Android.Support.Exif" version="25.3.1" />
+			<!-- All -->
+			<group>
+				<dependency id="MvvmCross.Platform" version="[$version$]" />
+			</group>
+
+			<!-- droid -->
+			<group targetFramework="MonoAndroid70">
+				<dependency id="MvvmCross.Platform" version="[$version$]" />
+				<dependency id="Xamarin.Android.Support.Exif" version="25.3.1" />
+			</group>
 		</dependencies>
 	</metadata>
 	<files>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
### :arrow_heading_down: What is the current behavior?
PictureChooser has a dependency on `Xamarin.Android.Support.Exif`
### :new: What is the new behavior (if this is a feature change)?
Only Android PictureChooser  has a dependency on `Xamarin.Android.Support.Exif`
### :boom: Does this PR introduce a breaking change?
No
### :bug: Recommendations for testing
Build the PictureChooser NuGet package
### :memo: Links to relevant issues/docs
#2272 
### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
