### PR TITLE
Fix bindings without forms base type

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using MvvmCross.Binding;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -15,6 +16,7 @@ namespace MvvmCross.Forms.Bindings
         public IProvideValueTarget Target { get; private set; }
         public BindableObject BindableObj { get; private set; }
         public BindableProperty BindableProp { get; private set; }
+        public string PropertyName { get; private set;  }
 
         public abstract object ProvideValue(IServiceProvider serviceProvider);
 
@@ -23,6 +25,14 @@ namespace MvvmCross.Forms.Bindings
             Target = (IProvideValueTarget)serviceProvider.GetService(typeof(IProvideValueTarget));
             BindableObj = Target.TargetObject as BindableObject;
             BindableProp = Target.TargetProperty as BindableProperty;
+
+            if (Target.TargetProperty is BindableProperty bp)
+            {
+                BindableProp = bp;
+                PropertyName = bp.PropertyName;
+            }
+            else if (Target.TargetProperty is PropertyInfo pi)
+                PropertyName = pi.Name;
 
             return ProvideValue(serviceProvider);
         }

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Text;
 using MvvmCross.Binding;
 using MvvmCross.Platform;
@@ -19,9 +20,9 @@ namespace MvvmCross.Forms.Bindings
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
-            if (BindableObj != null && BindableProp != null)
+            if (BindableObj != null && !string.IsNullOrEmpty(PropertyName))
             {
-                StringBuilder bindingBuilder = new StringBuilder($"{BindableProp.PropertyName} {Path}, Mode={Mode}");
+                StringBuilder bindingBuilder = new StringBuilder($"{PropertyName} {Path}, Mode={Mode}");
 
                 if (!string.IsNullOrEmpty(Converter))
                 {

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
@@ -17,9 +17,9 @@ namespace MvvmCross.Forms.Bindings
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
-            if (BindableObj != null && BindableProp != null)
+            if (BindableObj != null && !string.IsNullOrEmpty(PropertyName))
             {
-                StringBuilder bindingBuilder = new StringBuilder($"{BindableProp.PropertyName} {Source}");
+                StringBuilder bindingBuilder = new StringBuilder($"{PropertyName} {Source}");
 
                 if (!string.IsNullOrEmpty(Converter))
                 {

--- a/TestProjects/Playground/Playground.Core/Pages/ListViewPage.xaml
+++ b/TestProjects/Playground/Playground.Core/Pages/ListViewPage.xaml
@@ -6,7 +6,7 @@
                      xmlns:viewModels="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
                      xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
                      x:Class="Playground.Core.Pages.ListViewPage">
-         <views:MvxListView mvx:Bi.nd="ItemsSource TestItems; ItemClick ItemClickedCommand">
+         <views:MvxListView ItemsSource="{mvx:MvxBind TestItems}" ItemClick="{mvx:MvxBind ItemClickedCommand}">
             <ListView.ItemTemplate>
                  <DataTemplate>
                      <ViewCell>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Currently the extension only accepts types that inherit from a Forms bindings base. This now also takes other types like ICommand.

### :arrow_heading_down: What is the current behavior?

Logging message that no binding is possible.

### :new: What is the new behavior (if this is a feature change)?

Binding is done normally.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the Forms sample and use the ListView page.

### :memo: Links to relevant issues/docs
Fixes https://github.com/MvvmCross/MvvmCross/issues/2299

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
