### PR TITLE
Corrected documentation

### DIFF
--- a/docs/_documentation/platform/forms/xamarin-forms-customization.md
+++ b/docs/_documentation/platform/forms/xamarin-forms-customization.md
@@ -16,7 +16,7 @@ icons and more in your App.
 You can customize this behavior by overriding `GetResourceAssembly()` in your subclass:
 
 ```csharp
-protected override Assembly GetResourcesAssembly()
+protected override Assembly GetResourceAssembly()
 {
     // return your Assembly here
 }


### PR DESCRIPTION
`GetResourcesAssembly()` is not present in `MvxFormsApplicationActivity`, changed it to  `GetResourceAssembly()` to match the override.
