### PR TITLE
macOS: Add lifecycle events and presenter improvement

### DIFF
--- a/MvvmCross/Mac/Mac/MvvmCross.Mac.csproj
+++ b/MvvmCross/Mac/Mac/MvvmCross.Mac.csproj
@@ -85,6 +85,8 @@
     <Compile Include="Views\MvxTabViewController.cs" />
     <Compile Include="Views\IMvxTabViewController.cs" />
     <Compile Include="Views\Presenters\Attributes\MvxTabPresentationAttribute.cs" />
+    <Compile Include="Views\MvxSegueExtensionMethods.cs" />
+    <Compile Include="Views\IMvxMacViewSegue.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup>

--- a/MvvmCross/Mac/Mac/Views/IMvxMacViewSegue.cs
+++ b/MvvmCross/Mac/Mac/Views/IMvxMacViewSegue.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using AppKit;
+using Foundation;
+
+namespace MvvmCross.Mac.Views
+{
+    public interface IMvxMacViewSegue
+    {
+        object PrepareViewModelParametersForSegue(NSStoryboardSegue segue, NSObject sender);
+    }
+}

--- a/MvvmCross/Mac/Mac/Views/MvxSegueExtensionMethods.cs
+++ b/MvvmCross/Mac/Mac/Views/MvxSegueExtensionMethods.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AppKit;
+using Foundation;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.Views;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Mac.Views;
+using MvvmCross.Core.Platform;
+
+namespace MvvmCross.Mac.Views
+{
+    internal static class MvxSegueExtensionMethods
+    {
+        internal static Type GetViewModelType(this IMvxView view)
+        {
+            var viewType = view.GetType();
+            var props = viewType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var prop = props.Where(p => p.Name == "ViewModel").FirstOrDefault();
+            return prop?.PropertyType;
+        }
+
+        internal static void ViewModelRequestForSegue(this IMvxEventSourceViewController self, NSStoryboardSegue segue, NSObject sender)
+        {
+            var view = self as IMvxMacViewSegue;
+            var parameterValues = view == null ? null : view.PrepareViewModelParametersForSegue(segue, sender);
+
+            if (parameterValues is IMvxBundle)
+                self.ViewModelRequestForSegueImpl(segue, (IMvxBundle)parameterValues);
+            else if (parameterValues is IDictionary<string, string>)
+                self.ViewModelRequestForSegueImpl(segue, (IDictionary<string, string>)parameterValues);
+            else
+                self.ViewModelRequestForSegueImpl(segue, parameterValues);
+        }
+
+        private static void ViewModelRequestForSegueImpl(this IMvxEventSourceViewController self, NSStoryboardSegue segue, object parameterValuesObject)
+        {
+            self.ViewModelRequestForSegueImpl(segue, parameterValuesObject.ToSimplePropertyDictionary());
+        }
+
+        private static void ViewModelRequestForSegueImpl(this IMvxEventSourceViewController self, NSStoryboardSegue segue, IDictionary<string, string> parameterValues)
+        {
+            self.ViewModelRequestForSegueImpl(segue, new MvxBundle(parameterValues));
+        }
+
+        private static void ViewModelRequestForSegueImpl(this IMvxEventSourceViewController _, NSStoryboardSegue segue, IMvxBundle parameterBundle = null)
+        {
+            var view = segue.DestinationController as IMvxMacView;
+            if (view != null && view.Request == null)
+            {
+                var type = view.GetViewModelType();
+                if (type != null)
+                {
+                    view.Request = new MvxViewModelRequest(type, parameterBundle, null);
+                }
+            }
+        }
+    }
+}

--- a/MvvmCross/Mac/Mac/Views/MvxTabViewController.cs
+++ b/MvvmCross/Mac/Mac/Views/MvxTabViewController.cs
@@ -76,6 +76,42 @@ namespace MvvmCross.Mac.Views
         public MvxViewModelRequest Request { get; set; }
 
         public IMvxBindingContext BindingContext { get; set; }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            ViewModel?.ViewCreated();
+        }
+
+        public override void ViewWillAppear()
+        {
+            base.ViewWillAppear();
+            ViewModel?.ViewAppearing();
+        }
+
+        public override void ViewDidAppear()
+        {
+            base.ViewDidAppear();
+            ViewModel?.ViewAppeared();
+        }
+
+        public override void ViewWillDisappear()
+        {
+            base.ViewWillDisappear();
+            ViewModel?.ViewDisappearing();
+        }
+
+        public override void ViewDidDisappear()
+        {
+            base.ViewDidDisappear();
+            ViewModel?.ViewDisappeared();
+        }
+
+        public override void PrepareForSegue(NSStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.ViewModelRequestForSegue(segue, sender);
+        }
     }
 
     public class MvxTabViewController<TViewModel>

--- a/MvvmCross/Mac/Mac/Views/MvxViewController.cs
+++ b/MvvmCross/Mac/Mac/Views/MvxViewController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AppKit;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Core.ViewModels;
@@ -60,6 +61,42 @@ namespace MvvmCross.Mac.Views
         public MvxViewModelRequest Request { get; set; }
 
         public IMvxBindingContext BindingContext { get; set; }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            ViewModel?.ViewCreated();
+        }
+
+        public override void ViewWillAppear()
+        {
+            base.ViewWillAppear();
+            ViewModel?.ViewAppearing();
+        }
+
+        public override void ViewDidAppear()
+        {
+            base.ViewDidAppear();
+            ViewModel?.ViewAppeared();
+        }
+
+        public override void ViewWillDisappear()
+        {
+            base.ViewWillDisappear();
+            ViewModel?.ViewDisappearing();
+        }
+
+        public override void ViewDidDisappear()
+        {
+            base.ViewDidDisappear();
+            ViewModel?.ViewDisappeared();
+        }
+
+        public override void PrepareForSegue(NSStoryboardSegue segue, NSObject sender)
+        {
+            base.PrepareForSegue(segue, sender);
+            this.ViewModelRequestForSegue(segue, sender);
+        }
     }
 
     public class MvxViewController<TViewModel>

--- a/TestProjects/Playground/Playground.Mac/RootView.cs
+++ b/TestProjects/Playground/Playground.Mac/RootView.cs
@@ -42,6 +42,11 @@ namespace Playground.Mac
             set.Apply();
         }
 
+        public override void ViewDidDisappear()
+        {
+            base.ViewDidDisappear();
+        }
+
         public MvxBasePresentationAttribute PresentationAttribute()
         {
             if (!NSApplication.SharedApplication.Windows.Any())

--- a/TestProjects/Playground/Playground.Mac/WindowView.cs
+++ b/TestProjects/Playground/Playground.Mac/WindowView.cs
@@ -20,7 +20,8 @@ namespace Playground.Mac
             Title = "Window view";
         }
 
-        public ToolbarWindow WindowController {
+        public ToolbarWindow WindowController
+        {
             get { return View.Window != null ? (ToolbarWindow)View.Window.WindowController : null; }
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement / bug fix

### :arrow_heading_down: What is the current behavior?
1) MacViewPresenter uses custom collections for Windows and Windows <-> WindowControllers, which produces memory leaks because Windows are never released.
2) View callbacks are not called from macOS View classes

### :new: What is the new behavior (if this is a feature change)?
1) We use the SDK provided windows for all work
2) Added callbacks and also segue extension methods

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Playground.Mac

### :memo: Links to relevant issues/docs
Fixes #2199

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
