### PR TITLE
Add event hooks to MvxNavigationService.ChangePresentation

### DIFF
--- a/MvvmCross/Core/Core/MvvmCross.Core.csproj
+++ b/MvvmCross/Core/Core/MvvmCross.Core.csproj
@@ -156,6 +156,7 @@
     <Compile Include="ViewModels\Hints\MvxPopPresentationHint.cs" />
     <Compile Include="ViewModels\Hints\MvxPopToRootPresentationHint.cs" />
     <Compile Include="ViewModels\Hints\MvxRemovePresentationHint.cs" />
+    <Compile Include="Navigation\EventArguments\ChangePresentationEventArgs.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/MvvmCross/Core/Core/Navigation/EventArguments/ChangePresentationEventArgs.cs
+++ b/MvvmCross/Core/Core/Navigation/EventArguments/ChangePresentationEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using MvvmCross.Core.ViewModels;
+
+namespace MvvmCross.Core.Navigation.EventArguments
+{
+    public class ChangePresentationEventArgs : EventArgs
+    {
+        public ChangePresentationEventArgs()
+        {
+        }
+
+        public ChangePresentationEventArgs(MvxPresentationHint hint)
+        {
+            Hint = hint;
+        }
+
+        public MvxPresentationHint Hint { get; set; }
+
+        public bool? Result { get; set; }
+    }
+}

--- a/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/IMvxNavigationService.cs
@@ -10,6 +10,8 @@ namespace MvvmCross.Core.Navigation
     public delegate void AfterNavigateEventHandler(object sender, NavigateEventArgs e);
     public delegate void BeforeCloseEventHandler(object sender, NavigateEventArgs e);
     public delegate void AfterCloseEventHandler(object sender, NavigateEventArgs e);
+    public delegate void BeforeChangePresentationEventHandler(object sender, ChangePresentationEventArgs e);
+    public delegate void AfterChangePresentationEventHandler(object sender, ChangePresentationEventArgs e);
 
     /// <summary>
     /// Allows for Task and URI based navigation in MvvmCross
@@ -20,6 +22,8 @@ namespace MvvmCross.Core.Navigation
         event AfterNavigateEventHandler AfterNavigate;
         event BeforeCloseEventHandler BeforeClose;
         event AfterCloseEventHandler AfterClose;
+        event BeforeChangePresentationEventHandler BeforeChangePresentation;
+        event AfterChangePresentationEventHandler AfterChangePresentation;
 
         /// <summary>
         /// Navigates to an instance of a ViewModel
@@ -141,7 +145,7 @@ namespace MvvmCross.Core.Navigation
         /// <returns></returns>
         Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
-        Task Navigate<TViewModel>(IMvxBundle presentationBundle = null) 
+        Task Navigate<TViewModel>(IMvxBundle presentationBundle = null)
             where TViewModel : IMvxViewModel;
 
         Task Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null)

--- a/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Core/Core/Navigation/MvxNavigationService.cs
@@ -35,6 +35,8 @@ namespace MvvmCross.Core.Navigation
         public event AfterNavigateEventHandler AfterNavigate;
         public event BeforeCloseEventHandler BeforeClose;
         public event AfterCloseEventHandler AfterClose;
+        public event BeforeChangePresentationEventHandler BeforeChangePresentation;
+        public event AfterChangePresentationEventHandler AfterChangePresentation;
 
         public MvxNavigationService(IMvxNavigationCache navigationCache, IMvxViewModelLoader viewModelLoader)
         {
@@ -422,7 +424,15 @@ namespace MvvmCross.Core.Navigation
         public bool ChangePresentation(MvxPresentationHint hint)
         {
             MvxTrace.Trace("Requesting presentation change");
-            return ViewDispatcher.ChangePresentation(hint);
+            var args = new ChangePresentationEventArgs(hint);
+            OnBeforeChangePresentation(this, args);
+
+            var result = ViewDispatcher.ChangePresentation(hint);
+
+            args.Result = result;
+            OnAfterChangePresentation(this, args);
+
+            return result;
         }
 
         public virtual Task<bool> Close(IMvxViewModel viewModel)
@@ -479,6 +489,16 @@ namespace MvvmCross.Core.Navigation
         protected virtual void OnAfterClose(object sender, NavigateEventArgs e)
         {
             AfterClose?.Invoke(sender, e);
+        }
+
+        protected virtual void OnBeforeChangePresentation(object sender, ChangePresentationEventArgs e)
+        {
+            BeforeChangePresentation?.Invoke(sender, e);
+        }
+
+        protected virtual void OnAfterChangePresentation(object sender, ChangePresentationEventArgs e)
+        {
+            AfterChangePresentation?.Invoke(sender, e);
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
New feature / Doc update.

### :arrow_heading_down: What is the current behavior?

Currently there are no event hooks for `MvxNavigationService.ChangePresentation`. Also, there are no Unit Tests around the existing event hooks.

### :new: What is the new behavior (if this is a feature change)?

Added BeforeChangePresentation and AfterChangePresentation events. Added unit tests.

Also, there are no Unit Tests around the existing event hooks.

### :boom: Does this PR introduce a breaking change?

Technically yes, because new methods were added to the interface `IMvxNavigationService`.

### :bug: Recommendations for testing

Run unit tests.

### :memo: Links to relevant issues/docs
/

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
