### PR TITLE
Dictionary conversion

### DIFF
--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -125,11 +125,6 @@ namespace MvvmCross.Binding.BindingContext
             return WithConversion(converterName, converterParameter);
         }
 
-        public MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TFrom, TTo>(Dictionary<TFrom, TTo> converterParameter)
-        {
-            return WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), converterParameter);
-        }
-
         public MvxFluentBindingDescription<TTarget, TSource> WithFallback(object fallback)
         {
             SourceStepDescription.FallbackValue = fallback;

--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -14,6 +14,7 @@ using MvvmCross.Binding.Combiners;
 using MvvmCross.Binding.ValueConverters;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Converters;
+using System.Collections.Generic;
 
 namespace MvvmCross.Binding.BindingContext
 {
@@ -122,6 +123,11 @@ namespace MvvmCross.Binding.BindingContext
             var converterName = filler.FindName(typeof(TValueConverter));
 
             return WithConversion(converterName, converterParameter);
+        }
+
+        public MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TFrom, TTo>(Dictionary<TFrom, TTo> converterParameter)
+        {
+            return WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(converterParameter));
         }
 
         public MvxFluentBindingDescription<TTarget, TSource> WithFallback(object fallback)

--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -127,7 +127,7 @@ namespace MvvmCross.Binding.BindingContext
 
         public MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TFrom, TTo>(Dictionary<TFrom, TTo> converterParameter)
         {
-            return WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(converterParameter));
+            return WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), converterParameter);
         }
 
         public MvxFluentBindingDescription<TTarget, TSource> WithFallback(object fallback)

--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
@@ -1,6 +1,8 @@
-﻿using MvvmCross.Binding.Binders;
+using MvvmCross.Binding.Binders;
 using MvvmCross.Localization;
 using MvvmCross.Platform;
+using MvvmCross.Platform.Converters;
+using System.Collections.Generic;
 
 namespace MvvmCross.Binding.BindingContext
 {
@@ -15,5 +17,10 @@ namespace MvvmCross.Binding.BindingContext
                 .OneTime()
                 .WithConversion(valueConverter, localizationId);
         }
+
+        public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TTarget, TSource, TFrom, TTo>(
+            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription, IDictionary<TFrom, TTo> converterParameter)
+            where TTarget : class
+            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), converterParameter).OneWay();
     }
 }

--- a/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
+++ b/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
@@ -10,8 +10,14 @@ namespace MvvmCross.Platform.Converters
         {
             if (parameter is Dictionary<TKey, TValue> dict)
             {
-                TValue x = dict[value];
-                return x;
+                if (dict.ContainsKey(value))
+                {
+                    return dict[value];
+                }
+                else
+                {
+                    throw new KeyNotFoundException($"Could not find key {value.ToString()} for {typeof(MvxDictionaryValueConverter<TKey, TValue>).Name}.");
+                }
             }
             throw new ArgumentException($"Could not cast {parameter.GetType().Name} to {typeof(Dictionary<TKey, TValue>).Name}");
         }

--- a/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
+++ b/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace MvvmCross.Platform.Converters
+{
+    public class MvxDictionaryValueConverter<TKey, TValue> : MvxValueConverter<TKey, TValue>
+    {
+        protected override TValue Convert(TKey value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (parameter is Dictionary<TKey, TValue> dict)
+            {
+                TValue x = dict[value];
+                return x;
+            }
+            throw new ArgumentException($"Could not cast {parameter.GetType().ToString()} to {nameof(Dictionary<TKey, TValue>)}");
+        }
+    }
+}

--- a/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
+++ b/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
@@ -13,7 +13,7 @@ namespace MvvmCross.Platform.Converters
                 TValue x = dict[value];
                 return x;
             }
-            throw new ArgumentException($"Could not cast {parameter.GetType().ToString()} to {nameof(Dictionary<TKey, TValue>)}");
+            throw new ArgumentException($"Could not cast {parameter.GetType().Name} to {typeof(Dictionary<TKey, TValue>).Name}");
         }
     }
 }

--- a/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
+++ b/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
@@ -8,7 +8,7 @@ namespace MvvmCross.Platform.Converters
     {
         protected override TValue Convert(TKey value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (parameter is Dictionary<TKey, TValue> dict)
+            if (parameter is IDictionary<TKey, TValue> dict)
             {
                 if (dict.ContainsKey(value))
                 {

--- a/MvvmCross/Platform/Platform/MvvmCross.Platform.csproj
+++ b/MvvmCross/Platform/Platform/MvvmCross.Platform.csproj
@@ -42,6 +42,7 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="BindingFlags.cs" />
+    <Compile Include="Converters\MvxDictionaryValueConverter.cs" />
     <Compile Include="ExtensionMethods\MvxCrossCoreExtensions.cs" />
     <Compile Include="Converters\MvxBindingConstant.cs" />
     <Compile Include="Core\MvxDelegateExtensionMethods.cs" />
@@ -142,7 +143,5 @@
   </Target>
   -->
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="Logging\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/TestProjects/Forms/PageRenderer/PageRenderer.iOS/PageRendererExample.iOS.csproj
+++ b/TestProjects/Forms/PageRenderer/PageRenderer.iOS/PageRendererExample.iOS.csproj
@@ -129,6 +129,7 @@
   <ItemGroup>
     <ImageAsset Include="Resources\Images.xcassets\AppIcons.appiconset\Contents.json">
       <Visible>false</Visible>
+      <InProject>false</InProject>
     </ImageAsset>
   </ItemGroup>
   <ItemGroup>

--- a/TestProjects/Playground/Playground.Core/Playground.Core.csproj
+++ b/TestProjects/Playground/Playground.Core/Playground.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -34,6 +34,7 @@
     <Compile Include="..\..\..\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ViewModels\DictionaryBindingViewModel.cs" />
     <Compile Include="ViewModels\MixedNavFirstViewModel.cs" />
     <Compile Include="ViewModels\MixedNavMasterDetailViewModel.cs" />
     <Compile Include="ViewModels\MixedNavMasterRootContentViewModel.cs" />
@@ -100,9 +101,7 @@
       <Name>MvvmCross.Plugins.ResourceLoader</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Services\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\portable-net45+win8+wp8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/TestProjects/Playground/Playground.Core/ViewModels/DictionaryBindingViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/DictionaryBindingViewModel.cs
@@ -1,0 +1,48 @@
+using MvvmCross.Core.Navigation;
+using MvvmCross.Core.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Playground.Core.ViewModels
+{
+    public class DictionaryBindingViewModel : BaseViewModel
+    {
+        int _value = 0;
+        public int Value
+        {
+            get => _value;
+            set => SetProperty(ref _value, value);
+        }
+
+        IMvxAsyncCommand _closeCommand;
+        public IMvxAsyncCommand CloseCommand =>
+            _closeCommand ?? (_closeCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this)));
+
+
+        IMvxCommand _incrimentCommand;
+        private IMvxNavigationService _navigationService;
+
+        public IMvxCommand IncrimentCommand =>
+            _incrimentCommand ?? (_incrimentCommand = new MvxCommand(Incriment));
+
+        public DictionaryBindingViewModel(IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService;
+        }
+
+            private void Incriment()
+        {
+            if(Value < 3)
+            {
+                Value++;
+            }
+            else
+            {
+                Value = 0;
+            }
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Core/ViewModels/DictionaryBindingViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/DictionaryBindingViewModel.cs
@@ -22,18 +22,18 @@ namespace Playground.Core.ViewModels
             _closeCommand ?? (_closeCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this)));
 
 
-        IMvxCommand _incrimentCommand;
+        IMvxCommand _incrementCommand;
         private IMvxNavigationService _navigationService;
 
-        public IMvxCommand IncrimentCommand =>
-            _incrimentCommand ?? (_incrimentCommand = new MvxCommand(Incriment));
+        public IMvxCommand IncrementCommand =>
+            _incrementCommand ?? (_incrementCommand = new MvxCommand(Increment));
 
         public DictionaryBindingViewModel(IMvxNavigationService navigationService)
         {
             _navigationService = navigationService;
         }
 
-            private void Incriment()
+        private void Increment()
         {
             if(Value < 3)
             {

--- a/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -37,7 +37,7 @@ namespace Playground.Core.ViewModels
 
             ShowMixedNavigationCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<MixedNavFirstViewModel>());
 
-            ShowDictionarySheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<DictionaryBindingViewModel>());
+            ShowDictionaryBindingCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<DictionaryBindingViewModel>());
 
             _counter = 3;
         }
@@ -88,7 +88,7 @@ namespace Playground.Core.ViewModels
 
         public IMvxAsyncCommand ShowMixedNavigationCommand { get; private set; }
 
-        public IMvxAsyncCommand ShowDictionarySheetCommand { get; private set; }
+        public IMvxAsyncCommand ShowDictionaryBindingCommand { get; private set; }
 
         public IMvxAsyncCommand ShowListViewCommand => new MvxAsyncCommand(async () => await _navigationService.Navigate<ListViewModel>());
 

--- a/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -37,6 +37,8 @@ namespace Playground.Core.ViewModels
 
             ShowMixedNavigationCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<MixedNavFirstViewModel>());
 
+            ShowDictionarySheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<DictionaryBindingViewModel>());
+
             _counter = 3;
         }
 
@@ -85,6 +87,8 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowWindowCommand { get; private set; }
 
         public IMvxAsyncCommand ShowMixedNavigationCommand { get; private set; }
+
+        public IMvxAsyncCommand ShowDictionarySheetCommand { get; private set; }
 
         public IMvxAsyncCommand ShowListViewCommand => new MvxAsyncCommand(async () => await _navigationService.Navigate<ListViewModel>());
 

--- a/TestProjects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/TestProjects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SplashScreen.cs" />
     <Compile Include="Setup.cs" />
+    <Compile Include="Views\DictionaryBindingView.cs" />
     <Compile Include="Views\RootView.cs" />
     <Compile Include="Views\TabsRootView.cs" />
     <Compile Include="Views\Tab1View.cs" />
@@ -118,6 +119,7 @@
     <None Include="Properties\AndroidManifest.xml" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="packages.config" />
+    <AndroidResource Include="Resources\layout\dictionary_view.axml" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\RootView.axml" />

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
@@ -1,46 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:local="http://schemas.android.com/apk/res-auto"
-	android:id="@+id/main_frame"
-	android:orientation="vertical"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent">
-	<Button android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_marginTop="10dp"
-		android:text="Show Child"
-		local:MvxBind="Click ShowChildCommand;" />
-	<Button android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_marginTop="10dp"
-		android:text="Show Modal"
-		local:MvxBind="Click ShowModalCommand;" />
-	<Button android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_marginTop="10dp"
-		android:text="Show Modal Navigation"
-		local:MvxBind="Click ShowModalNavCommand;" />
-	<Button android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_marginTop="10dp"
-		android:text="Show Tabs"
-		local:MvxBind="Click ShowTabsCommand;" />
-	<Button android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_marginTop="10dp"
-		android:text="Show Master/Detail"
-		local:MvxBind="Click ShowSplitCommand;" />
-	<Button android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_marginTop="10dp"
-		android:text="Show Override Attribute"
-		local:MvxBind="Click ShowOverrideAttributeCommand" />
-	<Button android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_marginTop="10dp"
-		android:text="Show BottomSheet"
-		local:MvxBind="Click ShowSheetCommand" />
-	<FrameLayout android:id="@+id/content_frame"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent" />
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main_frame"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Child"
+        local:MvxBind="Click ShowChildCommand;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Modal"
+        local:MvxBind="Click ShowModalCommand;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Modal Navigation"
+        local:MvxBind="Click ShowModalNavCommand;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Tabs"
+        local:MvxBind="Click ShowTabsCommand;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Master/Detail"
+        local:MvxBind="Click ShowSplitCommand;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Override Attribute"
+        local:MvxBind="Click ShowOverrideAttributeCommand" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show BottomSheet"
+        local:MvxBind="Click ShowSheetCommand" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Dictionary Sheet"
+        local:MvxBind="Click ShowDictionarySheetCommand" />
+    <FrameLayout
+        android:id="@+id/content_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </LinearLayout>

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
@@ -52,7 +52,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:text="Show Dictionary Sheet"
-        local:MvxBind="Click ShowDictionarySheetCommand" />
+        local:MvxBind="Click ShowDictionaryBindingCommand" />
     <FrameLayout
         android:id="@+id/content_frame"
         android:layout_width="match_parent"

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/dictionary_view.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/dictionary_view.axml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/gray"
+    android:padding="@dimen/margin_medium">
+    <Button
+        android:id="@+id/next_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Next Background"
+        local:MvxBind="Click IncrimentCommand"
+        />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Close"
+        local:MvxBind="Click CloseCommand" />
+</LinearLayout>

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/dictionary_view.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/dictionary_view.axml
@@ -12,8 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Next Background"
-        local:MvxBind="Click IncrimentCommand"
-        />
+        local:MvxBind="Click IncrementCommand" />
     <Button
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/TestProjects/Playground/Playground.Droid/Views/DictionaryBindingView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/DictionaryBindingView.cs
@@ -25,9 +25,6 @@ namespace Playground.Droid.Views
                          Resource.Animation.abc_fade_out,
                          Resource.Animation.abc_fade_in,
                          Resource.Animation.abc_fade_out)]
-    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
-    [MvxFragmentPresentation(typeof(TabsRootViewModel), Resource.Id.content_frame)]
-    [MvxFragmentPresentation(fragmentHostViewType: typeof(ModalNavView), fragmentContentId: Resource.Id.dialog_content_frame)]
     [Register(nameof(DictionaryBindingView))]
     public class DictionaryBindingView : MvxFragment<DictionaryBindingViewModel>
     {
@@ -48,11 +45,6 @@ namespace Playground.Droid.Views
                 }).Apply();
 
             return view;
-        }
-
-        public override void OnDestroy()
-        {
-            base.OnDestroy();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Droid/Views/DictionaryBindingView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/DictionaryBindingView.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using Android.Widget;
+using Playground.Core.ViewModels;
+using MvvmCross.Droid.Views.Attributes;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Binding.Droid.BindingContext;
+using MvvmCross.Binding.BindingContext;
+using Android.Graphics.Drawables;
+using Android.Graphics;
+
+namespace Playground.Droid.Views
+{
+    [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
+                         Resource.Animation.abc_fade_in,
+                         Resource.Animation.abc_fade_out,
+                         Resource.Animation.abc_fade_in,
+                         Resource.Animation.abc_fade_out)]
+    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
+    [MvxFragmentPresentation(typeof(TabsRootViewModel), Resource.Id.content_frame)]
+    [MvxFragmentPresentation(fragmentHostViewType: typeof(ModalNavView), fragmentContentId: Resource.Id.dialog_content_frame)]
+    [Register(nameof(DictionaryBindingView))]
+    public class DictionaryBindingView : MvxFragment<DictionaryBindingViewModel>
+    {
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(Resource.Layout.dictionary_view, null);
+            var background = view.FindViewById<LinearLayout>(Resource.Id.container);
+
+            this.CreateBindingSet<DictionaryBindingView, DictionaryBindingViewModel>().Bind(background).For(v => v.Background).To(vm => vm.Value)
+                .WithDictionaryConversion(new Dictionary<int, Drawable>
+                {
+                    {0, new ColorDrawable(Color.Blue) },
+                    {1, new ColorDrawable(Color.Red) },
+                    {2, new ColorDrawable(Color.Yellow) },
+                    {3, new ColorDrawable(Color.Violet) }
+                }).Apply();
+
+            return view;
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
+++ b/TestProjects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
@@ -108,9 +108,11 @@
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
       <Visible>false</Visible>
+      <InProject>false</InProject>
     </ImageAsset>
     <ImageAsset Include="Assets.xcassets\Contents.json">
       <Visible>false</Visible>
+      <InProject>false</InProject>
     </ImageAsset>
   </ItemGroup>
   <ItemGroup />

--- a/TestProjects/Playground/Playground.TvOS/Playground.TvOS.csproj
+++ b/TestProjects/Playground/Playground.TvOS/Playground.TvOS.csproj
@@ -27,13 +27,15 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
-    <MtouchVerbosity></MtouchVerbosity>
+    <MtouchVerbosity>
+    </MtouchVerbosity>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -44,13 +46,15 @@
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-    <MtouchVerbosity></MtouchVerbosity>
+    <MtouchVerbosity>
+    </MtouchVerbosity>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -58,7 +62,8 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-    <MtouchVerbosity></MtouchVerbosity>
+    <MtouchVerbosity>
+    </MtouchVerbosity>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,7 +84,8 @@
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-    <MtouchVerbosity></MtouchVerbosity>
+    <MtouchVerbosity>
+    </MtouchVerbosity>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -88,25 +94,63 @@
     <Reference Include="Xamarin.TVOS" />
   </ItemGroup>
   <ItemGroup>
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Back.imagestacklayer\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Back.imagestacklayer\Content.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Front.imagestacklayer\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Front.imagestacklayer\Content.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Middle.imagestacklayer\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Middle.imagestacklayer\Content.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Back.imagestacklayer\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Back.imagestacklayer\Content.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Front.imagestacklayer\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Front.imagestacklayer\Content.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Middle.imagestacklayer\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Middle.imagestacklayer\Content.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Top Shelf Image Wide.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Top Shelf Image.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\LaunchImages.launchimage\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Back.imagestacklayer\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Back.imagestacklayer\Content.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Front.imagestacklayer\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Front.imagestacklayer\Content.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Middle.imagestacklayer\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Large.imagestack\Middle.imagestacklayer\Content.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Back.imagestacklayer\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Back.imagestacklayer\Content.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Front.imagestacklayer\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Front.imagestacklayer\Content.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Middle.imagestacklayer\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\App Icon - Small.imagestack\Middle.imagestacklayer\Content.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Top Shelf Image Wide.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\App Icon &amp; Top Shelf Image.brandassets\Top Shelf Image.imageset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImages.launchimage\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/TestProjects/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/TestProjects/Playground/Playground.iOS/Playground.iOS.csproj
@@ -85,9 +85,11 @@
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
       <Visible>false</Visible>
+      <InProject>false</InProject>
     </ImageAsset>
     <ImageAsset Include="Assets.xcassets\Contents.json">
       <Visible>false</Visible>
+      <InProject>false</InProject>
     </ImageAsset>
   </ItemGroup>
   <ItemGroup />

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -949,7 +949,7 @@ set.Bind(button).To(vm => vm.readonly).WithDictionaryConversion(
 		{false, BlueIcon}
 	});
 ```
-Note : This feature is only available in fluent binding.
+*Note* : This feature is only available in fluent binding.
 
 ### Default view properties
 

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -949,6 +949,7 @@ set.Bind(button).To(vm => vm.readonly).WithDictionaryConversion(
 		{false, BlueIcon}
 	});
 ```
+Note : This feature is only available in fluent binding.
 
 ### Default view properties
 

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -937,6 +937,18 @@ set.Bind(textField).To(vm => vm.Counter).WithConversion<SomeValueConverter>();
 
 Add something about the Generic implementation of IMvxTargetBinding [#1610](https://github.com/MvvmCross/MvvmCross/pull/1610)
 
+### Dictionary Conversion
+
+Dictionary conversion allows for mapped conversions to be set up within the view's binding code, useful for quickly binding thiings like icons to state properties.
+
+```c#
+set.Bind(button).To(vm => vm.readonly).WithDictionaryConversion(
+	new Dictionary<bool, Icon>
+	{
+		{true, GreyIcon},
+		{false, BlueIcon}
+	});
+```
 
 ### Default view properties
 

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -939,7 +939,7 @@ Add something about the Generic implementation of IMvxTargetBinding [#1610](http
 
 ### Dictionary Conversion
 
-Dictionary conversion allows for mapped conversions to be set up within the view's binding code, useful for quickly binding thiings like icons to state properties.
+Dictionary conversion allows for mapped conversions to be set up within the view's binding code, useful for quickly binding things like icons or color to state properties.
 
 ```c#
 set.Bind(button).To(vm => vm.readonly).WithDictionaryConversion(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?
This provides an alternate fluent binding description designed for 1-to-1 mappings, such as mapping icons to states, in the form of the WithDictionaryConversion method, which accepts a Dictionary as a parameter, with the key being the ViewModel property and the value being the controls expected value.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing
I've added to the android playground project to demonstrate the conversion, on the DictionaryBindingView

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
