### PR TITLE
[WIP] Added support for nested fragments (ChildFragmentManager)

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentPagerAdapter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentPagerAdapter.cs
@@ -122,7 +122,7 @@ namespace MvvmCross.Droid.Support.V4
             return fragment;
         }
 
-        private static string FragmentJavaName(Type fragmentType)
+        protected string FragmentJavaName(Type fragmentType)
         {
             return Class.FromType(fragmentType).Name;
         }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentPagerAdapter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentPagerAdapter.cs
@@ -101,6 +101,12 @@ namespace MvvmCross.Droid.Support.V4
             if (fss != null)
                 fragment.SetInitialSavedState(fss);
 
+            //if fragment tag is null let's set it to something meaning full;
+            if (string.IsNullOrEmpty(fragmentTag))
+            {
+                fragmentTag = FragmentJavaName(fragment.GetType());
+            }
+
 #if DEBUG
             Mvx.Trace("Adding item #{0}: f={1} t={2}", position, fragment, fragmentTag);
 #endif
@@ -114,6 +120,11 @@ namespace MvvmCross.Droid.Support.V4
             _curTransaction.Add(container.Id, fragment, fragmentTag);
 
             return fragment;
+        }
+
+        private static string FragmentJavaName(Type fragmentType)
+        {
+            return Class.FromType(fragmentType).Name;
         }
 
         public override bool IsViewFromObject(View view, Object objectValue)

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentStatePagerAdapter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.Fragment/MvxCachingFragmentStatePagerAdapter.cs
@@ -38,7 +38,7 @@ namespace MvvmCross.Droid.Support.V4
 
         public List<MvxViewPagerFragmentInfo> FragmentsInfo { get; }
 
-        protected static string FragmentJavaName(Type fragmentType)
+        protected string FragmentJavaName(Type fragmentType)
         {
             return Class.FromType(fragmentType).Name;
         }

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -594,7 +594,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             return FindFragmentInChildren(fragmentName, CurrentFragmentManager);
         }
 
-        private Fragment FindFragmentInChildren(string fragmentName, FragmentManager fragManager)
+        protected virtual Fragment FindFragmentInChildren(string fragmentName, FragmentManager fragManager)
         {
             if (fragManager?.Fragments != null && !fragManager.Fragments.Any()) return null;
 

--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -584,7 +584,36 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         protected virtual new Fragment GetFragmentByViewType(Type type)
         {
             var fragmentName = FragmentJavaName(type);
-            return CurrentFragmentManager?.FindFragmentByTag(fragmentName);
+            var fragment = CurrentFragmentManager?.FindFragmentByTag(fragmentName);
+
+            if (fragment != null)
+            {
+                return fragment;
+            }
+
+            return FindFragmentInChildren(fragmentName, CurrentFragmentManager);
+        }
+
+        private Fragment FindFragmentInChildren(string fragmentName, FragmentManager fragManager)
+        {
+            if (fragManager?.Fragments != null && !fragManager.Fragments.Any()) return null;
+
+            foreach (var fragment in fragManager.Fragments)
+            {
+                //let's try again finding it
+                var frag = fragment?.ChildFragmentManager?.FindFragmentByTag(fragmentName);
+
+                //if we found the frag lets return it!
+                if (frag != null)
+                {
+                    return frag;
+                }
+
+                //reloop for other fragments
+                FindFragmentInChildren(fragmentName, fragment?.ChildFragmentManager);
+            }
+
+            return null;
         }
     }
 }

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -570,7 +570,39 @@ namespace MvvmCross.Droid.Views
         protected virtual Fragment GetFragmentByViewType(Type type)
         {
             var fragmentName = FragmentJavaName(type);
-            return CurrentFragmentManager.FindFragmentByTag(fragmentName);
+            var fragment = CurrentFragmentManager?.FindFragmentByTag(fragmentName);
+
+            if (fragment != null)
+            {
+                return fragment;
+            }
+
+            return FindFragmentInChildren(fragmentName, CurrentFragmentManager);
+        }
+
+        protected virtual Fragment FindFragmentInChildren(string fragmentName, FragmentManager fragManager)
+        {
+            if(fragManager.BackStackEntryCount == 0)
+                return null;
+
+            for (int i = 0; i < fragManager.BackStackEntryCount; i++)
+            {
+                var parentFrag = fragManager.FindFragmentById(fragManager.GetBackStackEntryAt(i).Id);
+
+                //let's try again finding it
+                var frag = parentFrag?.ChildFragmentManager?.FindFragmentByTag(fragmentName);
+
+                //if we found the frag lets return it!
+                if (frag != null)
+                {
+                    return frag;
+                }
+
+                //reloop for other fragments
+                FindFragmentInChildren(fragmentName, parentFrag?.ChildFragmentManager);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Current behavior only supports FragmentManager and SupportFragmentManager on 1 nested level.
It also doesn't support nested fragments in PageViewer. 

### :new: What is the new behavior (if this is a feature change)?
The new behavior adds support for nested fragments (multi level) (for now only MvxAppCompatPresenter supports it).
Adds correct tagging on MvxCachedFragmentPagerAdapter so that nested fragments can be supported in PageViewer. 

### :boom: Does this PR introduce a breaking change?
Not yet (depends if we want to remove 2 of the PageAdapters into making only 2 available) 

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
Problems with the Android API I am using (found this like 2 hours ago) : 
https://stackoverflow.com/questions/6102007/is-there-a-way-to-get-references-for-all-currently-active-fragments-in-an-activi
When we look at the link above it seems that FragmentManager.Fragments is maybe not supposed to be used as its hidden (well its not really hidden in Xamarin). But I am concerned of future updates it might break the implementation. (if they end up making it private field). Also the non-AppCompat version we would need to use reflection to get the field with mActive as said per post. So I am not sure if this is a good solution.  

### :thinking: Checklist before submitting
Didnt have time to do the below yet.  I currently implemented it in my own project by just re-implementing the MvxCachedFragmentPagerAdapter and overwriting the MvxAppCompatPresenter. It works as far as I can see but to be added to MvvmCross it needs more work and maybe a different approach. 

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
