### PR TITLE
Fixes MvxObservableCollection.AddRange firing wrong changed event

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxObservableCollection.cs
@@ -87,15 +87,16 @@ namespace MvvmCross.Core.ViewModels
                 throw new ArgumentNullException(nameof(items));
             }
 
+            var itemsList = items.ToList();
             using (SuppressEvents())
             {
-                foreach (var item in items)
+                foreach (var item in itemsList)
                 {
                     Add(item);
                 }
             }
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList));
         }
 
         /// <summary>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce?

Bug Fix

### :arrow_heading_down: What is the current behavior?

Calling `AddRange` fires a `NotifyCollectionChangedEventArgs` with the given `IEnumerable<T>` as an item of `e.NewItems` (`e.NewItems[0]` is an `System.Linq.Enumerable.SelectArrayIterator<T>`). My expectation is that `e.NewItems` directly contains all elements passed to `AddRange` so that `e.NewItems[0] is T`.

### :new: What is the new behavior (if this is a feature change)?

Calling `AddRange` fires a correct `NotifyCollectionChangedEventArgs` by converting the enumerable to a list before firing the event.

### :boom: Does this PR introduce a breaking change?

No (as the previous behavior was obviously wrong).

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

Fixes #2338 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
