### PR TITLE
Checks fragment type when showing a DialogFragment and throws MvxException instead of InvalidCastException

### DIFF
--- a/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -346,7 +346,11 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         {
             var fragmentName = FragmentJavaName(attribute.ViewType);
             IMvxFragmentView mvxFragmentView = CreateFragment(attribute, fragmentName);
-            var dialog = (DialogFragment)mvxFragmentView;
+            var dialog = mvxFragmentView as DialogFragment;
+            if(dialog == null)
+            {
+                throw new MvxException("Fragment {0} does not extend {1}", fragmentName, typeof(DialogFragment).FullName);
+            }
 
             // MvxNavigationService provides an already instantiated ViewModel here,
             // therefore just assign it


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix / improvement

### :arrow_heading_down: What is the current behavior?

If a fragment with `MvxDialogFragmentPresentation` does not extends `DialogFragment` (e.g. `MvxFragment` instead) a navigation attempt fails with a not very helpful `InvalidCastException`.

### :new: What is the new behavior (if this is a feature change)?

An `MvxException` with a better error message is thrown.

### :boom: Does this PR introduce a breaking change?

Kind of? The previous behavior (throwing an `InvalidCastException`) is not documented.

### :bug: Recommendations for testing

/shrug

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
