### PR TITLE
Fix: When wrapping master page into navigation page, title was missing

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -334,7 +334,7 @@ namespace MvvmCross.Forms.Views
                         navigationMasterPage.PushAsync(page, attribute.Animated);
                     }
                     else if (attribute.WrapInNavigationPage)
-                        masterDetailHost.Master = new MvxNavigationPage(page);
+                        masterDetailHost.Master = new MvxNavigationPage(page) { Title = !string.IsNullOrEmpty(attribute.Title) ? attribute.Title : "MvvmCross" };
                     else
                         masterDetailHost.Master = page;
                 }


### PR DESCRIPTION
When wrapping master page into navigation page, title was missing. When title is missing for master page, xamarin forms throws exception. This commit should fix it.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

### :arrow_heading_down: What is the current behavior?

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
