### PR TITLE
Improvements to UIDatePicker target bindings

### DIFF
--- a/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
+++ b/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
@@ -51,8 +51,9 @@
     <Compile Include="Target\MvxBaseUIDatePickerTargetBinding.cs" />
     <Compile Include="Target\MvxBaseUIViewVisibleTargetBinding.cs" />
     <Compile Include="Target\MvxUIActivityIndicatorViewHiddenTargetBinding.cs" />
-    <Compile Include="Target\MvxUIDatePickerCountdownDurationTargetBinding.cs" />
+    <Compile Include="Target\MvxUIDatePickerMinMaxTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerDateTargetBinding.cs" />
+    <Compile Include="Target\MvxUIDatePickerCountdownDurationTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerTimeTargetBinding.cs" />
     <Compile Include="Target\MvxUILabelTextTargetBinding.cs" />
     <Compile Include="Target\MvxUISearchBarTextTargetBinding.cs" />

--- a/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
@@ -48,51 +48,51 @@ namespace MvvmCross.Binding.iOS
                 MvxIosPropertyBinding.UIControl_TouchDown,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_TouchDown));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_TouchDownRepeat,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_TouchDownRepeat));
             
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_TouchDragInside,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_TouchDragInside));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_TouchUpInside,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_TouchUpInside));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_ValueChanged,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_ValueChanged));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_PrimaryActionTriggered,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_PrimaryActionTriggered));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_EditingDidBegin,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_EditingDidBegin));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_EditingChanged,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_EditingChanged));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_EditingDidEnd,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_EditingDidEnd));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_EditingDidEndOnExit,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_EditingDidEndOnExit));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_AllTouchEvents,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_AllTouchEvents));
 
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_AllEditingEvents,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_AllEditingEvents));
             
-			registry.RegisterCustomBindingFactory<UIControl>(
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_AllEvents,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_AllEvents));
 
@@ -136,7 +136,21 @@ namespace MvvmCross.Binding.iOS
                 typeof(MvxUIDatePickerDateTargetBinding),
                 typeof(UIDatePicker),
                 MvxIosPropertyBinding.UIDatePicker_Date);
-                
+
+            registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxUIDatePickerMinMaxTargetBinding),
+                typeof(UIDatePicker),
+                MvxIosPropertyBinding.UIDatePicker_MinimumDate);
+
+            registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxUIDatePickerMinMaxTargetBinding),
+                typeof(UIDatePicker),
+                MvxIosPropertyBinding.UIDatePicker_MaximumDate);
+
+            registry.RegisterCustomBindingFactory<UIDatePicker>(
+                MvxIosPropertyBinding.UIDatePicker_Time,
+                view => new MvxUIDatePickerTimeTargetBinding(view, typeof(UIDatePicker).GetProperty(MvxIosPropertyBinding.UIDatePicker_Date)));
+
             registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxUIDatePickerCountDownDurationTargetBinding),
                 typeof(UIDatePicker),
@@ -145,10 +159,6 @@ namespace MvvmCross.Binding.iOS
             registry.RegisterCustomBindingFactory<UITextField>(
                 MvxIosPropertyBinding.UITextField_ShouldReturn,
                 textField => new MvxUITextFieldShouldReturnTargetBinding(textField));
-
-            registry.RegisterCustomBindingFactory<UIDatePicker>(
-                MvxIosPropertyBinding.UIDatePicker_Time,
-                view => new MvxUIDatePickerTimeTargetBinding(view, typeof(UIDatePicker).GetProperty(nameof(UIDatePicker.Date))));
 
             registry.RegisterCustomBindingFactory<UILabel>(
                 MvxIosPropertyBinding.UILabel_Text,

--- a/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
+++ b/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
@@ -9,20 +9,20 @@ namespace MvvmCross.Binding.iOS
 {
     internal static class MvxIosPropertyBinding
     {
-		public const string UIControl_TouchDown = "TouchDown";
-		public const string UIControl_TouchDownRepeat = "TouchDownRepeat";
-		public const string UIControl_TouchDragInside = "TouchDragInside";
+        public const string UIControl_TouchDown = "TouchDown";
+        public const string UIControl_TouchDownRepeat = "TouchDownRepeat";
+        public const string UIControl_TouchDragInside = "TouchDragInside";
         public const string UIControl_TouchUpInside = "TouchUpInside";
         public const string UIControl_ValueChanged = "ValueChanged";
-		public const string UIControl_PrimaryActionTriggered = "PrimaryActionTriggered";
-		public const string UIControl_EditingDidBegin = "EditingDidBegin";
-		public const string UIControl_EditingChanged = "EditingChanged";
-		public const string UIControl_EditingDidEnd = "EditingDidEnd";
-		public const string UIControl_EditingDidEndOnExit = "EditingDidEndOnExit";
-		public const string UIControl_AllTouchEvents = "AllTouchEvents";
-		public const string UIControl_AllEditingEvents = "AllEditingEvents";
-		public const string UIControl_AllEvents = "AllEvents";
-		public const string UIView_Visibility = "Visibility";
+        public const string UIControl_PrimaryActionTriggered = "PrimaryActionTriggered";
+        public const string UIControl_EditingDidBegin = "EditingDidBegin";
+        public const string UIControl_EditingChanged = "EditingChanged";
+        public const string UIControl_EditingDidEnd = "EditingDidEnd";
+        public const string UIControl_EditingDidEndOnExit = "EditingDidEndOnExit";
+        public const string UIControl_AllTouchEvents = "AllTouchEvents";
+        public const string UIControl_AllEditingEvents = "AllEditingEvents";
+        public const string UIControl_AllEvents = "AllEvents";
+        public const string UIView_Visibility = "Visibility";
         public const string UIView_Visible = "Visible";
         public const string UIActivityIndicatorView_Hidden = "Hidden";
         public const string UIView_Hidden = "Hidden";
@@ -31,9 +31,11 @@ namespace MvvmCross.Binding.iOS
         public const string UIPageControl_CurrentPage = "CurrentPage";
         public const string UISegmentedControl_SelectedSegment = "SelectedSegment";
         public const string UIDatePicker_Date = "Date";
+        public const string UIDatePicker_MaximumDate = "MaximumDate";
+        public const string UIDatePicker_MinimumDate = "MinimumDate";
+        public const string UIDatePicker_Time = "Time";
         public const string UIDatePicker_CountDownDuration = "CountDownDuration";
         public const string UITextField_ShouldReturn = "ShouldReturn";
-        public const string UIDatePicker_Time = "Time";
         public const string UILabel_Text = "Text";
         public const string UITextField_Text = "Text";
         public const string UITextView_Text = "Text";

--- a/MvvmCross/Binding/iOS/Target/MvxUIDatePickerMinMaxTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUIDatePickerMinMaxTargetBinding.cs
@@ -1,0 +1,39 @@
+// MvxUIDatePickerMinMaxTargetBinding.cs
+
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using System.Reflection;
+using MvvmCross.Platform.iOS;
+using UIKit;
+
+namespace MvvmCross.Binding.iOS.Target
+{
+    public class MvxUIDatePickerMinMaxTargetBinding : MvxBaseUIDatePickerTargetBinding
+    {
+        public MvxUIDatePickerMinMaxTargetBinding(object target, PropertyInfo targetPropertyInfo)
+            : base(target, targetPropertyInfo)
+        {
+            var targetPropertyName = targetPropertyInfo.Name;
+            if (targetPropertyName == nameof(UIDatePicker.Date))
+                throw new ArgumentException("This binding cannot be used with the Date property as the target.");
+        }
+
+        protected override object GetValueFrom(UIDatePicker view)
+        {
+            // This method should never be called.
+            throw new NotImplementedException();
+        }
+
+        protected override object MakeSafeValue(object value)
+        {
+            var valueUtc = ToUtcTime((DateTime)value);
+            var valueNSDate = valueUtc.ToNSDate();
+
+            return valueNSDate;
+        }
+    }
+}

--- a/MvvmCross/Platform/iOS/MvxIosDateTimeExtensionMethods.cs
+++ b/MvvmCross/Platform/iOS/MvxIosDateTimeExtensionMethods.cs
@@ -23,5 +23,10 @@ namespace MvvmCross.Platform.iOS
         {
             return NSDate.FromTimeIntervalSinceReferenceDate((date - ReferenceNSDateTime).TotalSeconds);
         }
+
+        public static DateTime WithKind(this DateTime date, DateTimeKind kind)
+        {
+            return new DateTime(date.Ticks, kind);
+        }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Features and bug fixes.

### :arrow_heading_down: What is the current behavior?

MvvmCross does not directly deal with dates in many places, but one such place is the bindings that target a `UIDatePicker` in iOS:

- MvxUIDatePickerDateTargetBinding
- MvxUIDatePickerTimeTargetBinding
- MvxUIDatePickerCountdownDurationTargetBinding
- MvxBaseUIDatePickerTargetBinding (abstract base class for the above)

The current implementation has several issues:

1. It uses the .NET `DateTime` class (implemented by Mono) to do time zone conversion, and it uses the explicit cast conversions between `DateTime` and `NSDate` (provided by Xamarin) to convert between the two. These implementations do not respond to time zone changes **while the app is running**. They initialize their notion of current system time zone when the app is started, and if time zone of the device changes while the app is running, they no longer produce the correct results.

2. When doing a two-way binding to the `UIDatePicker.Date` property, the binding converts a local `DateTime` to an `NSDate` in universal time (which is correct) but it does not perform the same conversion back to the view model when the `UIDatePicker` value is changed. Instead it writes back a UTC `DateTime` value, leading to strange behavior. To achieve correct results, an app must work around this by performing the write-back conversion using a converter.

3. There is no first-class support for binding to the `MinimumDate` and `MaximumDate` properties on `UIDatePicker`. If an app wants to do so, it must remember to do the conversion to `NSDate` and universal time using a converter.

### :new: What is the new behavior (if this is a feature change)?

This PR addresses the above issues in the following ways:

1. It changes all `UIDatePicker` target bindings listed above to use iOS-specific time zone conversion using the `NSTimeZone` class instead of relying on Mono implementation of `DateTime` methods. This makes the app responsive to time zone changes while the app is running.

2. It corrects `MvxUIDatePickerDateTargetBinding` to yield a proper local `DateTime` instead of a UTC `DateTime` with an unspecified Kind.

3. It adds a `MvxUIDatePickerMinMaxTargetBinding` for binding to `MinimumDate` and `MaximumDate` (using the same improved time zone conversion logic).

It also adds a useful extension method to `MvxIosDateTimeExtensionMethods` used from some of the above classes.

### :boom: Does this PR introduce a breaking change?

Very unlikely.

Apps which have previously worked around issue number 2 above using `DateTime.ToLocalTime()` will **not** be broken, because this method performs no conversion if the source `DateTime` already has its `Kind` property set to `Local`, which the improved binding code does. This should constitute the vast majority of those apps that even use this binding.

However, apps which have worked around that issue in some other strange ways (potentially involving homegrown timezone conversion logic) might be broken by this change, but honestly it's even hard to imagine that many such cases exist.

### :bug: Recommendations for testing

Any test cases that relate to binding between `DateTime` or `TimeSpan` values on the view model, and various properties on a `UIDatePicker` in an iOS app. In particular when running on a time zone different from UTC. I also encourage to test changing the device time zone while the app is running, which now works.

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
