### PR TITLE
Fix MvxViewModelRequest for fragments and improve ViewDestroy callback

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxDialogFragment.cs
@@ -76,7 +76,7 @@ namespace MvvmCross.Droid.Support.V4
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(viewFinishing: IsRemoving || Activity == null || Activity.IsFinishing);
         }
 
         public override void OnStart()

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragment.cs
@@ -56,7 +56,7 @@ namespace MvvmCross.Droid.Support.V4
             set
             {
                 _dataContext = value;
-                if (BindingContext != null)
+                if(BindingContext != null)
                     BindingContext.DataContext = value;
             }
         }
@@ -89,7 +89,7 @@ namespace MvvmCross.Droid.Support.V4
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(viewFinishing: IsRemoving || Activity == null || Activity.IsFinishing);
         }
 
         public override void OnStart()

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxFragmentActivity.cs
@@ -87,9 +87,7 @@ namespace MvvmCross.Droid.Support.V4
         protected override void OnDestroy()
         {
             base.OnDestroy();
-
-            if (IsFinishing)
-                ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(IsFinishing);
         }
 
         protected override void OnStart()

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V14.Preference/MvxPreferenceFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V14.Preference/MvxPreferenceFragment.cs
@@ -8,74 +8,74 @@ using MvvmCross.Droid.Views;
 namespace MvvmCross.Droid.Support.V14.Preference
 {
     [Register("mvvmcross.droid.support.v14.preference.MvxPreferenceFragment")]
-    public abstract class MvxPreferenceFragment 
+    public abstract class MvxPreferenceFragment
         : MvxEventSourcePreferenceFragment, IMvxFragmentView
-	{
-		protected MvxPreferenceFragment()
-		{
-			this.AddEventListeners();
-		}
+    {
+        protected MvxPreferenceFragment()
+        {
+            this.AddEventListeners();
+        }
 
-	    protected MvxPreferenceFragment(IntPtr javaReference, JniHandleOwnership transfer)
-	        : base(javaReference, transfer)
-	    {
-	    }
+        protected MvxPreferenceFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
 
-		public IMvxBindingContext BindingContext { get; set; }
+        public IMvxBindingContext BindingContext { get; set; }
 
-		private object _dataContext;
+        private object _dataContext;
 
-		public object DataContext
-		{
-			get
+        public object DataContext
+        {
+            get
             {
                 return _dataContext;
             }
-			set
-			{
-				_dataContext = value;
-				if (BindingContext != null)
-					BindingContext.DataContext = value;
-			}
-		}
+            set
+            {
+                _dataContext = value;
+                if (BindingContext != null)
+                    BindingContext.DataContext = value;
+            }
+        }
 
-		public virtual IMvxViewModel ViewModel
-		{
-			get
+        public virtual IMvxViewModel ViewModel
+        {
+            get
             {
                 return DataContext as IMvxViewModel;
             }
-			set
-			{
-				DataContext = value;
-				OnViewModelSet();
-			}
-		}
+            set
+            {
+                DataContext = value;
+                OnViewModelSet();
+            }
+        }
 
-		public virtual void OnViewModelSet()
-		{
-		}
+        public virtual void OnViewModelSet()
+        {
+        }
 
         public string UniqueImmutableCacheTag => Tag;
     }
 
-	public abstract class MvxPreferenceFragment<TViewModel>
-		: MvxPreferenceFragment, IMvxFragmentView<TViewModel> 
+    public abstract class MvxPreferenceFragment<TViewModel>
+        : MvxPreferenceFragment, IMvxFragmentView<TViewModel>
         where TViewModel : class, IMvxViewModel
-	{
-		protected MvxPreferenceFragment()
-		{
-		}
+    {
+        protected MvxPreferenceFragment()
+        {
+        }
 
-	    protected MvxPreferenceFragment(IntPtr javaReference, JniHandleOwnership transfer) 
+        protected MvxPreferenceFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-	    {
-	    }
+        {
+        }
 
-		public new TViewModel ViewModel
-		{
-			get { return (TViewModel)base.ViewModel; }
-			set { base.ViewModel = value; }
-		}
-	}
+        public new TViewModel ViewModel
+        {
+            get { return (TViewModel)base.ViewModel; }
+            set { base.ViewModel = value; }
+        }
+    }
 }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
@@ -94,9 +94,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         protected override void OnDestroy()
         {
             base.OnDestroy();
-
-            if (IsFinishing)
-                ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(IsFinishing);
         }
 
         protected override void OnStart()

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
@@ -77,7 +77,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(viewFinishing: IsRemoving || Activity == null || Activity.IsFinishing);
         }
 
         public override void OnStart()

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -172,18 +172,19 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 activity.StartActivity(intent);
         }
 
-        protected virtual ActivityOptionsCompat CreateActivityTransitionOptions(Android.Content.Intent intent,MvxActivityPresentationAttribute attribute){
+        protected virtual ActivityOptionsCompat CreateActivityTransitionOptions(Android.Content.Intent intent, MvxActivityPresentationAttribute attribute)
+        {
             ActivityOptionsCompat options = null;
             if (attribute.SharedElements != null)
-			{
-				IList<Pair> sharedElements = new List<Pair>();
-				foreach (var item in attribute.SharedElements)
-				{
-					intent.PutExtra(item.Key, ViewCompat.GetTransitionName(item.Value));
-					sharedElements.Add(Pair.Create(item.Value, item.Key));
-				}
-				options = ActivityOptionsCompat.MakeSceneTransitionAnimation(CurrentActivity, sharedElements.ToArray());
-			}
+            {
+                IList<Pair> sharedElements = new List<Pair>();
+                foreach (var item in attribute.SharedElements)
+                {
+                    intent.PutExtra(item.Key, ViewCompat.GetTransitionName(item.Value));
+                    sharedElements.Add(Pair.Create(item.Value, item.Key));
+                }
+                options = ActivityOptionsCompat.MakeSceneTransitionAnimation(CurrentActivity, sharedElements.ToArray());
+            }
 
             return options;
         }
@@ -261,30 +262,27 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             var fragmentView = fragment.ToFragment();
 
-            // MvxNavigationService provides an already instantiated ViewModel here,
-            // therefore just assign it
+            // MvxNavigationService provides an already instantiated ViewModel here
             if (request is MvxViewModelInstanceRequest instanceRequest)
             {
                 fragment.ViewModel = instanceRequest.ViewModelInstance;
             }
-            else
+
+            // save MvxViewModelRequest in the Fragment's Arguments
+            var bundle = new Bundle();
+            var serializedRequest = NavigationSerializer.Serializer.SerializeObject(request);
+            bundle.PutString(ViewModelRequestBundleKey, serializedRequest);
+
+            if (fragmentView != null)
             {
-                var bundle = new Bundle();
-                var serializedRequest = NavigationSerializer.Serializer.SerializeObject(request);
-                bundle.PutString(ViewModelRequestBundleKey, serializedRequest);
-
-
-                if (fragmentView != null)
+                if (fragmentView.Arguments == null)
                 {
-                    if (fragmentView.Arguments == null)
-                    {
-                        fragmentView.Arguments = bundle;
-                    }
-                    else
-                    {
-                        fragmentView.Arguments.Clear();
-                        fragmentView.Arguments.PutAll(bundle);
-                    }
+                    fragmentView.Arguments = bundle;
+                }
+                else
+                {
+                    fragmentView.Arguments.Clear();
+                    fragmentView.Arguments.PutAll(bundle);
                 }
             }
 
@@ -303,41 +301,43 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             OnFragmentChanged(ft, fragmentView, attribute);
         }
 
-        protected virtual void OnBeforeFragmentChanging(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute){
-			if (attribute.SharedElements != null)
-			{
-				foreach (var item in attribute.SharedElements)
-				{
-					string name = item.Key;
-					if (string.IsNullOrEmpty(name))
-						name = ViewCompat.GetTransitionName(item.Value);
-					ft.AddSharedElement(item.Value, name);
-				}
-			}
-			if (!attribute.EnterAnimation.Equals(int.MinValue) && !attribute.ExitAnimation.Equals(int.MinValue))
-			{
-				if (!attribute.PopEnterAnimation.Equals(int.MinValue) && !attribute.PopExitAnimation.Equals(int.MinValue))
-					ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation, attribute.PopEnterAnimation, attribute.PopExitAnimation);
-				else
-					ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation);
-			}
-			if (attribute.TransitionStyle != int.MinValue)
-				ft.SetTransitionStyle(attribute.TransitionStyle);
+        protected virtual void OnBeforeFragmentChanging(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
+        {
+            if (attribute.SharedElements != null)
+            {
+                foreach (var item in attribute.SharedElements)
+                {
+                    string name = item.Key;
+                    if (string.IsNullOrEmpty(name))
+                        name = ViewCompat.GetTransitionName(item.Value);
+                    ft.AddSharedElement(item.Value, name);
+                }
+            }
+            if (!attribute.EnterAnimation.Equals(int.MinValue) && !attribute.ExitAnimation.Equals(int.MinValue))
+            {
+                if (!attribute.PopEnterAnimation.Equals(int.MinValue) && !attribute.PopExitAnimation.Equals(int.MinValue))
+                    ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation, attribute.PopEnterAnimation, attribute.PopExitAnimation);
+                else
+                    ft.SetCustomAnimations(attribute.EnterAnimation, attribute.ExitAnimation);
+            }
+            if (attribute.TransitionStyle != int.MinValue)
+                ft.SetTransitionStyle(attribute.TransitionStyle);
         }
 
-        protected virtual void OnFragmentChanged(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute){
-            
+        protected virtual void OnFragmentChanged(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
+        {
+
         }
 
-		protected virtual void OnFragmentChanging(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
-		{
+        protected virtual void OnFragmentChanging(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
+        {
 
-		}
+        }
 
         protected virtual void OnFragmentPopped(FragmentTransaction ft, Fragment fragment, MvxFragmentPresentationAttribute attribute)
-		{
+        {
 
-		}
+        }
 
         protected override void ShowDialogFragment(Type view,
            MvxDialogFragmentPresentationAttribute attribute,
@@ -366,8 +366,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             OnBeforeFragmentChanging(ft, dialog, attribute);
 
-			if (attribute.AddToBackStack == true)
-				ft.AddToBackStack(fragmentName);
+            if (attribute.AddToBackStack == true)
+                ft.AddToBackStack(fragmentName);
 
             OnFragmentChanging(ft, dialog, attribute);
 
@@ -532,7 +532,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 var fragmentName = FragmentJavaName(fragmentAttribute.ViewType);
                 fragmentManager.PopBackStackImmediate(fragmentName, 1);
 
-                OnFragmentPopped(null,null,fragmentAttribute);
+                OnFragmentPopped(null, null, fragmentAttribute);
 
                 return true;
             }
@@ -554,7 +554,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 ft.Remove(fragment);
                 ft.CommitAllowingStateLoss();
 
-                OnFragmentPopped(ft, fragment ,fragmentAttribute);
+                OnFragmentPopped(ft, fragment, fragmentAttribute);
 
                 return true;
             }

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
@@ -119,7 +119,7 @@ namespace MvvmCross.Forms.Droid.Views
         protected override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(IsFinishing);
         }
 
         protected override void OnStart()

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsApplicationActivity.cs
@@ -117,7 +117,7 @@ namespace MvvmCross.Forms.Droid.Views
         protected override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(IsFinishing);
         }
 
         protected override void OnStart()

--- a/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxViewModel.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.Core.ViewModels
 
         void ViewDisappeared();
 
-        void ViewDestroy();
+        void ViewDestroy(bool viewFinishing = true);
 
         void Init(IMvxBundle parameters);
 

--- a/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxViewModel.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Core.ViewModels
         {
         }
 
-        public virtual void ViewDestroy()
+        public virtual void ViewDestroy(bool viewFinishing = true)
         {
         }
 
@@ -97,10 +97,10 @@ namespace MvvmCross.Core.ViewModels
     {
         public async Task Init(string parameter)
         {
-            if(!string.IsNullOrEmpty(parameter))
+            if (!string.IsNullOrEmpty(parameter))
             {
                 IMvxJsonConverter serializer;
-                if(!Mvx.TryResolve(out serializer))
+                if (!Mvx.TryResolve(out serializer))
                 {
                     throw new MvxIoCResolveException("There is no implementation of IMvxJsonConverter registered. You need to use the MvvmCross Json plugin or create your own implementation of IMvxJsonConverter.");
                 }
@@ -119,11 +119,12 @@ namespace MvvmCross.Core.ViewModels
     {
         public TaskCompletionSource<object> CloseCompletionSource { get; set; }
 
-        public override void ViewDestroy()
+        public override void ViewDestroy(bool viewFinishing = true)
         {
-            if(CloseCompletionSource != null && !CloseCompletionSource.Task.IsCompleted && !CloseCompletionSource.Task.IsFaulted)
+            if (viewFinishing && CloseCompletionSource != null && !CloseCompletionSource.Task.IsCompleted && !CloseCompletionSource.Task.IsFaulted)
                 CloseCompletionSource?.TrySetCanceled();
-            base.ViewDestroy();
+
+            base.ViewDestroy(viewFinishing);
         }
     }
 

--- a/MvvmCross/Droid/Droid/Views/Fragments/MvxDialogFragment.cs
+++ b/MvvmCross/Droid/Droid/Views/Fragments/MvxDialogFragment.cs
@@ -75,7 +75,7 @@ namespace MvvmCross.Droid.Views.Fragments
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(viewFinishing: IsRemoving || Activity == null || Activity.IsFinishing);
         }
 
         public override void OnStart()
@@ -113,7 +113,7 @@ namespace MvvmCross.Droid.Views.Fragments
         protected MvxDialogFragment(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
         {
         }
-    
+
         public new TViewModel ViewModel
         {
             get { return (TViewModel)base.ViewModel; }

--- a/MvvmCross/Droid/Droid/Views/Fragments/MvxFragment.cs
+++ b/MvvmCross/Droid/Droid/Views/Fragments/MvxFragment.cs
@@ -90,7 +90,7 @@ namespace MvvmCross.Droid.Views.Fragments
         public override void OnDestroy()
         {
             base.OnDestroy();
-            ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(viewFinishing: IsRemoving || Activity == null || Activity.IsFinishing);
         }
 
         public override void OnStart()

--- a/MvvmCross/Droid/Droid/Views/Fragments/MvxPreferenceFragment.cs
+++ b/MvvmCross/Droid/Droid/Views/Fragments/MvxPreferenceFragment.cs
@@ -34,7 +34,7 @@ namespace MvvmCross.Droid.Views.Fragments
             set
             {
                 _dataContext = value;
-                if (BindingContext != null)
+                if(BindingContext != null)
                     BindingContext.DataContext = value;
             }
         }
@@ -64,10 +64,10 @@ namespace MvvmCross.Droid.Views.Fragments
             ViewModel?.ViewCreated();
         }
 
-        public override void OnDestroy ()
+        public override void OnDestroy()
         {
-            base.OnDestroy ();
-            ViewModel?.ViewDestroy ();
+            base.OnDestroy();
+            ViewModel?.ViewDestroy(viewFinishing: IsRemoving || Activity == null || Activity.IsFinishing);
         }
 
         public override void OnStart()

--- a/MvvmCross/Droid/Droid/Views/MvxActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxActivity.cs
@@ -121,9 +121,7 @@ namespace MvvmCross.Droid.Views
         protected override void OnDestroy()
         {
             base.OnDestroy();
-
-            if (IsFinishing)
-                ViewModel?.ViewDestroy();
+            ViewModel?.ViewDestroy(IsFinishing);
         }
 
         protected override void OnStart()

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -131,7 +131,7 @@ namespace MvvmCross.Droid.Views
                 return overrideAttribute;
 
             IList<MvxBasePresentationAttribute> attributes = viewType.GetCustomAttributes<MvxBasePresentationAttribute>(true).ToList();
-            if(attributes != null && attributes.Count > 0)
+            if (attributes != null && attributes.Count > 0)
             {
                 MvxBasePresentationAttribute attribute = null;
 
@@ -197,7 +197,7 @@ namespace MvvmCross.Droid.Views
             }
             return null;
         }
-        
+
         protected Type GetCurrentActivityViewModelType()
         {
             Type currentActivityType = CurrentActivity.GetType();
@@ -324,29 +324,27 @@ namespace MvvmCross.Droid.Views
 
             var fragmentView = fragment.ToFragment();
 
-            // MvxNavigationService provides an already instantiated ViewModel here,
-            // therefore just assign it
+            // MvxNavigationService provides an already instantiated ViewModel here
             if (request is MvxViewModelInstanceRequest instanceRequest)
             {
                 fragment.ViewModel = instanceRequest.ViewModelInstance;
             }
-            else
-            {
-                var bundle = new Bundle();
-                var serializedRequest = NavigationSerializer.Serializer.SerializeObject(request);
-                bundle.PutString(ViewModelRequestBundleKey, serializedRequest);
 
-                if (fragmentView != null)
+            // save MvxViewModelRequest in the Fragment's Arguments
+            var bundle = new Bundle();
+            var serializedRequest = NavigationSerializer.Serializer.SerializeObject(request);
+            bundle.PutString(ViewModelRequestBundleKey, serializedRequest);
+
+            if (fragmentView != null)
+            {
+                if (fragmentView.Arguments == null)
                 {
-                    if (fragmentView.Arguments == null)
-                    {
-                        fragmentView.Arguments = bundle;
-                    }
-                    else
-                    {
-                        fragmentView.Arguments.Clear();
-                        fragmentView.Arguments.PutAll(bundle);
-                    }
+                    fragmentView.Arguments = bundle;
+                }
+                else
+                {
+                    fragmentView.Arguments.Clear();
+                    fragmentView.Arguments.PutAll(bundle);
                 }
             }
 

--- a/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxTabActivity.cs
@@ -83,35 +83,35 @@ namespace MvvmCross.Droid.Views
             base.OnCreate(bundle);
             ViewModel?.ViewCreated();
         }
-		protected override void OnDestroy()
-		{
-			base.OnDestroy();
-			ViewModel?.ViewDestroy();
-		}
+        protected override void OnDestroy()
+        {
+            base.OnDestroy();
+            ViewModel?.ViewDestroy(IsFinishing);
+        }
 
-		protected override void OnStart()
-		{
-			base.OnStart();
-			ViewModel?.ViewAppearing();
-		}
+        protected override void OnStart()
+        {
+            base.OnStart();
+            ViewModel?.ViewAppearing();
+        }
 
-		protected override void OnResume()
-		{
-			base.OnResume();
-			ViewModel?.ViewAppeared();
-		}
+        protected override void OnResume()
+        {
+            base.OnResume();
+            ViewModel?.ViewAppeared();
+        }
 
-		protected override void OnPause()
-		{
-			base.OnPause();
-			ViewModel?.ViewDisappearing();
-		}
+        protected override void OnPause()
+        {
+            base.OnPause();
+            ViewModel?.ViewDisappearing();
+        }
 
-		protected override void OnStop()
-		{
-			base.OnStop();
-			ViewModel?.ViewDisappeared();
-		}
+        protected override void OnStop()
+        {
+            base.OnStop();
+            ViewModel?.ViewDisappeared();
+        }
     }
 
     [Obsolete("TabActivity is obsolete. Use ViewPager + Indicator or any other Activity with Toolbar support.")]

--- a/TestProjects/Playground/Playground.Droid/Views/ChildView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/ChildView.cs
@@ -9,11 +9,11 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Views
 {
-    [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true, Resource.Animation.abc_fade_in,
-                Resource.Animation.abc_fade_out,
-                Resource.Animation.abc_fade_in,
-                Resource.Animation.abc_fade_out,
-                IsCacheableFragment = true)]
+    [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
+                             Resource.Animation.abc_fade_in,
+                             Resource.Animation.abc_fade_out,
+                             Resource.Animation.abc_fade_in,
+                             Resource.Animation.abc_fade_out)]
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
     [MvxFragmentPresentation(typeof(TabsRootViewModel), Resource.Id.content_frame)]
     [MvxFragmentPresentation(fragmentHostViewType: typeof(ModalNavView), fragmentContentId: Resource.Id.dialog_content_frame)]
@@ -27,6 +27,11 @@ namespace Playground.Droid.Views
             var view = this.BindingInflate(Resource.Layout.ChildView, null);
 
             return view;
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
This PR addesses two issues:
1) When using MvxNavigationService to show Fragments, the MvxViewModelRequest is not saved anywhere. As a result, when the device is rotated, the View comes back to life without a ViewModel after being destroyed.
2) ViewDestroy is currently called a single time on Activities, but not on Fragments, which is an inconsistent behavior as @ElteHupkes signaled on the [PR that introduced the change](2400).

### :new: What is the new behavior (if this is a feature change)?
1) The MvxViewModelRequest is stored in the fragment's arguments and is happily recreated when the view is recreated.
2) `MvxViewModel.ViewDestroy` now has a default parameter which indicates if the view is being finalized or not (default value is true).

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run TestProjects/Playground and ensure all scenarios are working.

### :memo: Links to relevant issues/docs
Related PR: #2400

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
