### PR TITLE
Fix Droid Activities when navigating for result

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
@@ -84,35 +84,37 @@ namespace MvvmCross.Droid.Support.V4
             ViewModel?.ViewCreated();
         }
 
-		protected override void OnDestroy()
-		{
-			base.OnDestroy();
-			ViewModel?.ViewDestroy();
-		}
+        protected override void OnDestroy()
+        {
+            base.OnDestroy();
 
-		protected override void OnStart()
-		{
-			base.OnStart();
-			ViewModel?.ViewAppearing();
-		}
+            if (IsFinishing)
+                ViewModel?.ViewDestroy();
+        }
 
-		protected override void OnResume()
-		{
-			base.OnResume();
-			ViewModel?.ViewAppeared();
-		}
+        protected override void OnStart()
+        {
+            base.OnStart();
+            ViewModel?.ViewAppearing();
+        }
 
-		protected override void OnPause()
-		{
-			base.OnPause();
-			ViewModel?.ViewDisappearing();
-		}
+        protected override void OnResume()
+        {
+            base.OnResume();
+            ViewModel?.ViewAppeared();
+        }
 
-		protected override void OnStop()
-		{
-			base.OnStop();
-			ViewModel?.ViewDisappeared();
-		}
+        protected override void OnPause()
+        {
+            base.OnPause();
+            ViewModel?.ViewDisappearing();
+        }
+
+        protected override void OnStop()
+        {
+            base.OnStop();
+            ViewModel?.ViewDisappeared();
+        }
     }
 
     public abstract class MvxFragmentActivity<TViewModel>

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
@@ -94,7 +94,9 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         protected override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+
+            if (IsFinishing)
+                ViewModel?.ViewDestroy();
         }
 
         protected override void OnStart()

--- a/MvvmCross/Droid/Droid/Views/MvxActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxActivity.cs
@@ -1,4 +1,4 @@
-﻿﻿// MvxActivity.cs
+﻿// MvxActivity.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -105,7 +105,7 @@ namespace MvvmCross.Droid.Views
                     {
                         if (f.IsVisible)
                             fragments.Add(f);
-                    }   
+                    }
                 }
 
                 return fragments;
@@ -121,7 +121,9 @@ namespace MvvmCross.Droid.Views
         protected override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+
+            if (IsFinishing)
+                ViewModel?.ViewDestroy();
         }
 
         protected override void OnStart()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
When navigating for result to a new Activity, if the device is rotated, there is a premature call to ViewModel.ViewDestroy.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed. Solution is to call ViewModel.ViewDestroy only if the Activity is being finished.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Playground TestProject: Make TabsRootViewModel derive from `MvxViewModelResult<bool>` and watch for the navigation result from RootViewModel. When using this branch, View rotation will work as expected. 

### :memo: Links to relevant issues/docs
Fixes #2384.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
