### PR TITLE
ToList modals, as can't change list you are modifying

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -441,12 +441,13 @@ namespace MvvmCross.Forms.Views
                 }
             }
         }
-
+       
         protected virtual void CloseModalStack(IReadOnlyList<Page> modals)
         {
-            if (modals != null && modals.Count > 0)
+            var modalList = modals.ToList();
+            if (modalList != null && modalList.Count > 0)
             {
-                foreach (var modal in modals)
+                foreach (var modal in modalList)
                 {
                     modal.Navigation.PopModalAsync();
                 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix on closing modals, in iOS.

### :arrow_heading_down: What is the current behavior?
Crashes when closing modal stack, because it is modifying the list it is looping in.

### :new: What is the new behavior (if this is a feature change)?
Creates a copy of the list, to iterate through

### :boom: Does this PR introduce a breaking change?
No

### :thinking: Checklist before submitting

- [X] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
