### PR TITLE
Fix MvxTabBarViewController.CloseTab: Pick correct ViewController

### DIFF
--- a/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/iOS/iOS/Views/MvxTabBarViewController.cs
@@ -142,7 +142,7 @@ namespace MvvmCross.iOS.Views
                 var root = ((UINavigationController)vc).ViewControllers.FirstOrDefault();
                 if (root != null && root.GetIMvxIosView().ViewModel == viewModel)
                 {
-                    toClose = root;
+                    toClose = vc;
                     break;
                 }
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When trying to close a Tab that is wrapped in a NavigationController, inside a MvxTabBarViewController, nothing happens.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed (the tab is closed).

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run Playground.iOS and try to close a tab wrapped in a navigation controller.

### :memo: Links to relevant issues/docs
/

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
