### PR TITLE
Fixing issue with default page presentationattribute where viewmodelt…

### DIFF
--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -63,7 +63,7 @@ namespace MvvmCross.Uwp.Views
         public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
         {
             MvxTrace.Trace($"PresentationAttribute not found for {viewType.Name}. Assuming new page presentation");
-            return new MvxPagePresentationAttribute();
+            return new MvxPagePresentationAttribute() { ViewType = viewType, ViewModelType = viewModelType };
         }
 
         

--- a/TestProjects/Playground/Playground.Uwp/Views/ChildView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/ChildView.xaml.cs
@@ -5,7 +5,6 @@ using MvvmCross.Uwp.Views;
 
 namespace Playground.Uwp.Views
 {
-    [MvxPagePresentation]
     public sealed partial class ChildView
     {
         public ChildView()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
If no attribute specified for UWP page, attempting to navigate to corresponding viewmodel will not work

### :new: What is the new behavior (if this is a feature change)?
Issue was that the default mvpagepresentationattribute wasn't being populated with viewmodel and view type information. With this fix the attribute is correctly setup and navigation will work.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run playground UWP sample - ChildPage doesn't have an attribute set, yet navigation works

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2404

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ X ] Rebased onto current develop
