### PR TITLE
Add ability to show a different host view for a Forms page

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
@@ -51,6 +51,7 @@ namespace MvvmCross.Forms.Droid.Views
                 {
                     _formsPagePresenter = new MvxFormsPagePresenter(FormsApplication, ViewsContainer, ViewModelTypeFinder);
                     _formsPagePresenter.ClosePlatformViews = ClosePlatformViews;
+                    _formsPagePresenter.ShowPlatformHost = ShowPlatformHost;
                     Mvx.RegisterSingleton<IMvxFormsPagePresenter>(_formsPagePresenter);
                 }
                 return _formsPagePresenter;
@@ -110,6 +111,21 @@ namespace MvvmCross.Forms.Droid.Views
             if (!(CurrentActivity is MvxFormsAppCompatActivity || CurrentActivity is MvxFormsApplicationActivity) && 
                 !(CurrentActivity is MvxSplashScreenActivity || CurrentActivity is MvxSplashScreenAppCompatActivity))
                 CurrentActivity.Finish();
+            return true;
+        }
+
+        public virtual bool ShowPlatformHost(Type hostViewModel = null)
+        {
+            // if there is no Actitivty host associated, assume is the current activity
+            if (hostViewModel == null)
+                hostViewModel = GetCurrentActivityViewModelType();
+
+            var currentHostViewModelType = GetCurrentActivityViewModelType();
+            if (hostViewModel != currentHostViewModelType)
+            {
+                var hostViewModelRequest = MvxViewModelRequest.GetDefaultRequest(hostViewModel);
+                Show(hostViewModelRequest);
+            }
             return true;
         }
     }

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
@@ -64,7 +64,7 @@ namespace MvvmCross.Forms.Droid.Views
 
         public override void Show(MvxViewModelRequest request)
         {
-            var action = GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute); 
+            var action = GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute);
 
             if (FormsApplication.MainPage == null && attribute is MvxPagePresentationAttribute && CurrentActivity is MvxFormsAppCompatActivity activity)
                 activity.InitializeForms(null);

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
@@ -62,6 +62,16 @@ namespace MvvmCross.Forms.Droid.Views
             }
         }
 
+        public override void Show(MvxViewModelRequest request)
+        {
+            var action = GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute); 
+
+            if (FormsApplication.MainPage == null && attribute is MvxPagePresentationAttribute && CurrentActivity is MvxFormsAppCompatActivity activity)
+                activity.InitializeForms(null);
+
+            action.ShowAction.Invoke(attribute.ViewType, attribute, request);
+        }
+
         public override void RegisterAttributeTypes()
         {
             base.RegisterAttributeTypes();

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
@@ -102,11 +102,14 @@ namespace MvvmCross.Forms.Droid.Views
             InitializeForms(bundle);
         }
 
-        protected virtual void InitializeForms(Bundle bundle)
+        public virtual void InitializeForms(Bundle bundle)
         {
-            var resourceAssembly = GetResourceAssembly();
-            global::Xamarin.Forms.Forms.Init(this, bundle, resourceAssembly);
-            LoadApplication(FormsApplication);
+            if (FormsApplication.MainPage != null)
+            {
+                var resourceAssembly = GetResourceAssembly();
+                global::Xamarin.Forms.Forms.Init(this, bundle, resourceAssembly);
+                LoadApplication(FormsApplication);
+            }
         }
 
         protected virtual Assembly GetResourceAssembly()

--- a/MvvmCross-Forms/MvvmCross.Forms/Views/Attributes/MvxPagePresentationAttribute.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/Attributes/MvxPagePresentationAttribute.cs
@@ -10,6 +10,15 @@ namespace MvvmCross.Forms.Views.Attributes
         {
         }
 
+        /// <summary>
+        /// ViewModel Type to show as host before showing the actual view. Optional when not using switching between Forms views and native views.
+        /// </summary>
+        public Type HostViewModelType { get; set; }
+
+        /// <summary>
+        /// Wraps the Page in a MvxNavigationPage if set to true. If the current stack already is a MvxNavigationPage it will push the Page onto that.
+        /// </summary>
+        /// <value><c>true</c> if wrap in navigation page; otherwise, <c>false</c>.</value>
         public virtual bool WrapInNavigationPage { get; set; } = true;
 
         /// <summary>

--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -75,6 +75,7 @@ namespace MvvmCross.Forms.Views
             }
         }
 
+        public virtual Func<Type ,bool> ShowPlatformHost { get; set; }
         public virtual Func<bool> ClosePlatformViews { get; set; }
 
         public virtual Page CreatePage(Type viewType, MvxViewModelRequest request, MvxBasePresentationAttribute attribute)
@@ -158,6 +159,7 @@ namespace MvvmCross.Forms.Views
         {
             CloseAllModals();
             ClosePlatformViews?.Invoke();
+            ShowPlatformHost?.Invoke(attribute.HostViewModelType);
 
             var page = CreatePage(view, request, attribute);
 
@@ -206,6 +208,7 @@ namespace MvvmCross.Forms.Views
         {
             CloseAllModals();
             ClosePlatformViews?.Invoke();
+            ShowPlatformHost?.Invoke(attribute.HostViewModelType);
 
             var page = CreatePage(view, request, attribute);
             PushOrReplacePage(FormsApplication.MainPage, page, attribute);
@@ -223,6 +226,7 @@ namespace MvvmCross.Forms.Views
         {
             CloseAllModals();
             ClosePlatformViews?.Invoke();
+            ShowPlatformHost?.Invoke(attribute.HostViewModelType);
 
             var page = CreatePage(view, request, attribute);
 
@@ -286,6 +290,7 @@ namespace MvvmCross.Forms.Views
             MvxViewModelRequest request)
         {
             ClosePlatformViews?.Invoke();
+            ShowPlatformHost?.Invoke(attribute.HostViewModelType);
 
             var page = CreatePage(view, request, attribute);
 
@@ -340,6 +345,7 @@ namespace MvvmCross.Forms.Views
         {
             CloseAllModals();
             ClosePlatformViews?.Invoke();
+            ShowPlatformHost?.Invoke(attribute.HostViewModelType);
 
             var page = CreatePage(view, request, attribute);
 
@@ -361,6 +367,7 @@ namespace MvvmCross.Forms.Views
         {
             CloseAllModals();
             ClosePlatformViews?.Invoke();
+            ShowPlatformHost?.Invoke(attribute.HostViewModelType);
 
             var page = CreatePage(view, request, attribute);
 

--- a/MvvmCross/Core/Core/Views/MvxAttributeViewPresenter.cs
+++ b/MvvmCross/Core/Core/Views/MvxAttributeViewPresenter.cs
@@ -94,10 +94,10 @@ namespace MvvmCross.Core.Views
             return CreatePresentationAttribute(viewModelType, viewType);
         }
 
-        public virtual MvxPresentationAttributeAction GetPresentationAttributeAction(MvxViewModelRequest request, out MvxBasePresentationAttribute attribute)
+        public virtual MvxPresentationAttributeAction GetPresentationAttributeAction(Type viewModelType, out MvxBasePresentationAttribute attribute)
         {
-            attribute = GetPresentationAttribute(request.ViewModelType);
-            attribute.ViewModelType = request.ViewModelType;
+            attribute = GetPresentationAttribute(viewModelType);
+            attribute.ViewModelType = viewModelType;
             var viewType = attribute.ViewType;
             var attributeType = attribute.GetType();
 
@@ -108,7 +108,8 @@ namespace MvvmCross.Core.Views
                 if (attributeAction.ShowAction == null)
                     throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
 
-                //attributeAction.ShowAction.Invoke(viewType, attribute, request);
+                if (attributeAction.CloseAction == null)
+                    throw new NullReferenceException($"attributeAction.CloseAction is null for attribute: {attributeType.Name}");
 
                 return attributeAction;
             }

--- a/MvvmCross/Core/Core/Views/MvxAttributeViewPresenter.cs
+++ b/MvvmCross/Core/Core/Views/MvxAttributeViewPresenter.cs
@@ -93,5 +93,27 @@ namespace MvvmCross.Core.Views
 
             return CreatePresentationAttribute(viewModelType, viewType);
         }
+
+        public virtual MvxPresentationAttributeAction GetPresentationAttributeAction(MvxViewModelRequest request, out MvxBasePresentationAttribute attribute)
+        {
+            attribute = GetPresentationAttribute(request.ViewModelType);
+            attribute.ViewModelType = request.ViewModelType;
+            var viewType = attribute.ViewType;
+            var attributeType = attribute.GetType();
+
+            if (AttributeTypesToActionsDictionary.TryGetValue(
+                attributeType,
+                out MvxPresentationAttributeAction attributeAction))
+            {
+                if (attributeAction.ShowAction == null)
+                    throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
+
+                //attributeAction.ShowAction.Invoke(viewType, attribute, request);
+
+                return attributeAction;
+            }
+
+            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+        }
     }
 }

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -237,7 +237,7 @@ namespace MvvmCross.Droid.Views
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         #region Show implementations
@@ -482,21 +482,7 @@ namespace MvvmCross.Droid.Views
 
         public override void Close(IMvxViewModel viewModel)
         {
-            var attribute = GetPresentationAttribute(viewModel.GetType());
-            var attributeType = attribute.GetType();
-
-            if (AttributeTypesToActionsDictionary.TryGetValue(
-                attributeType,
-                out MvxPresentationAttributeAction attributeAction))
-            {
-                if (attributeAction.CloseAction == null)
-                    throw new NullReferenceException($"attributeAction.CloseAction is null for attribute: {attributeType.Name}");
-
-                attributeAction.CloseAction.Invoke(viewModel, attribute);
-                return;
-            }
-
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
         }
 
         #region Close implementations

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -237,23 +237,7 @@ namespace MvvmCross.Droid.Views
 
         public override void Show(MvxViewModelRequest request)
         {
-            var attribute = GetPresentationAttribute(request.ViewModelType);
-            attribute.ViewModelType = request.ViewModelType;
-            var viewType = attribute.ViewType;
-            var attributeType = attribute.GetType();
-
-            if (AttributeTypesToActionsDictionary.TryGetValue(
-                attributeType,
-                out MvxPresentationAttributeAction attributeAction))
-            {
-                if (attributeAction.ShowAction == null)
-                    throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
-
-                attributeAction.ShowAction.Invoke(viewType, attribute, request);
-                return;
-            }
-
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         #region Show implementations

--- a/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
@@ -165,22 +165,7 @@ namespace MvvmCross.Mac.Views.Presenters
 
         public override void Show(MvxViewModelRequest request)
         {
-            var attribute = GetPresentationAttribute(request.ViewModelType);
-            attribute.ViewModelType = request.ViewModelType;
-            var attributeType = attribute.GetType();
-
-            if (AttributeTypesToActionsDictionary.TryGetValue(
-                attributeType,
-                out MvxPresentationAttributeAction attributeAction))
-            {
-                if (attributeAction.ShowAction == null)
-                    throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
-
-                attributeAction.ShowAction.Invoke(attribute.ViewType, attribute, request);
-                return;
-            }
-
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         protected virtual void ShowWindowViewController(

--- a/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
@@ -165,7 +165,7 @@ namespace MvvmCross.Mac.Views.Presenters
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         protected virtual void ShowWindowViewController(

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -93,7 +93,7 @@ namespace MvvmCross.Uwp.Views
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         public override void ChangePresentation(MvxPresentationHint hint)
@@ -111,23 +111,7 @@ namespace MvvmCross.Uwp.Views
 
         public override void Close(IMvxViewModel viewModel)
         {
-            var attribute = GetPresentationAttribute(viewModel.GetType());
-            var attributeType = attribute.GetType();
-
-            if (AttributeTypesToActionsDictionary.TryGetValue(
-                attributeType,
-                out MvxPresentationAttributeAction attributeAction))
-            {
-                if (attributeAction.CloseAction == null)
-                {
-                    throw new NullReferenceException($"attributeAction.CloseAction is null for attribute: {attributeType.Name}");
-                }
-
-                attributeAction.CloseAction.Invoke(viewModel, attribute);
-                return;
-            }
-
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
         }
 
         protected virtual async void BackButtonOnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -93,25 +93,7 @@ namespace MvvmCross.Uwp.Views
 
         public override void Show(MvxViewModelRequest request)
         {
-            var attribute = GetPresentationAttribute(request.ViewModelType);
-            attribute.ViewModelType = request.ViewModelType;
-            var viewType = attribute.ViewType;
-            var attributeType = attribute.GetType();
-
-            if (AttributeTypesToActionsDictionary.TryGetValue(
-                attributeType,
-                out MvxPresentationAttributeAction attributeAction))
-            {
-                if (attributeAction.ShowAction == null)
-                {
-                    throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
-                }
-
-                attributeAction.ShowAction.Invoke(viewType, attribute, request);
-                return;
-            }
-
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         public override void ChangePresentation(MvxPresentationHint hint)

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -168,7 +168,7 @@ namespace MvvmCross.iOS.Views.Presenters
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         #region Show implementations
@@ -348,21 +348,7 @@ namespace MvvmCross.iOS.Views.Presenters
 
         public override void Close(IMvxViewModel viewModel)
         {
-            var attribute = GetPresentationAttribute(viewModel.GetType());
-            var attributeType = attribute.GetType();
-
-            if (AttributeTypesToActionsDictionary.TryGetValue(
-                attributeType,
-                out MvxPresentationAttributeAction attributeAction))
-            {
-                if (attributeAction.CloseAction == null)
-                    throw new NullReferenceException($"attributeAction.CloseAction is null for attribute: {attributeType.Name}");
-
-                attributeAction.CloseAction.Invoke(viewModel, attribute);
-                return;
-            }
-
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
         }
 
         #region Close implementations

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -168,22 +168,7 @@ namespace MvvmCross.iOS.Views.Presenters
 
         public override void Show(MvxViewModelRequest request)
         {
-            var attribute = GetPresentationAttribute(request.ViewModelType);
-            attribute.ViewModelType = request.ViewModelType;
-            var attributeType = attribute.GetType();
-
-            if (AttributeTypesToActionsDictionary.TryGetValue(
-                attributeType,
-                out MvxPresentationAttributeAction attributeAction))
-            {
-                if (attributeAction.ShowAction == null)
-                    throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
-
-                attributeAction.ShowAction.Invoke(attribute.ViewType, attribute, request);
-                return;
-            }
-
-            throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         #region Show implementations

--- a/TestProjects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/TestProjects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -9,14 +9,14 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Playground.Droid</RootNamespace>
     <AssemblyName>Playground.Droid</AssemblyName>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -189,7 +189,7 @@
       <Name>MvvmCross.Droid.Support.Design</Name>
     </ProjectReference>
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj">
-      <Project>{fea3804a-3bc6-42bd-b40a-1a80d82a9579}</Project>
+      <Project>{56CD2748-857D-442A-9268-95D99F552840}</Project>
       <Name>Playground.Core</Name>
     </ProjectReference>
   </ItemGroup>

--- a/TestProjects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/TestProjects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -10,14 +10,14 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Playground.Forms.Droid</RootNamespace>
     <AssemblyName>Playground.Forms.Droid</AssemblyName>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -220,7 +220,7 @@
       <Name>MvvmCross.Droid.Support.V7.RecyclerView</Name>
     </ProjectReference>
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj">
-      <Project>{fea3804a-3bc6-42bd-b40a-1a80d82a9579}</Project>
+      <Project>{56CD2748-857D-442A-9268-95D99F552840}</Project>
       <Name>Playground.Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\Playground.Forms.UI\Playground.Forms.UI.csproj">

--- a/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
+++ b/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
@@ -167,7 +167,7 @@
       <Name>MvvmCross.Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj">
-      <Project>{fea3804a-3bc6-42bd-b40a-1a80d82a9579}</Project>
+      <Project>{56CD2748-857D-442A-9268-95D99F552840}</Project>
       <Name>Playground.Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\Playground.Forms.UI\Playground.Forms.UI.csproj">

--- a/TestProjects/Playground/Playground.Mac/Playground.Mac.csproj
+++ b/TestProjects/Playground/Playground.Mac/Playground.Mac.csproj
@@ -148,7 +148,7 @@
       <Name>MvvmCross.Platform.Mac</Name>
     </ProjectReference>
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj">
-      <Project>{fea3804a-3bc6-42bd-b40a-1a80d82a9579}</Project>
+      <Project>{56CD2748-857D-442A-9268-95D99F552840}</Project>
       <Name>Playground.Core</Name>
     </ProjectReference>
   </ItemGroup>

--- a/TestProjects/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/TestProjects/Playground/Playground.iOS/Playground.iOS.csproj
@@ -190,7 +190,7 @@
       <Name>MvvmCross.Platform</Name>
     </ProjectReference>
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj">
-      <Project>{fea3804a-3bc6-42bd-b40a-1a80d82a9579}</Project>
+      <Project>{56CD2748-857D-442A-9268-95D99F552840}</Project>
       <Name>Playground.Core</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature/fix

### :arrow_heading_down: What is the current behavior?

Currently when you navigate to a native view from a Forms view you cannot navigate further forwards. You need to close the view to go to the Forms host first. This lets you set the type to host in so you can navigate forward.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
