### PR TITLE
Fixing launch when splash screen isn't used

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
@@ -89,7 +89,7 @@ namespace MvvmCross.Forms.Droid.Views
             CloseFragments();
             if (!(CurrentActivity is MvxFormsAppCompatActivity || CurrentActivity is MvxFormsApplicationActivity) && 
                 !(CurrentActivity is MvxSplashScreenActivity || CurrentActivity is MvxSplashScreenAppCompatActivity))
-                CurrentActivity.Finish();
+                CurrentActivity?.Finish();
             return true;
         }
 

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAppCompatActivity.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Forms.Droid.Views
         {
             BindingContext = new MvxAndroidBindingContext(this, this);
             this.AddEventListeners();
-            _resourceAssembly = Assembly.GetCallingAssembly();
+            _resourceAssembly = this.GetType().Assembly;
         }
 
         public object DataContext

--- a/MvvmCross/Core/Core/ViewModels/IMvxAppStart.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxAppStart.cs
@@ -1,14 +1,16 @@
-﻿// IMvxAppStart.cs
+// IMvxAppStart.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using System.Threading.Tasks;
+
 namespace MvvmCross.Core.ViewModels
 {
     public interface IMvxAppStart
     {
-        void Start(object hint = null);
+        Task Start(object hint = null);
     }
 }

--- a/MvvmCross/Core/Core/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxAppStart.cs
@@ -1,4 +1,4 @@
-﻿// MvxAppStart.cs
+// MvxAppStart.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -6,6 +6,7 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Platform.Platform;
 
 namespace MvvmCross.Core.ViewModels
@@ -15,7 +16,7 @@ namespace MvvmCross.Core.ViewModels
         : MvxNavigatingObject, IMvxAppStart
         where TViewModel : IMvxViewModel
     {
-        public void Start(object hint = null)
+        public async Task Start(object hint = null)
         {
             if (hint != null)
             {

--- a/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
@@ -1,14 +1,14 @@
-﻿// MvxAppStart.cs
+// MvxAppStart.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-using MvvmCross.Platform.Platform;
 using MvvmCross.Core.Navigation;
-using MvvmCross.Platform;
 using MvvmCross.Platform.Exceptions;
+using MvvmCross.Platform.Platform;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Core.ViewModels
 {
@@ -23,7 +23,7 @@ namespace MvvmCross.Core.ViewModels
             NavigationService = navigationService;
         }
 
-        public void Start(object hint = null)
+        public async Task Start(object hint = null)
         {
             if (hint != null)
             {
@@ -31,7 +31,7 @@ namespace MvvmCross.Core.ViewModels
             }
             try
             {
-                NavigationService.Navigate<TViewModel>();
+                await NavigationService.Navigate<TViewModel>();
             }
             catch (System.Exception exception)
             {

--- a/MvvmCross/Droid/Droid/Platform/MvxAndroidSetupSingleton.cs
+++ b/MvvmCross/Droid/Droid/Platform/MvxAndroidSetupSingleton.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Android.Content;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Droid.Views;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Core;
@@ -43,6 +44,10 @@ namespace MvvmCross.Droid.Platform
                 {
                     IsInitialisedTaskCompletionSource = new TaskCompletionSource<bool>();
                     _setup.Initialize();
+
+                    var start = Mvx.Resolve<IMvxAppStart>();
+                    start.Start().Wait();
+
                     _initialized = true;
 
                     if (_currentSplashScreen != null)

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -200,7 +200,7 @@ namespace MvvmCross.Droid.Views
 
         protected Type GetCurrentActivityViewModelType()
         {
-            Type currentActivityType = CurrentActivity.GetType();
+            Type currentActivityType = CurrentActivity?.GetType();
 
             var activityViewModelType = ViewModelTypeFinder.FindTypeOrNull(currentActivityType);
             return activityViewModelType;

--- a/TestProjects/Android-Support/Fragments/Example.Core/AppStart.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/AppStart.cs
@@ -1,7 +1,8 @@
-﻿using Example.Core.ViewModels;
+using Example.Core.ViewModels;
 using MvvmCross.Core.Navigation;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Platform;
+using System.Threading.Tasks;
 
 namespace Example.Core
 {
@@ -11,10 +12,10 @@ namespace Example.Core
         /// Start is called on startup of the app
         /// Hint contains information in case the app is started with extra parameters
         /// </summary>
-        public void Start(object hint = null)
+        public async Task Start(object hint = null)
         {
             Mvx.Resolve<IMvxNavigationService>().Navigate<LoginViewModel>();
-			//ShowViewModel<LoginViewModel>();
+            //ShowViewModel<LoginViewModel>();
         }
     }
 }

--- a/TestProjects/Playground/Playground.Forms.Droid/MainActivity.cs
+++ b/TestProjects/Playground/Playground.Forms.Droid/MainActivity.cs
@@ -1,17 +1,17 @@
-﻿using Android.App;
+using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using MvvmCross.Forms.Droid.Views;
-using MvvmCross.Platform;
 using Playground.Core.ViewModels;
 
 namespace Playground.Forms.Droid
 {
     [Activity(
-        Label = "Playground.Forms", 
+        Label = "Playground.Forms",
         Icon = "@mipmap/icon",
         Theme = "@style/AppTheme",
-        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation, 
+        MainLauncher = true,
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation,
         LaunchMode = LaunchMode.SingleTask)]
     public class MainActivity : MvxFormsAppCompatActivity<MainViewModel>
     {

--- a/TestProjects/Playground/Playground.Forms.Droid/SplashScreen.cs
+++ b/TestProjects/Playground/Playground.Forms.Droid/SplashScreen.cs
@@ -4,24 +4,25 @@ using MvvmCross.Droid.Views;
 
 namespace Playground.Forms.Droid
 {
-    [Activity(
-        Label = "Playground.Forms"
-        , MainLauncher = true
-        , Icon = "@mipmap/icon"
-        , Theme = "@style/AppTheme.Splash"
-        , NoHistory = true
-        , ScreenOrientation = ScreenOrientation.Portrait)]
-    public class SplashScreen : MvxSplashScreenActivity
-    {
-        public SplashScreen()
-            : base(Resource.Layout.SplashScreen)
-        {
-        }
+    // NOTE: Uncomment this block and remove the "MainLauncher = true" from MainActivity to show Splashscreen
+    //[Activity(
+    //    Label = "Playground.Forms"
+    //    , MainLauncher = true
+    //    , Icon = "@mipmap/icon"
+    //    , Theme = "@style/AppTheme.Splash"
+    //    , NoHistory = true
+    //    , ScreenOrientation = ScreenOrientation.Portrait)]
+    //public class SplashScreen : MvxSplashScreenActivity
+    //{
+    //    public SplashScreen()
+    //        : base(Resource.Layout.SplashScreen)
+    //    {
+    //    }
 
-        protected override void TriggerFirstNavigate()
-        {
-            StartActivity(typeof(MainActivity));
-            base.TriggerFirstNavigate();
-        }
-    }
+    //    protected override void TriggerFirstNavigate()
+    //    {
+    //        StartActivity(typeof(MainActivity));
+    //        base.TriggerFirstNavigate();
+    //    }
+    //}
 }

--- a/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
@@ -21,7 +21,7 @@ namespace Playground.Forms.Uwp
             InitializeComponent();
 
             var start = Mvx.Resolve<IMvxAppStart>();
-            start.Start();
+            start.Start().Wait();
 
             var presenter = Mvx.Resolve<IMvxFormsViewPresenter>() as MvxFormsUwpViewPresenter;
             LoadApplication(presenter.FormsApplication);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Android with Xamarin Forms doesn't load when there's no splash screen.

### :new: What is the new behavior (if this is a feature change)?
Android with Xamarin Forms launches correctly

### :boom: Does this PR introduce a breaking change?
Yes, IMvxStart.Start is now async

### :bug: Recommendations for testing
Run the Playground.Forms.Droid

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
