### PR TITLE
Fix Xamarin-Sidebar initialization 

### DIFF
--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 {
     public class MvxSidebarPresenter : MvxIosViewPresenter
     {
-        protected virtual IMvxSidebarViewController SideBarViewController { get; set; }
+        protected virtual MvxSidebarViewController SideBarViewController { get; set; }
 
         public MvxSidebarPresenter(IUIApplicationDelegate applicationDelegate, UIWindow window)
                     : base(applicationDelegate, window)
@@ -96,13 +96,13 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
                     break;
                 case MvxPanelEnum.Center:
                 default:
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController);
+                    viewController.ShowMenuButton(SideBarViewController);
                     break;
                 case MvxPanelEnum.CenterWithLeft:
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: true, showRight: false);
+                    viewController.ShowMenuButton(SideBarViewController, showLeft: true, showRight: false);
                     break;
                 case MvxPanelEnum.CenterWithRight:
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: false, showRight: true);
+                    viewController.ShowMenuButton(SideBarViewController, showLeft: false, showRight: true);
                     break;
             }
 
@@ -111,7 +111,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
         protected virtual bool ShowPanel(MvxSidebarPresentationAttribute attribute, UIViewController viewController)
         {
-            var navigationController = (SideBarViewController as MvxSidebarViewController).NavigationController;
+            var navigationController = (SideBarViewController).NavigationController;
 
             if (navigationController == null)
                 return false;
@@ -127,11 +127,11 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
                     break;
                 case MvxPanelEnum.CenterWithLeft:
                     navigationController.PushViewController(viewController, attribute.Animated);
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: true, showRight: false);
+                    viewController.ShowMenuButton(SideBarViewController, showLeft: true, showRight: false);
                     break;
                 case MvxPanelEnum.CenterWithRight:
                     navigationController.PushViewController(viewController, attribute.Animated);
-                    viewController.ShowMenuButton(SideBarViewController as MvxSidebarViewController, showLeft: false, showRight: true);
+                    viewController.ShowMenuButton(SideBarViewController, showLeft: false, showRight: true);
                     break;
             }
 
@@ -141,11 +141,11 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
         protected override void ShowRootViewController(UIViewController viewController, MvxRootPresentationAttribute attribute, MvxViewModelRequest request)
         {
             // check if viewController is a MvxSidebarPanelController
-            if (viewController is IMvxSidebarViewController)
+            if (viewController is MvxSidebarViewController sidebarView)
             {
                 MasterNavigationController = new MvxNavigationController();
 
-                SideBarViewController = viewController as IMvxSidebarViewController;
+                SideBarViewController = sidebarView;
                 SideBarViewController.SetNavigationController(MasterNavigationController);
 
                 SetWindowRootViewController(viewController);

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -111,7 +111,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
         protected virtual bool ShowPanel(MvxSidebarPresentationAttribute attribute, UIViewController viewController)
         {
-            var navigationController = (SideBarViewController).NavigationController;
+            var navigationController = SideBarViewController.NavigationController;
 
             if (navigationController == null)
                 return false;
@@ -163,9 +163,9 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             {
                 SideBarViewController = null;
                 MasterNavigationController = null;
+            
+                base.ShowRootViewController(viewController, attribute, request);
             }
-
-            base.ShowRootViewController(viewController, attribute, request);
         }
 
         protected virtual bool CloseSidebarViewController(IMvxViewModel viewModel, MvxSidebarPresentationAttribute attribute)

--- a/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSidebarViewController.cs
+++ b/MvvmCross-iOSSupport/MvvmCross.iOS.Support.XamarinSidebar/Views/MvxSidebarViewController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using MvvmCross.Core.ViewModels;
+using MvvmCross.iOS.Support.XamarinSidebar.Extensions;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters;
 using MvvmCross.Platform;
@@ -15,6 +16,8 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
     {
         private readonly UIViewController _subRootViewController;
 
+        private bool _menuSetupSet;
+
         public MvxSidebarViewController()
         {
             _subRootViewController = new UIViewController();
@@ -26,12 +29,40 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
         }
 
         public bool StatusBarHidden { get; set; }
+
         public bool ToggleStatusBarHiddenOnOpen { get; set; } = false;
+
         public new UINavigationController NavigationController { get; private set; }
+
         public SidebarController LeftSidebarController { get; private set; }
+
         public SidebarController RightSidebarController { get; private set; }
-        public bool HasLeftMenu => LeftSidebarController != null && LeftSidebarController.MenuAreaController != null;
-        public bool HasRightMenu => RightSidebarController != null && RightSidebarController.MenuAreaController != null;
+
+        public bool HasLeftMenu
+        {
+            get
+            {
+                if (!_menuSetupSet)
+                {
+                    SetupSideMenu();
+                    _menuSetupSet = true;
+                }
+                return LeftSidebarController != null && LeftSidebarController.MenuAreaController != null;
+            }
+        }
+
+        public bool HasRightMenu
+        {
+            get
+            {
+                if (!_menuSetupSet)
+                {
+                    SetupSideMenu();
+                    _menuSetupSet = true;
+                }
+                return RightSidebarController != null && RightSidebarController.MenuAreaController != null;
+            }
+        }
 
         protected virtual void SetupSideMenu()
         {
@@ -123,9 +154,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
 
         protected virtual void ConfigureSideMenu(SidebarController sidebarController)
         {
-            var mvxSideMenuSettings = sidebarController.MenuAreaController as IMvxSidebarMenu;
-
-            if (mvxSideMenuSettings != null)
+            if (sidebarController.MenuAreaController is IMvxSidebarMenu mvxSideMenuSettings)
             {
                 sidebarController.DarkOverlayAlpha = mvxSideMenuSettings.DarkOverlayAlpha;
                 sidebarController.HasDarkOverlay = mvxSideMenuSettings.HasDarkOverlay;
@@ -150,13 +179,6 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Views
                     }
                 };
             }
-        }
-
-        public override void ViewDidLoad()
-        {
-            base.ViewDidLoad();
-
-            SetupSideMenu();
         }
 
         public override UIStatusBarAnimation PreferredStatusBarUpdateAnimation

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/MvvmCross.iOS.Support.XamarinSidebarSample.iOS.csproj
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/MvvmCross.iOS.Support.XamarinSidebarSample.iOS.csproj
@@ -86,7 +86,6 @@
     <None Include="Info.plist" />
     <None Include="Entitlements.plist" />
     <None Include="packages.config" />
-    <None Include="ToDo-MvvmCross\_ iOS UI.txt" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />

--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/ToDo-MvvmCross/_ iOS UI.txt
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/ToDo-MvvmCross/_ iOS UI.txt
@@ -1,4 +1,0 @@
-The steps to get this iOS UI working are:
-
-1. Add a reference to your Core PCL project
-2. Modify AppDelegate.cs to create the new Setup and to call the IMvxAppStart - there is sample code for this in AppDelegate.cs.txt


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix / Code improvement.

### :arrow_heading_down: What is the current behavior?
Sidebar Menu is not always initialized and menu icons are not displayed.
On the other side, the Sidebar Presenter had a property of type `IMvxSidebarViewController` but the only way it could work was if it was actually a `MvxSidebarViewController`.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed and the property type is changed to `MvxSidebarViewController`.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
1) Run TestProjects/XamarinSidebar sample on current develop. Appreciate that the menu icon is not displayed.
2) Download this branch and run the same project. The menu icon is now successfully displayed.
### :memo: Links to relevant issues/docs
Closes #2188
Closes #2247
Could be related to #2268

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
