### PR TITLE
Update doc to net standard 2 support

### DIFF
--- a/docs/_documentation/getting-started/netstandard.md
+++ b/docs/_documentation/getting-started/netstandard.md
@@ -9,10 +9,12 @@ This document will briefly cover how you use .NET Standard in your core project,
 
 This document will asume that you are using the new `csproj` files and not using `project.json` to define your .NET Standard project.
 
+## .NET Standard 1.0 - 1.6
+
 In order to consume PCL projects in any .NET Standard project you need to add a package target fallback for the PCL profile you want to consume. So let us assume you want to add `MvvmCross.Bindings` to your project. This library uses the PCL profile which has a signature that looks like `portable-net45+win+wpa81+wp80`. To add this as a target fallback you simply edit your `csproj` file and add the following line to it.
 
 ```xml
-<PackageTargetFallback>portable-net45+win+wpa81+wp80</PackageTargetFallback>
+<PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
 ```
 
 This line would normaly belong in the `PropertyGroup` which contains the `TargetFramework`, so it would look like. You can have multiple `;`-separated fallbacks here, which helps you consume different profiles.
@@ -21,7 +23,7 @@ This line would normaly belong in the `PropertyGroup` which contains the `Target
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageTargetFallback>portable-net45+win+wpa81+wp80</PackageTargetFallback>
+    <PackageTargetFallback>portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
 
   <!-- other entries -->
@@ -29,3 +31,11 @@ This line would normaly belong in the `PropertyGroup` which contains the `Target
 ```
 
 From here you should be able to add MvvmCross and other PCL based NuGet packages to your .NET Standard project.
+
+## .NET Standard 2
+
+When using .NET Standard 2 you do not need to specify a package target fallback. In .NET Standard 2 `PackageTargetFallback` flag has been depricated and instead defaults to net461 (.NET Framework 4.6.1) or higher. If however, this does not suit your use case you can override this behaviour with the `AssetTargetFallback`.
+
+```xml
+<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+```

--- a/docs/_documentation/getting-started/netstandard.md
+++ b/docs/_documentation/getting-started/netstandard.md
@@ -11,7 +11,7 @@ This document will asume that you are using the new `csproj` files and not using
 
 ## .NET Standard 1.0 - 1.6
 
-In order to consume PCL projects in any .NET Standard project you need to add a package target fallback for the PCL profile you want to consume. So let us assume you want to add `MvvmCross.Bindings` to your project. This library uses the PCL profile which has a signature that looks like `portable-net45+win+wpa81+wp80`. To add this as a target fallback you simply edit your `csproj` file and add the following line to it.
+In order to consume PCL projects in a .NET Standard project tageting versions 1.0 through to 1.6, you need to add a package target fallback for the PCL profile you want to consume. So let us assume you want to add `MvvmCross.Bindings` to your project. This library uses the PCL profile which has a signature that looks like `portable-net45+win+wpa81+wp80`. To add this as a target fallback you simply edit your `csproj` file and add the following line to it.
 
 ```xml
 <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>

--- a/docs/_documentation/getting-started/netstandard.md
+++ b/docs/_documentation/getting-started/netstandard.md
@@ -22,8 +22,8 @@ This line would normaly belong in the `PropertyGroup` which contains the `Target
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageTargetFallback>portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
+    <TargetFramework>netstandard1.4</TargetFramework>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
 
   <!-- other entries -->


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
No specific information for the changes required to support .NET Standard 2.

### :new: What is the new behavior (if this is a feature change)?
Docs now show the separate change between .NET Standard 2 and prior versions.

### :boom: Does this PR introduce a breaking change?
n/a

### :bug: Recommendations for testing
n/a

### :memo: Links to relevant issues/docs
https://www.mvvmcross.com/documentation/getting-started/netstandard

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
