### PR TITLE
Fixing issue where icon disappears when navigating within master deta…

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -534,22 +534,14 @@ namespace MvvmCross.Forms.Views
 
                 // If the root isn't a navigation page, we need to wrap the new page
                 // in a navigation wrapper.
-                if (navigationRootPage == null)
+                if (navigationRootPage == null || attribute.NoHistory)
                 {
                     var navpage = new NavigationPage(page);
                     ReplacePageRoot(rootPage, navpage, attribute);
                 }
                 else
                 {
-                    if (attribute.NoHistory)
-                    {
-                        navigationRootPage.Navigation.InsertPageBefore(page, navigationRootPage.RootPage);
-                        navigationRootPage.Navigation.PopToRootAsync(attribute.Animated);
-                    }
-                    else
-                    {
-                        navigationRootPage.PushAsync(page, attribute.Animated);
-                    }
+                    navigationRootPage.PushAsync(page, attribute.Animated);
                 }
             }
             else


### PR DESCRIPTION
Fixing issue on iOS where master detail icon disappears on navigation

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
On navigation to page with NoHistory=true, icon disappears

### :new: What is the new behavior (if this is a feature change)?
Icon doesn't disappear

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
In playground set one of the details pages to NoHistory=true in attribute
Run playground and navigate

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2427

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [X ] Rebased onto current develop
