### PR TITLE
Fix post date since MvvmCross 5.6 was released in Dec not Nov

### DIFF
--- a/docs/_posts/2017-11-09-mvvmcross-56-release.md
+++ b/docs/_posts/2017-11-09-mvvmcross-56-release.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: MvvmCross 5.6
-date:   2017-11-23 14:00:00 +0100
+date:   2017-12-11 14:00:00 +0100
 categories: mvvmcross
 ---
 


### PR DESCRIPTION
I noticed that the date at https://www.mvvmcross.com/mvvmcross-56-release/ doesn't match the fact that 5.6 was released in Dec not Nov. Thanks for all you do!