### PR TITLE
Avoid the Foundation.You_Should_Not_Call_base_In_This_Method exception

### DIFF
--- a/MvvmCross-Forms/MvvmCross.Forms.Mac/Platform/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross-Forms/MvvmCross.Forms.Mac/Platform/MvxFormsApplicationDelegate.cs
@@ -31,13 +31,11 @@ namespace MvvmCross.Forms.Mac
         public override void WillBecomeActive(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.ActivatedFromMemory);
-            base.WillBecomeActive(notification);
         }
 
         public override void DidResignActive(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Deactivated);
-            base.DidResignActive(notification);
         }
 
         public override void WillTerminate(Foundation.NSNotification notification)

--- a/MvvmCross/Mac/Mac/Platform/MvxApplicationDelegate.cs
+++ b/MvvmCross/Mac/Mac/Platform/MvxApplicationDelegate.cs
@@ -15,13 +15,11 @@ namespace MvvmCross.Mac.Platform
         public override void WillBecomeActive(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.ActivatedFromMemory);
-            base.WillBecomeActive(notification);
         }
 
         public override void DidResignActive(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Deactivated);
-            base.DidResignActive(notification);
         }
 
         public override void WillTerminate(Foundation.NSNotification notification)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?

When running the Playground.Mac project, there will be an exception of `Foundation.You_Should_Not_Call_base_In_This_Method `
### :new: What is the new behavior (if this is a feature change)?
No exception

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Playgournd.Mac project

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
