### PR TITLE
Add possibility to get translation directly instead of binding to object

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/La.n.g.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/La.n.g.cs
@@ -6,8 +6,10 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System.Collections.Generic;
+using System.Linq;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings;
+using MvvmCross.Localization;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Core;
 using Xamarin.Forms;
@@ -34,9 +36,16 @@ namespace MvvmCross.Forms.Bindings
                                             null,
                                             CallBackWhenngIsChanged);
 
-        public static string Getng(BindableObject obj)
+        public static string Getng(object obj)
         {
-            return obj.GetValue(ngProperty) as string;
+            if (obj is BindableObject bindable)
+                return bindable.GetValue(ngProperty) as string;
+            else if (obj is string text)
+            {
+                return Mvx.Resolve<IMvxTextProvider>().GetText("", "", text);
+            }
+            else
+                return null;
         }
 
         public static void Setng(BindableObject obj,

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/La.n.g.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/La.n.g.cs
@@ -6,10 +6,8 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System.Collections.Generic;
-using System.Linq;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings;
-using MvvmCross.Localization;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Core;
 using Xamarin.Forms;

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/La.n.g.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/La.n.g.cs
@@ -36,16 +36,9 @@ namespace MvvmCross.Forms.Bindings
                                             null,
                                             CallBackWhenngIsChanged);
 
-        public static string Getng(object obj)
+        public static string Getng(BindableObject obj)
         {
-            if (obj is BindableObject bindable)
-                return bindable.GetValue(ngProperty) as string;
-            else if (obj is string text)
-            {
-                return Mvx.Resolve<IMvxTextProvider>().GetText("", "", text);
-            }
-            else
-                return null;
+            return obj.GetValue(ngProperty) as string;
         }
 
         public static void Setng(BindableObject obj,

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms.Xaml;
 
 namespace MvvmCross.Forms.Bindings
 {
-    public abstract class MvxBaseBindExtension : BindableObject, IMarkupExtension
+    public abstract class MvxBaseBindExtension : IMarkupExtension
     {
         public MvxBindingMode Mode { get; set; } = MvxBindingMode.Default;
         public string Converter { get; set; }

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms.Xaml;
 
 namespace MvvmCross.Forms.Bindings
 {
-    public abstract class MvxBaseBindExtension : IMarkupExtension
+    public abstract class MvxBaseBindExtension : BindableObject, IMarkupExtension
     {
         public MvxBindingMode Mode { get; set; } = MvxBindingMode.Default;
         public string Converter { get; set; }

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
@@ -14,23 +14,20 @@ namespace MvvmCross.Forms.Bindings
         public string FallbackValue { get; set; }
 
         public IProvideValueTarget Target { get; private set; }
-        public BindableObject BindableObj { get; private set; }
-        public BindableProperty BindableProp { get; private set; }
-        public string PropertyName { get; private set;  }
+        public object BindableObj { get; private set; }
+        public object BindableProp { get; private set; }
+        public string PropertyName { get; private set; } = string.Empty;
 
         public abstract object ProvideValue(IServiceProvider serviceProvider);
 
         object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
         {
             Target = (IProvideValueTarget)serviceProvider.GetService(typeof(IProvideValueTarget));
-            BindableObj = Target.TargetObject as BindableObject;
-            BindableProp = Target.TargetProperty as BindableProperty;
+            BindableObj = Target.TargetObject;
+            BindableProp = Target.TargetProperty;
 
             if (Target.TargetProperty is BindableProperty bp)
-            {
-                BindableProp = bp;
                 PropertyName = bp.PropertyName;
-            }
             else if (Target.TargetProperty is PropertyInfo pi)
                 PropertyName = pi.Name;
 

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
@@ -20,7 +20,7 @@ namespace MvvmCross.Forms.Bindings
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
-            if (BindableObj != null && !string.IsNullOrEmpty(PropertyName))
+            if (BindableObj is BindableObject obj && !string.IsNullOrEmpty(PropertyName))
             {
                 StringBuilder bindingBuilder = new StringBuilder($"{PropertyName} {Path}, Mode={Mode}");
 
@@ -44,7 +44,11 @@ namespace MvvmCross.Forms.Bindings
                     bindingBuilder.Append($", CommandParameter={CommandParameter}");
                 }
 
-                BindableObj.SetValue(Bi.ndProperty, bindingBuilder.ToString());
+                obj.SetValue(Bi.ndProperty, bindingBuilder.ToString());
+            }
+            else if (BindableObj is IMarkupExtension ext)
+            {
+                return ext.ProvideValue(serviceProvider);
             }
             else
             {

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Reflection;
 using System.Text;
-using MvvmCross.Binding;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Platform;
 using Xamarin.Forms;

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindExtension.cs
@@ -52,7 +52,7 @@ namespace MvvmCross.Forms.Bindings
             }
             else
             {
-                Mvx.Trace(MvxTraceLevel.Diagnostic, "Cannot only use MvxBind on a bindable property");
+                Mvx.Trace(MvxTraceLevel.Diagnostic, "Can only use MvxBind on a bindable property");
             }
 
             return null;

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindingCreator.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxBindingCreator.cs
@@ -20,7 +20,7 @@ namespace MvvmCross.Forms.Bindings
                                    object newValue,
                                    Func<string, IEnumerable<MvxBindingDescription>> parseBindingDescriptions)
         {
-            var attachedObject = sender as Element;
+            var attachedObject = sender as BindableObject;
 
             if (attachedObject == null)
             {
@@ -39,7 +39,7 @@ namespace MvvmCross.Forms.Bindings
             ApplyBindings(attachedObject, bindingDescriptions);
         }
 
-        protected abstract void ApplyBindings(Element attachedObject,
+        protected abstract void ApplyBindings(BindableObject attachedObject,
                                               IEnumerable<MvxBindingDescription> bindingDescriptions);
     }
 }

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxFormsBindingCreator.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxFormsBindingCreator.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Forms.Bindings
 {
     public class MvxFormsBindingCreator : MvxBindingCreator
     {
-        protected override void ApplyBindings(Element attachedObject,
+        protected override void ApplyBindings(BindableObject attachedObject,
                                               IEnumerable<MvxBindingDescription> bindingDescriptions)
         {
             var binder = MvxBindingSingletonCache.Instance.Binder;
@@ -27,7 +27,7 @@ namespace MvvmCross.Forms.Bindings
             RegisterBindingsForUpdates(attachedObject, bindings);
         }
 
-        private void RegisterBindingsForUpdates(Element attachedObject,
+        private void RegisterBindingsForUpdates(BindableObject attachedObject,
                                                 IEnumerable<IMvxUpdateableBinding> bindings)
         {
             if (bindings == null)
@@ -40,7 +40,7 @@ namespace MvvmCross.Forms.Bindings
             }
         }
 
-        private IList<IMvxUpdateableBinding> GetOrCreateBindingsList(Element attachedObject)
+        private IList<IMvxUpdateableBinding> GetOrCreateBindingsList(BindableObject attachedObject)
         {
             var existing = attachedObject.GetValue(BindingsListProperty) as IList<IMvxUpdateableBinding>;
 
@@ -73,9 +73,9 @@ namespace MvvmCross.Forms.Bindings
             attachAction();
             var subscription = attachedObject.WeakSubscribe((s, a) =>
                                                             {
-                                                                if (a.PropertyName == nameof(Element.Parent))
+                                                                if (attachedObject is Element element && a.PropertyName == nameof(Element.Parent))
                                                                 {
-                                                                    if (attachedObject.Parent != null)
+                                                                    if (element.Parent != null)
                                                                     {
                                                                         attachAction();
                                                                     }

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using MvvmCross.Forms.Bindings;
 using MvvmCross.Localization;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Platform;

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Forms.Bindings
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
-            if (BindableObj != null && !string.IsNullOrEmpty(PropertyName))
+            if (BindableObj is BindableObject obj && !string.IsNullOrEmpty(PropertyName))
             {
                 StringBuilder bindingBuilder = new StringBuilder($"{PropertyName} {Source}");
 
@@ -41,7 +41,14 @@ namespace MvvmCross.Forms.Bindings
                     bindingBuilder.Append($", FallbackValue={FallbackValue}");
                 }
 
-                BindableObj.SetValue(La.ngProperty, bindingBuilder.ToString());
+                obj.SetValue(La.ngProperty, bindingBuilder.ToString());
+            }
+            else if(BindableObj is IMarkupExtension ext)
+            {
+                var test = ext.ProvideValue(serviceProvider);
+
+                //TODO: return real value here
+                return "";
             }
             else
             {

--- a/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Bindings/MvxLangExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using MvvmCross.Forms.Bindings;
+using MvvmCross.Localization;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Platform;
 using Xamarin.Forms;
@@ -12,6 +13,12 @@ namespace MvvmCross.Forms.Bindings
     public class MvxLangExtension : MvxBaseBindExtension
     {
         public string Source { get; set; }
+
+        public string NameSpaceKey { get; set; } = "";
+
+        public string TypeKey { get; set; } = "";
+
+        public object[] Arguments { get; set; }
 
         public string Key { get; set; }
 
@@ -43,16 +50,20 @@ namespace MvvmCross.Forms.Bindings
 
                 obj.SetValue(La.ngProperty, bindingBuilder.ToString());
             }
+            else if(Mvx.CanResolve<IMvxTextProvider>())
+            {
+                if(Arguments == null)
+                    return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source);
+                else
+                    return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source, Arguments);
+            }
             else if(BindableObj is IMarkupExtension ext)
             {
-                var test = ext.ProvideValue(serviceProvider);
-
-                //TODO: return real value here
-                return "";
+                return ext.ProvideValue(serviceProvider);
             }
             else
             {
-                Mvx.Trace(MvxTraceLevel.Diagnostic, "Cannot only use MvxLang on a bindable property");
+                Mvx.Trace(MvxTraceLevel.Diagnostic, "Can only use MvxLang on a bindable property");
             }
 
             return null;

--- a/MvvmCross-Forms/MvvmCross.Forms/MvvmCross.Forms.csproj
+++ b/MvvmCross-Forms/MvvmCross.Forms/MvvmCross.Forms.csproj
@@ -136,6 +136,10 @@
       <Project>{64DCD397-9019-41E8-A928-E5F5C5DF185B}</Project>
       <Name>MvvmCross.Binding</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\MvvmCross\Core\Localization\MvvmCross.Localization.csproj">
+      <Project>{D89351C1-D48F-4AD0-A0B9-353A93425AB7}</Project>
+      <Name>MvvmCross.Localization</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/TestProjects/Playground/Playground.Core/App.cs
+++ b/TestProjects/Playground/Playground.Core/App.cs
@@ -1,5 +1,8 @@
 ﻿using MvvmCross.Core.ViewModels;
+using MvvmCross.Localization;
+using MvvmCross.Platform;
 using MvvmCross.Platform.IoC;
+using Playground.Core.Services;
 using Playground.Core.ViewModels;
 
 namespace Playground.Core
@@ -12,6 +15,9 @@ namespace Playground.Core
                 .EndingWith("Service")
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
+
+            var test = new TextProviderBuilder();
+            Mvx.RegisterSingleton<IMvxTextProvider>(test.TextProvider);
 
             RegisterNavigationServiceAppStart<RootViewModel>();
         }

--- a/TestProjects/Playground/Playground.Core/App.cs
+++ b/TestProjects/Playground/Playground.Core/App.cs
@@ -16,8 +16,7 @@ namespace Playground.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-            var test = new TextProviderBuilder();
-            Mvx.RegisterSingleton<IMvxTextProvider>(test.TextProvider);
+            Mvx.RegisterSingleton<IMvxTextProvider>(new TextProviderBuilder().TextProvider);
 
             RegisterNavigationServiceAppStart<RootViewModel>();
         }

--- a/TestProjects/Playground/Playground.Core/Playground.Core.csproj
+++ b/TestProjects/Playground/Playground.Core/Playground.Core.csproj
@@ -68,6 +68,7 @@
     <EmbeddedResource Include="Resources\Text.json" />
     <Compile Include="Services\TextProviderBuilder.cs" />
     <Compile Include="Models\SampleModel.cs" />
+    <Compile Include="ViewModels\BaseViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross\Core\Core\MvvmCross.Core.csproj">
@@ -101,6 +102,14 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\portable-net45+win8+wp8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/TestProjects/Playground/Playground.Core/Services/TextProviderBuilder.cs
+++ b/TestProjects/Playground/Playground.Core/Services/TextProviderBuilder.cs
@@ -8,7 +8,7 @@ namespace Playground.Core.Services
 {
     public class TextProviderBuilder : MvxTextProviderBuilder
     {
-        public TextProviderBuilder() : base("MvxBindingsExample", "Resources", new MvxEmbeddedJsonDictionaryTextProvider(false))
+        public TextProviderBuilder() : base("Playground.Core", "Resources", new MvxEmbeddedJsonDictionaryTextProvider(false))
         {
         }
 

--- a/TestProjects/Playground/Playground.Core/ViewModels/BaseViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/BaseViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using MvvmCross.Core.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class BaseViewModel : MvxViewModel
+    {
+        public BaseViewModel()
+        {
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Core/packages.config
+++ b/TestProjects/Playground/Playground.Core/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="portable45-net45+win8+wp8+wpa81" />
+</packages>

--- a/TestProjects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/TestProjects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -118,6 +118,11 @@
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Xamarin.Forms.2.4.0.74863\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\netstandard1.3\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
@@ -226,6 +231,18 @@
     <ProjectReference Include="..\Playground.Forms.UI\Playground.Forms.UI.csproj">
       <Project>{545c1972-05dc-4aec-87cb-70ccd3296f8d}</Project>
       <Name>Playground.Forms.UI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross\Core\Localization\MvvmCross.Localization.csproj">
+      <Project>{D89351C1-D48F-4AD0-A0B9-353A93425AB7}</Project>
+      <Name>MvvmCross.Localization</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross-Plugins\Json\MvvmCross.Plugins.Json\MvvmCross.Plugins.Json.csproj">
+      <Project>{D518E8E6-3CE6-4706-A286-E8BC6A2F64DC}</Project>
+      <Name>MvvmCross.Plugins.Json</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross-Plugins\JsonLocalization\MvvmCross.Plugins.JsonLocalization\MvvmCross.Plugins.JsonLocalization.csproj">
+      <Project>{71D719FA-95B0-4A05-B064-AB8D0B7085DF}</Project>
+      <Name>MvvmCross.Plugins.JsonLocalization</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/TestProjects/Playground/Playground.Forms.Droid/Setup.cs
+++ b/TestProjects/Playground/Playground.Forms.Droid/Setup.cs
@@ -11,6 +11,7 @@ using Serilog;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
+using MvvmCross.Plugins.Json;
 
 namespace Playground.Forms.Droid
 {
@@ -46,9 +47,17 @@ namespace Playground.Forms.Droid
         {
             return new DebugTrace();
         }
+
         protected override IEnumerable<Assembly> GetViewAssemblies()
         {
             return base.GetViewAssemblies().Union(new[] { typeof(FormsApp).GetTypeInfo().Assembly });
+        }
+
+        protected override void PerformBootstrapActions()
+        {
+            base.PerformBootstrapActions();
+
+            PluginLoader.Instance.EnsureLoaded();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Forms.Droid/packages.config
+++ b/TestProjects/Playground/Playground.Forms.Droid/packages.config
@@ -1,19 +1,60 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CSharp" version="4.0.1" targetFramework="monoandroid80" />
+  <package id="Microsoft.CSharp" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid80" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="monoandroid80" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="monoandroid80" />
   <package id="Serilog" version="2.5.0" targetFramework="monoandroid80" />
   <package id="Serilog.Sinks.Xamarin" version="0.1.29" targetFramework="monoandroid80" />
-  <package id="System.Collections" version="4.0.11" targetFramework="monoandroid80" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Collections" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Collections.NonGeneric" version="4.0.1" targetFramework="monoandroid80" />
+  <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Console" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="monoandroid80" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="monoandroid80" />
-  <package id="System.Linq" version="4.1.0" targetFramework="monoandroid80" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="monoandroid80" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="monoandroid80" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="monoandroid80" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="monoandroid80" />
-  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="monoandroid80" />
-  <package id="System.Threading" version="4.0.11" targetFramework="monoandroid80" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.IO" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Linq" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime.Serialization.Formatters" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Threading" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Support.Annotations" version="25.3.1" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Support.Compat" version="25.3.1" targetFramework="monoandroid71" />

--- a/TestProjects/Playground/Playground.Forms.UI/Pages/BindingsPage.xaml
+++ b/TestProjects/Playground/Playground.Forms.UI/Pages/BindingsPage.xaml
@@ -9,7 +9,17 @@
 
     <ScrollView>
         <StackLayout Margin="5">
-            <Label Text="Default (OneWay) Binding" />
+            <Picker SelectedIndex="1" HorizontalOptions="FillAndExpand">
+                    <Picker.ItemsSource>
+                       <x:Array Type="{x:Type x:String}">
+                            <mvx:MvxLang Source="ThisIsLocalizedToo" />
+                            <mvx:MvxLang Source="ThisIsLocalized" />
+                            <mvx:MvxLang Source="ThisIsLocalizedToo" />
+                            <mvx:MvxLang Source="ThisIsLocalized" />
+                       </x:Array>
+                   </Picker.ItemsSource>
+            </Picker>
+           <!-- <Label Text="Default (OneWay) Binding" />
 	        <Label mvx:Bi.nd="Text BindableText" />
             <BoxView Margin="5"
                      HeightRequest="4"
@@ -32,7 +42,7 @@
             <Label Text="Lang Binding" />
             <Label mvx:La.ng="Text ThisIsLocalized" />
             <Label Text="{mvx:MvxLang ThisIsLocalizedToo}" />
-            <Label Text="{mvx:MvxBind TextSource, Mode=OneTime, Converter=Language, ConverterParameter=ThisIsLocalizedThroughMvxBind}" />
+            <Label Text="{mvx:MvxBind TextSource, Mode=OneTime, Converter=Language, ConverterParameter=ThisIsLocalizedThroughMvxBind}" />-->
         </StackLayout>
     </ScrollView>
 </core:MvxContentPage>

--- a/TestProjects/Playground/Playground.Forms.UI/Pages/BindingsPage.xaml
+++ b/TestProjects/Playground/Playground.Forms.UI/Pages/BindingsPage.xaml
@@ -12,14 +12,12 @@
             <Picker SelectedIndex="1" HorizontalOptions="FillAndExpand">
                     <Picker.ItemsSource>
                        <x:Array Type="{x:Type x:String}">
-                            <mvx:MvxLang Source="ThisIsLocalizedToo" />
-                            <mvx:MvxLang Source="ThisIsLocalized" />
-                            <mvx:MvxLang Source="ThisIsLocalizedToo" />
-                            <mvx:MvxLang Source="ThisIsLocalized" />
+                            <mvx:MvxLang Source="ThisIsLocalizedToo" NameSpaceKey="Playground.Core" TypeKey="Text" />
+                            <mvx:MvxLang Source="ThisIsLocalized" NameSpaceKey="Playground.Core" TypeKey="Text" />
                        </x:Array>
                    </Picker.ItemsSource>
             </Picker>
-           <!-- <Label Text="Default (OneWay) Binding" />
+           <Label Text="Default (OneWay) Binding" />
 	        <Label mvx:Bi.nd="Text BindableText" />
             <BoxView Margin="5"
                      HeightRequest="4"
@@ -42,7 +40,7 @@
             <Label Text="Lang Binding" />
             <Label mvx:La.ng="Text ThisIsLocalized" />
             <Label Text="{mvx:MvxLang ThisIsLocalizedToo}" />
-            <Label Text="{mvx:MvxBind TextSource, Mode=OneTime, Converter=Language, ConverterParameter=ThisIsLocalizedThroughMvxBind}" />-->
+            <Label Text="{mvx:MvxBind TextSource, Mode=OneTime, Converter=Language, ConverterParameter=ThisIsLocalizedThroughMvxBind}" />
         </StackLayout>
     </ScrollView>
 </core:MvxContentPage>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When having a different context, it was not possible to retrieve translation

### :new: What is the new behavior (if this is a feature change)?

Now it tries to return it directly if possible.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the playground form droid and go to bindings page

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
