### PR TITLE
Fixes #2431 MvxBottomSheetDialogFragment not forwarding events

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
@@ -34,7 +34,6 @@ namespace MvvmCross.Droid.Support.Design
         public IMvxBindingContext BindingContext { get; set; }
 
         private object _dataContext;
-
         public object DataContext
         {
             get

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
@@ -1,4 +1,4 @@
-﻿// MvxBottomSheetDialogFragment.cs
+// MvxBottomSheetDialogFragment.cs
 // (c) Copyright Cirrious Ltd. http://www.cirrious.com
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -66,6 +66,60 @@ namespace MvvmCross.Droid.Support.Design
         }
 
         public virtual string UniqueImmutableCacheTag => Tag;
+
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            ViewModel?.ViewCreated();
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void OnStart()
+        {
+            base.OnStart();
+            ViewModel?.ViewAppearing();
+        }
+
+        public override void OnResume()
+        {
+            base.OnResume();
+            ViewModel?.ViewAppeared();
+        }
+
+        public override void OnPause()
+        {
+            base.OnPause();
+            ViewModel?.ViewDisappearing();
+        }
+
+        public override void OnStop()
+        {
+            base.OnStop();
+            ViewModel?.ViewDisappeared();
+        }
+
+        public override void OnCancel(IDialogInterface dialog)
+        {
+            base.OnCancel(dialog);
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void DismissAllowingStateLoss()
+        {
+            base.DismissAllowingStateLoss();
+            ViewModel?.ViewDestroy();
+        }
+
+        public override void Dismiss()
+        {
+            base.Dismiss();
+            ViewModel?.ViewDestroy();
+        }
     }
 
     public abstract class MvxBottomSheetDialogFragment<TViewModel>

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Design/MvxBottomSheetDialogFragment.cs
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using Android.Content;
 using Android.OS;
 using Android.Runtime;
 using MvvmCross.Binding.BindingContext;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
`MvxBottomSheetDialogFragment` is not forwarding events from the view to the viewmodel.

### :new: What is the new behavior (if this is a feature change)?
I've update `MvxBottomSheetDialogFragment` to forward events from the view to the viewmodel the same way as `MvxAppCompatDialogFragment` and `MvxFragment`.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
You could navigate to a MvxBottomSheetDialogFragment then close the dialog by tapping outside or using the back button then verify the returned `Task` is canceled.

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2431

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
