### PR TITLE
change GetCustomAttributes

### DIFF
--- a/MvvmCross/Core/Platform/ReflectionExtensions.cs
+++ b/MvvmCross/Core/Platform/ReflectionExtensions.cs
@@ -9,7 +9,7 @@ namespace MvvmCross.Platform
     {
         public static Attribute[] GetCustomAttributes(this Type type, Type attributeType, bool inherit)
         {
-            return type.GetTypeInfo().GetCustomAttributes(attributeType, inherit).OfType<Attribute>().ToArray();
+            return CustomAttributeExtensions.GetCustomAttributes(type, attributeType, inherit).ToArray();
         }
 
         public static bool IsInstanceOfType(this Type type, object obj)


### PR DESCRIPTION
change GetCustomAttributes

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Reduce cumbersome calls and type conversions.

### :arrow_heading_down: What is the current behavior?
Maintain the original function, but optimize the code

### :new: What is the new behavior (if this is a feature change)?
The first parameter(this Type type)conversion to MemberInfo Type,
In fact called:

> System.Reflection.CustomAttributeExtensions.GetCustomAttributes(this MemberInfo element, Type attributeType, bool inherit);



### :boom: Does this PR introduce a breaking change?
no.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://docs.microsoft.com/en-us/dotnet/api/system.attribute.getcustomattributes?view=netframework-4.7.1#System_Attribute_GetCustomAttributes_System_Reflection_MemberInfo_System_Type_System_Boolean_

### :thinking: Checklist before submitting
return type.GetTypeInfo().GetCustomAttributes(attributeType, inherit).OfType<Attribute>().ToArray();

- [* ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
