### PR TITLE
Make it possible to start Forms app without splashscreen

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Platform/MvxFormsAndroidSetup.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Platform/MvxFormsAndroidSetup.cs
@@ -47,7 +47,10 @@ namespace MvvmCross.Forms.Droid.Platform
             get
             {
                 if (!Xamarin.Forms.Forms.IsInitialized)
-                    Xamarin.Forms.Forms.Init(Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity, null);
+                {
+                    var activity = Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity ?? ApplicationContext;
+                    Xamarin.Forms.Forms.Init(activity, null);
+                }
                 if (_formsApplication == null)
                     _formsApplication = CreateFormsApplication();
                 return _formsApplication;

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
@@ -93,6 +93,10 @@ namespace MvvmCross.Forms.Droid.Views
 
         protected override void OnCreate(Bundle bundle)
         {
+            // Required for proper Push notifications handling      
+            var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);
+            setupSingleton.EnsureInitialized();
+
             base.OnCreate(bundle);
             ViewModel?.ViewCreated();
             InitializeForms(bundle);

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
@@ -91,6 +91,10 @@ namespace MvvmCross.Forms.Droid.Views
 
         protected override void OnCreate(Bundle bundle)
         {
+            // Required for proper Push notifications handling      
+            var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);
+            setupSingleton.EnsureInitialized();
+
             base.OnCreate(bundle);
             ViewModel?.ViewCreated();
             InitializeForms(bundle);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Forms crashes when no splashscreen is used.

### :new: What is the new behavior (if this is a feature change)?
It works as long as you set a MainPage or invoke IMvxAppStart.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
