### PR TITLE
Fix behavir of getting Forms resource assembly

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
@@ -69,10 +69,10 @@ namespace MvvmCross.Forms.Droid.Views
         {
             base.OnCreate(bundle);
 
-            InitializeForms();
+            InitializeForms(bundle);
         }
 
-        protected virtual void InitializeForms()
+        protected virtual void InitializeForms(Bundle bundle)
         {
             // Required for proper Push notifications handling
             var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Android.Content;
 using Android.OS;
 using MvvmCross.Binding.BindingContext;
@@ -71,14 +72,24 @@ namespace MvvmCross.Forms.Droid.Views
         {
             base.OnCreate(bundle);
 
+            InitializeForms();
+        }
+
+        protected virtual void InitializeForms()
+        {
             // Required for proper Push notifications handling
             var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);
             setupSingleton.EnsureInitialized();
             LifetimeListener.OnCreate(this, bundle);
 
-            var resourceAssembly = Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity.GetType().Assembly;
+            var resourceAssembly = GetResourceAssembly();
             global::Xamarin.Forms.Forms.Init(this, bundle, resourceAssembly);
             LoadApplication(FormsApplication);
+        }
+
+        protected virtual Assembly GetResourceAssembly()
+        {
+            return Assembly.GetCallingAssembly();
         }
 
         public void MvxInternalStartActivityForResult(Intent intent, int requestCode)

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
@@ -47,16 +47,13 @@ namespace MvvmCross.Forms.Droid.Views
 
         public object DataContext
         {
-            get { return BindingContext?.DataContext; }
-            set { BindingContext.DataContext = value; }
+            get => BindingContext?.DataContext;
+            set => BindingContext.DataContext = value;
         }
 
         public IMvxViewModel ViewModel
         {
-            get
-            {
-                return DataContext as IMvxViewModel;
-            }
+            get => DataContext as IMvxViewModel;
             set
             {
                 DataContext = value;
@@ -107,7 +104,7 @@ namespace MvvmCross.Forms.Droid.Views
         protected override void OnStop()
         {
             base.OnStop();
-            
+
             LifetimeListener.OnStop(this);
         }
 
@@ -131,7 +128,7 @@ namespace MvvmCross.Forms.Droid.Views
 
             LifetimeListener.OnPause(this);
         }
-        
+
         protected override void OnRestart()
         {
             base.OnRestart();

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
@@ -69,10 +69,10 @@ namespace MvvmCross.Forms.Droid.Views
         {
             base.OnCreate(bundle);
 
-            InitializeForms();
+            InitializeForms(bundle);
         }
 
-        protected virtual void InitializeForms()
+        protected virtual void InitializeForms(Bundle bundle)
         {
             // Required for proper Push notifications handling
             var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Android.Content;
 using Android.OS;
 using MvvmCross.Binding.BindingContext;
@@ -71,14 +72,24 @@ namespace MvvmCross.Forms.Droid.Views
         {
             base.OnCreate(bundle);
 
+            InitializeForms();
+        }
+
+        protected virtual void InitializeForms()
+        {
             // Required for proper Push notifications handling
             var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);
             setupSingleton.EnsureInitialized();
             LifetimeListener.OnCreate(this, bundle);
 
-            var resourceAssembly = Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity.GetType().Assembly;
+            var resourceAssembly = GetResourceAssembly();
             global::Xamarin.Forms.Forms.Init(this, bundle, resourceAssembly);
             LoadApplication(FormsApplication);
+        }
+
+        protected virtual Assembly GetResourceAssembly()
+        {
+            return Assembly.GetCallingAssembly();
         }
 
         public void MvxInternalStartActivityForResult(Intent intent, int requestCode)

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
@@ -47,16 +47,13 @@ namespace MvvmCross.Forms.Droid.Views
 
         public object DataContext
         {
-            get { return BindingContext?.DataContext; }
-            set { BindingContext.DataContext = value; }
+            get => BindingContext?.DataContext;
+            set => BindingContext.DataContext = value;
         }
 
         public IMvxViewModel ViewModel
         {
-            get
-            {
-                return DataContext as IMvxViewModel;
-            }
+            get => DataContext as IMvxViewModel;
             set
             {
                 DataContext = value;
@@ -107,7 +104,7 @@ namespace MvvmCross.Forms.Droid.Views
         protected override void OnStop()
         {
             base.OnStop();
-            
+
             LifetimeListener.OnStop(this);
         }
 
@@ -131,7 +128,7 @@ namespace MvvmCross.Forms.Droid.Views
 
             LifetimeListener.OnPause(this);
         }
-        
+
         protected override void OnRestart()
         {
             base.OnRestart();

--- a/docs/_documentation/platform/forms/xamarin-forms-customization.md
+++ b/docs/_documentation/platform/forms/xamarin-forms-customization.md
@@ -1,0 +1,26 @@
+---
+layout: documentation
+title: Xamarin.Forms Startup Customization
+category: Platform specifics
+---
+
+# Android Resources
+
+Xamarin.Forms relies on you to pass along the `Assembly` where your resources are contained
+in its `Init` method. Using the signature where you do not pass on this `Assembly`,
+Xamarin.Forms uses `Assembly.GetCallingAssembly()` to guess it. This means if you subclass `MvxFormsApplicationActivity` or 
+`MvxFormsAppCompatActivity` in another Assembly than the calling assembly, the wrong assembly
+gets passed on to Xamarin.Forms and it cannot find resources. This will result in missing 
+icons and more in your App.
+
+You can customize this behavior by overriding `GetResourceAssembly()` in your subclass:
+
+```csharp
+protected override Assembly GetResourcesAssembly()
+{
+    // return your Assembly here
+}
+```
+
+A very simple assumption could be that your `Setup.cs` file is always in your Application
+project and you could just write: `return typeof(Setup).Assembly;`.

--- a/docs/_documentation/platform/forms/xamarin-forms.md
+++ b/docs/_documentation/platform/forms/xamarin-forms.md
@@ -1,6 +1,6 @@
 ---
 layout: documentation
-title: Xamarin.Forms with MvvmCross
+title: Xamarin.Forms Tutorial
 category: Platform specifics
 ---
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
docs, code

### :arrow_heading_down: What is the current behavior?

### :new: What is the new behavior (if this is a feature change)?
`Assembly.GetCallingAssembly()` is used by default, but provides a way to `override` default behavior.

### :boom: Does this PR introduce a breaking change?
Yes. #2270 merged in the behavior that Assembly should always be resolved by getting `IMvxAndroidCurrentTopActivity` from the IoC and use the Assembly of the top Acitivity.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
#2270 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
