### PR TITLE
New events binding

### DIFF
--- a/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Reflection;
+using System.Windows.Input;
+
+namespace MvvmCross.Binding.Bindings.Target
+{
+    public class MvxEventNameTargetBinding : MvxTargetBinding
+    {
+        private readonly EventInfo _targetEventInfo;
+        private readonly bool _useEventArgsAsCommandParameter;
+
+        private ICommand _currentCommand;
+
+        public MvxEventNameTargetBinding(object target, string targetEventName, bool useEventArgsAsCommandParameter = true) : base(target)
+        {
+            _targetEventInfo = target.GetType().GetTypeInfo().GetDeclaredEvent(targetEventName);
+            _useEventArgsAsCommandParameter = useEventArgsAsCommandParameter;
+
+            //  addMethod is used because of error:
+            // "Attempting to JIT compile method '(wrapper delegate-invoke) <Module>:invoke_void__this___UIControl_EventHandler (UIKit.UIControl,System.EventHandler)' while running with --aot-only."
+            // see https://bugzilla.xamarin.com/show_bug.cgi?id=3682
+            var addMethod = _targetEventInfo.AddMethod;
+            addMethod.Invoke(target, new object[] { new EventHandler(HandleEvent) });
+        }
+
+        public override Type TargetType { get; } = typeof(ICommand);
+
+        public override MvxBindingMode DefaultMode { get; } = MvxBindingMode.OneWay;
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                var target = Target;
+                if (target != null)
+                {
+                    var removeMethod = _targetEventInfo.RemoveMethod;
+                    removeMethod.Invoke(target, new object[] { new EventHandler(HandleEvent) });
+                }
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        private void HandleEvent(object sender, EventArgs parameter)
+        {
+            var commandParameter = _useEventArgsAsCommandParameter ? (object)parameter : null;
+
+            if (_currentCommand != null && _currentCommand.CanExecute(commandParameter))
+                _currentCommand.Execute(commandParameter);
+        }
+
+        public override void SetValue(object value)
+        {
+            var command = value as ICommand;
+            _currentCommand = command;
+        }
+    }
+
+    public class MvxEventNameTargetBinding<TEventArgs> : MvxTargetBinding
+    {
+        private readonly EventInfo _targetEventInfo;
+        private readonly bool _useEventArgsAsCommandParameter;
+
+        private ICommand _currentCommand;
+
+        public MvxEventNameTargetBinding(object target, string targetEventName, bool useEventArgsAsCommandParameter = true) : base(target)
+        {
+            _targetEventInfo = target.GetType().GetTypeInfo().GetDeclaredEvent(targetEventName);
+            _useEventArgsAsCommandParameter = useEventArgsAsCommandParameter;
+
+            //  addMethod is used because of error:
+            // "Attempting to JIT compile method '(wrapper delegate-invoke) <Module>:invoke_void__this___UIControl_EventHandler (UIKit.UIControl,System.EventHandler)' while running with --aot-only."
+            // see https://bugzilla.xamarin.com/show_bug.cgi?id=3682
+            var addMethod = _targetEventInfo.AddMethod;
+            addMethod.Invoke(target, new object[] { new EventHandler<TEventArgs>(HandleEvent) });
+        }
+
+        public override Type TargetType { get; } = typeof(ICommand);
+
+        public override MvxBindingMode DefaultMode { get; } = MvxBindingMode.OneWay;
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                var target = Target;
+                if (target != null)
+                {
+                    var removeMethod = _targetEventInfo.RemoveMethod;
+                    removeMethod.Invoke(target, new object[] { new EventHandler<TEventArgs>(HandleEvent) });
+                }
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        private void HandleEvent(object sender, TEventArgs parameter)
+        {
+            var commandParameter = _useEventArgsAsCommandParameter ? (object)parameter : null;
+
+            if (_currentCommand != null && _currentCommand.CanExecute(commandParameter))
+                _currentCommand.Execute(commandParameter);
+        }
+
+        public override void SetValue(object value)
+        {
+            var command = value as ICommand;
+            _currentCommand = command;
+        }
+    }
+}

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
@@ -1,26 +1,20 @@
 ﻿using System;
-using System.Reflection;
 using System.Windows.Input;
+using MvvmCross.Platform.WeakSubscription;
 
 namespace MvvmCross.Binding.Bindings.Target
 {
     public class MvxEventNameTargetBinding : MvxTargetBinding
     {
-        private readonly EventInfo _targetEventInfo;
         private readonly bool _useEventArgsAsCommandParameter;
+        private readonly IDisposable _eventSubscription;
 
         private ICommand _currentCommand;
 
         public MvxEventNameTargetBinding(object target, string targetEventName, bool useEventArgsAsCommandParameter = true) : base(target)
         {
-            _targetEventInfo = target.GetType().GetTypeInfo().GetDeclaredEvent(targetEventName);
             _useEventArgsAsCommandParameter = useEventArgsAsCommandParameter;
-
-            //  addMethod is used because of error:
-            // "Attempting to JIT compile method '(wrapper delegate-invoke) <Module>:invoke_void__this___UIControl_EventHandler (UIKit.UIControl,System.EventHandler)' while running with --aot-only."
-            // see https://bugzilla.xamarin.com/show_bug.cgi?id=3682
-            var addMethod = _targetEventInfo.AddMethod;
-            addMethod.Invoke(target, new object[] { new EventHandler(HandleEvent) });
+            _eventSubscription = target.WeakSubscribe(targetEventName, HandleEvent);
         }
 
         public override Type TargetType { get; } = typeof(ICommand);
@@ -31,12 +25,7 @@ namespace MvvmCross.Binding.Bindings.Target
         {
             if (isDisposing)
             {
-                var target = Target;
-                if (target != null)
-                {
-                    var removeMethod = _targetEventInfo.RemoveMethod;
-                    removeMethod.Invoke(target, new object[] { new EventHandler(HandleEvent) });
-                }
+                _eventSubscription.Dispose();
             }
 
             base.Dispose(isDisposing);

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
@@ -24,10 +24,8 @@ namespace MvvmCross.Binding.Bindings.Target
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)
-            {
                 _eventSubscription.Dispose();
-            }
-
+            
             base.Dispose(isDisposing);
         }
 

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
@@ -24,9 +24,7 @@ namespace MvvmCross.Binding.Bindings.Target
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)
-            {
                 _eventSubscription.Dispose();
-            }
 
             base.Dispose(isDisposing);
         }

--- a/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
+++ b/MvvmCross/Core/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
@@ -4,7 +4,7 @@ using System.Windows.Input;
 
 namespace MvvmCross.Binding.Bindings.Target
 {
-    public class MvxEventNameTargetBinding : MvxTargetBinding
+    public class MvxEventNameTargetBinding<TEventArgs> : MvxTargetBinding
     {
         private readonly EventInfo _targetEventInfo;
         private readonly bool _useEventArgsAsCommandParameter;
@@ -20,7 +20,7 @@ namespace MvvmCross.Binding.Bindings.Target
             // "Attempting to JIT compile method '(wrapper delegate-invoke) <Module>:invoke_void__this___UIControl_EventHandler (UIKit.UIControl,System.EventHandler)' while running with --aot-only."
             // see https://bugzilla.xamarin.com/show_bug.cgi?id=3682
             var addMethod = _targetEventInfo.AddMethod;
-            addMethod.Invoke(target, new object[] { new EventHandler(HandleEvent) });
+            addMethod.Invoke(target, new object[] { new EventHandler<TEventArgs>(HandleEvent) });
         }
 
         public override Type TargetType { get; } = typeof(ICommand);
@@ -35,14 +35,14 @@ namespace MvvmCross.Binding.Bindings.Target
                 if (target != null)
                 {
                     var removeMethod = _targetEventInfo.RemoveMethod;
-                    removeMethod.Invoke(target, new object[] { new EventHandler(HandleEvent) });
+                    removeMethod.Invoke(target, new object[] { new EventHandler<TEventArgs>(HandleEvent) });
                 }
             }
 
             base.Dispose(isDisposing);
         }
 
-        private void HandleEvent(object sender, EventArgs parameter)
+        private void HandleEvent(object sender, TEventArgs parameter)
         {
             var commandParameter = _useEventArgsAsCommandParameter ? (object)parameter : null;
 

--- a/MvvmCross/Core/Binding/MvvmCross.Binding.csproj
+++ b/MvvmCross/Core/Binding/MvvmCross.Binding.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Combiners\MvxLessThanValueCombiner.cs" />
     <Compile Include="Combiners\MvxNotEqualToPairwiseValueCombiner.cs" />
     <Compile Include="Bindings\Target\MvxEventNameTargetBinding.cs" />
+    <Compile Include="Bindings\Target\MvxEventNameTargetBindingOfTEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Platform\Platform\MvvmCross.Platform.csproj">

--- a/MvvmCross/Core/Binding/MvvmCross.Binding.csproj
+++ b/MvvmCross/Core/Binding/MvvmCross.Binding.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Combiners\MvxLessThanOrEqualToValueCombiner.cs" />
     <Compile Include="Combiners\MvxLessThanValueCombiner.cs" />
     <Compile Include="Combiners\MvxNotEqualToPairwiseValueCombiner.cs" />
+    <Compile Include="Bindings\Target\MvxEventNameTargetBinding.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Platform\Platform\MvvmCross.Platform.csproj">

--- a/docs/_documentation/fundamentals/custom-data-binding.md
+++ b/docs/_documentation/fundamentals/custom-data-binding.md
@@ -129,6 +129,10 @@ This class is a subclass of [`MvxConvertingTargetBinding`](#mvxconvertingtargetb
 
 This class is a subclass of [`MvxPropertyInfoTargetBinding`](#mvxpropertyinfotargetbinding), which is a shortcut to adding `TwoWay` bindings based on a specific event. Similarly to `MvxPropertyInfoTargetBinding` it uses the `PropertyInfo` to implement the `SetValue()` method. Additionally it implements the `SubscribeToEvents()` method, based on the assumption that there is an event which is called the same as the name of the property, postfixed with `Changed`. So if your property is called `MyProperty` it assumes that the corresponding event is called `MyPropertChanged`.
 
+#### MvxEventNameTargetBinding
+
+This class is a subclass of [`MvxTargetBinding`](#mvxtargetbinding), which is a shortcut to adding `OneWay` binding to a command based on a specific event. Acceptable event delegates are `EventHandler` and `EventHandler<TEventArgs>` where `TEventArgs` can be any class or structure (with `TEventArgs` you have to use the generic version of this binding). All you have to pass for this binding is the target object and the name of the target event. By default it also passes event handler's `EventArgs` (or `TEventArgs`) as a command parameter, but you can disable it in the constructor.
+
 #### MvxAndroidTargetBinding
 
 This class is a subclass of [`MvxConvertingTargetBinding`](#mvxconvertingtargetbinding), which provides the current `IMvxAndroidGlobals`, to be able to get the current `ApplicationContext` for stuff like getting resources from the Android Resources and other operations which require the `ApplicationContext`.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature:
I've created new target event binding, which uses event name (string) instead of EventInfo and also can use EventArgs parameter as Command parameter

### :arrow_heading_down: What is the current behavior?
Current MvxEventHandlerEventInfoTargetBinding and MvxEventInfoTargetBinding uses EventInfo reflection property as an argument for binding. Also it doesn't support command parameter in binding.

### :new: What is the new behavior (if this is a feature change)?
My approach is to use event name only. It can be simply for use as here: new MvxEventNameTargetBinding(button, nameof(button.Clicked)). Also by default it uses EventHandler EventArgs or TEventArgs and passes it as a CommandParameter.

### :boom: Does this PR introduce a breaking change?
No, only adding new target binding

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
