### PR TITLE
Fixing navigation to master detail pages for UWP

### DIFF
--- a/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs
@@ -130,11 +130,25 @@ namespace MvvmCross.Uwp.Views
 
                 if (attribute.Position == SplitPanePosition.Content)
                 {
-                    splitView.Content = (UIElement)Activator.CreateInstance(viewType);
+                    var nestedFrame = splitView.Content as Frame;
+                    if (nestedFrame == null)
+                    {
+                        nestedFrame = new Frame();
+                        splitView.Content = nestedFrame;
+                    }
+                    var requestText = GetRequestText(request);
+                    nestedFrame.Navigate(viewType, requestText);
                 }
                 else if (attribute.Position == SplitPanePosition.Pane)
                 {
-                    splitView.Pane = (UIElement)Activator.CreateInstance(viewType);
+                    var nestedFrame = splitView.Pane as Frame;
+                    if (nestedFrame == null)
+                    {
+                        nestedFrame = new Frame();
+                        splitView.Pane = nestedFrame;
+                    }
+                    var requestText = GetRequestText(request);
+                    nestedFrame.Navigate(viewType, requestText);
                 }
             }
         }

--- a/TestProjects/Playground/Playground.Core/ViewModels/SplitDetailViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SplitDetailViewModel.cs
@@ -16,6 +16,8 @@ namespace Playground.Core.ViewModels
 
         public IMvxAsyncCommand ShowChildCommand { get; private set; }
 
+        public string ContentText => "Text for the Content Area";
+
         public override void ViewAppeared()
         {
             base.ViewAppeared();

--- a/TestProjects/Playground/Playground.Core/ViewModels/SplitMasterViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/SplitMasterViewModel.cs
@@ -18,6 +18,8 @@ namespace Playground.Core.ViewModels
             ShowRootViewModel = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
         }
 
+        public string PaneText => "Text for the Master Pane";
+
         public IMvxAsyncCommand OpenDetailCommand { get; private set; }
 
         public IMvxAsyncCommand OpenDetailNavCommand { get; private set; }

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitDetailView.xaml
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitDetailView.xaml
@@ -5,5 +5,8 @@
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:views="using:MvvmCross.Uwp.Views"
                       mc:Ignorable="d">
-    <TextBlock Text="Content" />
+    <StackPanel>
+        <TextBlock Text="Content" />
+        <TextBlock Text="{Binding ContentText}" />
+    </StackPanel>
 </views:MvxWindowsPage>

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitMasterView.xaml
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitMasterView.xaml
@@ -5,5 +5,8 @@
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:views="using:MvvmCross.Uwp.Views"
                       mc:Ignorable="d">
-    <TextBlock Text="Pane" />
+    <StackPanel>
+        <TextBlock Text="Pane" />
+        <TextBlock Text="{Binding PaneText}" />
+    </StackPanel>
 </views:MvxWindowsPage>

--- a/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml.cs
+++ b/TestProjects/Playground/Playground.Uwp/Views/SplitRootView.xaml.cs
@@ -16,16 +16,6 @@ namespace Playground.Uwp.Views
         public SplitRootView()
         {
             this.InitializeComponent();
-            this.DataContextChanged += OnDataContextChanged;
-        }
-
-        private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
-        {
-            if (DataContext is SplitRootViewModel viewModel)
-            {
-                viewModel.ShowInitialMenuCommand.Execute();
-                viewModel.ShowDetailCommand.Execute();
-            }
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Master details implementation doesn't navigate to either master or detail pages - this means the MVX lifecycle is completely skipped

### :new: What is the new behavior (if this is a feature change)?
Both Master and Detail are hosted in a frame, which means the mvx page/viewmodel lifecycle is invoked

### :boom: Does this PR introduce a breaking change?
Yes - existing users of the MasterDetail implementation will see different behaviour

### :bug: Recommendations for testing
Run UWP playground sample

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [X ] Rebased onto current develop
