### PR TITLE
Fix Playground.Droid tabs

### DIFF
--- a/MvvmCross/Droid/Droid/Views/IMvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/IMvxAndroidViewPresenter.cs
@@ -12,6 +12,5 @@ namespace MvvmCross.Droid.Views
     public interface IMvxAndroidViewPresenter
         : IMvxViewPresenter
     {
-        //TODO: Add methods for dialog and fragment
     }
 }

--- a/TestProjects/Playground/Playground.Droid/Views/TabsRootView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/TabsRootView.cs
@@ -8,7 +8,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Views
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme")]
+    [Activity(Theme = "@style/AppTheme", ConfigurationChanges = Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     public class TabsRootView : MvxAppCompatActivity<TabsRootViewModel>
     {
         protected override void OnCreate(Bundle bundle)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Sample bug fix

### :arrow_heading_down: What is the current behavior?
ViewPager fragments are not restored when using MvxNavigationService

### :new: What is the new behavior (if this is a feature change)?
ViewPager fragments are restored when using MvxNavigationService

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Playground.Droid -> navigate to TabsRootView -> Rotate screen. Tabs should be there.

### :memo: Links to relevant issues/docs
Fixes #2403

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
