### PR TITLE
Add hint to set the current page in a parent page

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -177,6 +177,18 @@ namespace MvvmCross.Forms.Views
                     navigation.RemovePage(page);
                 return;
             }
+            if(hint is MvxPagePresentationHint pageHint)
+            {
+                var pageType = ViewsContainer.GetViewType(pageHint.ViewModel);
+                if (GetType().GetMethod("GetHostPageOfType").MakeGenericMethod(pageType).Invoke(this, new object[] { FormsApplication.MainPage }) is Page page)
+                {
+                    if (page.Parent is TabbedPage tabbedPage)
+                        tabbedPage.CurrentPage = page;
+                    else if (page.Parent is CarouselPage carouselPage && page is ContentPage contentPage)
+                        carouselPage.CurrentPage = contentPage;
+                }
+                return;
+            }
 
             base.ChangePresentation(hint);
         }
@@ -602,7 +614,7 @@ namespace MvvmCross.Forms.Views
             if (rootPage == null)
                 rootPage = FormsApplication.MainPage;
 
-            if(rootPage.Navigation?.ModalStack?.Count > 0)
+            if(rootPage?.Navigation?.ModalStack?.Count > 0)
             {
                 foreach (var item in rootPage.Navigation.ModalStack)
                 {

--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -152,7 +152,7 @@ namespace MvvmCross.Forms.Views
 
         public override void ChangePresentation(MvxPresentationHint hint)
         {
-            var navigation = GetHostPageOfType<NavigationPage>().Navigation;
+            var navigation = GetPageOfType<NavigationPage>().Navigation;
             if (hint is MvxPopToRootPresentationHint popToRootHint)
             {
                 navigation.PopToRootAsync(popToRootHint.Animated);
@@ -180,7 +180,7 @@ namespace MvvmCross.Forms.Views
             if(hint is MvxPagePresentationHint pageHint)
             {
                 var pageType = ViewsContainer.GetViewType(pageHint.ViewModel);
-                if (GetType().GetMethod("GetHostPageOfType").MakeGenericMethod(pageType).Invoke(this, new object[] { FormsApplication.MainPage }) is Page page)
+                if (GetPageOfTypeByType(pageType) is Page page)
                 {
                     if (page.Parent is TabbedPage tabbedPage)
                         tabbedPage.CurrentPage = page;
@@ -211,7 +211,7 @@ namespace MvvmCross.Forms.Views
             }
             else
             {
-                var carouselHost = GetHostPageOfType<MvxCarouselPage>();
+                var carouselHost = GetPageOfType<MvxCarouselPage>();
                 if (carouselHost == null)
                 {
                     MvxTrace.Trace($"Current root is not a CarouselPage show your own first to use custom Host. Assuming we need to create one.");
@@ -228,7 +228,7 @@ namespace MvvmCross.Forms.Views
                 return ClosePage(FormsApplication.MainPage, null, attribute);
             else
             {
-                var carouselHost = GetHostPageOfType<MvxCarouselPage>();
+                var carouselHost = GetPageOfType<MvxCarouselPage>();
                 var page = carouselHost.Children.OfType<IMvxPage>().FirstOrDefault(x => x.ViewModel == viewModel);
                 if (page is ContentPage carouselPage)
                     carouselHost.Children.Remove(carouselPage);
@@ -311,7 +311,7 @@ namespace MvvmCross.Forms.Views
             }
             else
             {
-                var masterDetailHost = GetHostPageOfType<MvxMasterDetailPage>();
+                var masterDetailHost = GetPageOfType<MvxMasterDetailPage>();
                 if (masterDetailHost == null)
                 {
                     //Assume we have to create the host
@@ -343,7 +343,7 @@ namespace MvvmCross.Forms.Views
 
         public virtual bool CloseMasterDetailPage(IMvxViewModel viewModel, MvxMasterDetailPagePresentationAttribute attribute)
         {
-            var masterDetailHost = GetHostPageOfType<MvxMasterDetailPage>();
+            var masterDetailHost = GetPageOfType<MvxMasterDetailPage>();
             switch (attribute.Position)
             {
                 case MasterDetailPosition.Root:
@@ -441,7 +441,7 @@ namespace MvvmCross.Forms.Views
             }
             else
             {
-                var tabHost = GetHostPageOfType<MvxTabbedPage>();
+                var tabHost = GetPageOfType<MvxTabbedPage>();
                 if (tabHost == null)
                 {
                     MvxTrace.Trace($"Current root is not a TabbedPage show your own first to use custom Host. Assuming we need to create one.");
@@ -459,7 +459,7 @@ namespace MvvmCross.Forms.Views
                 return ClosePage(FormsApplication.MainPage, null, attribute);
             else
             {
-                var tabHost = GetHostPageOfType<MvxTabbedPage>();
+                var tabHost = GetPageOfType<MvxTabbedPage>();
                 var page = tabHost.Children.OfType<IMvxPage>().FirstOrDefault(x => x.ViewModel == viewModel);
                 if (page is Page tabPage)
                     tabHost.Children.Remove(tabPage);
@@ -523,7 +523,7 @@ namespace MvvmCross.Forms.Views
                 rootPage = FormsApplication.MainPage;
             }
 
-            var navigationRootPage = GetHostPageOfType<NavigationPage>(rootPage);
+            var navigationRootPage = GetPageOfType<NavigationPage>(rootPage);
 
             // Step down through any nested navigation pages to make sure we're pushing to the
             // most nested navigation page
@@ -609,7 +609,16 @@ namespace MvvmCross.Forms.Views
             return null;
         }
 
-        public virtual TPage GetHostPageOfType<TPage>(Page rootPage = null) where TPage : Page
+        //Needs to have a different method name
+        public virtual Page GetPageOfTypeByType(Type viewType, Page rootPage = null)
+        {
+            if (rootPage == null)
+                rootPage = FormsApplication.MainPage;
+            
+            return GetType().GetMethod(nameof(GetPageOfType)).MakeGenericMethod(viewType).Invoke(this, new object[] { rootPage }) as Page;
+        }
+
+        public virtual TPage GetPageOfType<TPage>(Page rootPage = null) where TPage : Page
         {
             if (rootPage == null)
                 rootPage = FormsApplication.MainPage;
@@ -618,7 +627,7 @@ namespace MvvmCross.Forms.Views
             {
                 foreach (var item in rootPage.Navigation.ModalStack)
                 {
-                    var modalPage = GetHostPageOfType<TPage>(item);
+                    var modalPage = GetPageOfType<TPage>(item);
                     if (modalPage is TPage)
                         return modalPage;
                 }
@@ -629,23 +638,23 @@ namespace MvvmCross.Forms.Views
             else if (rootPage is NavigationPage navigationRootPage)
             {
                 if (navigationRootPage.CurrentPage is NavigationPage navigationNestedPage)
-                    return GetHostPageOfType<TPage>(navigationNestedPage);
+                    return GetPageOfType<TPage>(navigationNestedPage);
                 else
-                    return GetHostPageOfType<TPage>(navigationRootPage.CurrentPage);
+                    return GetPageOfType<TPage>(navigationRootPage.CurrentPage);
             }
             else if (rootPage is MasterDetailPage masterDetailRoot)
             {
-                var detailHost = GetHostPageOfType<TPage>(masterDetailRoot.Detail);
+                var detailHost = GetPageOfType<TPage>(masterDetailRoot.Detail);
                 if (detailHost is TPage)
                     return detailHost;
                 else
-                    return GetHostPageOfType<TPage>(masterDetailRoot.Master);
+                    return GetPageOfType<TPage>(masterDetailRoot.Master);
             }
             else if (rootPage is CarouselPage carouselPage)
             {
                 foreach (var item in carouselPage.Children)
                 {
-                    var nestedPage = GetHostPageOfType<TPage>(item);
+                    var nestedPage = GetPageOfType<TPage>(item);
                     if (nestedPage is TPage)
                         return nestedPage;
                 }
@@ -655,7 +664,7 @@ namespace MvvmCross.Forms.Views
             {
                 foreach (var item in tabbedPage.Children)
                 {
-                    var nestedPage = GetHostPageOfType<TPage>(item);
+                    var nestedPage = GetPageOfType<TPage>(item);
                     if (nestedPage is TPage)
                         return nestedPage;
                 }

--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -550,7 +550,7 @@ namespace MvvmCross.Forms.Views
             }
         }
 
-        protected virtual NavigationPage TopNavigationPage(Page rootPage = null)
+        public virtual NavigationPage TopNavigationPage(Page rootPage = null)
         {
             if (rootPage == null)
                 rootPage = FormsApplication.MainPage;
@@ -597,10 +597,20 @@ namespace MvvmCross.Forms.Views
             return null;
         }
 
-        protected virtual TPage GetHostPageOfType<TPage>(Page rootPage = null) where TPage : Page
+        public virtual TPage GetHostPageOfType<TPage>(Page rootPage = null) where TPage : Page
         {
             if (rootPage == null)
                 rootPage = FormsApplication.MainPage;
+
+            if(rootPage.Navigation?.ModalStack?.Count > 0)
+            {
+                foreach (var item in rootPage.Navigation.ModalStack)
+                {
+                    var modalPage = GetHostPageOfType<TPage>(item);
+                    if (modalPage is TPage)
+                        return modalPage;
+                }
+            }
 
             if (rootPage is TPage)
                 return rootPage as TPage;

--- a/MvvmCross/Core/Core/MvvmCross.Core.csproj
+++ b/MvvmCross/Core/Core/MvvmCross.Core.csproj
@@ -157,6 +157,7 @@
     <Compile Include="ViewModels\Hints\MvxPopToRootPresentationHint.cs" />
     <Compile Include="ViewModels\Hints\MvxRemovePresentationHint.cs" />
     <Compile Include="Navigation\EventArguments\ChangePresentationEventArgs.cs" />
+    <Compile Include="ViewModels\Hints\MvxPagePresentationHint.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/MvvmCross/Core/Core/ViewModels/Hints/MvxPagePresentationHint.cs
+++ b/MvvmCross/Core/Core/ViewModels/Hints/MvxPagePresentationHint.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace MvvmCross.Core.ViewModels.Hints
+{
+    //Only available on Xamarin.Forms
+    public class MvxPagePresentationHint
+        : MvxPresentationHint
+    {
+        public MvxPagePresentationHint(Type viewModel)
+        {
+            ViewModel = viewModel;
+        }
+
+        public Type ViewModel { get; private set; }
+    }
+}

--- a/TestProjects/Playground/Playground.Core/ViewModels/Tab3ViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/Tab3ViewModel.cs
@@ -1,5 +1,6 @@
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.ViewModels.Hints;
 
 namespace Playground.Core.ViewModels
 {
@@ -14,10 +15,14 @@ namespace Playground.Core.ViewModels
             ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
 
             CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+
+            ShowPageOneCommand = new MvxCommand(() => _navigationService.ChangePresentation(new MvxPagePresentationHint(typeof(Tab1ViewModel))));
         }
 
         public IMvxAsyncCommand ShowRootViewModelCommand { get; private set; }
 
         public IMvxAsyncCommand CloseViewModelCommand { get; private set; }
+
+        public IMvxCommand ShowPageOneCommand { get; private set; }
     }
 }

--- a/TestProjects/Playground/Playground.Forms.UI/Pages/Tab3Page.xaml
+++ b/TestProjects/Playground/Playground.Forms.UI/Pages/Tab3Page.xaml
@@ -11,6 +11,7 @@
             <Label Text="I'm a tab page" />
             <Button Text="Show root" mvx:Bi.nd="Command ShowRootViewModelCommand"/>
             <Button Text="Close tab" mvx:Bi.nd="Command CloseViewModelCommand"/>
+            <Button Text="Go to page 1" mvx:Bi.nd="Command ShowPageOneCommand"/>
         </StackLayout>
     </ContentPage.Content>
 </views:MvxContentPage>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

You can't change the current page if it is already open

### :new: What is the new behavior (if this is a feature change)?

Ability to change presentation to one

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the Playground

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
