### PR TITLE
MvxRecyclerViewAdapter: Support worker threads

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V17.Leanback/Listeners/MvxOnChildViewHolderSelectedListener.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V17.Leanback/Listeners/MvxOnChildViewHolderSelectedListener.cs
@@ -18,7 +18,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Listeners
 		{
 			base.OnChildViewHolderSelected(parent, child, position, subposition);
 
-			var adapter = parent.GetAdapter() as MvxRecyclerAdapter;
+			var adapter = parent.GetAdapter() as IMvxRecyclerAdapter;
 			var item = adapter?.GetItem(position);
 
 			if (item == null)

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Windows.Input;
+using Android.App;
+using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross.Binding;
@@ -26,7 +28,7 @@ using Object = Java.Lang.Object;
 namespace MvvmCross.Droid.Support.V7.RecyclerView
 {
     [Register("mvvmcross.droid.support.v7.recyclerview.MvxRecyclerAdapter")]
-    public class MvxRecyclerAdapter 
+    public class MvxRecyclerAdapter
         : Android.Support.V7.Widget.RecyclerView.Adapter, IMvxRecyclerAdapter, IMvxRecyclerAdapterBindableHolder
     {
         private readonly IMvxAndroidBindingContext _bindingContext;
@@ -104,7 +106,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             get { return _itemsSource; }
             set { SetItemsSource(value); }
         }
-        
+
         public virtual IMvxTemplateSelector ItemTemplateSelector
         {
             get
@@ -151,7 +153,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         public override Android.Support.V7.Widget.RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
         {
             var itemBindingContext = new MvxAndroidBindingContext(parent.Context, BindingContext.LayoutInflaterHolder);
-            
+
             var vh = new MvxRecyclerViewHolder(InflateViewForHolder(parent, viewType, itemBindingContext), itemBindingContext)
             {
                 Click = ItemClick,
@@ -241,7 +243,15 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
 
         protected virtual void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            NotifyDataSetChanged(e);
+            if (Looper.MainLooper == Looper.MyLooper())
+            {
+                NotifyDataSetChanged(e);
+            }
+            else
+            {
+                var h = new Handler(Looper.MainLooper);
+                h.Post(() => NotifyDataSetChanged(e));
+            }
         }
 
         public virtual void NotifyDataSetChanged(NotifyCollectionChangedEventArgs e)

--- a/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/ExampleRecyclerViewModel.cs
+++ b/TestProjects/Android-Support/Fragments/Example.Core/ViewModels/ExampleRecyclerViewModel.cs
@@ -13,19 +13,28 @@ namespace Example.Core.ViewModels
 
         public ExampleRecyclerViewModel()
         {
-            Items = new ObservableCollection<ListItem> {
-                new ListItem { Title = "title one" },
-                new ListItem { Title = "title two" },
-                new ListItem { Title = "title three" },
-                new ListItem { Title = "title four" },
-                new ListItem { Title = "title five" }
-            };
+            Items = new ObservableCollection<ListItem>();
+        }
+
+        public override void ViewAppeared()
+        {
+            base.ViewAppeared();
+
+            Task.Run(() =>
+            {
+                Items.Add(new ListItem { Title = "title one" });
+                Items.Add(new ListItem { Title = "title two" });
+                Items.Add(new ListItem { Title = "title three" });
+                Items.Add(new ListItem { Title = "title four" });
+                Items.Add(new ListItem { Title = "title five" });
+            });
         }
 
         private ObservableCollection<ListItem> _items;
         public ObservableCollection<ListItem> Items
         {
-            get {
+            get
+            {
                 return _items;
             }
             set


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement

### :arrow_heading_down: What is the current behavior?
When a user tries to update a bound ItemsSource collection from a worker thread, MvxRecyclerViewAdapter just 💥💥. 

### :new: What is the new behavior (if this is a feature change)?
MvxRecyclerViewAdapter handles collection changes from worker threads.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run TestProjects/Android-Support. `ExampleRecyclerViewModel` updates a collection from background.

### :memo: Links to relevant issues/docs
Closes #2144

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
