### PR TITLE
MvxAndroidViewsContainer: Remove NewTask flag as default

### DIFF
--- a/MvvmCross/Droid/Droid/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Droid/Droid/Views/MvxAndroidViewsContainer.cs
@@ -144,8 +144,6 @@ namespace MvvmCross.Droid.Views
 
         protected virtual void AdjustIntentForPresentation(Intent intent, MvxViewModelRequest request)
         {
-            intent.AddFlags(ActivityFlags.NewTask);
-
             //todo we want to do things here... clear top, remove history item, etc
             //#warning ClearTop is not enough :/ Need to work on an Intent based scheme like http://stackoverflow.com/questions/3007998/on-logout-clear-activity-history-stack-preventing-back-button-from-opening-l
             //            if (request.ClearTop)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement

### :arrow_heading_down: What is the current behavior?
Each time a new Activity is launched on Android, by default the flag NewTask is added.

### :new: What is the new behavior (if this is a feature change)?
The behaviour described above is fixed. 

As @davidschwegler commented on the original issue:

> NewTask is generally only used in rare cases where the calling app wants to switch to a completely different activity task (eg a different app's activity stack), rather than placing the called activity on top of your own stack.

### :boom: Does this PR introduce a breaking change?
Probably no, but we need to communicate this in the release blog.

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
Closes #962

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
