### PR TITLE
Adds CountDownDuration target binding for UIDatePicker

### DIFF
--- a/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
+++ b/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Target\MvxBaseUIDatePickerTargetBinding.cs" />
     <Compile Include="Target\MvxBaseUIViewVisibleTargetBinding.cs" />
     <Compile Include="Target\MvxUIActivityIndicatorViewHiddenTargetBinding.cs" />
+    <Compile Include="Target\MvxUIDatePickerCountdownDurationTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerDateTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerTimeTargetBinding.cs" />
     <Compile Include="Target\MvxUILabelTextTargetBinding.cs" />

--- a/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
@@ -136,6 +136,11 @@ namespace MvvmCross.Binding.iOS
                 typeof(MvxUIDatePickerDateTargetBinding),
                 typeof(UIDatePicker),
                 MvxIosPropertyBinding.UIDatePicker_Date);
+                
+            registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxUIDatePickerCountDownDurationTargetBinding),
+                typeof(UIDatePicker),
+                MvxIosPropertyBinding.UIDatePicker_CountDownDuration);
 
             registry.RegisterCustomBindingFactory<UITextField>(
                 MvxIosPropertyBinding.UITextField_ShouldReturn,

--- a/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
+++ b/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
@@ -31,6 +31,7 @@ namespace MvvmCross.Binding.iOS
         public const string UIPageControl_CurrentPage = "CurrentPage";
         public const string UISegmentedControl_SelectedSegment = "SelectedSegment";
         public const string UIDatePicker_Date = "Date";
+        public const string UIDatePicker_CountDownDuration = "CountDownDuration";
         public const string UITextField_ShouldReturn = "ShouldReturn";
         public const string UIDatePicker_Time = "Time";
         public const string UILabel_Text = "Text";

--- a/MvvmCross/Binding/iOS/MvxIosPropertyBindingExtensions.cs
+++ b/MvvmCross/Binding/iOS/MvxIosPropertyBindingExtensions.cs
@@ -73,6 +73,9 @@ namespace MvvmCross.Binding.iOS
 
         public static string BindDate(this UIDatePicker uiDatePicker)
             => MvxIosPropertyBinding.UIDatePicker_Date;
+        
+        public static string BindCountDownDuration(this UIDatePicker uiDatePicker)
+            => MvxIosPropertyBinding.UIDatePicker_CountDownDuration;
 
         public static string BindShouldReturn(this UITextField uiTextField)
             => MvxIosPropertyBinding.UITextField_ShouldReturn;

--- a/MvvmCross/Binding/iOS/Target/MvxUIDatePickerCountdownDurationTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUIDatePickerCountdownDurationTargetBinding.cs
@@ -1,0 +1,28 @@
+// MvxUIDatePickerTimeTargetBinding.cs
+
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using System.Reflection;
+using UIKit;
+
+namespace MvvmCross.Binding.iOS.Target
+{
+    public class MvxUIDatePickerCountDownDurationTargetBinding : MvxBaseUIDatePickerTargetBinding
+    {
+        public MvxUIDatePickerCountDownDurationTargetBinding(object target, PropertyInfo targetPropertyInfo)
+            : base(target, targetPropertyInfo)
+        {
+        }
+
+        protected override object GetValueFrom(UIDatePicker view)
+        {
+            return view.CountDownDuration;
+        }
+
+        public override Type TargetType => typeof(double);
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR adds a new target binding for the `CountDownDuration` property of `UIDatePicker`.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

See issue #2352

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop