### PR TITLE
Fix weird adding behaviour for Android. The first elements in lists w…

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxObservableCollection.cs
@@ -96,7 +96,7 @@ namespace MvvmCross.Core.ViewModels
                 }
             }
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList,this.Items.Count));
         }
 
         /// <summary>


### PR DESCRIPTION
…ere duplicated consistently without index.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes a bug for android recyclerviews when you're adding elements by range on a mvxobservablecollection

### :arrow_heading_down: What is the current behavior?
Adding elements by range results in the first item of the recyclerview to duplicate every time a range is added.

### :new: What is the new behavior (if this is a feature change)?
Doesn't happen

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Simply add ranges in batches on a mvxobservablecollection bound to a mvxrecyclerview

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
