### PR TITLE
Remove IMvxCommand implementation from MvxCommand<T>

### DIFF
--- a/MvvmCross/Core/Core/ViewModels/IMvxCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/IMvxCommand.cs
@@ -27,6 +27,8 @@ namespace MvvmCross.Core.ViewModels
         [Obsolete("Use the strongly typed version of CanExecute instead", true)]
         new bool CanExecute(object parameter);
 
+        void RaiseCanExecuteChanged();
+
         void Execute(T parameter);
 
         bool CanExecute(T parameter);

--- a/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
+++ b/MvvmCross/Core/Core/ViewModels/MvxCommand.cs
@@ -182,7 +182,7 @@ namespace MvvmCross.Core.ViewModels
 
     public class MvxCommand<T>
         : MvxCommandBase
-        , IMvxCommand, IMvxCommand<T>
+        , IMvxCommand<T>
     {
         private readonly Func<T, bool> _canExecute;
         private readonly Action<T> _execute;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Inconsistency fix

### :arrow_heading_down: What is the current behavior?
MvxCommand\<T> implements both IMvxCommand and IMvxCommand\<T>.

### :new: What is the new behavior (if this is a feature change)?
MvxCommand\<T> no longer implements IMvxCommand, consistent with MvxAsyncCommand\<T> not implementing IMvxAsyncCommand and it forces typing.

### :boom: Does this PR introduce a breaking change?
Yes, all MvxCommand\<T> can no longer be cast to IMvxCommand. Use the typed version IMvxCommand\<T>.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#2520 

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
