### PR TITLE
Adding NativePage to Playground sample for UWP

### DIFF
--- a/TestProjects/Playground/Playground.Core/Playground.Core.csproj
+++ b/TestProjects/Playground/Playground.Core/Playground.Core.csproj
@@ -41,6 +41,7 @@
     <Compile Include="ViewModels\MixedNavTab2ViewModel.cs" />
     <Compile Include="ViewModels\MixedNavTab1ViewModel.cs" />
     <Compile Include="ViewModels\MixedNavTabsViewModel.cs" />
+    <Compile Include="ViewModels\NativeViewModel.cs" />
     <Compile Include="ViewModels\WindowChildViewModel.cs" />
     <Compile Include="ViewModels\RootViewModel.cs" />
     <Compile Include="ViewModels\ChildViewModel.cs" />

--- a/TestProjects/Playground/Playground.Core/ViewModels/NativeViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/NativeViewModel.cs
@@ -1,0 +1,8 @@
+using MvvmCross.Core.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class NativeViewModel:MvxViewModel
+    {
+    }
+}

--- a/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/TestProjects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -29,6 +29,8 @@ namespace Playground.Core.ViewModels
 
             ShowSplitCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitRootViewModel>());
 
+            ShowNativeCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NativeViewModel>());
+
             ShowOverrideAttributeCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<OverrideAttributeViewModel>());
 
             ShowSheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SheetViewModel>());
@@ -81,6 +83,8 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowSplitCommand { get; private set; }
 
         public IMvxAsyncCommand ShowOverrideAttributeCommand { get; private set; }
+
+        public IMvxAsyncCommand ShowNativeCommand { get; private set; }
 
         public IMvxAsyncCommand ShowSheetCommand { get; private set; }
 

--- a/TestProjects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
+++ b/TestProjects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
@@ -18,6 +18,7 @@
                 <Button Text="Show Master/Detail" mvx:Bi.nd="Command ShowSplitCommand"/>
                 <Button Text="Show Mixed Navigation" mvx:Bi.nd="Command ShowMixedNavigationCommand"/>
                 <Label Text="Native views" />
+                <Button Text="Show Native Page" mvx:Bi.nd="Command ShowNativeCommand"/>
                 <Button Text="Show Override" mvx:Bi.nd="Command ShowOverrideAttributeCommand"/>
                 <Button Text="Show BottomSheet" mvx:Bi.nd="Command ShowSheetCommand"/>
                 <Label Text="Test views" />

--- a/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/MainPage.xaml.cs
@@ -16,6 +16,10 @@ namespace Playground.Forms.Uwp
     {
         public MainPage()
         {
+            // This is required so that navigating to a native page and back again doesn't
+            // reload XF
+            NavigationCacheMode = Windows.UI.Xaml.Navigation.NavigationCacheMode.Required;
+
             this.InitializeComponent();
 
             InitializeComponent();

--- a/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml
+++ b/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml
@@ -1,0 +1,14 @@
+<views:MvxWindowsPage x:Class="Playground.Forms.Uwp.NativePage"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:views="using:MvvmCross.Uwp.Views"
+                      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                      mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <TextBlock Text="Press back to go back button to the Forms application"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Center" />
+    </Grid>
+</views:MvxWindowsPage>

--- a/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml.cs
+++ b/TestProjects/Playground/Playground.Forms.Uwp/NativePage.xaml.cs
@@ -1,0 +1,10 @@
+namespace Playground.Forms.Uwp
+{
+    public sealed partial class NativePage 
+    {
+        public NativePage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/TestProjects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/TestProjects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -100,6 +100,9 @@
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="NativePage.xaml.cs">
+      <DependentUpon>NativePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Setup.cs" />
   </ItemGroup>
@@ -128,6 +131,10 @@
     <Page Include="MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="NativePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Sample update

### :arrow_heading_down: What is the current behavior?
No sample for UWP to show navigation to native page from forms application

### :new: What is the new behavior (if this is a feature change)?
Playground sample demonstrates how to navigate to a native UWP page

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run playground sample

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ X ] Rebased onto current develop
