### PR TITLE
Update WithDictionaryConversion binding to have optional fallback

### DIFF
--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
@@ -2,6 +2,7 @@ using MvvmCross.Binding.Binders;
 using MvvmCross.Localization;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Converters;
+using System;
 using System.Collections.Generic;
 
 namespace MvvmCross.Binding.BindingContext
@@ -9,8 +10,10 @@ namespace MvvmCross.Binding.BindingContext
     public static class MvxFluentBindingDescriptionExtensions
     {
         public static MvxFluentBindingDescription<TTarget, TSource> ToLocalizationId<TTarget, TSource>(
-            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription, string localizationId)
-            where TSource : IMvxLocalizedTextSourceOwner where TTarget : class
+            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
+            string localizationId)
+            where TSource : IMvxLocalizedTextSourceOwner
+            where TTarget : class
         {
             var valueConverter = Mvx.Resolve<IMvxValueConverterLookup>().Find("Language");
             return bindingDescription.To(vm => vm.LocalizedTextSource)
@@ -19,8 +22,11 @@ namespace MvvmCross.Binding.BindingContext
         }
 
         public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TTarget, TSource, TFrom, TTo>(
-            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription, IDictionary<TFrom, TTo> converterParameter)
+            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
+            IDictionary<TFrom, TTo> converterParameter,
+            TTo fallback = default(TTo))
             where TTarget : class
-            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), converterParameter).OneWay();
+            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), new Tuple<IDictionary<TFrom, TTo>, TTo>(converterParameter, fallback))
+            .OneWay();
     }
 }

--- a/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
+++ b/MvvmCross/Core/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
@@ -23,10 +23,17 @@ namespace MvvmCross.Binding.BindingContext
 
         public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TTarget, TSource, TFrom, TTo>(
             this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
-            IDictionary<TFrom, TTo> converterParameter,
-            TTo fallback = default(TTo))
+            IDictionary<TFrom, TTo> converterParameter)
             where TTarget : class
-            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), new Tuple<IDictionary<TFrom, TTo>, TTo>(converterParameter, fallback))
+            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), new Tuple<IDictionary<TFrom, TTo>, TTo, bool>(converterParameter, default(TTo), false))
+            .OneWay();
+
+        public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TTarget, TSource, TFrom, TTo>(
+            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
+            IDictionary<TFrom, TTo> converterParameter,
+            TTo fallback)
+            where TTarget : class
+            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), new Tuple<IDictionary<TFrom, TTo>, TTo, bool>(converterParameter, fallback, true))
             .OneWay();
     }
 }

--- a/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
+++ b/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
@@ -8,18 +8,21 @@ namespace MvvmCross.Platform.Converters
     {
         protected override TValue Convert(TKey value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (parameter is IDictionary<TKey, TValue> dict)
+            try
             {
-                if (dict.ContainsKey(value))
+                var typedParameters = (Tuple<IDictionary<TKey, TValue>, TValue>)parameter;
+
+                if (typedParameters.Item1.ContainsKey(value))
                 {
-                    return dict[value];
+                    return typedParameters.Item1[value];
                 }
-                else
-                {
-                    throw new KeyNotFoundException($"Could not find key {value.ToString()} for {typeof(MvxDictionaryValueConverter<TKey, TValue>).Name}.");
-                }
+
+                return typedParameters.Item2;
             }
-            throw new ArgumentException($"Could not cast {parameter.GetType().Name} to {typeof(Dictionary<TKey, TValue>).Name}");
+            catch (InvalidCastException ex)
+            {
+                throw new ArgumentException($"Dictionary Converter expected a parameter of type \"{typeof(Tuple<IDictionary<TKey, TValue>, TValue>)}\" but received type \"{parameter.GetType()}\"", nameof(parameter), ex);
+            }
         }
     }
 }

--- a/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
+++ b/MvvmCross/Platform/Platform/Converters/MvxDictionaryValueConverter.cs
@@ -10,18 +10,22 @@ namespace MvvmCross.Platform.Converters
         {
             try
             {
-                var typedParameters = (Tuple<IDictionary<TKey, TValue>, TValue>)parameter;
+                var typedParameters = (Tuple<IDictionary<TKey, TValue>, TValue, bool>)parameter;
 
                 if (typedParameters.Item1.ContainsKey(value))
                 {
                     return typedParameters.Item1[value];
                 }
+                else if (typedParameters.Item3)
+                {
+                    return typedParameters.Item2;
+                }
 
-                return typedParameters.Item2;
+                throw new KeyNotFoundException($"Could not find key {value?.ToString()} for {typeof(MvxDictionaryValueConverter<TKey, TValue>)}.");
             }
             catch (InvalidCastException ex)
             {
-                throw new ArgumentException($"Dictionary Converter expected a parameter of type \"{typeof(Tuple<IDictionary<TKey, TValue>, TValue>)}\" but received type \"{parameter.GetType()}\"", nameof(parameter), ex);
+                throw new ArgumentException($"Dictionary Converter expected a parameter of type \"{typeof(Tuple<IDictionary<TKey, TValue>, TValue, bool>)}\" but received type \"{parameter.GetType()}\"", nameof(parameter), ex);
             }
         }
     }

--- a/MvvmCross/Platform/Test/Converters/MvxDictionaryValueConverterTests.cs
+++ b/MvvmCross/Platform/Test/Converters/MvxDictionaryValueConverterTests.cs
@@ -1,0 +1,58 @@
+using MvvmCross.Platform.Converters;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace MvvmCross.Platform.Test.Converters
+{
+    [TestFixture]
+    public class MvxDictionaryValueConverterTests : MvxDictionaryValueConverter<MvxDictionaryValueConverterTests.TestStates, string>
+    {
+        private Dictionary<TestStates, string> _testStatedictionary;
+
+        private const string StateUnknown = "State Unknown";
+        private const string StateRunning = "State Running";
+        private const string StateCompleted = "State Completed";
+        private const string Fallback = "State fallback";
+
+        public enum TestStates
+        {
+            Unknown,
+            Running,
+            Completed,
+            Failed
+        }
+
+        [SetUp]
+        public void Init()
+        {
+            _testStatedictionary = new Dictionary<TestStates, string>
+            {
+                [TestStates.Unknown] = StateUnknown,
+                [TestStates.Running] = StateRunning,
+                [TestStates.Completed] = StateCompleted
+            };
+        }
+
+        [TestCase(TestStates.Unknown, ExpectedResult = StateUnknown)]
+        [TestCase(TestStates.Running, ExpectedResult = StateRunning)]
+        [TestCase(TestStates.Completed, ExpectedResult = StateCompleted)]
+        public string Convert_MatchingKey_ReturnsDictionaryValue(TestStates state)
+        {
+            return Convert(state, null, new Tuple<IDictionary<TestStates, string>, string>(_testStatedictionary, Fallback), CultureInfo.CurrentUICulture);
+        }
+
+        [TestCase(TestStates.Failed, ExpectedResult = Fallback)]
+        public string Convert_NoMatchingDictionaryKey_ReturnsFallback(TestStates state)
+        {
+            return Convert(state, null, new Tuple<IDictionary<TestStates, string>, string>(_testStatedictionary, Fallback), CultureInfo.CurrentUICulture);
+        }
+
+        [Test]
+        public void Convert_InvalidParamterType_ThrowArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Convert(TestStates.Unknown, null, _testStatedictionary, CultureInfo.CurrentUICulture));
+        }
+    }
+}

--- a/MvvmCross/Platform/Test/MvvmCross.Platform.Test.csproj
+++ b/MvvmCross/Platform/Test/MvvmCross.Platform.Test.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\..\..\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Converters\MvxDictionaryValueConverterTests.cs" />
     <Compile Include="Mocks\MockBootstrapAction.cs" />
     <Compile Include="MvxBootstrapTest.cs" />
     <Compile Include="MvxIoCPropertyInjectionTest.cs" />

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/RootView.axml
@@ -51,7 +51,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
-        android:text="Show Dictionary Sheet"
+        android:text="Show WithDictionaryConversion Binding"
         local:MvxBind="Click ShowDictionaryBindingCommand" />
     <FrameLayout
         android:id="@+id/content_frame"

--- a/TestProjects/Playground/Playground.Droid/Resources/layout/dictionary_view.axml
+++ b/TestProjects/Playground/Playground.Droid/Resources/layout/dictionary_view.axml
@@ -7,6 +7,10 @@
     android:layout_height="match_parent"
     android:background="@color/gray"
     android:padding="@dimen/margin_medium">
+    <TextView
+      android:id="@+id/txt_description"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content" />
     <Button
         android:id="@+id/next_button"
         android:layout_width="match_parent"

--- a/TestProjects/Playground/Playground.Droid/Views/DictionaryBindingView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/DictionaryBindingView.cs
@@ -1,22 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using Android.App;
-using Android.Content;
+using Android.Graphics;
+using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Runtime;
-using Android.Util;
 using Android.Views;
 using Android.Widget;
-using Playground.Core.ViewModels;
-using MvvmCross.Droid.Views.Attributes;
-using MvvmCross.Droid.Support.V4;
-using MvvmCross.Binding.Droid.BindingContext;
 using MvvmCross.Binding.BindingContext;
-using Android.Graphics.Drawables;
-using Android.Graphics;
+using MvvmCross.Binding.Droid.BindingContext;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Droid.Views.Attributes;
+using Playground.Core.ViewModels;
+using System.Collections.Generic;
 
 namespace Playground.Droid.Views
 {
@@ -34,15 +27,25 @@ namespace Playground.Droid.Views
 
             var view = this.BindingInflate(Resource.Layout.dictionary_view, null);
             var background = view.FindViewById<LinearLayout>(Resource.Id.container);
+            var descriptionLabel = view.FindViewById<TextView>(Resource.Id.txt_description);
 
-            this.CreateBindingSet<DictionaryBindingView, DictionaryBindingViewModel>().Bind(background).For(v => v.Background).To(vm => vm.Value)
+            var bindingSet = this.CreateBindingSet<DictionaryBindingView, DictionaryBindingViewModel>();
+            bindingSet.Bind(background).For(v => v.Background).To(vm => vm.Value)
                 .WithDictionaryConversion(new Dictionary<int, Drawable>
                 {
-                    {0, new ColorDrawable(Color.Blue) },
-                    {1, new ColorDrawable(Color.Red) },
-                    {2, new ColorDrawable(Color.Yellow) },
-                    {3, new ColorDrawable(Color.Violet) }
-                }).Apply();
+                    [0] = new ColorDrawable(Color.Blue),
+                    [1] = new ColorDrawable(Color.Red),
+                    [2] = new ColorDrawable(Color.Yellow),
+                    [3] = new ColorDrawable(Color.Violet)
+                });
+            bindingSet.Bind(descriptionLabel).To(vm => vm.Value)
+                .WithDictionaryConversion(new Dictionary<int, string>
+                {
+                    [0] = "Description for blue",
+                    [1] = "Description for Red",
+                }, "Fallback description");
+
+            bindingSet.Apply();
 
             return view;
         }

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -950,7 +950,7 @@ set.Bind(button).To(vm => vm.readonly)
     });
 ```
 
-Additionally, a fallback can be supplied for use in the case where a key cannot be found against the supplied Dictionary.
+Additionally, a fallback can be supplied for when a key cannot be found against the supplied Dictionary.
 
 ```c#
 set.Bind(button).To(vm => vm.readonly)

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -939,16 +939,28 @@ Add something about the Generic implementation of IMvxTargetBinding [#1610](http
 
 ### Dictionary Conversion
 
-Dictionary conversion allows for mapped conversions to be set up within the view's binding code, useful for quickly binding things like icons or color to state properties.
+Dictionary conversion allows for mapped conversions to be set up within the view's binding code, useful for quickly binding things like icons or colors to state properties.
 
 ```c#
-set.Bind(button).To(vm => vm.readonly).WithDictionaryConversion(
-	new Dictionary<bool, Icon>
-	{
-		{true, GreyIcon},
-		{false, BlueIcon}
-	});
+set.Bind(button).To(vm => vm.readonly)
+   .WithDictionaryConversion(new Dictionary<bool, Icon>
+    {
+        {true, GreyIcon},
+        {false, BlueIcon}
+    });
 ```
+
+Additionally, a fallback can be supplied for use in the case where a key cannot be found against the supplied Dictionary.
+
+```c#
+set.Bind(button).To(vm => vm.readonly)
+   .WithDictionaryConversion(new Dictionary<bool, Icon>
+    {
+        {true, GreyIcon},
+        {false, BlueIcon}
+    }, RedIcon);
+```
+
 *Note* : This feature is only available in fluent binding.
 
 ### Default view properties


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently using `WithDictionaryConversion` requires that you provide a mapping for every key (ViewModel state) that you want to use.

### :new: What is the new behavior (if this is a feature change)?
You can now specify a fallback value to be used in the case were no key is found in your dictionary. Useful in the use case where you are binding to an enum that has multiple named constants and you only want to change on the one state for all others a single fallback can suffice. 

**_Note_** This change makes use of .NET Tuple as to not bring in a dependency on ValueTuple. However, once MvvmCross moves over to .NET Standard 2.0 the converter can be updated to the more readable ValueTuple syntax.

### :boom: Does this PR introduce a breaking change?
Yes, but potential a low impact one.  The breaking change would only be in rare case that the developer explicitly made use of the  `MvxDictionaryValueConverter`. If they made use of `MvxDictionaryValueConverter` via the `WithDictionaryConversion` binding extension method they would be unaffected.

### :bug: Recommendations for testing
See updated Android Playground project.

### :memo: Links to relevant issues/docs
Existing doc [link](https://www.mvvmcross.com/documentation/fundamentals/data-binding#dictionary-conversion)

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
