### PR TITLE
iOS LinkerPleaseInclude: Added DidProcessEditing line

### DIFF
--- a/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/LinkerPleaseInclude.cs
+++ b/TestProjects/iOS-Support/XamarinSidebar/MvvmCross.iOS.Support.Sidebar/LinkerPleaseInclude.cs
@@ -42,6 +42,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.iOS
         public void Include(UITextView textView)
         {
             textView.Text = textView.Text + "";
+            textView.TextStorage.DidProcessEditing += (sender, e) => textView.Text = "";
             textView.Changed += (sender, args) => { textView.Text = ""; };
         }
 

--- a/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
+++ b/nuspec/iOSContent/LinkerPleaseInclude.cs.pp
@@ -43,6 +43,7 @@ namespace $rootnamespace$
         public void Include(UITextView textView)
         {
             textView.Text = textView.Text + "";
+            textView.TextStorage.DidProcessEditing += (sender, e) => textView.Text = "";
             textView.Changed += (sender, args) => { textView.Text = ""; };
         }
 


### PR DESCRIPTION
**Note: As this PR modifies the LinkerPleaseInclude file, we need to make sure we leave a note about it in the next release notes**

-----

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
#2460 fixed the `MvxUITextViewTextTargetBinding`, but the source event is normally stripped when linking sdk assemblies.

### :new: What is the new behavior (if this is a feature change)?
Added source event to LinkerPleaseInclude. 

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Use the binding and deploy any app linking sdk assemblies. It will crash.
Then apply this change to LinkerPleaseInclude and run again.

### :memo: Links to relevant issues/docs
This is part of: #2460

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
