### PR TITLE
Cleanup EnsureBindingContextSet

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
@@ -33,7 +33,7 @@ namespace MvvmCross.Droid.Support.Design
         public IMvxBindingContext BindingContext { get; set; }
 
         private object _dataContext;
-       
+
         public object DataContext
         {
             get
@@ -63,11 +63,6 @@ namespace MvvmCross.Droid.Support.Design
 
         public virtual void OnViewModelSet()
         {
-        }
-
-        protected void EnsureBindingContextSet(Bundle b0)
-        {
-            this.EnsureBindingContextIsSet(b0);
         }
 
         public virtual string UniqueImmutableCacheTag => Tag;

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
@@ -65,11 +65,6 @@ namespace MvvmCross.Droid.Support.V4
         {
         }
 
-        protected void EnsureBindingContextSet(Bundle b0)
-        {
-            this.EnsureBindingContextIsSet(b0);
-        }
-
         public virtual string UniqueImmutableCacheTag => Tag;
 
         public override void OnCreate(Bundle savedInstanceState)

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentExtensions.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentExtensions.cs
@@ -80,7 +80,7 @@ namespace MvvmCross.Droid.Support.V4
             }
         }
 
-        public static void EnsureBindingContextIsSet(this IMvxFragmentView fragment, Bundle b0)
+        public static void EnsureBindingContextIsSet(this IMvxFragmentView fragment)
         {
             var actualFragment = fragment.ToFragment();
             if (actualFragment == null)

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
@@ -66,11 +66,6 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         {
         }
 
-        protected void EnsureBindingContextSet(Bundle b0)
-        {
-            this.EnsureBindingContextIsSet(b0);
-        }
-
         public virtual string UniqueImmutableCacheTag => Tag;
 
         public override void OnCreate(Bundle savedInstanceState)

--- a/MvvmCross/Droid/Droid/Views/Fragments/MvxDialogFragment.cs
+++ b/MvvmCross/Droid/Droid/Views/Fragments/MvxDialogFragment.cs
@@ -64,11 +64,6 @@ namespace MvvmCross.Droid.Views.Fragments
         {
         }
 
-        protected void EnsureBindingContextSet(Bundle b0)
-        {
-            this.EnsureBindingContextIsSet(b0);
-        }
-
         public string UniqueImmutableCacheTag => Tag;
 
         public override void OnCreate(Bundle bundle)
@@ -77,10 +72,10 @@ namespace MvvmCross.Droid.Views.Fragments
             ViewModel?.ViewCreated();
         }
 
-        public override void OnDestroy ()
+        public override void OnDestroy()
         {
-            base.OnDestroy ();
-            ViewModel?.ViewDestroy ();
+            base.OnDestroy();
+            ViewModel?.ViewDestroy();
         }
 
         public override void OnStart()

--- a/MvvmCross/Droid/Droid/Views/Fragments/MvxFragmentExtensions.cs
+++ b/MvvmCross/Droid/Droid/Views/Fragments/MvxFragmentExtensions.cs
@@ -79,7 +79,7 @@ namespace MvvmCross.Droid.Views.Fragments
             }
         }
 
-        public static void EnsureBindingContextIsSet(this IMvxFragmentView fragment, Bundle b0)
+        public static void EnsureBindingContextIsSet(this IMvxFragmentView fragment)
         {
             var actualFragment = fragment.ToFragment();
             if (actualFragment == null)

--- a/TestProjects/Forms/MasterDetail/MasterDetailExample.iOS/MasterDetailExample.iOS.csproj
+++ b/TestProjects/Forms/MasterDetail/MasterDetailExample.iOS/MasterDetailExample.iOS.csproj
@@ -22,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
   </PropertyGroup>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code cleanup.

### :arrow_heading_down: What is the current behavior?
Some fragment classes have a method `protected void EnsureBindingContextSet(Bundle b0)`, which is not virtual, is not used anywhere and the only thing it does is to call an extension method.
Also, the extension method `EnsureBindingContextSet` has a parameter that is not used within it.

### :new: What is the new behavior (if this is a feature change)?
The method is deleted and the unused parameter for the extension method is removed.

### :boom: Does this PR introduce a breaking change?
Yes, it's a minor breaking change because a method (protected, *not* virtual) was deleted. If approved, we should hold merging until releasing 5.4.

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
[This is the commit](https://github.com/MvvmCross/MvvmCross-AndroidSupport/commit/051e09f2709f6ac40743e1a8a70f5252845f201c#diff-2fa38c253ad869be51c179bd36fcc917R45) where the removed method was added
Closes #1525


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
