### PR TITLE
Fix modals close in MvxIosViewPresenter

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -524,7 +524,7 @@ namespace MvvmCross.iOS.Views.Presenters
                 var root = ((UINavigationController)vc).ViewControllers.FirstOrDefault();
                 if (root != null && root.GetIMvxIosView().ViewModel == toClose)
                 {
-                    controllerToClose = root;
+                    controllerToClose = vc;
                     break;
                 }
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
After closing a Modal ViewController wrapped in a UINavigationController, it's impossible to keep navigating through apps.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Playground.iOS, tap on "Show Modal Nav" button, then tap on "Close" and then tap on "ShowChild". ChildViewController will appear after having closed the modal.

### :memo: Links to relevant issues/docs
Fixes #2276

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
