### PR TITLE
Add UIBarButtonItem target binding

### DIFF
--- a/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
+++ b/MvvmCross/Binding/iOS/MvvmCross.Binding.iOS.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Target\MvxBaseUIDatePickerTargetBinding.cs" />
     <Compile Include="Target\MvxBaseUIViewVisibleTargetBinding.cs" />
     <Compile Include="Target\MvxUIActivityIndicatorViewHiddenTargetBinding.cs" />
+    <Compile Include="Target\MvxUIBarButtonItemTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerMinMaxTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerDateTargetBinding.cs" />
     <Compile Include="Target\MvxUIDatePickerCountdownDurationTargetBinding.cs" />

--- a/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
@@ -1,4 +1,4 @@
-﻿// MvxIosBindingBuilder.cs
+// MvxIosBindingBuilder.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -217,6 +217,10 @@ namespace MvvmCross.Binding.iOS
             registry.RegisterCustomBindingFactory<UITextField>(
                 MvxIosPropertyBinding.UITextField_TextFocus,
                 textField => new MvxUITextFieldTextFocusTargetBinding(textField));
+
+            registry.RegisterCustomBindingFactory<UIBarButtonItem>(
+                MvxIosPropertyBinding.UIBarButtonItem_Clicked,
+                view => new MvxUIBarButtonItemTargetBinding(view));
 
             /*
             registry.RegisterCustomBindingFactory<UIView>("TwoFingerDoubleTap",

--- a/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
+++ b/MvvmCross/Binding/iOS/MvxIosPropertyBinding.cs
@@ -1,4 +1,4 @@
-﻿// MvxIosPropertyBinding.cs
+// MvxIosPropertyBinding.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -50,5 +50,6 @@ namespace MvvmCross.Binding.iOS
         public const string UIView_DoubleTap = "DoubleTap";
         public const string UIView_TwoFingerTap = "TwoFingerTap";
         public const string UITextField_TextFocus = "TextFocus";
+        public const string UIBarButtonItem_Clicked = "Clicked";
     }
 }

--- a/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.Binding.iOS.Target
         {
             if (control == null)
             {
-                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - UIControl is null in MvxUIControlTargetBinding");
+                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - UIControl is null in MvxUIBarButtonItemTargetBinding");
             }
             else
             {

--- a/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
@@ -16,7 +16,6 @@ namespace MvvmCross.Binding.iOS.Target
 
         protected UIBarButtonItem Control => Target as UIBarButtonItem;
 
-
         public MvxUIBarButtonItemTargetBinding(UIBarButtonItem control)
             : base(control)
         {

--- a/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Windows.Input;
+using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.Platform.Platform;
+using MvvmCross.Platform.WeakSubscription;
+using UIKit;
+
+namespace MvvmCross.Binding.iOS.Target
+{
+    public class MvxUIBarButtonItemTargetBinding
+        : MvxConvertingTargetBinding
+    {
+        private ICommand _command;
+        private IDisposable _canExecuteSubscription;
+        private readonly EventHandler<EventArgs> _canExecuteEventHandler;
+
+        protected UIBarButtonItem Control => Target as UIBarButtonItem;
+
+
+        public MvxUIBarButtonItemTargetBinding(UIBarButtonItem control)
+            : base(control)
+        {
+            if (control == null)
+            {
+                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - UIControl is null in MvxUIControlTargetBinding");
+            }
+            else
+            {
+                control.Clicked += OnClicked;
+            }
+
+            _canExecuteEventHandler = OnCanExecuteChanged;
+        }
+
+        private void OnClicked(object sender, EventArgs e)
+        {
+            if (_command == null)
+                return;
+
+            if (!_command.CanExecute(null))
+                return;
+
+            _command.Execute(null);
+        }
+
+        public override Type TargetType => typeof(ICommand);
+        protected override void SetValueImpl(object target, object value)
+        {
+            if (_canExecuteSubscription != null)
+            {
+                _canExecuteSubscription.Dispose();
+                _canExecuteSubscription = null;
+            }
+            _command = value as ICommand;
+            if (_command != null)
+            {
+                _canExecuteSubscription = _command.WeakSubscribe(_canExecuteEventHandler);
+            }
+            RefreshEnabledState();
+        }
+
+        private void OnCanExecuteChanged(object sender, EventArgs e)
+        {
+            RefreshEnabledState();
+        }
+
+        private void RefreshEnabledState()
+        {
+            var view = Control;
+            if (view == null)
+                return;
+
+            var shouldBeEnabled = false;
+            if (_command != null)
+            {
+                shouldBeEnabled = _command.CanExecute(null);
+            }
+            view.Enabled = shouldBeEnabled;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                var view = Control;
+                if (view != null)
+                    view.Clicked -= OnClicked;
+               
+                _canExecuteSubscription?.Dispose();
+                _canExecuteSubscription = null;
+            }
+
+            base.Dispose(isDisposing);
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds ability to bind a `ICommand` to a `UIBarButtonItem`

### :arrow_heading_down: What is the current behavior?
There is a default property to bind for `UIBarButtonItem`, but nothing that tells MvvmCross what and how to bind.

### :new: What is the new behavior (if this is a feature change)?
Adds ability to bind against a `ICommand` and set `Enabled` depending on `ICommand.CanExecute()`, similar to how it works for `UIControl` derivatives

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
1. Bind a `ICommand` to a `UIBarButtonItem`
2. Try toggle `CanExecute()` and watch `Enabled` to be set accordingly
3. Try click `UIBarButtonItem` and see the click fire the `Execute()` method of the `ICommand`

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
