### PR TITLE
Fix UISwitch Target binding registration

### DIFF
--- a/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Binding/iOS/MvxIosBindingBuilder.cs
@@ -176,10 +176,10 @@ namespace MvvmCross.Binding.iOS
                 MvxIosPropertyBinding.UIView_LayerBorderWidth,
                 view => new MvxUIViewLayerBorderWidthTargetBinding(view));
 
-            registry.RegisterPropertyInfoBindingFactory(
-                typeof(MvxUISwitchOnTargetBinding),
-                typeof(UISwitch),
-                MvxIosPropertyBinding.UISwitch_On);
+            registry.RegisterCustomBindingFactory<UISwitch>(
+                MvxIosPropertyBinding.UISwitch_On,
+                uiSwitch => new MvxUISwitchOnTargetBinding(uiSwitch)
+            );
 
             registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxUISearchBarTextTargetBinding),


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Throws exception when trying to bind UISwitch because it was registered as a PropertyTargetBinding, which expects a ctor with two arguments. This ctor was removed as part of #2452 

### :new: What is the new behavior (if this is a feature change)?
No exception UISwitch binding works

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Make a binding for UISwitch

### :memo: Links to relevant issues/docs
Fixes #2462 
Broken by #2452 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
