### PR TITLE
Fix MvxUIBarButtonItemTargetBinding

### DIFF
--- a/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
+++ b/MvvmCross/Binding/iOS/Target/MvxUIBarButtonItemTargetBinding.cs
@@ -19,6 +19,14 @@ namespace MvvmCross.Binding.iOS.Target
         public MvxUIBarButtonItemTargetBinding(UIBarButtonItem control)
             : base(control)
         {
+            if (control == null)
+            {
+                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - UIControl is null in MvxUIBarButtonItemTargetBinding");
+            }
+            else
+            {
+                _clickSubscription = control.WeakSubscribe(nameof(control.Clicked), OnClicked);
+            }
             _canExecuteEventHandler = OnCanExecuteChanged;
         }
 
@@ -37,19 +45,6 @@ namespace MvvmCross.Binding.iOS.Target
                 _canExecuteSubscription = _command.WeakSubscribe(_canExecuteEventHandler);
             }
             RefreshEnabledState();
-        }
-
-        public override void SubscribeToEvents()
-        {
-            var control = Control;
-            if (control == null)
-            {
-                MvxBindingTrace.Trace(MvxTraceLevel.Error, "Error - UIControl is null in MvxUIBarButtonItemTargetBinding");
-            }
-            else
-            {
-                _clickSubscription = control.WeakSubscribe(nameof(control.Clicked), OnClicked);
-            }
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
`MvxUIBarButtonItemTargetBinding.SubscribeToEvents` is never called. Therefore, the binding is not working.

### :new: What is the new behavior (if this is a feature change)?
Removed `MvxUIBarButtonItemTargetBinding.SubscribeToEvents` and applied the subscription on the ctor.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Sorry that I couldn't add a repro case to Playground, but adding a UIBarButtonItem and a binding to any view should be enough.

### :memo: Links to relevant issues/docs
Fixes #2456

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
