### PR TITLE
Fixing double-navigation when navigation is hosted within master-detail

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -524,7 +524,7 @@ namespace MvvmCross.Forms.Views
                     // NR: This is a really hacky solution to a bug where if "NavigationPage.HasNavigationBar="False"
                     // is set in the page XAML, the navigation bar is still shown. Looks like after first navigation
                     // this is resolved
-                    var navpage = new MvxNavigationPage(new MvxContentPage());
+                    var navpage = new NavigationPage(new MvxContentPage());
                     ReplacePageRoot(rootPage, navpage, attribute);
                     navpage.Navigation.InsertPageBefore(page, navpage.RootPage);
                     navpage.Navigation.PopToRootAsync(attribute.Animated);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
ViewAppeared is called multiple times for a ViewModel that is directly associated with a 
MvxMasterDetailPage when the first details page is set to WrapInNavigationPage. ViewAppeared is called once for the MvxMasterDetailPage, and again for the MvxNavigationPage injected into the details pane.

### :new: What is the new behavior (if this is a feature change)?
Switch from MvxNavigationPage to regular NavigationPage prevents the ViewAppeared method being invoked twice

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
In playground sample, move code from Initialize method to the ViewAppeared override method - before this change, the ViewAppeared method is called twice; after the change the method is only called once

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop


Discussion question: The MvxFormsPagePresenter currently injects MvxNavigationPage and MvxContentPage, rather than the built in NavigationPage / ContentPage. This has the potential negative effect of invoking ViewAppeared method multiple times if the view model is passed down through inheritance. This is the issue with the scenario fixed in this PR:

- In the playground sample the SplitRootViewModel is connected to the SplitRootPage which inherits from MvxMasterDetailPage
- If you attempt to navigate to the details page in the ViewAppeared method of the SpitRootViewModel, an MvxNavigationPage is (before this PR) created and assigned to the Detail property on the MvxMasterDetailPage. 
- By inheritance the BindingContext is passed down to the new MvxNavigationPage, which means that the SplitRootViewModel is now also associated with the MvxNavigationPage.
- The ViewAppeared method is now invoked a second time when the MvxNavigationPage appears, which is not good.

I hope this explains the background for this PR and the need for a discussion on this topic. My position is that we should not be using the Mvx classes when injecting Navigation and Content pages but would love to know the other side of the argument as to why it's important to use them. Are there cases where this implicit inheritance is important? 
