### PR TITLE
Improve UWP view presenter to use presentation attributes

### DIFF
--- a/MvvmCross/Core/Core/Platform/LogProviders/ConsoleLogProvider.cs
+++ b/MvvmCross/Core/Core/Platform/LogProviders/ConsoleLogProvider.cs
@@ -178,9 +178,7 @@ namespace MvvmCross.Core.Platform.LogProviders
 
             static ConsoleColorValues()
             {
-                Type = Type.GetType("System.ConsoleColor");
-                if (Type == null)
-                    Type = Type.GetType("System.ConsoleColor, System.Console");
+                Type = Type.GetType("System.ConsoleColor") ?? Type.GetType("System.ConsoleColor, System.Console");
 
                 if (Type == null) return;
                 Red = (int)Enum.Parse(Type, "Red", false);

--- a/MvvmCross/Core/Core/Platform/LogProviders/ConsoleLogProvider.cs
+++ b/MvvmCross/Core/Core/Platform/LogProviders/ConsoleLogProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq.Expressions;
@@ -179,6 +179,9 @@ namespace MvvmCross.Core.Platform.LogProviders
             static ConsoleColorValues()
             {
                 Type = Type.GetType("System.ConsoleColor");
+                if (Type == null)
+                    Type = Type.GetType("System.ConsoleColor, System.Console");
+
                 if (Type == null) return;
                 Red = (int)Enum.Parse(Type, "Red", false);
                 Yellow = (int)Enum.Parse(Type, "Yellow", false);

--- a/MvvmCross/Platform/UWP/MvvmCross.Platform.Uwp.csproj
+++ b/MvvmCross/Platform/UWP/MvvmCross.Platform.Uwp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/MvvmCross/Windows/Uwp/Attributes/MvxPagePresentationAttribute.cs
+++ b/MvvmCross/Windows/Uwp/Attributes/MvxPagePresentationAttribute.cs
@@ -7,7 +7,7 @@ using MvvmCross.Core.Views;
 
 namespace MvvmCross.Uwp.Attributes
 {
-    public class ContentPagePresentationAttribute : MvxBasePresentationAttribute
+    public class MvxPagePresentationAttribute : MvxBasePresentationAttribute
     {
     }
 }

--- a/MvvmCross/Windows/Uwp/Attributes/MvxPagePresentationAttribute.cs
+++ b/MvvmCross/Windows/Uwp/Attributes/MvxPagePresentationAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MvvmCross.Core.Views;
+
+namespace MvvmCross.Uwp.Attributes
+{
+    public class ContentPagePresentationAttribute : MvxBasePresentationAttribute
+    {
+    }
+}

--- a/MvvmCross/Windows/Uwp/Attributes/MvxSplitViewPresentationAttribute.cs
+++ b/MvvmCross/Windows/Uwp/Attributes/MvxSplitViewPresentationAttribute.cs
@@ -4,7 +4,13 @@ namespace MvvmCross.Uwp.Attributes
 {
     public class MvxSplitViewPresentationAttribute : MvxBasePresentationAttribute
     {
-        public MvxSplitViewPresentationAttribute(SplitPanePosition position = SplitPanePosition.Content)
+
+        public MvxSplitViewPresentationAttribute() : this(SplitPanePosition.Content)
+        {
+            
+        }
+
+        public MvxSplitViewPresentationAttribute(SplitPanePosition position)
         {
             Position = position;
         }

--- a/MvvmCross/Windows/Uwp/Attributes/MvxSplitViewPresentationAttribute.cs
+++ b/MvvmCross/Windows/Uwp/Attributes/MvxSplitViewPresentationAttribute.cs
@@ -1,0 +1,21 @@
+using MvvmCross.Core.Views;
+
+namespace MvvmCross.Uwp.Attributes
+{
+    public class MvxSplitViewPresentationAttribute : MvxBasePresentationAttribute
+    {
+        public MvxSplitViewPresentationAttribute(SplitPanePosition position = SplitPanePosition.Content)
+        {
+            Position = position;
+        }
+
+        public SplitPanePosition Position { get; set; }
+    }
+
+    public enum SplitPanePosition
+    {
+        Pane,
+        Content
+    }
+
+}

--- a/MvvmCross/Windows/Uwp/MvvmCross.Uwp.csproj
+++ b/MvvmCross/Windows/Uwp/MvvmCross.Uwp.csproj
@@ -43,7 +43,8 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Attributes\ContentPagePresentationAttribute.cs" />
+    <Compile Include="Attributes\MvxPagePresentationAttribute.cs" />
+    <Compile Include="Attributes\MvxSplitViewPresentationAttribute.cs" />
     <Compile Include="Platform\MvxDebugTrace.cs" />
     <Compile Include="Platform\MvxWindowsSetup.cs" />
     <Compile Include="..\..\..\AssemblyInfo.cs">

--- a/MvvmCross/Windows/Uwp/MvvmCross.Uwp.csproj
+++ b/MvvmCross/Windows/Uwp/MvvmCross.Uwp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -43,6 +43,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\ContentPagePresentationAttribute.cs" />
     <Compile Include="Platform\MvxDebugTrace.cs" />
     <Compile Include="Platform\MvxWindowsSetup.cs" />
     <Compile Include="..\..\..\AssemblyInfo.cs">
@@ -86,6 +87,7 @@
       <Name>MvvmCross.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -35,31 +35,25 @@ namespace MvvmCross.Uwp.Views
         }
 
         private IMvxViewModelTypeFinder _viewModelTypeFinder;
-        public IMvxViewModelTypeFinder ViewModelTypeFinder
-        {
-            get
-            {
+        public IMvxViewModelTypeFinder ViewModelTypeFinder {
+            get {
                 if (_viewModelTypeFinder == null)
                     _viewModelTypeFinder = Mvx.Resolve<IMvxViewModelTypeFinder>();
                 return _viewModelTypeFinder;
             }
-            set
-            {
+            set {
                 _viewModelTypeFinder = value;
             }
         }
 
         private IMvxViewsContainer _viewsContainer;
-        public IMvxViewsContainer ViewsContainer
-        {
-            get
-            {
+        public IMvxViewsContainer ViewsContainer {
+            get {
                 if (_viewsContainer == null)
                     _viewsContainer = Mvx.Resolve<IMvxViewsContainer>();
                 return _viewsContainer;
             }
-            set
-            {
+            set {
                 _viewsContainer = value;
             }
         }
@@ -83,7 +77,7 @@ namespace MvvmCross.Uwp.Views
                 new MvxPresentationAttributeAction
                 {
                     ShowAction = (view, attribute, request) => ShowPage(view, (MvxPagePresentationAttribute)attribute, request),
-                    CloseAction = (viewModel, attribute) => ClosePage(viewModel, (MvxPagePresentationAttribute)attribute)
+                    CloseAction = (viewModel, attribute) => ClosePage(viewModel)
                 });
 
             AttributeTypesToActionsDictionary.Add(
@@ -95,7 +89,7 @@ namespace MvvmCross.Uwp.Views
                 });
         }
 
-       
+
 
         private void ShowSplitView(Type view, MvxSplitViewPresentationAttribute attribute, MvxViewModelRequest request)
         {
@@ -107,7 +101,7 @@ namespace MvvmCross.Uwp.Views
                 var splitView = FindControl<SplitView>(currentPage.Content, typeof(SplitView));
                 if (splitView == null)
                 {
-                    splitView = new SplitView() {DisplayMode = SplitViewDisplayMode.Inline, IsPaneOpen = true};
+                    splitView = new SplitView { DisplayMode = SplitViewDisplayMode.Inline, IsPaneOpen = true };
                     currentPage.Content = splitView;
                 }
 
@@ -117,16 +111,18 @@ namespace MvvmCross.Uwp.Views
                 }
                 else if (attribute.Position == SplitPanePosition.Pane)
                 {
-                    splitView.Pane = (UIElement) Activator.CreateInstance(viewType);
+                    splitView.Pane = (UIElement)Activator.CreateInstance(viewType);
                 }
-
             }
         }
 
         private T FindControl<T>(UIElement parent, Type targetType) where T : FrameworkElement
         {
 
-            if (parent == null) return null;
+            if (parent == null)
+            {
+                return null;
+            }
 
             if (parent.GetType() == targetType)
             {
@@ -150,10 +146,10 @@ namespace MvvmCross.Uwp.Views
 
         private bool CloseSplitView(IMvxViewModel viewModel, MvxSplitViewPresentationAttribute attribute)
         {
-            return ClosePage(viewModel, attribute);
+            return ClosePage(viewModel);
         }
 
-        private bool ClosePage(IMvxViewModel viewModel, MvxBasePresentationAttribute attribute)
+        private bool ClosePage(IMvxViewModel viewModel)
         {
             var currentView = _rootFrame.Content as IMvxView;
             if (currentView == null)
@@ -253,7 +249,9 @@ namespace MvvmCross.Uwp.Views
                 out MvxPresentationAttributeAction attributeAction))
             {
                 if (attributeAction.ShowAction == null)
+                {
                     throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
+                }
 
                 attributeAction.ShowAction.Invoke(viewType, attribute, request);
                 return;
@@ -300,8 +298,9 @@ namespace MvvmCross.Uwp.Views
                 attributeType,
                 out MvxPresentationAttributeAction attributeAction))
             {
-                if (attributeAction.CloseAction == null)
+                if (attributeAction.CloseAction == null) { 
                     throw new NullReferenceException($"attributeAction.CloseAction is null for attribute: {attributeType.Name}");
+                }
 
                 attributeAction.CloseAction.Invoke(viewModel, attribute);
                 return;

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -205,6 +205,12 @@ namespace MvvmCross.Uwp.Views
             var viewType = ViewsContainer.GetViewType(viewModelType);
             var attributes = viewType.GetCustomAttributes(typeof(MvxBasePresentationAttribute), true).ToList();
             var attribute = attributes.OfType<MvxBasePresentationAttribute>().FirstOrDefault();
+
+            if (attribute != null)
+            {
+                attribute.ViewType = viewType;
+            }
+
             return attribute;
         }
 

--- a/TestProjects/Playground/Playground.Forms.Uwp/App.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/App.xaml.cs
@@ -49,16 +49,7 @@ namespace Playground.Forms.Uwp
                 rootFrame = new Frame();
 
                 rootFrame.NavigationFailed += OnNavigationFailed;
-
-                var color = System.ConsoleColor.Blue;
-                var colorType = color.GetType();
-                var temp = System.Console.ForegroundColor;
-                System.Console.ForegroundColor = color;
-                System.Console.ForegroundColor = temp;
-
-                var test = Type.GetType("System.ConsoleColor, System.Console");
-                var test2 = Type.GetType("System.ConsoleColor");
-
+                
                 var setup = new Setup(rootFrame, e);
                 setup.Initialize();
 

--- a/TestProjects/Playground/Playground.Forms.Uwp/App.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -49,6 +49,18 @@ namespace Playground.Forms.Uwp
                 rootFrame = new Frame();
 
                 rootFrame.NavigationFailed += OnNavigationFailed;
+
+                var color = System.ConsoleColor.Blue;
+                var colorType = color.GetType();
+                var temp = System.Console.ForegroundColor;
+                System.Console.ForegroundColor = color;
+                System.Console.ForegroundColor = temp;
+
+                var test = Type.GetType("System.ConsoleColor, System.Console");
+                var test2 = Type.GetType("System.ConsoleColor");
+
+                var setup = new Setup(rootFrame, e);
+                setup.Initialize();
 
                 if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 {

--- a/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLog.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLog.cs
@@ -1,0 +1,13 @@
+using System;
+using MvvmCross.Platform.Logging;
+
+namespace Playground.Forms.Uwp
+{
+    public class EmptyVoidLog : IMvxLog
+    {
+        public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
+        {
+            return true;
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLogProvider.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLogProvider.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MvvmCross.Platform.Logging;
+
+namespace Playground.Forms.Uwp
+{
+
+    public class EmptyVoidLog : IMvxLog
+    {
+        public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
+        {
+            return true;
+        }
+    }
+
+    public class EmptyVoidLogProvider : IMvxLogProvider
+    {
+        private EmptyVoidLog _voidLog;
+
+        public EmptyVoidLogProvider()
+        {
+            _voidLog = new EmptyVoidLog();
+        }
+
+        public IMvxLog GetLogFor<T>()
+        {
+            return _voidLog;
+        }
+
+        public IMvxLog GetLogFor(string name)
+        {
+            return _voidLog;
+        }
+
+        public IDisposable OpenNestedContext(string message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable OpenMappedContext(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLogProvider.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLogProvider.cs
@@ -3,17 +3,9 @@ using MvvmCross.Platform.Logging;
 
 namespace Playground.Forms.Uwp
 {
-    public class EmptyVoidLog : IMvxLog
-    {
-        public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
-        {
-            return true;
-        }
-    }
-
     public class EmptyVoidLogProvider : IMvxLogProvider
     {
-        private EmptyVoidLog _voidLog;
+        private readonly EmptyVoidLog _voidLog;
 
         public EmptyVoidLogProvider()
         {

--- a/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLogProvider.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/EmptyVoidLogProvider.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MvvmCross.Platform.Logging;
 
 namespace Playground.Forms.Uwp
 {
-
     public class EmptyVoidLog : IMvxLog
     {
         public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)

--- a/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml
+++ b/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml
@@ -1,13 +1,15 @@
-﻿<Page
+<forms:WindowsPage
     x:Class="Playground.Forms.Uwp.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Playground.Forms.Uwp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:forms="using:Xamarin.Forms.Platform.UWP"
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     </Grid>
-</Page>
+</forms:WindowsPage>
+

--- a/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
@@ -1,17 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.Views;
+using MvvmCross.Forms.Uwp.Presenters;
+using MvvmCross.Platform;
+using Xamarin.Forms.Platform.UWP;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -20,11 +11,24 @@ namespace Playground.Forms.Uwp
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class MainPage : Page
+    public sealed partial class MainPage : WindowsPage
     {
         public MainPage()
         {
             this.InitializeComponent();
+            var bla = typeof(MvvmCross.Plugins.JsonLocalization.PluginLoader);
+           
+            InitializeComponent();
+            
+
+            var start = Mvx.Resolve<IMvxAppStart>();
+            start.Start();
+
+            
+            
+
+            var presenter = Mvx.Resolve<IMvxViewPresenter>() as MvxFormsUwpViewPresenter;
+            LoadApplication(presenter.FormsApplication);
         }
     }
 }

--- a/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
@@ -16,16 +16,11 @@ namespace Playground.Forms.Uwp
         public MainPage()
         {
             this.InitializeComponent();
-            var bla = typeof(MvvmCross.Plugins.JsonLocalization.PluginLoader);
            
             InitializeComponent();
-            
 
             var start = Mvx.Resolve<IMvxAppStart>();
             start.Start();
-
-            
-            
 
             var presenter = Mvx.Resolve<IMvxViewPresenter>() as MvxFormsUwpViewPresenter;
             LoadApplication(presenter.FormsApplication);

--- a/TestProjects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/TestProjects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -95,10 +95,12 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="EmptyVoidLogProvider.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Setup.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -130,6 +132,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.0.1</Version>
     </PackageReference>
+    <PackageReference Include="NETStandard.Library">
+      <Version>2.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross-Forms\MvvmCross.Forms.Uwp\MvvmCross.Forms.Uwp.csproj">
@@ -139,6 +144,18 @@
     <ProjectReference Include="..\..\..\MvvmCross-Forms\MvvmCross.Forms\MvvmCross.Forms.csproj">
       <Project>{0797d39c-c59b-4fe2-bb16-ab6fa0119c69}</Project>
       <Name>MvvmCross.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross-Plugins\JsonLocalization\MvvmCross.Plugins.JsonLocalization\MvvmCross.Plugins.JsonLocalization.csproj">
+      <Project>{71d719fa-95b0-4a05-b064-ab8d0b7085df}</Project>
+      <Name>MvvmCross.Plugins.JsonLocalization</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross-Plugins\Location\MvvmCross.Plugins.Location\MvvmCross.Plugins.Location.csproj">
+      <Project>{8b0a9e43-e90f-455c-ae56-45bc70429167}</Project>
+      <Name>MvvmCross.Plugins.Location</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross-Plugins\ResourceLoader\MvvmCross.Plugins.ResourceLoader\MvvmCross.Plugins.ResourceLoader.csproj">
+      <Project>{75ca1824-c7f3-4827-93ed-e75b2c01cb2c}</Project>
+      <Name>MvvmCross.Plugins.ResourceLoader</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\MvvmCross\Binding\UWP\MvvmCross.Binding.Uwp.csproj">
       <Project>{637533ee-756b-4817-94b2-7c1e56132208}</Project>

--- a/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
@@ -7,6 +7,7 @@ using Windows.ApplicationModel.Activation;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
+using MvvmCross.Forms.Platform;
 using MvvmCross.Forms.Uwp;
 using MvvmCross.Forms.Uwp.Presenters;
 using MvvmCross.Platform;
@@ -32,17 +33,14 @@ namespace Playground.Forms.Uwp
             return new Core.App();
         }
 
-        protected override IMvxLogProvider CreateLogProvider()
+        protected override MvxFormsApplication CreateFormsApplication()
         {
-            return new EmptyVoidLogProvider();
+            return new Core.FormsApp();
         }
 
         protected override IMvxWindowsViewPresenter CreateViewPresenter(IMvxWindowsFrame rootFrame)
         {
-
-            Xamarin.Forms.Forms.Init(_launchActivatedEventArgs);
-            var xamarinFormsApp = CreateFormsApplication();
-            var presenter = new MvxFormsUwpViewPresenter(rootFrame, xamarinFormsApp);
+            var presenter = new MvxFormsUwpViewPresenter(rootFrame, FormsApplication);
             Mvx.RegisterSingleton<IMvxViewPresenter>(presenter);
 
             return presenter;

--- a/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
@@ -37,13 +37,6 @@ namespace Playground.Forms.Uwp
             return new EmptyVoidLogProvider();
         }
 
-        protected override void InitializeLastChance()
-        {
-            base.InitializeLastChance();
-            var a = Mvx.Resolve<IMvxNavigationService>();
-            var b = Mvx.Resolve<IMvxLogProvider>();
-        }
-
         protected override IMvxWindowsViewPresenter CreateViewPresenter(IMvxWindowsFrame rootFrame)
         {
 

--- a/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
@@ -1,31 +1,20 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.ApplicationModel.Activation;
-using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.Forms.Platform;
 using MvvmCross.Forms.Uwp;
 using MvvmCross.Forms.Uwp.Presenters;
 using MvvmCross.Platform;
-using MvvmCross.Platform.Logging;
-using MvvmCross.Platform.Platform;
 using MvvmCross.Uwp.Views;
-using Xamarin.Forms.Internals;
 using XamlControls = Windows.UI.Xaml.Controls;
 
 namespace Playground.Forms.Uwp
 {
     public class Setup : MvxFormsWindowsSetup
     {
-        private readonly LaunchActivatedEventArgs _launchActivatedEventArgs;
 
         public Setup(XamlControls.Frame rootFrame, LaunchActivatedEventArgs e) : base(rootFrame, e)
         {
-            _launchActivatedEventArgs = e;
         }
 
         protected override IMvxApplication CreateApp()

--- a/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/Setup.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Activation;
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.Views;
+using MvvmCross.Forms.Uwp;
+using MvvmCross.Forms.Uwp.Presenters;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Logging;
+using MvvmCross.Platform.Platform;
+using MvvmCross.Uwp.Views;
+using Xamarin.Forms.Internals;
+using XamlControls = Windows.UI.Xaml.Controls;
+
+namespace Playground.Forms.Uwp
+{
+    public class Setup : MvxFormsWindowsSetup
+    {
+        private readonly LaunchActivatedEventArgs _launchActivatedEventArgs;
+
+        public Setup(XamlControls.Frame rootFrame, LaunchActivatedEventArgs e) : base(rootFrame, e)
+        {
+            _launchActivatedEventArgs = e;
+        }
+
+        protected override IMvxApplication CreateApp()
+        {
+            return new Core.App();
+        }
+
+        protected override IMvxLogProvider CreateLogProvider()
+        {
+            return new EmptyVoidLogProvider();
+        }
+
+        protected override void InitializeLastChance()
+        {
+            base.InitializeLastChance();
+            var a = Mvx.Resolve<IMvxNavigationService>();
+            var b = Mvx.Resolve<IMvxLogProvider>();
+        }
+
+        protected override IMvxWindowsViewPresenter CreateViewPresenter(IMvxWindowsFrame rootFrame)
+        {
+
+            Xamarin.Forms.Forms.Init(_launchActivatedEventArgs);
+            var xamarinFormsApp = CreateFormsApplication();
+            var presenter = new MvxFormsUwpViewPresenter(rootFrame, xamarinFormsApp);
+            Mvx.RegisterSingleton<IMvxViewPresenter>(presenter);
+
+            return presenter;
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Forms.iOS/AppDelegate.cs
+++ b/TestProjects/Playground/Playground.Forms.iOS/AppDelegate.cs
@@ -1,4 +1,3 @@
-using System;
 using Foundation;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Forms.iOS;
@@ -10,8 +9,6 @@ namespace Playground.Forms.iOS
     [Register("AppDelegate")]
     public partial class AppDelegate : MvxFormsApplicationDelegate
     {
-        public override UIWindow Window { get; set; }
-
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
             Window = new UIWindow(UIScreen.MainScreen.Bounds);
@@ -26,11 +23,7 @@ namespace Playground.Forms.iOS
 
             Window.MakeKeyAndVisible();
 
-            var trick = typeof(System.Console);
-            var color = System.Console.ForegroundColor;
-            System.Console.ForegroundColor = ConsoleColor.Blue;
-            System.Console.ForegroundColor = color;
-            return true;
+            return base.FinishedLaunching(app, options);
         }
     }
 }

--- a/TestProjects/Playground/Playground.Forms.iOS/AppDelegate.cs
+++ b/TestProjects/Playground/Playground.Forms.iOS/AppDelegate.cs
@@ -10,6 +10,8 @@ namespace Playground.Forms.iOS
     [Register("AppDelegate")]
     public partial class AppDelegate : MvxFormsApplicationDelegate
     {
+        public override UIWindow Window { get; set; }
+
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
             Window = new UIWindow(UIScreen.MainScreen.Bounds);
@@ -24,7 +26,11 @@ namespace Playground.Forms.iOS
 
             Window.MakeKeyAndVisible();
 
-            return base.FinishedLaunching(app, options);
+            var trick = typeof(System.Console);
+            var color = System.Console.ForegroundColor;
+            System.Console.ForegroundColor = ConsoleColor.Blue;
+            System.Console.ForegroundColor = color;
+            return true;
         }
     }
 }

--- a/TestProjects/Playground/Playground.Forms.iOS/AppDelegate.cs
+++ b/TestProjects/Playground/Playground.Forms.iOS/AppDelegate.cs
@@ -1,3 +1,4 @@
+using System;
 using Foundation;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Forms.iOS;

--- a/TestProjects/Playground/Playground.Forms.iOS/Info.plist
+++ b/TestProjects/Playground/Playground.Forms.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>Playground.Forms.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.futura4retail.Playground-Forms-iOS</string>
+	<string>com.companyname.Playground-Forms-iOS</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.3</string>
+	<string>10.3</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/TestProjects/Playground/Playground.Forms.iOS/Info.plist
+++ b/TestProjects/Playground/Playground.Forms.iOS/Info.plist
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key>
 	<string>Playground.Forms.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.companyname.Playground-Forms-iOS</string>
+	<string>com.futura4retail.Playground-Forms-iOS</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>10.3</string>
+	<string>9.3</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
+++ b/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
@@ -31,6 +31,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
+    <CodesignProvision>Xamarin Development</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>
@@ -79,8 +80,11 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebuggerPort>38360</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARM64</MtouchArch>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
+    <AppExtensionDebugBundleId />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -110,7 +114,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
-    <Folder Include="Views\" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" />

--- a/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
+++ b/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
@@ -31,7 +31,8 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
-    <CodesignProvision>Xamarin Development</CodesignProvision>
+    <CodesignProvision>
+    </CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>

--- a/TestProjects/Playground/Playground.Uwp/App.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/App.xaml.cs
@@ -53,6 +53,15 @@ namespace Playground.Uwp
             {
                 if (rootFrame.Content == null)
                 {
+                    var color = System.ConsoleColor.Blue;
+                    var colorType = color.GetType();
+                    var temp = System.Console.ForegroundColor;
+                    System.Console.ForegroundColor = color;
+                    System.Console.ForegroundColor = temp;
+
+                    var test = Type.GetType("System.ConsoleColor, System.Console");
+                    var test2 = Type.GetType("System.ConsoleColor");
+
                     var setup = new Setup(rootFrame);
                     setup.Initialize();
 

--- a/TestProjects/Playground/Playground.Uwp/App.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/App.xaml.cs
@@ -53,15 +53,6 @@ namespace Playground.Uwp
             {
                 if (rootFrame.Content == null)
                 {
-                    var color = System.ConsoleColor.Blue;
-                    var colorType = color.GetType();
-                    var temp = System.Console.ForegroundColor;
-                    System.Console.ForegroundColor = color;
-                    System.Console.ForegroundColor = temp;
-
-                    var test = Type.GetType("System.ConsoleColor, System.Console");
-                    var test2 = Type.GetType("System.ConsoleColor");
-
                     var setup = new Setup(rootFrame);
                     setup.Initialize();
 

--- a/TestProjects/Playground/Playground.Uwp/EmptyVoidLog.cs
+++ b/TestProjects/Playground/Playground.Uwp/EmptyVoidLog.cs
@@ -1,0 +1,13 @@
+using System;
+using MvvmCross.Platform.Logging;
+
+namespace Playground.Uwp
+{
+    public class EmptyVoidLog : IMvxLog
+    {
+        public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
+        {
+            return true;
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Uwp/EmptyVoidLogProvider.cs
+++ b/TestProjects/Playground/Playground.Uwp/EmptyVoidLogProvider.cs
@@ -1,0 +1,45 @@
+using System;
+using MvvmCross.Platform.Logging;
+ 
+
+namespace Playground.Uwp
+{
+
+    public class EmptyVoidLog : IMvxLog
+    {
+        public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
+        {
+            return true;
+        }
+    }
+
+    public class EmptyVoidLogProvider : IMvxLogProvider
+    {
+        private EmptyVoidLog _voidLog;
+
+        public EmptyVoidLogProvider()
+        {
+            _voidLog = new EmptyVoidLog();
+        }
+
+        public IMvxLog GetLogFor<T>()
+        {
+            return _voidLog;
+        }
+
+        public IMvxLog GetLogFor(string name)
+        {
+            return _voidLog;
+        }
+
+        public IDisposable OpenNestedContext(string message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable OpenMappedContext(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Uwp/EmptyVoidLogProvider.cs
+++ b/TestProjects/Playground/Playground.Uwp/EmptyVoidLogProvider.cs
@@ -3,18 +3,9 @@ using MvvmCross.Platform.Logging;
 
 namespace Playground.Uwp
 {
-
-    public class EmptyVoidLog : IMvxLog
-    {
-        public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
-        {
-            return true;
-        }
-    }
-
     public class EmptyVoidLogProvider : IMvxLogProvider
     {
-        private EmptyVoidLog _voidLog;
+        private readonly EmptyVoidLog _voidLog;
 
         public EmptyVoidLogProvider()
         {

--- a/TestProjects/Playground/Playground.Uwp/EmptyVoidLogProvider.cs
+++ b/TestProjects/Playground/Playground.Uwp/EmptyVoidLogProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using MvvmCross.Platform.Logging;
- 
 
 namespace Playground.Uwp
 {

--- a/TestProjects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/TestProjects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/TestProjects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/TestProjects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -96,6 +96,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="EmptyVoidLogProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="Views\ChildView.xaml.cs">
@@ -135,6 +136,14 @@
     <ProjectReference Include="..\..\..\MvvmCross-Forms\MvvmCross.Forms\MvvmCross.Forms.csproj">
       <Project>{0797d39c-c59b-4fe2-bb16-ab6fa0119c69}</Project>
       <Name>MvvmCross.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross-Plugins\JsonLocalization\MvvmCross.Plugins.JsonLocalization\MvvmCross.Plugins.JsonLocalization.csproj">
+      <Project>{71d719fa-95b0-4a05-b064-ab8d0b7085df}</Project>
+      <Name>MvvmCross.Plugins.JsonLocalization</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross-Plugins\ResourceLoader\MvvmCross.Plugins.ResourceLoader\MvvmCross.Plugins.ResourceLoader.csproj">
+      <Project>{75ca1824-c7f3-4827-93ed-e75b2c01cb2c}</Project>
+      <Name>MvvmCross.Plugins.ResourceLoader</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\MvvmCross\Binding\UWP\MvvmCross.Binding.Uwp.csproj">
       <Project>{637533ee-756b-4817-94b2-7c1e56132208}</Project>

--- a/TestProjects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/TestProjects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -105,6 +105,15 @@
     <Compile Include="Views\RootView.xaml.cs">
       <DependentUpon>RootView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SplitDetailView.xaml.cs">
+      <DependentUpon>SplitDetailView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SplitMasterView.xaml.cs">
+      <DependentUpon>SplitMasterView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SplitRootView.xaml.cs">
+      <DependentUpon>SplitRootView.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -180,6 +189,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\RootView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SplitDetailView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SplitMasterView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SplitRootView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/TestProjects/Playground/Playground.Uwp/Setup.cs
+++ b/TestProjects/Playground/Playground.Uwp/Setup.cs
@@ -1,5 +1,6 @@
 using Windows.UI.Xaml.Controls;
 using MvvmCross.Core.ViewModels;
+using MvvmCross.Platform.Logging;
 using MvvmCross.Uwp.Platform;
 using MvvmCross.Uwp.Views;
 
@@ -15,9 +16,19 @@ namespace Playground.Uwp
         {
         }
 
+        protected override IMvxLogProvider CreateLogProvider()
+        {
+            return new EmptyVoidLogProvider();
+        }
+
         protected override IMvxApplication CreateApp()
         {
             return new Core.App();
+        }
+
+        protected override IMvxWindowsViewPresenter CreateViewPresenter(IMvxWindowsFrame rootFrame)
+        {
+            return base.CreateViewPresenter(rootFrame);
         }
     }
 }

--- a/TestProjects/Playground/Playground.Uwp/Setup.cs
+++ b/TestProjects/Playground/Playground.Uwp/Setup.cs
@@ -25,10 +25,5 @@ namespace Playground.Uwp
         {
             return new Core.App();
         }
-
-        protected override IMvxWindowsViewPresenter CreateViewPresenter(IMvxWindowsFrame rootFrame)
-        {
-            return base.CreateViewPresenter(rootFrame);
-        }
     }
 }

--- a/TestProjects/Playground/Playground.Uwp/Views/ChildView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/ChildView.xaml.cs
@@ -12,12 +12,14 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using MvvmCross.Uwp.Attributes;
 using MvvmCross.Uwp.Views;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
 namespace Playground.Uwp.Views
 {
+    [ContentPagePresentation]
     public sealed partial class ChildView : MvxWindowsPage
     {
         public ChildView()

--- a/TestProjects/Playground/Playground.Uwp/Views/RootView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/RootView.xaml.cs
@@ -6,7 +6,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Uwp.Views
 {
     [MvxViewFor(typeof(RootViewModel))]
-    [ContentPagePresentation]
+    [MvxPagePresentation]
     public sealed partial class RootView : MvxWindowsPage
     {
         public RootView()

--- a/TestProjects/Playground/Playground.Uwp/Views/RootView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/RootView.xaml.cs
@@ -1,10 +1,12 @@
 using MvvmCross.Core.ViewModels;
+using MvvmCross.Uwp.Attributes;
 using MvvmCross.Uwp.Views;
 using Playground.Core.ViewModels;
 
 namespace Playground.Uwp.Views
 {
     [MvxViewFor(typeof(RootViewModel))]
+    [ContentPagePresentation]
     public sealed partial class RootView : MvxWindowsPage
     {
         public RootView()

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitDetailView.xaml
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitDetailView.xaml
@@ -1,5 +1,5 @@
-<views:MvxWindowsPage
-    x:Class="Playground.Uwp.Views.RootView"
+﻿<views:MvxWindowsPage
+    x:Class="Playground.Uwp.Views.SplitDetailView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Playground.Uwp.Views"
@@ -8,9 +8,7 @@
     xmlns:views="using:MvvmCross.Uwp.Views"
     mc:Ignorable="d">
 
-    <StackPanel>
-        <Button Content="Show Child (Stack Navigation)" Command="{Binding ShowChildCommand}" Margin="5" Padding="5" />
-        <Button Content="Show SplitView" Command="{Binding ShowSplitCommand}" Margin="5" Padding="5" />
-    </StackPanel>
+    <TextBlock Text="Content" />
+    
 </views:MvxWindowsPage>
 

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitDetailView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitDetailView.xaml.cs
@@ -19,10 +19,13 @@ using MvvmCross.Uwp.Views;
 
 namespace Playground.Uwp.Views
 {
-    [MvxPagePresentation]
-    public sealed partial class ChildView : MvxWindowsPage
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [MvxSplitViewPresentation(Position = SplitPanePosition.Content)]
+    public sealed partial class SplitDetailView : MvxWindowsPage
     {
-        public ChildView()
+        public SplitDetailView()
         {
             this.InitializeComponent();
         }

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitMasterView.xaml
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitMasterView.xaml
@@ -1,5 +1,5 @@
-<views:MvxWindowsPage
-    x:Class="Playground.Uwp.Views.RootView"
+﻿<views:MvxWindowsPage
+    x:Class="Playground.Uwp.Views.SplitMasterView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Playground.Uwp.Views"
@@ -8,9 +8,7 @@
     xmlns:views="using:MvvmCross.Uwp.Views"
     mc:Ignorable="d">
 
-    <StackPanel>
-        <Button Content="Show Child (Stack Navigation)" Command="{Binding ShowChildCommand}" Margin="5" Padding="5" />
-        <Button Content="Show SplitView" Command="{Binding ShowSplitCommand}" Margin="5" Padding="5" />
-    </StackPanel>
+    <TextBlock Text="Pane" />
+    
 </views:MvxWindowsPage>
 

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitMasterView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitMasterView.xaml.cs
@@ -19,10 +19,13 @@ using MvvmCross.Uwp.Views;
 
 namespace Playground.Uwp.Views
 {
-    [MvxPagePresentation]
-    public sealed partial class ChildView : MvxWindowsPage
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [MvxSplitViewPresentation(Position = SplitPanePosition.Pane)]
+    public sealed partial class SplitMasterView : MvxWindowsPage
     {
-        public ChildView()
+        public SplitMasterView()
         {
             this.InitializeComponent();
         }

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml
@@ -1,5 +1,5 @@
 <views:MvxWindowsPage
-    x:Class="Playground.Uwp.Views.RootView"
+    x:Class="Playground.Uwp.Views.SplitRootView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Playground.Uwp.Views"
@@ -7,10 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:views="using:MvvmCross.Uwp.Views"
     mc:Ignorable="d">
-
-    <StackPanel>
-        <Button Content="Show Child (Stack Navigation)" Command="{Binding ShowChildCommand}" Margin="5" Padding="5" />
-        <Button Content="Show SplitView" Command="{Binding ShowSplitCommand}" Margin="5" Padding="5" />
-    </StackPanel>
+    
 </views:MvxWindowsPage>
 

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml.cs
@@ -1,6 +1,4 @@
-using System;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Navigation;
 using MvvmCross.Uwp.Attributes;
 using MvvmCross.Uwp.Views;
 using Playground.Core.ViewModels;
@@ -29,13 +27,5 @@ namespace Playground.Uwp.Views
                 viewModel.ShowDetailCommand.Execute();
             }
         }
-
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            
-            base.OnNavigatedTo(e);
-        }
-
-        
     }
 }

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml.cs
@@ -1,0 +1,41 @@
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Navigation;
+using MvvmCross.Uwp.Attributes;
+using MvvmCross.Uwp.Views;
+using Playground.Core.ViewModels;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Playground.Uwp.Views
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [MvxPagePresentation]
+    public sealed partial class SplitRootView : MvxWindowsPage
+    {
+        public SplitRootView()
+        {
+            this.InitializeComponent();
+            this.DataContextChanged += OnDataContextChanged;
+        }
+
+        private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+        {
+            if (DataContext is SplitRootViewModel viewModel)
+            {
+                viewModel.ShowInitialMenuCommand.Execute();
+                viewModel.ShowDetailCommand.Execute();
+            }
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            
+            base.OnNavigatedTo(e);
+        }
+
+        
+    }
+}

--- a/TestProjects/Playground/Playground.Uwp/project.json
+++ b/TestProjects/Playground/Playground.Uwp/project.json
@@ -1,9 +1,10 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
+    "NETStandard.Library": "2.0.1"
   },
   "frameworks": {
-    "uap10.0.10586": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Changing the UWP view presenter to make use of new attribute system.

### :arrow_heading_down: What is the current behavior?
Presenter is not able to make us of attributes.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
Yes, UWP Pages need annotations now.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
