### PR TITLE
Adding support for navigation to native pages with no presentation attribute to UWP

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Droid/Views/MvxFormsAndroidViewPresenter.cs
@@ -45,6 +45,7 @@ namespace MvvmCross.Forms.Droid.Views
                     _formsPagePresenter = new MvxFormsPagePresenter(FormsApplication, ViewsContainer, ViewModelTypeFinder, attributeTypesToActionsDictionary: AttributeTypesToActionsDictionary);
                     _formsPagePresenter.ClosePlatformViews = ClosePlatformViews;
                     _formsPagePresenter.ShowPlatformHost = ShowPlatformHost;
+                    _formsPagePresenter.PlatformCreatePresentationAttribute = CreatePresentationAttribute;
                     Mvx.RegisterSingleton(_formsPagePresenter);
                 }
                 return _formsPagePresenter;
@@ -65,12 +66,6 @@ namespace MvvmCross.Forms.Droid.Views
             base.RegisterAttributeTypes();
 
             FormsPagePresenter.RegisterAttributeTypes();
-        }
-
-        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
-        {
-            var presentationAttribute = FormsPagePresenter.CreatePresentationAttribute(viewModelType, viewType);
-            return presentationAttribute ?? base.CreatePresentationAttribute(viewModelType, viewType);
         }
 
         public virtual bool ClosePlatformViews()

--- a/MvvmCross-Forms/MvvmCross.Forms.Mac/Views/MvxFormsMacViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Mac/Views/MvxFormsMacViewPresenter.cs
@@ -1,25 +1,11 @@
-// MvxFormsIosPagePresenter.cs
-// 2015 (c) Copyright Cheesebaron. http://ostebaronen.dk
-// MvvmCross.Forms is licensed using Microsoft Public License (Ms-PL)
-// Contributions and inspirations noted in readme.md and license.txt
-//
-// Project Lead - Tomasz Cielecki, @cheesebaron, mvxplugins@ostebaronen.dk
-// Contributor - Marcos Cobeña Morián, @CobenaMarcos, marcoscm@me.com
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using AppKit;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Core.Views;
 using MvvmCross.Forms.Platform;
 using MvvmCross.Forms.Views;
-using MvvmCross.Forms.Views.Attributes;
-using MvvmCross.Mac.Views;
 using MvvmCross.Mac.Views.Presenters;
 using MvvmCross.Platform;
-using MvvmCross.Platform.Platform;
-using Xamarin.Forms;
+using System;
 
 namespace MvvmCross.Forms.Mac.Presenters
 {
@@ -48,6 +34,7 @@ namespace MvvmCross.Forms.Mac.Presenters
                 {
                     _formsPagePresenter = new MvxFormsPagePresenter(FormsApplication, ViewsContainer, ViewModelTypeFinder, attributeTypesToActionsDictionary: AttributeTypesToActionsDictionary);
                     _formsPagePresenter.ClosePlatformViews = ClosePlatformViews;
+                    _formsPagePresenter.PlatformCreatePresentationAttribute = CreatePresentationAttribute;
                     Mvx.RegisterSingleton(_formsPagePresenter);
                 }
                 return _formsPagePresenter;
@@ -68,12 +55,6 @@ namespace MvvmCross.Forms.Mac.Presenters
             base.RegisterAttributeTypes();
 
             FormsPagePresenter.RegisterAttributeTypes();
-        }
-
-        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
-        {
-            var presentationAttribute = FormsPagePresenter.CreatePresentationAttribute(viewModelType, viewType);
-            return presentationAttribute ?? base.CreatePresentationAttribute(viewModelType, viewType);
         }
 
         public virtual bool ClosePlatformViews()

--- a/MvvmCross-Forms/MvvmCross.Forms.Uwp/Views/MvxFormsUwpViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Uwp/Views/MvxFormsUwpViewPresenter.cs
@@ -46,6 +46,7 @@ namespace MvvmCross.Forms.Uwp.Presenters
                 {
                     _formsPagePresenter = new MvxFormsPagePresenter(FormsApplication, ViewsContainer, ViewModelTypeFinder, attributeTypesToActionsDictionary: AttributeTypesToActionsDictionary);
                     _formsPagePresenter.ClosePlatformViews = ClosePlatformViews;
+                    _formsPagePresenter.PlatformCreatePresentationAttribute = CreatePresentationAttribute;
                     Mvx.RegisterSingleton(_formsPagePresenter);
                 }
                 return _formsPagePresenter;
@@ -66,12 +67,6 @@ namespace MvvmCross.Forms.Uwp.Presenters
         public override void ChangePresentation(MvxPresentationHint hint)
         {
             FormsPagePresenter.ChangePresentation(hint);
-        }
-
-        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
-        {
-            var presentationAttribute = FormsPagePresenter.CreatePresentationAttribute(viewModelType, viewType);
-            return presentationAttribute ?? base.CreatePresentationAttribute(viewModelType, viewType);
         }
 
         public virtual bool ClosePlatformViews()

--- a/MvvmCross-Forms/MvvmCross.Forms.iOS/Views/MvxFormsIosViewPresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.iOS/Views/MvxFormsIosViewPresenter.cs
@@ -48,6 +48,7 @@ namespace MvvmCross.Forms.iOS.Presenters
                 {
                     _formsPagePresenter = new MvxFormsPagePresenter(FormsApplication, ViewsContainer, ViewModelTypeFinder, attributeTypesToActionsDictionary: AttributeTypesToActionsDictionary);
                     _formsPagePresenter.ClosePlatformViews = ClosePlatformViews;
+                    _formsPagePresenter.PlatformCreatePresentationAttribute = CreatePresentationAttribute;
                     Mvx.RegisterSingleton(_formsPagePresenter);
                 }
                 return _formsPagePresenter;
@@ -71,12 +72,6 @@ namespace MvvmCross.Forms.iOS.Presenters
             base.RegisterAttributeTypes();
 
             FormsPagePresenter.RegisterAttributeTypes();
-        }
-
-        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
-        {
-            var presentationAttribute = FormsPagePresenter.CreatePresentationAttribute(viewModelType, viewType);
-            return presentationAttribute ?? base.CreatePresentationAttribute(viewModelType, viewType);
         }
 
         public virtual bool ClosePlatformViews()

--- a/MvvmCross-Forms/MvvmCross.Forms/Views/IMvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/IMvxFormsPagePresenter.cs
@@ -16,6 +16,9 @@ namespace MvvmCross.Forms.Views
 
         Func<bool> ClosePlatformViews { get; set; }
 
+        // This method allows each platform to create attributes for native views
+        Func<Type,Type, MvxBasePresentationAttribute> PlatformCreatePresentationAttribute { get; set; }
+
         Func<Type, bool> ShowPlatformHost { get; set; }
     }
 }

--- a/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -55,6 +55,8 @@ namespace MvvmCross.Forms.Views
             }
         }
 
+        public Func<Type, Type, MvxBasePresentationAttribute> PlatformCreatePresentationAttribute { get; set; }
+
         public virtual Func<Type, bool> ShowPlatformHost { get; set; }
         public virtual Func<bool> ClosePlatformViews { get; set; }
 
@@ -153,7 +155,7 @@ namespace MvvmCross.Forms.Views
 
         public async override void ChangePresentation(MvxPresentationHint hint)
         {
-            var navigation = GetPageOfType<NavigationPage>().Navigation;
+            var navigation = GetPageOfType<NavigationPage>()?.Navigation;
             if (hint is MvxPopToRootPresentationHint popToRootHint)
             {
                 // Make sure all modals are closed
@@ -355,7 +357,7 @@ namespace MvvmCross.Forms.Views
                 return new MvxNavigationPagePresentationAttribute() { ViewType = viewType, ViewModelType = viewModelType };
             }
 
-            return null;
+            return PlatformCreatePresentationAttribute?.Invoke(viewModelType,viewType);
         }
 
         public virtual void ShowContentPage(

--- a/TestProjects/Playground/Playground.Core/ViewModels/NativeViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/NativeViewModel.cs
@@ -1,0 +1,9 @@
+﻿using MvvmCross.Core.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class NativeViewModel: MvxViewModel
+    {
+
+    }
+}

--- a/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -29,6 +29,8 @@ namespace Playground.Core.ViewModels
 
             ShowSplitCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitRootViewModel>());
 
+            ShowNativeCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NativeViewModel>());
+
             ShowOverrideAttributeCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<OverrideAttributeViewModel>());
 
             ShowSheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SheetViewModel>());
@@ -81,6 +83,8 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowSplitCommand { get; private set; }
 
         public IMvxAsyncCommand ShowOverrideAttributeCommand { get; private set; }
+
+        public IMvxAsyncCommand ShowNativeCommand { get; private set; }
 
         public IMvxAsyncCommand ShowSheetCommand { get; private set; }
 

--- a/TestProjects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
+++ b/TestProjects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
@@ -17,6 +17,7 @@
                 <Button Text="Show Master/Detail" mvx:Bi.nd="Command ShowSplitCommand"/>
                 <Button Text="Show Mixed Navigation" mvx:Bi.nd="Command ShowMixedNavigationCommand"/>
                 <Label Text="Native views" />
+                <Button Text="Show Native Page" mvx:Bi.nd="Command ShowNativeCommand"/>
                 <Button Text="Show Override" mvx:Bi.nd="Command ShowOverrideAttributeCommand"/>
                 <Button Text="Show BottomSheet" mvx:Bi.nd="Command ShowSheetCommand"/>
                 <Label Text="Test views" />

--- a/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
@@ -16,7 +16,9 @@ namespace Playground.Forms.Uwp
     {
         public MainPage()
         {
-            this.InitializeComponent();
+            // This is required so that navigating to a native page and back again doesn't
+            // reload XF
+            NavigationCacheMode = Windows.UI.Xaml.Navigation.NavigationCacheMode.Required;
 
             InitializeComponent();
 

--- a/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml
+++ b/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml
@@ -1,0 +1,13 @@
+<views:MvxWindowsPage xmlns:views="using:MvvmCross.Uwp.Views"
+    x:Class="Playground.Forms.Uwp.NativePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Playground.Forms.Uwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    </Grid>
+</views:MvxWindowsPage>

--- a/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml.cs
@@ -1,0 +1,15 @@
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Playground.Forms.Uwp
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class NativePage
+    {
+        public NativePage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/TestProjects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -100,6 +100,9 @@
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="NativePage.xaml.cs">
+      <DependentUpon>NativePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Setup.cs" />
   </ItemGroup>
@@ -128,6 +131,10 @@
     <Page Include="MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="NativePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
When attempting to navigate to a native view on UWP if no presentation attribute is specified, an exception is thrown

### :new: What is the new behavior (if this is a feature change)?
Application will navigate to the native view

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run the Playground Forms UWP application

### :memo: Links to relevant issues/docs
Fixes #2466

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ X ] Rebased onto current develop
