### PR TITLE
MvxTableViewSource.CollectionChangedOnCollectionChanged: Allow execution from a worker thread

### DIFF
--- a/MvvmCross/Binding/Mac/Views/MvxTableViewSource.cs
+++ b/MvvmCross/Binding/Mac/Views/MvxTableViewSource.cs
@@ -28,12 +28,12 @@ namespace MvvmCross.Binding.Mac.Views
 
         public MvxTableViewSource(NSTableView tableView) : base()
         {
-            this._tableView = tableView;
+            _tableView = tableView;
         }
 
         public override nint GetRowCount(NSTableView tableView)
         {
-            return this.ItemsSource.Count();
+            return ItemsSource.Count();
         }
 
         [MvxSetToNullAfterBinding]
@@ -41,35 +41,34 @@ namespace MvvmCross.Binding.Mac.Views
         {
             get
             {
-                return this._itemsSource;
+                return _itemsSource;
             }
             set
             {
-                if (ReferenceEquals(this._itemsSource, value)
-                    && !this.ReloadOnAllItemsSourceSets)
+                if (ReferenceEquals(_itemsSource, value)
+                    && !ReloadOnAllItemsSourceSets)
                     return;
 
-                if (this._subscription != null)
+                if (_subscription != null)
                 {
-                    this._subscription.Dispose();
-                    this._subscription = null;
+                    _subscription.Dispose();
+                    _subscription = null;
                 }
 
-                this._itemsSource = value;
+                _itemsSource = value;
 
-                var collectionChanged = this._itemsSource as INotifyCollectionChanged;
-                if (collectionChanged != null)
+                if (_itemsSource is INotifyCollectionChanged collectionChanged)
                 {
-                    this._subscription = collectionChanged.WeakSubscribe(this.CollectionChangedOnCollectionChanged);
+                    _subscription = collectionChanged.WeakSubscribe(CollectionChangedOnCollectionChanged);
                 }
 
-                this.ReloadTableData();
+                ReloadTableData();
             }
         }
 
         private void ReloadTableData()
         {
-            this._tableView.ReloadData();
+            _tableView.ReloadData();
         }
 
         private NSView GetOrCreateViewFor(NSTableView tableView, NSTableColumn tableColumn)
@@ -91,14 +90,13 @@ namespace MvvmCross.Binding.Mac.Views
 
         public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, nint row)
         {
-            if (this.ItemsSource == null)
+            if (ItemsSource == null)
                 return null;
 
-            var item = this.ItemsSource.ElementAt((int)row);
-            var view = this.GetOrCreateViewFor(tableView, tableColumn);
+            var item = ItemsSource.ElementAt((int)row);
+            var view = GetOrCreateViewFor(tableView, tableColumn);
 
-            var bindable = view as IMvxDataConsumer;
-            if (bindable != null)
+            if (view is IMvxDataConsumer bindable)
                 bindable.DataContext = item;
 
             return view;
@@ -143,15 +141,15 @@ namespace MvvmCross.Binding.Mac.Views
 
         public override void SelectionDidChange(NSNotification notification)
         {
-            var command = this.SelectionChangedCommand;
+            var command = SelectionChangedCommand;
             if (command == null)
                 return;
 
-            var row = this._tableView.SelectedRow;
+            var row = _tableView.SelectedRow;
             if (row < 0)
                 return;
 
-            var item = this.ItemsSource.ElementAt((int)row);
+            var item = ItemsSource.ElementAt((int)row);
 
             if (!command.CanExecute(item))
                 return;
@@ -166,25 +164,25 @@ namespace MvvmCross.Binding.Mac.Views
                 case NotifyCollectionChangedAction.Add:
                     {
                         var newIndexSet = CreateNSIndexSet(args.NewStartingIndex, args.NewItems.Count);
-                        this._tableView.InsertRows(newIndexSet, NSTableViewAnimation.Fade);
+                        _tableView.InsertRows(newIndexSet, NSTableViewAnimation.Fade);
                         return true;
                     }
                 case NotifyCollectionChangedAction.Remove:
                     {
                         var newIndexSet = CreateNSIndexSet(args.OldStartingIndex, args.OldItems.Count);
-                        this._tableView.RemoveRows(newIndexSet, NSTableViewAnimation.Fade);
+                        _tableView.RemoveRows(newIndexSet, NSTableViewAnimation.Fade);
                         return true;
                     }
                 case NotifyCollectionChangedAction.Move:
                     {
                         if (args.NewItems.Count != 1 && args.OldItems.Count != 1)
                             return false;
-                        this._tableView.MoveRow(args.OldStartingIndex, args.NewStartingIndex);
+                        _tableView.MoveRow(args.OldStartingIndex, args.NewStartingIndex);
                         return true;
                     }
                 case NotifyCollectionChangedAction.Replace:
                     {
-                        this._tableView.ReloadData();
+                        _tableView.ReloadData();
                         return true;
                     }
                 default:

--- a/MvvmCross/Binding/Mac/Views/MvxTableViewSource.cs
+++ b/MvvmCross/Binding/Mac/Views/MvxTableViewSource.cs
@@ -31,7 +31,7 @@ namespace MvvmCross.Binding.Mac.Views
             this._tableView = tableView;
         }
 
-		public override nint GetRowCount (NSTableView tableView)
+        public override nint GetRowCount(NSTableView tableView)
         {
             return this.ItemsSource.Count();
         }
@@ -89,7 +89,7 @@ namespace MvvmCross.Binding.Mac.Views
             return view;
         }
 
-		public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, nint row)
+        public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, nint row)
         {
             if (this.ItemsSource == null)
                 return null;
@@ -106,7 +106,25 @@ namespace MvvmCross.Binding.Mac.Views
 
         protected virtual void CollectionChangedOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
-            this.TryDoAnimatedChange(args);
+            Action action = () =>
+            {
+                if (!UseAnimations)
+                {
+                    ReloadTableData();
+                }
+                else
+                {
+                    if (TryDoAnimatedChange(args))
+                        return;
+
+                    ReloadTableData();
+                }
+            };
+
+            if (NSThread.IsMain)
+                action();
+            else
+                InvokeOnMainThread(action);
         }
 
         protected static NSIndexSet CreateNSIndexSet(int startingPosition, int count)
@@ -121,6 +139,7 @@ namespace MvvmCross.Binding.Mac.Views
         }
 
         public bool ReloadOnAllItemsSourceSets { get; set; }
+        public bool UseAnimations { get; set; }
 
         public override void SelectionDidChange(NSNotification notification)
         {

--- a/MvvmCross/Binding/iOS/Views/MvxTableViewSource.cs
+++ b/MvvmCross/Binding/iOS/Views/MvxTableViewSource.cs
@@ -92,18 +92,25 @@ namespace MvvmCross.Binding.iOS.Views
         protected virtual void CollectionChangedOnCollectionChanged(object sender,
                                                                     NotifyCollectionChangedEventArgs args)
         {
-            if (!UseAnimations)
+            Action action = () =>
             {
-                ReloadTableData();
-                return;
-            }
+                if (!UseAnimations)
+                {
+                    ReloadTableData();
+                }
+                else
+                {
+                    if (TryDoAnimatedChange(args))
+                        return;
 
-            if (TryDoAnimatedChange(args))
-            {
-                return;
-            }
+                    ReloadTableData();
+                }
+            };
 
-            ReloadTableData();
+            if (NSThread.IsMain)
+                action();
+            else
+                InvokeOnMainThread(action);
         }
 
         protected bool TryDoAnimatedChange(NotifyCollectionChangedEventArgs args)

--- a/MvvmCross/Binding/tvOS/Views/MvxTableViewSource.cs
+++ b/MvvmCross/Binding/tvOS/Views/MvxTableViewSource.cs
@@ -92,18 +92,25 @@ namespace MvvmCross.Binding.tvOS.Views
         protected virtual void CollectionChangedOnCollectionChanged(object sender,
                                                                     NotifyCollectionChangedEventArgs args)
         {
-            if (!UseAnimations)
+            Action action = () =>
             {
-                ReloadTableData();
-                return;
-            }
+                if (!UseAnimations)
+                {
+                    ReloadTableData();
+                }
+                else
+                {
+                    if (TryDoAnimatedChange(args))
+                        return;
 
-            if (TryDoAnimatedChange(args))
-            {
-                return;
-            }
+                    ReloadTableData();
+                }
+            };
 
-            ReloadTableData();
+            if (NSThread.IsMain)
+                action();
+            else
+                InvokeOnMainThread(action);
         }
 
         protected bool TryDoAnimatedChange(NotifyCollectionChangedEventArgs args)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement.

### :arrow_heading_down: What is the current behavior?
If CollectionChangedOnCollectionChanged is called from a worker thread, the app will 💥 .

### :new: What is the new behavior (if this is a feature change)?
CollectionChangedOnCollectionChanged can be called from a worker thread.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
Fixes #2360 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
