### PR TITLE
Allow RootViewController animations with attributes

### DIFF
--- a/MvvmCross/iOS/iOS/Views/Presenters/Attributes/MvxRootPresentationAttribute.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/Attributes/MvxRootPresentationAttribute.cs
@@ -1,10 +1,20 @@
 ﻿using MvvmCross.Core.Views;
+using UIKit;
 
 namespace MvvmCross.iOS.Views.Presenters.Attributes
 {
     public class MvxRootPresentationAttribute : MvxBasePresentationAttribute
     {
+        public static float DefaultAnimationDuration = 1.0f;
+
         public static bool DefaultWrapInNavigationController = false;
+
+        public static UIViewAnimationOptions DefaultAnimationOptions = UIViewAnimationOptions.TransitionNone;
+
+        public float AnimationDuration { get; set; } = DefaultAnimationDuration;
+
+        public UIViewAnimationOptions AnimationOptions { get; set; } = DefaultAnimationOptions;
+
         public bool WrapInNavigationController { get; set; } = DefaultWrapInNavigationController;
     }
 }

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -206,11 +206,11 @@ namespace MvvmCross.iOS.Views.Presenters
             {
                 MasterNavigationController = CreateNavigationController(viewController);
 
-                SetWindowRootViewController(MasterNavigationController);
+                SetWindowRootViewController(MasterNavigationController, attribute);
             }
             else
             {
-                SetWindowRootViewController(viewController);
+                SetWindowRootViewController(viewController, attribute);
 
                 CloseMasterNavigationController();
             }
@@ -542,12 +542,26 @@ namespace MvvmCross.iOS.Views.Presenters
             SplitViewController = null;
         }
 
-        protected virtual void SetWindowRootViewController(UIViewController controller)
+        protected void RemoveWindowSubviews()
         {
             foreach (var v in _window.Subviews)
                 v.RemoveFromSuperview();
+        }
 
-            _window.RootViewController = controller;
+        protected virtual void SetWindowRootViewController(UIViewController controller, MvxRootPresentationAttribute attribute)
+        {
+            RemoveWindowSubviews();
+
+            if (attribute.AnimationOptions == UIViewAnimationOptions.TransitionNone)
+            {
+                _window.RootViewController = controller;
+                return;
+            }
+
+            UIView.Transition(
+                _window, attribute.AnimationDuration, attribute.AnimationOptions,
+                () => _window.RootViewController = controller, null
+            );
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
No default way of animating your RootViewController

### :new: What is the new behavior (if this is a feature change)?
Configurable animations (controller by `UIViewAnimationOptions`) using the `MvxRootPresentationAttribute`
Also, a small separation of the `SetWindowRootViewController`, allowing for subclasses of `MvxIosViewPresenter` to reliably reproduce the initial part of the method (extracted to `RemoveWindowSubviews`) when overriding it.

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Fiddle around with the test project by changing any ChildAttribute to a RootAtribute and providing an animation. I recommend checking `TransitionFlipFromRight` for maximum amusement.

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
