### PR TITLE
Improve IMvxOverridePresentationAttribute by providing the MvxViewModelRequest as parameter

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -59,11 +59,11 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 });
         }
 
-        public override MvxBasePresentationAttribute GetPresentationAttribute(Type viewModelType)
+        public override MvxBasePresentationAttribute GetPresentationAttribute(MvxViewModelRequest request)
         {
-            var viewType = ViewsContainer.GetViewType(viewModelType);
+            var viewType = ViewsContainer.GetViewType(request.ViewModelType);
 
-            var overrideAttribute = GetOverridePresentationAttribute(viewModelType, viewType);
+            var overrideAttribute = GetOverridePresentationAttribute(request, viewType);
             if (overrideAttribute != null)
                 return overrideAttribute;
 
@@ -129,7 +129,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 return attribute;
             }
 
-            return CreatePresentationAttribute(viewModelType, viewType);
+            return CreatePresentationAttribute(request.ViewModelType, viewType);
         }
 
         public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)

--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
@@ -76,7 +76,7 @@ namespace MvvmCross.Forms.Droid.Views
         public virtual bool ClosePlatformViews()
         {
             CloseFragments();
-            if (!(CurrentActivity is MvxFormsAppCompatActivity || CurrentActivity is MvxFormsApplicationActivity) && 
+            if (!(CurrentActivity is MvxFormsAppCompatActivity || CurrentActivity is MvxFormsApplicationActivity) &&
                 !(CurrentActivity is MvxSplashScreenActivity || CurrentActivity is MvxSplashScreenAppCompatActivity))
                 CurrentActivity?.Finish();
             return true;

--- a/MvvmCross/Core/Core/Views/IMvxAttributeViewPresenter.cs
+++ b/MvvmCross/Core/Core/Views/IMvxAttributeViewPresenter.cs
@@ -12,8 +12,8 @@ namespace MvvmCross.Core.Views
         void RegisterAttributeTypes();
 
         //TODO: Maybe move those to helper class
-        MvxBasePresentationAttribute GetPresentationAttribute(Type viewModelType);
+        MvxBasePresentationAttribute GetPresentationAttribute(MvxViewModelRequest request);
         MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType);
-        MvxBasePresentationAttribute GetOverridePresentationAttribute(Type viewModelType, Type viewType);
+        MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType);
     }
 }

--- a/MvvmCross/Core/Core/Views/IMvxOverridePresentationAttribute.cs
+++ b/MvvmCross/Core/Core/Views/IMvxOverridePresentationAttribute.cs
@@ -1,7 +1,9 @@
-﻿namespace MvvmCross.Core.Views
+﻿using MvvmCross.Core.ViewModels;
+
+namespace MvvmCross.Core.Views
 {
     public interface IMvxOverridePresentationAttribute
     {
-        MvxBasePresentationAttribute PresentationAttribute();
+        MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request);
     }
 }

--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs
@@ -122,11 +122,11 @@ namespace MvvmCross.Droid.Views
                 });
         }
 
-        public override MvxBasePresentationAttribute GetPresentationAttribute(Type viewModelType)
+        public override MvxBasePresentationAttribute GetPresentationAttribute(MvxViewModelRequest request)
         {
-            var viewType = ViewsContainer.GetViewType(viewModelType);
+            var viewType = ViewsContainer.GetViewType(request.ViewModelType);
 
-            var overrideAttribute = GetOverridePresentationAttribute(viewModelType, viewType);
+            var overrideAttribute = GetOverridePresentationAttribute(request, viewType);
             if (overrideAttribute != null)
                 return overrideAttribute;
 
@@ -175,7 +175,7 @@ namespace MvvmCross.Droid.Views
                 return attribute;
             }
 
-            return CreatePresentationAttribute(viewModelType, viewType);
+            return CreatePresentationAttribute(request.ViewModelType, viewType);
         }
 
         public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
@@ -208,7 +208,7 @@ namespace MvvmCross.Droid.Views
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         #region Show implementations
@@ -437,7 +437,7 @@ namespace MvvmCross.Droid.Views
 
         public override void Close(IMvxViewModel viewModel)
         {
-            GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
+            GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
         }
 
         #region Close implementations

--- a/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs
@@ -31,14 +31,14 @@ namespace MvvmCross.Mac.Views.Presenters
             return new MvxWindowPresentationAttribute();
         }
 
-        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(Type viewModelType, Type viewType)
+        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType)
         {
             if (viewType?.GetInterface(nameof(IMvxOverridePresentationAttribute)) != null)
             {
                 var viewInstance = this.CreateViewControllerFor(viewType, null) as NSViewController;
                 using (viewInstance)
                 {
-                    var presentationAttribute = (viewInstance as IMvxOverridePresentationAttribute)?.PresentationAttribute();
+                    var presentationAttribute = (viewInstance as IMvxOverridePresentationAttribute)?.PresentationAttribute(request);
 
                     if (presentationAttribute == null)
                     {
@@ -50,7 +50,7 @@ namespace MvvmCross.Mac.Views.Presenters
                             presentationAttribute.ViewType = viewType;
 
                         if (presentationAttribute.ViewModelType == null)
-                            presentationAttribute.ViewModelType = viewModelType;
+                            presentationAttribute.ViewModelType = request.ViewModelType;
 
                         return presentationAttribute;
                     }
@@ -154,7 +154,7 @@ namespace MvvmCross.Mac.Views.Presenters
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         protected virtual void ShowWindowViewController(

--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -69,12 +69,12 @@ namespace MvvmCross.Uwp.Views
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         public override void Close(IMvxViewModel viewModel)
         {
-            GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
+            GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
         }
 
         protected virtual async void BackButtonOnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)
@@ -180,7 +180,7 @@ namespace MvvmCross.Uwp.Views
             var viewType = viewFinder.GetViewType(viewModel.GetType());
             if (viewType.HasRegionAttribute())
             {
-                var containerView = _rootFrame.UnderlyingControl?.FindControl<Frame>( viewType.GetRegionName());
+                var containerView = _rootFrame.UnderlyingControl?.FindControl<Frame>(viewType.GetRegionName());
 
                 if (containerView == null)
                     throw new MvxException($"Region '{viewType.GetRegionName()}' not found in view '{viewType}'");

--- a/MvvmCross/Windows/Wpf/Views/Presenters/MvxWpfViewPresenter.cs
+++ b/MvvmCross/Windows/Wpf/Views/Presenters/MvxWpfViewPresenter.cs
@@ -87,7 +87,7 @@ namespace MvvmCross.Wpf.Views.Presenters
             return new MvxContentPresentationAttribute();
         }
 
-        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(Type viewModelType, Type viewType)
+        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType)
         {
             if (viewType?.GetInterface(nameof(IMvxOverridePresentationAttribute)) != null)
             {
@@ -96,7 +96,7 @@ namespace MvvmCross.Wpf.Views.Presenters
                 {
                     MvxBasePresentationAttribute presentationAttribute = null;
                     if (viewInstance is IMvxOverridePresentationAttribute overrideInstance)
-                        presentationAttribute = overrideInstance.PresentationAttribute();
+                        presentationAttribute = overrideInstance.PresentationAttribute(request);
 
                     if (presentationAttribute == null)
                     {
@@ -108,7 +108,7 @@ namespace MvvmCross.Wpf.Views.Presenters
                             presentationAttribute.ViewType = viewType;
 
                         if (presentationAttribute.ViewModelType == null)
-                            presentationAttribute.ViewModelType = viewModelType;
+                            presentationAttribute.ViewModelType = request.ViewModelType;
 
                         return presentationAttribute;
                     }

--- a/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs
@@ -41,14 +41,14 @@ namespace MvvmCross.iOS.Views.Presenters
             return new MvxChildPresentationAttribute() { ViewType = viewType, ViewModelType = viewModelType };
         }
 
-        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(Type viewModelType, Type viewType)
+        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType)
         {
             if (viewType?.GetInterface(nameof(IMvxOverridePresentationAttribute)) != null)
             {
                 var viewInstance = this.CreateViewControllerFor(viewType, null) as UIViewController;
                 using (viewInstance)
                 {
-                    var presentationAttribute = (viewInstance as IMvxOverridePresentationAttribute)?.PresentationAttribute();
+                    var presentationAttribute = (viewInstance as IMvxOverridePresentationAttribute)?.PresentationAttribute(request);
 
                     if (presentationAttribute == null)
                     {
@@ -60,7 +60,7 @@ namespace MvvmCross.iOS.Views.Presenters
                             presentationAttribute.ViewType = viewType;
 
                         if (presentationAttribute.ViewModelType == null)
-                            presentationAttribute.ViewModelType = viewModelType;
+                            presentationAttribute.ViewModelType = request.ViewModelType;
 
                         return presentationAttribute;
                     }
@@ -154,7 +154,7 @@ namespace MvvmCross.iOS.Views.Presenters
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
         #region Show implementations
@@ -334,7 +334,7 @@ namespace MvvmCross.iOS.Views.Presenters
 
         public override void Close(IMvxViewModel viewModel)
         {
-            GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
+            GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
         }
 
         #region Close implementations

--- a/MvvmCross/tvOS/tvOS/Views/Presenters/MvxTvosViewPresenter.cs
+++ b/MvvmCross/tvOS/tvOS/Views/Presenters/MvxTvosViewPresenter.cs
@@ -24,7 +24,7 @@ using UIKit;
 namespace MvvmCross.tvOS.Views.Presenters
 {
     public class MvxTvosViewPresenter
-        :  MvxAttributeViewPresenter, IMvxTvosViewPresenter
+        : MvxAttributeViewPresenter, IMvxTvosViewPresenter
     {
         private readonly IUIApplicationDelegate _applicationDelegate;
         protected IUIApplicationDelegate ApplicationDelegate => _applicationDelegate;
@@ -48,27 +48,30 @@ namespace MvvmCross.tvOS.Views.Presenters
 
         public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
         {
-            if (MasterNavigationController == null && 
+            if (MasterNavigationController == null &&
                TabBarViewController == null ||
                !TabBarViewController.CanShowChildView())
             {
                 MvxTrace.Trace($"PresentationAttribute nor MasterNavigationController found for {viewType.Name}. " +
                     $"Assuming Root presentation");
-                return new MvxRootPresentationAttribute() { 
-                    WrapInNavigationController = true, 
-                    ViewType = viewType, 
-                    ViewModelType = viewModelType };
+                return new MvxRootPresentationAttribute()
+                {
+                    WrapInNavigationController = true,
+                    ViewType = viewType,
+                    ViewModelType = viewModelType
+                };
             }
             MvxTrace.Trace($"PresentationAttribute not found for {viewType.Name}. " +
                 $"Assuming animated Child presentation");
-            return new MvxChildPresentationAttribute() { 
-                ViewType = viewType, 
-                ViewModelType = viewModelType };
+            return new MvxChildPresentationAttribute()
+            {
+                ViewType = viewType,
+                ViewModelType = viewModelType
+            };
 
         }
 
-        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(Type viewModelType, 
-                                                                                      Type viewType)
+        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType)
         {
             if (viewType?.GetInterface(nameof(IMvxOverridePresentationAttribute)) != null)
             {
@@ -76,7 +79,7 @@ namespace MvvmCross.tvOS.Views.Presenters
 
                 using (viewInstance)
                 {
-                    var presentationAttribute = (viewInstance as IMvxOverridePresentationAttribute)?.PresentationAttribute();
+                    var presentationAttribute = (viewInstance as IMvxOverridePresentationAttribute)?.PresentationAttribute(request);
 
                     if (presentationAttribute == null)
                     {
@@ -88,10 +91,10 @@ namespace MvvmCross.tvOS.Views.Presenters
                             presentationAttribute.ViewType = viewType;
 
                         if (presentationAttribute.ViewModelType == null)
-                            presentationAttribute.ViewModelType = viewModelType;
+                            presentationAttribute.ViewModelType = request.ViewModelType;
 
                         return presentationAttribute;
-                    }    
+                    }
                 }
             }
             return null;
@@ -106,11 +109,11 @@ namespace MvvmCross.tvOS.Views.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowRootViewController(viewController, 
-                                               (MvxRootPresentationAttribute)attribute, 
+                        ShowRootViewController(viewController,
+                                               (MvxRootPresentationAttribute)attribute,
                                                request);
                     },
-                    CloseAction = (viewModel, attribute) => CloseRootViewController(viewModel, 
+                    CloseAction = (viewModel, attribute) => CloseRootViewController(viewModel,
                                                                                     (MvxRootPresentationAttribute)attribute)
                 });
 
@@ -121,11 +124,11 @@ namespace MvvmCross.tvOS.Views.Presenters
                   ShowAction = (viewType, attribute, request) =>
                   {
                       var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                      ShowChildViewController(viewController, 
-                                              (MvxChildPresentationAttribute)attribute, 
+                      ShowChildViewController(viewController,
+                                              (MvxChildPresentationAttribute)attribute,
                                               request);
                   },
-                  CloseAction = (viewModel, attribute) => CloseChildViewController(viewModel, 
+                  CloseAction = (viewModel, attribute) => CloseChildViewController(viewModel,
                                                                                    (MvxChildPresentationAttribute)attribute)
               });
 
@@ -137,11 +140,11 @@ namespace MvvmCross.tvOS.Views.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowTabViewController(viewController, 
-                                              (MvxTabPresentationAttribute)attribute, 
+                        ShowTabViewController(viewController,
+                                              (MvxTabPresentationAttribute)attribute,
                                               request);
                     },
-                    CloseAction = (viewModel, attribute) => CloseTabViewController(viewModel, 
+                    CloseAction = (viewModel, attribute) => CloseTabViewController(viewModel,
                                                                                    (MvxTabPresentationAttribute)attribute)
                 });
 
@@ -166,8 +169,8 @@ namespace MvvmCross.tvOS.Views.Presenters
                       var viewController = (UIViewController)this.CreateViewControllerFor(request);
                       ShowMasterDetailSplitViewController(viewController, (MvxMasterDetailPresentationAttribute)attribute, request);
                   },
-                  CloseAction = (viewModel, attribute) => CloseMasterSplitViewController(viewModel, (MvxMasterDetailPresentationAttribute)attribute) 
-                  });
+                  CloseAction = (viewModel, attribute) => CloseMasterSplitViewController(viewModel, (MvxMasterDetailPresentationAttribute)attribute)
+              });
         }
 
         protected virtual bool CloseRootViewController(IMvxViewModel viewModel,
@@ -179,13 +182,13 @@ namespace MvvmCross.tvOS.Views.Presenters
 
         protected virtual bool CloseChildViewController(IMvxViewModel viewModel, MvxChildPresentationAttribute attribute)
         {
-            if(ModalViewControllers.Any())
+            if (ModalViewControllers.Any())
             {
                 foreach (var navController in ModalViewControllers.Where(v => v is UINavigationController))
                 {
                     if (TryCloseViewControllerInsideStack((UINavigationController)navController, viewModel))
                         return true;
-                }     
+                }
             }
 
             if (TabBarViewController != null && TabBarViewController.CloseChildViewModel(viewModel))
@@ -202,7 +205,7 @@ namespace MvvmCross.tvOS.Views.Presenters
             if (TabBarViewController == null)
                 return;
 
-            if (TabBarViewController is UITabBarController tabController 
+            if (TabBarViewController is UITabBarController tabController
                && tabController.ViewControllers != null)
             {
                 foreach (var viewController in tabController.ViewControllers)
@@ -221,10 +224,10 @@ namespace MvvmCross.tvOS.Views.Presenters
             return false;
         }
 
-        protected virtual bool CloseModalViewController(IMvxViewModel viewModel, 
+        protected virtual bool CloseModalViewController(IMvxViewModel viewModel,
                                                         MvxModalPresentationAttribute attribute)
         {
-            return CloseModalViewController(viewModel);   
+            return CloseModalViewController(viewModel);
         }
 
         protected virtual bool CloseModalViewController(IMvxViewModel viewModel)
@@ -342,15 +345,15 @@ namespace MvvmCross.tvOS.Views.Presenters
             SplitViewController = null;
         }
 
-        public override void Close(IMvxViewModel viewModel )
+        public override void Close(IMvxViewModel viewModel)
         {
-            GetPresentationAttributeAction(viewModel.GetType(), out MvxBasePresentationAttribute attribute)
+            GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute)
                 .CloseAction.Invoke(viewModel, attribute);
         }
 
         public override void Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request.ViewModelType, out MvxBasePresentationAttribute attribute)
+            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute)
                 .ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
@@ -358,8 +361,8 @@ namespace MvvmCross.tvOS.Views.Presenters
                                            MvxRootPresentationAttribute attribute,
                                            MvxViewModelRequest request)
         {
-           if (viewController is IMvxTabBarViewController)
-           {
+            if (viewController is IMvxTabBarViewController)
+            {
                 //NOTE clean up must be done first incase we are enbedding into a navigation controller
                 //before setting the tab view controller, otherwise this will reset the view stack and your tab
                 //controller will be null. 
@@ -369,13 +372,13 @@ namespace MvvmCross.tvOS.Views.Presenters
                 CleanupModalViewControllers();
 
                 return;
-           }
+            }
 
-           SetupWindowRootNavigation(viewController, attribute);
+            SetupWindowRootNavigation(viewController, attribute);
 
-           CleanupModalViewControllers();
-           CloseTabBarViewController();
-           CloseSplitViewController();
+            CleanupModalViewControllers();
+            CloseTabBarViewController();
+            CloseSplitViewController();
         }
 
         protected virtual void ShowChildViewController(UIViewController viewController,
@@ -412,8 +415,8 @@ namespace MvvmCross.tvOS.Views.Presenters
             throw new MvxException($"Trying to show View type: {viewController.GetType().Name} as child, but there is no current stack!");
         }
 
-        protected virtual void ShowModalViewController(UIViewController viewController, 
-                                                       MvxModalPresentationAttribute attribute, 
+        protected virtual void ShowModalViewController(UIViewController viewController,
+                                                       MvxModalPresentationAttribute attribute,
                                                        MvxViewModelRequest request)
         {
             // setup modal based on attribute
@@ -471,7 +474,7 @@ namespace MvvmCross.tvOS.Views.Presenters
             }
             else if (SplitViewController != null && attribute.Position == MasterDetailPosition.Detail)
             {
-                ShowDetailView(viewController, attribute.WrapInNavigationController);   
+                ShowDetailView(viewController, attribute.WrapInNavigationController);
             }
             else if (viewController is MvxSplitViewController && attribute.Position == MasterDetailPosition.Root)
             {
@@ -484,7 +487,7 @@ namespace MvvmCross.tvOS.Views.Presenters
                 CloseTabBarViewController();
                 return;
             }
-            else 
+            else
             {
                 throw new MvxException("Trying to show a master page without a SplitViewController, this is not possible!");
             }
@@ -531,20 +534,20 @@ namespace MvvmCross.tvOS.Views.Presenters
                 TabBarViewController = tabBarController;
         }
 
-        protected void SetupWindowRootNavigation(UIViewController viewController, 
+        protected void SetupWindowRootNavigation(UIViewController viewController,
                                                  MvxRootPresentationAttribute attribute)
         {
             if (attribute.WrapInNavigationController)
             {
-                MasterNavigationController = CreateNavigationController(viewController);     
+                MasterNavigationController = CreateNavigationController(viewController);
                 SetWindowRootViewController(MasterNavigationController);
             }
-            else 
+            else
             {
-                SetWindowRootViewController(viewController);     
+                SetWindowRootViewController(viewController);
                 CloseMasterNavigationController();
             }
-                
+
         }
 
         protected void SetupSplitViewWindowRootNavigation(UIViewController viewController,
@@ -567,7 +570,7 @@ namespace MvvmCross.tvOS.Views.Presenters
         {
             foreach (var v in _window.Subviews)
                 v.RemoveFromSuperview();
-            
+
             _window.AddSubview(controller.View);
             _window.RootViewController = controller;
         }
@@ -602,10 +605,10 @@ namespace MvvmCross.tvOS.Views.Presenters
 
         protected void CleanupModalViewControllers()
         {
-            while(ModalViewControllers.Any())
+            while (ModalViewControllers.Any())
             {
-                CloseModalViewController(ModalViewControllers.LastOrDefault());     
-            }  
+                CloseModalViewController(ModalViewControllers.LastOrDefault());
+            }
         }
 
     }

--- a/TestProjects/Eventhooks/Eventhooks.Core/ViewModels/FirstViewModel.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Core/ViewModels/FirstViewModel.cs
@@ -3,47 +3,47 @@ using MvvmCross.Platform.Platform;
 
 namespace Eventhooks.Core.ViewModels
 {
-	public class FirstViewModel
-		: MvxViewModel
-	{
-	    public override void ViewCreated()
-	    {
-	        MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is created");
-	    }
+    public class FirstViewModel
+        : MvxViewModel
+    {
+        public override void ViewCreated()
+        {
+            MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is created");
+        }
 
-	    public override void ViewDestroy()
-	    {
-	        MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is destroyed");
-	    }
+        public override void ViewDestroy(bool viewFinishing = true)
+        {
+            MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is destroyed");
+        }
 
-	    public override void ViewAppearing()
-		{
-			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is appearing");
-		}
+        public override void ViewAppearing()
+        {
+            MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is appearing");
+        }
 
-		public override void ViewAppeared()
-		{
-			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View appeared");
-		}
+        public override void ViewAppeared()
+        {
+            MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View appeared");
+        }
 
-		public override void ViewDisappearing()
-		{
-			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is disappearing");
-		}
+        public override void ViewDisappearing()
+        {
+            MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View is disappearing");
+        }
 
-		public override void ViewDisappeared()
-		{
-			MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View has disappeared");
-		}
+        public override void ViewDisappeared()
+        {
+            MvxTrace.Trace(MvxTraceLevel.Diagnostic, "View has disappeared");
+        }
 
-		public IMvxCommand ShowSecondView
-		{
-			get { return new MvxCommand(ExecuteSecondViewCommand); }
-		}
+        public IMvxCommand ShowSecondView
+        {
+            get { return new MvxCommand(ExecuteSecondViewCommand); }
+        }
 
-		private void ExecuteSecondViewCommand()
-		{
-			ShowViewModel<SecondViewModel>();
-		}
-	}
+        private void ExecuteSecondViewCommand()
+        {
+            ShowViewModel<SecondViewModel>();
+        }
+    }
 }

--- a/TestProjects/Eventhooks/Eventhooks.Core/ViewModels/SecondViewModel.cs
+++ b/TestProjects/Eventhooks/Eventhooks.Core/ViewModels/SecondViewModel.cs
@@ -10,7 +10,7 @@ namespace Eventhooks.Core.ViewModels
             MvxTrace.Trace(MvxTraceLevel.Diagnostic, "2nd View is created");
         }
 
-        public override void ViewDestroy()
+        public override void ViewDestroy(bool viewFinishing = true)
         {
             MvxTrace.Trace(MvxTraceLevel.Diagnostic, "2nd View is destroyed");
         }

--- a/TestProjects/Playground/Playground.Droid/Views/OverrideAttributeView.cs
+++ b/TestProjects/Playground/Playground.Droid/Views/OverrideAttributeView.cs
@@ -3,6 +3,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross.Binding.Droid.BindingContext;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.Droid.Support.V4;
 using MvvmCross.Droid.Views.Attributes;
@@ -24,7 +25,7 @@ namespace Playground.Droid.Views
             return view;
         }
 
-        public MvxBasePresentationAttribute PresentationAttribute()
+        public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
             return new MvxFragmentPresentationAttribute(
                 typeof(RootViewModel),

--- a/TestProjects/Playground/Playground.Forms.Droid/Views/OverrideAttributeView.cs
+++ b/TestProjects/Playground/Playground.Forms.Droid/Views/OverrideAttributeView.cs
@@ -3,6 +3,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross.Binding.Droid.BindingContext;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.Droid.Support.V4;
 using MvvmCross.Droid.Views.Attributes;
@@ -23,9 +24,9 @@ namespace Playground.Forms.Droid.Views
             return view;
         }
 
-        public MvxBasePresentationAttribute PresentationAttribute()
+        public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
-            return new MvxFragmentPresentationAttribute(){ AddToBackStack = true };
+            return new MvxFragmentPresentationAttribute() { AddToBackStack = true };
         }
     }
 }

--- a/TestProjects/Playground/Playground.Forms.iOS/Views/OverrideAttributeView.cs
+++ b/TestProjects/Playground/Playground.Forms.iOS/Views/OverrideAttributeView.cs
@@ -1,5 +1,6 @@
 using System;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
@@ -20,7 +21,7 @@ namespace Playground.iOS.Forms.Views
         {
         }
 
-        public MvxBasePresentationAttribute PresentationAttribute()
+        public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
             return new MvxModalPresentationAttribute
             {

--- a/TestProjects/Playground/Playground.Mac/RootView.cs
+++ b/TestProjects/Playground/Playground.Mac/RootView.cs
@@ -10,6 +10,7 @@ using Playground.Core.ViewModels;
 using MvvmCross.Binding.BindingContext;
 using System.Linq;
 using MvvmCross.Core.Views;
+using MvvmCross.Core.ViewModels;
 
 namespace Playground.Mac
 {
@@ -47,7 +48,7 @@ namespace Playground.Mac
             base.ViewDidDisappear();
         }
 
-        public MvxBasePresentationAttribute PresentationAttribute()
+        public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
             if (!NSApplication.SharedApplication.Windows.Any())
                 return null;

--- a/TestProjects/Playground/Playground.TvOS/Views/OverrideAttributeView.cs
+++ b/TestProjects/Playground/Playground.TvOS/Views/OverrideAttributeView.cs
@@ -1,25 +1,23 @@
 using System;
-
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.tvOS.Views;
 using MvvmCross.tvOS.Views.Presenters.Attributes;
-
 using Playground.Core.ViewModels;
-
 using UIKit;
 
 namespace Playground.TvOS
 {
     [MvxFromStoryboard("Main")]
-    public partial class OverrideAttributeView 
+    public partial class OverrideAttributeView
         : MvxViewController<OverrideAttributeViewModel>, IMvxOverridePresentationAttribute
-	{
-		public OverrideAttributeView (IntPtr handle) : base (handle)
-		{
-		}
+    {
+        public OverrideAttributeView(IntPtr handle) : base(handle)
+        {
+        }
 
-        public MvxBasePresentationAttribute PresentationAttribute()
+        public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
             return new MvxModalPresentationAttribute
             {
@@ -41,5 +39,5 @@ namespace Playground.TvOS
             set.Apply();
         }
 
-	}
+    }
 }

--- a/TestProjects/Playground/Playground.iOS/Views/OverrideAttributeView.cs
+++ b/TestProjects/Playground/Playground.iOS/Views/OverrideAttributeView.cs
@@ -1,5 +1,6 @@
 using System;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters.Attributes;
@@ -15,7 +16,7 @@ namespace Playground.iOS.Views
         {
         }
 
-        public MvxBasePresentationAttribute PresentationAttribute()
+        public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
             return new MvxModalPresentationAttribute
             {

--- a/docs/_documentation/presenters/android-view-presenter.md
+++ b/docs/_documentation/presenters/android-view-presenter.md
@@ -105,7 +105,7 @@ Note: If you intend to display your fragment in more than one host activity, ple
 To override a presentation attribute at runtime you can implement the `IMvxOverridePresentationAttribute` in your view and determine the presentation attribute in the `PresentationAttribute` method like this:
 
 ```c#
-public MvxBasePresentationAttribute PresentationAttribute()
+public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
 {
     return new MvxFragmentPresentationAttribute()
     {
@@ -114,9 +114,11 @@ public MvxBasePresentationAttribute PresentationAttribute()
 }
 ```
 
-If you return `null` from the `PresentationAttribute` the View Presenter will fallback to the attribute used to decorate the view. If the view is not decorated with a presentation attribute it will use the default presentation attribute.
+As you can see in the code snippet, you will be able to make your choice using a `MvxViewModelRequest`. This object will contain the `PresentationValues` dictionary alongside other properties. 
 
-__Note:__ Be aware that your ViewModel will be null during `PresentationAttribute`, so the logic you can perform there is limited here. Reason to this limitation is MvvmCross Presenters are stateless, you can't connect an already instantiated ViewModel with a new View.
+If you return `null` from the `PresentationAttribute` method, the ViewPresenter will fallback to the attribute used to decorate the view. If the view is not decorated with any presentation attribute, then it will use the default attribute instead.
+
+__Hint:__ Be aware that `this.ViewModel` property will be null during `PresentationAttribute`. If you want to have the ViewModel instance available, you need to use the `MvxNavigationService` and cast the `request` parameter to `MvxViewModelInstanceRequest`.
 
 ## Extensibility
 

--- a/docs/_documentation/presenters/ios-view-presenter.md
+++ b/docs/_documentation/presenters/ios-view-presenter.md
@@ -97,7 +97,7 @@ There is an attribute member that can be used to customize the presentation:
 To override a presentation attribute at runtime you can implement the `IMvxOverridePresentationAttribute` in your view controller and determine the presentation attribute in the `PresentationAttribute` method like this:
 
 ```c#
-public MvxBasePresentationAttribute PresentationAttribute()
+public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
 {
     return new MvxModalPresentationAttribute
     {
@@ -107,9 +107,11 @@ public MvxBasePresentationAttribute PresentationAttribute()
 }
 ```
 
-If you return `null` from the `PresentationAttribute` the iOS View Presenter will fallback to the attribute used to decorate the view controller. If the view controller is not decorated with a presentation attribute it will use the default presentation attribute (a _animated_ child presentation).
+As you can see in the code snippet, you will be able to make your choice using a `MvxViewModelRequest`. This object will contain the `PresentationValues` dictionary alongside other properties. 
 
-__Note:__ Be aware that your ViewModel will be null during `PresentationAttribute`, so the logic you can perform there is limited here. Reason to this limitation is MvvmCross Presenters are stateless, you can't connect an already instantiated ViewModel with a new View.
+If you return `null` from the `PresentationAttribute` method, the ViewPresenter will fallback to the attribute used to decorate the view. If the view is not decorated with any presentation attribute, then it will use the default attribute instead.
+
+__Hint:__ Be aware that `this.ViewModel` property will be null during `PresentationAttribute`. If you want to have the ViewModel instance available, you need to use the `MvxNavigationService` and cast the `request` parameter to `MvxViewModelInstanceRequest`.
 
 ## Extensibility
 The presenter is completely extensible! You can override any attribute and customize attribute members.

--- a/docs/_documentation/presenters/mac-view-presenter.md
+++ b/docs/_documentation/presenters/mac-view-presenter.md
@@ -82,7 +82,7 @@ The presentation can be customized through this properties:
 
 To override a presentation attribute at runtime you can implement the `IMvxOverridePresentationAttribute` in your ViewController and determine the presentation attribute in the `PresentationAttribute` method like this:
 ```c#
-public MvxBasePresentationAttribute PresentationAttribute()
+public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
 {
     return new MvxModalPresentationAttribute
     {
@@ -91,9 +91,11 @@ public MvxBasePresentationAttribute PresentationAttribute()
 }
 ```
 
-If you return `null` from the `PresentationAttribute` the Mac View Presenter will fallback to the attribute used to decorate the view controller. If the view controller is not decorated with a presentation attribute it will use the default presentation attribute (a new window).
+As you can see in the code snippet, you will be able to make your choice using a `MvxViewModelRequest`. This object will contain the `PresentationValues` dictionary alongside other properties. 
 
-__Note:__ Be aware that your ViewModel will be null during `PresentationAttribute`, so the logic you can perform there is limited here. Reason to this limitation is MvvmCross Presenters are stateless, you can't connect an already instantiated ViewModel with a new View.
+If you return `null` from the `PresentationAttribute` method, the ViewPresenter will fallback to the attribute used to decorate the view. If the view is not decorated with any presentation attribute, then it will use the default attribute instead.
+
+__Hint:__ Be aware that `this.ViewModel` property will be null during `PresentationAttribute`. If you want to have the ViewModel instance available, you need to use the `MvxNavigationService` and cast the `request` parameter to `MvxViewModelInstanceRequest`.
 
 ## Extensibility
 The presenter is completely extensible! You can override any attribute and customize attribute members.

--- a/docs/_documentation/presenters/tvos-view-presenter.md
+++ b/docs/_documentation/presenters/tvos-view-presenter.md
@@ -85,7 +85,7 @@ There is an attribute member that can be used to customize the presentation:
 To override a presentation attribute at runtime you can implement the `IMvxOverridePresentationAttribute` in your view controller and determine the presentation attribute in the `PresentationAttribute` method like this:
 
 ```c#
-public MvxBasePresentationAttribute PresentationAttribute()
+public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
 {
     return new MvxModalPresentationAttribute
     {
@@ -95,9 +95,11 @@ public MvxBasePresentationAttribute PresentationAttribute()
 }
 ```
 
-If you return `null` from the `PresentationAttribute` the tvOS View Presenter will fallback to the attribute used to decorate the view controller. If the view controller is not decorated with a presentation attribute it will use the default presentation attribute (a _animated_ child presentation).
+As you can see in the code snippet, you will be able to make your choice using a `MvxViewModelRequest`. This object will contain the `PresentationValues` dictionary alongside other properties. 
 
-__Note:__ Be aware that your ViewModel will be null during `PresentationAttribute`, so the logic you can perform there is limited here. Reason to this limitation is MvvmCross Presenters are stateless, you can't connect an already instantiated ViewModel with a new View.
+If you return `null` from the `PresentationAttribute` method, the ViewPresenter will fallback to the attribute used to decorate the view. If the view is not decorated with any presentation attribute, then it will use the default attribute instead.
+
+__Hint:__ Be aware that `this.ViewModel` property will be null during `PresentationAttribute`. If you want to have the ViewModel instance available, you need to use the `MvxNavigationService` and cast the `request` parameter to `MvxViewModelInstanceRequest`.
 
 ## Extensibility
 The presenter is completely extensible! You can override any attribute and customize attribute members.

--- a/docs/_documentation/presenters/wpf-view-presenter.md
+++ b/docs/_documentation/presenters/wpf-view-presenter.md
@@ -82,22 +82,20 @@ If a `Window` class has no attribute over it, the presenter will assume _Window_
 To override a presentation attribute at runtime you can implement the `IMvxOverridePresentationAttribute` in your view and determine the presentation attribute in the `PresentationAttribute` method like this:
 
 ```c#
-public partial class WindowView :
-    MvxWindow<WindowViewModel>,
-    IMvxOverridePresentationAttribute
+public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
 {
-    public WindowView() => InitializeComponent();
-
-    // Override a presentation attribute at runtime
-    public MvxBasePresentationAttribute PresentationAttribute() =>
-        new MvxWindowPresentationAttribute
-        {
-            Identifier = $"{nameof(WindowView)}.{ViewModel.Count}"
-        };
+    return new MvxWindowPresentationAttribute
+    {
+        Identifier = $"{nameof(WindowView)}.{ViewModel.Count}"
+    };
 }
 ```
 
-If you return `null` from the `PresentationAttribute`, the presenter will assume presentation the same way as views without attributes.
+As you can see in the code snippet, you will be able to make your choice using a `MvxViewModelRequest`. This object will contain the `PresentationValues` dictionary alongside other properties. 
+
+If you return `null` from the `PresentationAttribute` method, the ViewPresenter will fallback to the attribute used to decorate the view. If the view is not decorated with any presentation attribute, then it will use the default attribute instead.
+
+__Hint:__ Be aware that `this.ViewModel` property will be null during `PresentationAttribute`. If you want to have the ViewModel instance available, you need to use the `MvxNavigationService` and cast the `request` parameter to `MvxViewModelInstanceRequest`.
 
 
 ## Extensibility


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
`IMvxOverridePresentationAttribute` is currently very limited, as there is almost any information the developer has to make a decision.

### :new: What is the new behavior (if this is a feature change)?
`IMvxOverridePresentationAttribute.PresentationAttribute` now has the MvxViewModelRequest as parameter, and if the navigation is performed using the MvxNavigationService, then the ViewModel instance is available through a cast to `MvxViewModelInstanceRequest`.

### :boom: Does this PR introduce a breaking change?
Yes, some method signatures have changed in interfaces and classes. 

### :bug: Recommendations for testing
Run TestProjects/Playground.

### :memo: Links to relevant issues/docs
Fixes: #2340
Also closes #2211, as this will provide a much better way to manage dynamic values for presentation.

### :thinking: Checklist before submitting

- [x] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
