### PR TITLE
Fixes Bugs in UWP PresentationAttribute handling

### DIFF
--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsExtensionMethods.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsExtensionMethods.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Uwp.Views
             {
                 var child = VisualTreeHelper.GetChild(parent, i) as UIElement;
 
-                result = FindControl<T>(child);
+                result = FindControl<T>(child, name);
                 if (result != null)
                 {
                     return result;

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -66,12 +66,12 @@ namespace MvvmCross.Uwp.Views
             return new MvxPagePresentationAttribute() { ViewType = viewType, ViewModelType = viewModelType };
         }
 
-        
+
         public override void Show(MvxViewModelRequest request)
         {
             GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
-        
+
         public override void Close(IMvxViewModel viewModel)
         {
             GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
@@ -125,7 +125,7 @@ namespace MvvmCross.Uwp.Views
                 var splitView = currentPage.Content.FindControl<SplitView>();
                 if (splitView == null)
                 {
-                    throw new MvxException($"Failed to find a SplitView in the visual tree of {viewType.Name}");
+                    return;
                 }
 
                 if (attribute.Position == SplitPanePosition.Content)

--- a/TestProjects/Playground/Playground.Uwp/Views/SecondChildView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/SecondChildView.xaml.cs
@@ -2,8 +2,8 @@ using MvvmCross.Uwp.Attributes;
 
 namespace Playground.Uwp.Views
 {
-    [MvxRegionPresentation("Nested")]
-    public sealed partial class SecondChildView 
+    [MvxRegionPresentation("NestedFrame")]
+    public sealed partial class SecondChildView
     {
         public SecondChildView()
         {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

fixes #2423 

### :arrow_heading_down: What is the current behavior?
- If more than one region is defined in an UWP-View and they are distinguished by their name, always the first is used, ignoring the name.

- The Playground.Uwp-App is crashing when I try to open the SplitView-Page with an MvxException with the message "Failed to find a SplitView in the visual tree of SplitMasterView" 

### :new: What is the new behavior (if this is a feature change)?
- The name in the MvxRegionPresentationAttribute is not ignored on subviews.

- The SplitView Demo opens and shows pane and content.

### :boom: Does this PR introduce a breaking change?
No.


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop

I wanted to update our Project to MvvmCross 5.5 and could not do this because of this two small bugs. With the changed Attributes in 5.5 i could not find a way to get the following code working. Neither using the MvxRegionPresentationAttribute to fill the frames nor omitting the Frames and using the MvxSplitViewPresentationAttribute worked.


     <SplitView x:Name="RootSplitView">
            <SplitView.Pane>
                <Frame x:Name="Menu" />
            </SplitView.Pane>

            <Frame x:Name="Page" />
        </SplitView>