### PR TITLE
Fix the namespace in the MvvmCross.Forms.StarterPack

### DIFF
--- a/nuspec/Forms/CoreContent/App.xaml.cs.pp
+++ b/nuspec/Forms/CoreContent/App.xaml.cs.pp
@@ -1,5 +1,5 @@
 ﻿using MvvmCross.Core.ViewModels;
-using MvvmCross.Forms.Core;
+using MvvmCross.Forms.Platform;
 using MvvmCross.Platform;
 using Xamarin.Forms;
 

--- a/nuspec/Forms/CoreContent/App.xaml.pp
+++ b/nuspec/Forms/CoreContent/App.xaml.pp
@@ -2,7 +2,7 @@
 <d:MvxFormsApplication xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="$rootnamespace$.Core.App" 
-    xmlns:d="clr-namespace:MvvmCross.Forms.Core;assembly=MvvmCross.Forms">
+    xmlns:d="clr-namespace:MvvmCross.Forms.Platform;assembly=MvvmCross.Forms.Platform">
 	<Application.Resources>
 		<!-- Application resource dictionary -->
 	</Application.Resources>

--- a/nuspec/Forms/CoreContent/CoreApp.cs.pp
+++ b/nuspec/Forms/CoreContent/CoreApp.cs.pp
@@ -12,7 +12,7 @@ namespace $rootnamespace$.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-            RegisterAppStart<ViewModels.MainViewModel>();
+            RegisterNavigationServiceAppStart<ViewModels.MainViewModel>();
         }
     }
 }

--- a/nuspec/Forms/CoreContent/MainPage.xaml.cs.pp
+++ b/nuspec/Forms/CoreContent/MainPage.xaml.cs.pp
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using MvvmCross.Forms.Core;
+using MvvmCross.Forms.Views;
 using $rootnamespace$.Core.ViewModels;
 using Xamarin.Forms;
 

--- a/nuspec/Forms/CoreContent/MainPage.xaml.pp
+++ b/nuspec/Forms/CoreContent/MainPage.xaml.pp
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:$rootnamespace$.Core.Pages"
     x:Class="$rootnamespace$.Core.Pages.MainPage"
     xmlns:viewModels="clr-namespace:$rootnamespace$.Core.ViewModels;assembly=$rootnamespace$.Core"
-    xmlns:d="clr-namespace:MvvmCross.Forms.Core;assembly=MvvmCross.Core">
+    xmlns:d="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms">
 	<ContentPage.Content>
         <StackLayout>
         <Button Text="Show text" Command="{Binding ShowTextCommand}" />

--- a/nuspec/Forms/DroidContent/FormsActivity.cs.pp
+++ b/nuspec/Forms/DroidContent/FormsActivity.cs.pp
@@ -2,8 +2,7 @@
 using Android.Content.PM;
 using Android.OS;
 using MvvmCross.Droid.Views;
-using MvvmCross.Forms.Droid;
-using MvvmCross.Forms.Presenters;
+using MvvmCross.Forms.Droid.Views;
 using MvvmCross.Platform;
 
 namespace $rootnamespace$

--- a/nuspec/Forms/DroidContent/Setup.cs.pp
+++ b/nuspec/Forms/DroidContent/Setup.cs.pp
@@ -3,8 +3,8 @@ using MvvmCross.Droid.Platform;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Platform.Platform;
 using MvvmCross.Droid.Views;
-using MvvmCross.Forms.Core;
-using MvvmCross.Forms.Droid.Presenters;
+using MvvmCross.Forms.Platform;
+using MvvmCross.Forms.Droid.Platform;
 using MvvmCross.Forms.Droid;
 
 namespace $rootnamespace$

--- a/nuspec/Forms/iOSContent/Setup.cs.pp
+++ b/nuspec/Forms/iOSContent/Setup.cs.pp
@@ -15,7 +15,7 @@ namespace $rootnamespace$
         {
         }
 
-        protected override MvvmCross.Forms.Core.MvxFormsApplication CreateFormsApplication()
+        protected override MvvmCross.Forms.Platform.MvxFormsApplication CreateFormsApplication()
         {
             return new Core.App();
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
After MvvmCross.Forms.StarterPack v5.3.2 is added to a Xamarin.Form cross platform solution, it does not compile.

### :new: What is the new behavior (if this is a feature change)?
All the .Core, .iOS, .Droid projects can compile.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
In Xamarin.Studio, create a new Forms app, Add the MvvmCross.Forms.StarterPack into the .Core /iOS/Droid projects and compile.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
