### PR TITLE
Fix console log provider

### DIFF
--- a/MvvmCross/Core/Core/Platform/LogProviders/ConsoleLogProvider.cs
+++ b/MvvmCross/Core/Core/Platform/LogProviders/ConsoleLogProvider.cs
@@ -15,7 +15,6 @@ namespace MvvmCross.Core.Platform.LogProviders
         private static readonly Action<string> ConsoleWriteLine;
         private static readonly Func<int> GetConsoleForeground;
         private static readonly Action<int> SetConsoleForeground;
-        private static bool _providerIsAvailableOverride = true;
         private static readonly IDictionary<MvxLogLevel, int> Colors;
 
         static ConsoleLogProvider()
@@ -44,9 +43,7 @@ namespace MvvmCross.Core.Platform.LogProviders
         }
 
         internal static bool IsLoggerAvailable()
-        {
-            return ProviderIsAvailableOverride && ConsoleType != null && ConsoleColorType != null;
-        }
+            => ConsoleType != null && ConsoleColorType != null;
 
         protected override Logger GetLogger(string name)
             => new ColouredConsoleLogger(name, ConsoleWriteLine, GetConsoleForeground, SetConsoleForeground).Log;
@@ -58,12 +55,6 @@ namespace MvvmCross.Core.Platform.LogProviders
             Exception e);
 
         internal static MessageFormatterDelegate MessageFormatter { get; set; }
-
-        public static bool ProviderIsAvailableOverride
-        {
-            get { return _providerIsAvailableOverride; }
-            set { _providerIsAvailableOverride = value; }
-        }
 
         private static string DefaultMessageFormatter(string loggerName, MvxLogLevel level, object message, Exception e)
         {

--- a/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/DroidContent/LinkerPleaseInclude.cs.pp
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections.Specialized;
 using System.Windows.Input;
 using Android.App;
 using Android.Views;
@@ -107,6 +108,19 @@ namespace $rootnamespace$
         public void Include(MvxNavigationService service, IMvxViewModelLoader loader)
         {
             service = new MvxNavigationService(null, loader);
+        }
+
+        public void Include(ConsoleColor color)
+        {
+            Console.Write("");
+            Console.WriteLine("");
+            color = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.ForegroundColor = ConsoleColor.Magenta;
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.ForegroundColor = ConsoleColor.Gray;
+            Console.ForegroundColor = ConsoleColor.DarkGray;
         }
     }
 }

--- a/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
@@ -1,11 +1,12 @@
+using System;
 using System.Collections.Specialized;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.iOS.Views;
-using UIKit;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
+using UIKit;
 
 namespace $rootnamespace$
 {
@@ -119,6 +120,19 @@ namespace $rootnamespace$
         public void Include(MvxNavigationService service, IMvxViewModelLoader loader)
         {
             service = new MvxNavigationService(null, loader);
+        }
+
+        public void Include(ConsoleColor color)
+        {
+            Console.Write("");
+            Console.WriteLine("");
+            color = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.ForegroundColor = ConsoleColor.Magenta;
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.ForegroundColor = ConsoleColor.Gray;
+            Console.ForegroundColor = ConsoleColor.DarkGray;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for the exploding ConsoleProvider

I've added content to the LinkerPleaseInclude file in order to prevent the linker from stripping the Console methods. Since we are relying on reflection, this is the only solution right now. Once we migrate to netstandard, this won't be an issue and I'll update the provider.

### :arrow_heading_down: What is the current behavior?
Stuff explodes when linker is enabled 💥 

### :new: What is the new behavior (if this is a feature change)?
Explosion free MvvmCross®

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Include the newly added LinkerPleaseInclude in a project that has the Linker settings set to max and see if anything breaks.

### :memo: Links to relevant issues/docs
Closes #2333 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
