### PR TITLE
Add LogLevel availability check to IMvxLog

### DIFF
--- a/MvvmCross/Core/Core/Platform/LogProviders/MvxLog.cs
+++ b/MvvmCross/Core/Core/Platform/LogProviders/MvxLog.cs
@@ -14,6 +14,8 @@ namespace MvvmCross.Core.Platform.LogProviders
             _logger = logger;
         }
 
+        public bool IsLogLevelEnabled(MvxLogLevel logLevel) => _logger(logLevel, null);
+
         public bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
         {
             if (messageFunc == null)

--- a/MvvmCross/Platform/Platform/Logging/IMvxLog.cs
+++ b/MvvmCross/Platform/Platform/Logging/IMvxLog.cs
@@ -5,5 +5,7 @@ namespace MvvmCross.Platform.Logging
     public interface IMvxLog
     {
         bool Log(MvxLogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters);
+
+        bool IsLogLevelEnabled(MvxLogLevel logLevel);
     }
 }

--- a/MvvmCross/Platform/Platform/Logging/MvxLogExtensions.cs
+++ b/MvvmCross/Platform/Platform/Logging/MvxLogExtensions.cs
@@ -7,37 +7,37 @@ namespace MvvmCross.Platform.Logging
         public static bool IsDebugEnabled(this IMvxLog logger)
         {
             GuardAgainstNullLogger(logger);
-            return logger.Log(MvxLogLevel.Debug, null);
+            return logger.IsLogLevelEnabled(MvxLogLevel.Debug);
         }
 
         public static bool IsErrorEnabled(this IMvxLog logger)
         {
             GuardAgainstNullLogger(logger);
-            return logger.Log(MvxLogLevel.Error, null);
+            return logger.IsLogLevelEnabled(MvxLogLevel.Error);
         }
 
         public static bool IsFatalEnabled(this IMvxLog logger)
         {
             GuardAgainstNullLogger(logger);
-            return logger.Log(MvxLogLevel.Fatal, null);
+            return logger.IsLogLevelEnabled(MvxLogLevel.Fatal);
         }
 
         public static bool IsInfoEnabled(this IMvxLog logger)
         {
             GuardAgainstNullLogger(logger);
-            return logger.Log(MvxLogLevel.Info, null);
+            return logger.IsLogLevelEnabled(MvxLogLevel.Info);
         }
 
         public static bool IsTraceEnabled(this IMvxLog logger)
         {
             GuardAgainstNullLogger(logger);
-            return logger.Log(MvxLogLevel.Trace, null);
+            return logger.IsLogLevelEnabled(MvxLogLevel.Trace);
         }
 
         public static bool IsWarnEnabled(this IMvxLog logger)
         {
             GuardAgainstNullLogger(logger);
-            return logger.Log(MvxLogLevel.Warn, null);
+            return logger.IsLogLevelEnabled(MvxLogLevel.Warn);
         }
 
         public static void Debug(this IMvxLog logger, Func<string> messageFunc)
@@ -292,7 +292,7 @@ namespace MvvmCross.Platform.Logging
         {
             if (logger == null)
             {
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             }
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Improvement

### :arrow_heading_down: What is the current behavior?
Right now the `MvxLogExtensions` assume that all implementations of `IMvxLog` will behave like `MvxLog` when it comes to checking log levels; an incorrect assumption.

### :new: What is the new behavior (if this is a feature change)?
The underlying implementation of `MvxLog` remains the same: Relying on the current log provider to return a bool value indicating whether or not that log level is enabled. The interface change, however, will make consumers more aware of how level checking should work.

### :boom: Does this PR introduce a breaking change?
Nopity nope

### :bug: Recommendations for testing
ping @softlion 😄 

### :memo: Links to relevant issues/docs
Closes #2437

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Nuspec files were updated (when applicable)
- [x] Rebased onto current develop
