### PR TITLE
Fix for Expand/Colapse problem when GroupClick is bound.

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxExpandableListView.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxExpandableListView.cs
@@ -151,7 +151,8 @@ namespace MvvmCross.Binding.Droid.Views
 
         private void GroupOnClick(object sender, GroupClickEventArgs e)
         {
-           ExecuteCommandOnGroup(GroupClick, e.GroupPosition);
+            ExecuteCommandOnGroup(GroupClick, e.GroupPosition);
+            e.Handled = false;
         }
 
         private void EnsureItemLongClickOverloaded()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When GroupClick is bound the group is not expanding/collapsing

### :new: What is the new behavior (if this is a feature change)?
When GroupClick is bound the group will still expand/collapse

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2408

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
