### PR TITLE
Fixing issue where content page with attributes set to NoHistory and …

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -492,10 +492,6 @@ namespace MvvmCross.Forms.Views
                 rootPage = FormsApplication.MainPage;
             }
 
-            //By default push to the detail page
-            if(GetHostPageOfType<MasterDetailPage>(rootPage) is MasterDetailPage masterRoot)
-                rootPage = masterRoot.Detail;
-
             var navigationRootPage = GetHostPageOfType<NavigationPage>(rootPage);
 
             // Step down through any nested navigation pages to make sure we're pushing to the

--- a/TestProjects/Playground/Playground.Core/ViewModels/SplitDetailNavViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SplitDetailNavViewModel.cs
@@ -11,9 +11,12 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
+            MainMenuCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<MixedNavFirstViewModel>());
             CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
         }
 
+        public IMvxAsyncCommand MainMenuCommand { get; private set; }
         public IMvxAsyncCommand CloseCommand { get; private set; }
+
     }
 }

--- a/TestProjects/Playground/Playground.Forms.UI/Pages/SplitDetailNavPage.xaml
+++ b/TestProjects/Playground/Playground.Forms.UI/Pages/SplitDetailNavPage.xaml
@@ -11,6 +11,8 @@
     <ContentPage.Content>
         <StackLayout Margin="10">
             <Label Text="I'm a detail navigation page" />
+            <Button Text="Main Menu"
+                    mvx:Bi.nd="Command MainMenuCommand" />
             <Button Text="Close"
                     mvx:Bi.nd="Command CloseCommand" />
         </StackLayout>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Attempting to navigate to page that has WrapInNavigation=false and NoHistory=true when a master details page is in use, navigates to the page in the details pane. It should navigate to the page at the root level (ie replacing the master details page)

### :new: What is the new behavior (if this is a feature change)?
Page is navigated to at root level

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run playground sample - navigate to Master Details and then select Main Menu option - this should navigate back to the login prompt, instead of showing it in the details pane

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ x ] Rebased onto current develop
