### PR TITLE
MvxNavigationServiceAppStart: Don't swallow exceptions

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxNavigationServiceAppStart.cs
@@ -23,7 +23,7 @@ namespace MvvmCross.Core.ViewModels
             NavigationService = navigationService;
         }
 
-        public void Start(object hint = null)
+        public async void Start(object hint = null)
         {
             if (hint != null)
             {
@@ -31,7 +31,7 @@ namespace MvvmCross.Core.ViewModels
             }
             try
             {
-                NavigationService.Navigate<TViewModel>();
+                await NavigationService.Navigate<TViewModel>();
             }
             catch (System.Exception exception)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MvxNavigationServiceAppStart does not throw exceptions inside `Navigate`.

### :new: What is the new behavior (if this is a feature change)?
Exceptions are thrown.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
1. Set Playground.Mac as starter project
2. Introduce an Interface like `IMyService`
3. Inject `IMyService` in Playground.Core -> RootViewModel
4. Run the app.

### :memo: Links to relevant issues/docs
Fixes: #2447

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
