### PR TITLE
MvvmCross.Droid.Support.V14.Preference

### DIFF
--- a/MvvmCross.Android.Support/V14.Preference/EventSource/MvxBaseFragmentAdapter.cs
+++ b/MvvmCross.Android.Support/V14.Preference/EventSource/MvxBaseFragmentAdapter.cs
@@ -9,11 +9,10 @@ using System;
 using Android.App;
 using Android.Content;
 using Android.OS;
-//using Android.Support.V4.App;
 using MvvmCross.Droid.Views;
 using MvvmCross.Platform.Core;
 
-namespace MvvmCross.Droid.Support.V4.EventSource
+namespace MvvmCross.Droid.Support.V14.EventSource
 {
     public class MvxBaseFragmentAdapter
     {

--- a/MvvmCross.Android.Support/V14.Preference/EventSource/MvxBindingFragmentAdapter.cs
+++ b/MvvmCross.Android.Support/V14.Preference/EventSource/MvxBindingFragmentAdapter.cs
@@ -1,0 +1,143 @@
+﻿// MvxBindingFragmentAdapter.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using Android.App;
+using Android.OS;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.Views;
+using MvvmCross.Droid.Platform;
+using MvvmCross.Droid.Views;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Core;
+using MvvmCross.Platform.Platform;
+
+namespace MvvmCross.Droid.Support.V14.EventSource
+{
+    public class MvxBindingFragmentAdapter
+        : MvxBaseFragmentAdapter
+    {
+        public IMvxFragmentView FragmentView => Fragment as IMvxFragmentView;
+
+        public MvxBindingFragmentAdapter(IMvxEventSourceFragment eventSource)
+            : base(eventSource)
+        {
+            if (!(eventSource is IMvxFragmentView))
+                throw new ArgumentException("eventSource must be an IMvxFragmentView");
+        }
+
+        protected override void HandleCreateCalled(object sender, MvxValueEventArgs<Bundle> bundleArgs)
+        {
+            FragmentView.EnsureSetupInitialized();
+
+            // Create is called after Fragment is attached to Activity
+            // it's safe to assume that Fragment has activity
+
+            var hostMvxView = Fragment.Activity as IMvxAndroidView;
+            if (hostMvxView == null)
+            {
+                MvxTrace.Warning($"Fragment host for fragment type {Fragment.GetType()} is not of type IMvxAndroidView");
+                return;
+            }
+
+            // if restoring state, Activity.ViewModel might be null, so a harder mechanism is necessary
+            var viewModelType = hostMvxView.ViewModel != null
+                                       ? hostMvxView.ViewModel.GetType()
+                                       : hostMvxView.FindAssociatedViewModelTypeOrNull();
+
+            if (viewModelType == null)
+            {
+                MvxTrace.Warning($"ViewModel type for Activity {Fragment.Activity.GetType()} not found when trying to show fragment: {Fragment.GetType()}");
+                return;
+            }
+
+            Bundle bundle = null;
+            MvxViewModelRequest request = null;
+            if (bundleArgs?.Value != null)
+            {
+                // saved state
+                bundle = bundleArgs.Value;
+            }
+            else
+            {
+                var fragment = FragmentView as Fragment;
+                if (fragment?.Arguments != null)
+                {
+                    bundle = fragment.Arguments;
+                    var json = bundle.GetString("__mvxViewModelRequest");
+                    if (!string.IsNullOrEmpty(json))
+                    {
+                        IMvxNavigationSerializer serializer;
+                        if (!Mvx.TryResolve(out serializer))
+                        {
+                            MvxTrace.Warning(
+                                "Navigation Serializer not available, deserializing ViewModel Request will be hard");
+                        }
+                        else
+                        {
+                            request = serializer.Serializer.DeserializeObject<MvxViewModelRequest>(json);
+                        }
+                    }
+                }
+            }
+
+            IMvxSavedStateConverter converter;
+            if (!Mvx.TryResolve(out converter))
+            {
+                MvxTrace.Warning("Saved state converter not available - saving state will be hard");
+            }
+            else
+            {
+                if (bundle != null)
+                {
+                    var mvxBundle = converter.Read(bundle);
+                    FragmentView.OnCreate(mvxBundle, request);
+                }
+            }
+        }
+
+        protected override void HandleCreateViewCalled(object sender,
+            MvxValueEventArgs<MvxCreateViewParameters> args)
+        {
+            FragmentView.EnsureBindingContextIsSet(args.Value.Inflater);
+        }
+
+        protected override void HandleSaveInstanceStateCalled(object sender, MvxValueEventArgs<Bundle> bundleArgs)
+        {
+            // it is guarannted that SaveInstanceState call will be executed before OnStop (thus before Fragment detach)
+            // it is safe to assume that Fragment has activity attached
+
+            var mvxBundle = FragmentView.CreateSaveStateBundle();
+            if (mvxBundle != null)
+            {
+                IMvxSavedStateConverter converter;
+                if (!Mvx.TryResolve(out converter))
+                {
+                    MvxTrace.Warning("Saved state converter not available - saving state will be hard");
+                }
+                else
+                {
+                    converter.Write(bundleArgs.Value, mvxBundle);
+                }
+            }
+            var cache = Mvx.Resolve<IMvxMultipleViewModelCache>();
+            cache.Cache(FragmentView.ViewModel, FragmentView.UniqueImmutableCacheTag);
+        }
+
+        protected override void HandleDestroyViewCalled(object sender, EventArgs e)
+        {
+            FragmentView.BindingContext?.ClearAllBindings();
+            base.HandleDestroyViewCalled(sender, e);
+        }
+
+        protected override void HandleDisposeCalled(object sender, EventArgs e)
+        {
+            FragmentView.BindingContext?.ClearAllBindings();
+            base.HandleDisposeCalled(sender, e);
+        }
+    }
+}

--- a/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceDialogFragment.cs
+++ b/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceDialogFragment.cs
@@ -1,0 +1,133 @@
+﻿// MvxEventSourceDialogFragment.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using MvvmCross.Droid.Views;
+using MvvmCross.Platform.Core;
+
+namespace MvvmCross.Droid.Support.V14.EventSource
+{
+    public class MvxEventSourceDialogFragment
+        : DialogFragment, IMvxEventSourceFragment
+    {
+        public event EventHandler<MvxValueEventArgs<Context>> AttachCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateWillBeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateCalled;
+
+        public event EventHandler<MvxValueEventArgs<MvxCreateViewParameters>> CreateViewCalled;
+
+        public event EventHandler StartCalled;
+
+        public event EventHandler ResumeCalled;
+
+        public event EventHandler PauseCalled;
+
+        public event EventHandler StopCalled;
+
+        public event EventHandler DestroyViewCalled;
+
+        public event EventHandler DestroyCalled;
+
+        public event EventHandler DetachCalled;
+
+        public event EventHandler DisposeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        protected MvxEventSourceDialogFragment()
+        {
+        }
+
+        protected MvxEventSourceDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+
+		public override void OnAttach(Context context)
+        {
+            AttachCalled.Raise(this, context);
+            base.OnAttach(context);
+        }
+
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            CreateWillBeCalled.Raise(this, savedInstanceState);
+            base.OnCreate(savedInstanceState);
+            CreateCalled.Raise(this, savedInstanceState);
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            CreateViewCalled.Raise(this, new MvxCreateViewParameters(inflater, container, savedInstanceState));
+            return base.OnCreateView(inflater, container, savedInstanceState);
+        }
+
+        public override void OnStart()
+        {
+            StartCalled.Raise(this);
+            base.OnStart();
+        }
+
+        public override void OnResume()
+        {
+            ResumeCalled.Raise(this);
+            base.OnResume();
+        }
+
+        public override void OnPause()
+        {
+            PauseCalled.Raise(this);
+            base.OnPause();
+        }
+
+        public override void OnStop()
+        {
+            StopCalled.Raise(this);
+            base.OnStop();
+        }
+
+        public override void OnDestroyView()
+        {
+            DestroyViewCalled.Raise(this);
+            base.OnDestroyView();
+        }
+
+        public override void OnDestroy()
+        {
+            DestroyCalled.Raise(this);
+            base.OnDestroy();
+        }
+
+        public override void OnDetach()
+        {
+            DetachCalled.Raise(this);
+            base.OnDetach();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCalled.Raise(this);
+            }
+            base.Dispose(disposing);
+        }
+
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
+    }
+}

--- a/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceFragment.cs
+++ b/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceFragment.cs
@@ -1,0 +1,133 @@
+﻿// MvxEventSourceFragment.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using MvvmCross.Droid.Views;
+using MvvmCross.Platform.Core;
+
+namespace MvvmCross.Droid.Support.V14.EventSource
+{
+    public class MvxEventSourceFragment
+        : Fragment, IMvxEventSourceFragment
+    {
+        public event EventHandler<MvxValueEventArgs<Context>> AttachCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateWillBeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateCalled;
+
+        public event EventHandler<MvxValueEventArgs<MvxCreateViewParameters>> CreateViewCalled;
+
+        public event EventHandler StartCalled;
+
+        public event EventHandler ResumeCalled;
+
+        public event EventHandler PauseCalled;
+
+        public event EventHandler StopCalled;
+
+        public event EventHandler DestroyViewCalled;
+
+        public event EventHandler DestroyCalled;
+
+        public event EventHandler DetachCalled;
+
+        public event EventHandler DisposeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        public MvxEventSourceFragment()
+        {
+        }
+
+        public MvxEventSourceFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+
+		public override void OnAttach(Context context)
+        {
+            AttachCalled.Raise(this, context);
+            base.OnAttach(context);
+        }
+
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            CreateWillBeCalled.Raise(this, savedInstanceState);
+            base.OnCreate(savedInstanceState);
+            CreateCalled.Raise(this, savedInstanceState);
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            CreateViewCalled.Raise(this, new MvxCreateViewParameters(inflater, container, savedInstanceState));
+            return base.OnCreateView(inflater, container, savedInstanceState);
+        }
+
+        public override void OnStart()
+        {
+            StartCalled.Raise(this);
+            base.OnStart();
+        }
+
+        public override void OnResume()
+        {
+            ResumeCalled.Raise(this);
+            base.OnResume();
+        }
+
+        public override void OnPause()
+        {
+            PauseCalled.Raise(this);
+            base.OnPause();
+        }
+
+        public override void OnStop()
+        {
+            StopCalled.Raise(this);
+            base.OnStop();
+        }
+
+        public override void OnDestroyView()
+        {
+            DestroyViewCalled.Raise(this);
+            base.OnDestroyView();
+        }
+
+        public override void OnDestroy()
+        {
+            DestroyCalled.Raise(this);
+            base.OnDestroy();
+        }
+
+        public override void OnDetach()
+        {
+            DetachCalled.Raise(this);
+            base.OnDetach();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCalled.Raise(this);
+            }
+            base.Dispose(disposing);
+        }
+
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
+    }
+}

--- a/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceFragmentActivity.cs
+++ b/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceFragmentActivity.cs
@@ -1,0 +1,132 @@
+﻿// MvxEventSourceFragmentActivity.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using MvvmCross.Platform.Droid.Views;
+using MvvmCross.Platform.Core;
+using Android.Support.V4.App;
+
+namespace MvvmCross.Droid.Support.V14.EventSource
+{
+    public abstract class MvxEventSourceFragmentActivity
+        : FragmentActivity, IMvxEventSourceActivity
+    {
+        protected MvxEventSourceFragmentActivity()
+        {
+        }
+
+        protected MvxEventSourceFragmentActivity(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+        }
+
+        protected override void OnCreate(Bundle bundle)
+        {
+            CreateWillBeCalled.Raise(this, bundle);
+            base.OnCreate(bundle);
+            CreateCalled.Raise(this, bundle);
+        }
+
+        protected override void OnDestroy()
+        {
+            DestroyCalled.Raise(this);
+            base.OnDestroy();
+        }
+
+        protected override void OnNewIntent(Intent intent)
+        {
+            base.OnNewIntent(intent);
+            NewIntentCalled.Raise(this, intent);
+        }
+
+        protected override void OnResume()
+        {
+            base.OnResume();
+            ResumeCalled.Raise(this);
+        }
+
+        protected override void OnPause()
+        {
+            PauseCalled.Raise(this);
+            base.OnPause();
+        }
+
+        protected override void OnStart()
+        {
+            base.OnStart();
+            StartCalled.Raise(this);
+        }
+
+        protected override void OnRestart()
+        {
+            base.OnRestart();
+            RestartCalled.Raise(this);
+        }
+
+        protected override void OnStop()
+        {
+            StopCalled.Raise(this);
+            base.OnStop();
+        }
+
+        protected override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
+
+        public override void StartActivityForResult(Intent intent, int requestCode)
+        {
+            StartActivityForResultCalled.Raise(this, new MvxStartActivityForResultParameters(intent, requestCode));
+            base.StartActivityForResult(intent, requestCode);
+        }
+
+        protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
+        {
+            ActivityResultCalled.Raise(this, new MvxActivityResultParameters(requestCode, resultCode, data));
+            base.OnActivityResult(requestCode, resultCode, data);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCalled.Raise(this);
+            }
+            base.Dispose(disposing);
+        }
+
+        public event EventHandler DisposeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateWillBeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateCalled;
+
+        public event EventHandler DestroyCalled;
+
+        public event EventHandler<MvxValueEventArgs<Intent>> NewIntentCalled;
+
+        public event EventHandler ResumeCalled;
+
+        public event EventHandler PauseCalled;
+
+        public event EventHandler StartCalled;
+
+        public event EventHandler RestartCalled;
+
+        public event EventHandler StopCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        public event EventHandler<MvxValueEventArgs<MvxStartActivityForResultParameters>> StartActivityForResultCalled;
+
+        public event EventHandler<MvxValueEventArgs<MvxActivityResultParameters>> ActivityResultCalled;
+    }
+}

--- a/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceListFragment.cs
+++ b/MvvmCross.Android.Support/V14.Preference/EventSource/MvxEventSourceListFragment.cs
@@ -1,0 +1,132 @@
+﻿// MvxEventSourceListFragment.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using MvvmCross.Droid.Views;
+using MvvmCross.Platform.Core;
+
+namespace MvvmCross.Droid.Support.V14.EventSource
+{
+    public class MvxEventSourceListFragment
+        : ListFragment, IMvxEventSourceFragment
+    {
+        public event EventHandler<MvxValueEventArgs<Context>> AttachCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateWillBeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateCalled;
+
+        public event EventHandler<MvxValueEventArgs<MvxCreateViewParameters>> CreateViewCalled;
+
+        public event EventHandler StartCalled;
+
+        public event EventHandler ResumeCalled;
+
+        public event EventHandler PauseCalled;
+
+        public event EventHandler StopCalled;
+
+        public event EventHandler DestroyViewCalled;
+
+        public event EventHandler DestroyCalled;
+
+        public event EventHandler DetachCalled;
+
+        public event EventHandler DisposeCalled;
+
+        public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        protected MvxEventSourceListFragment()
+        {
+        }
+
+        protected MvxEventSourceListFragment(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+        }
+
+		public override void OnAttach(Context context)
+        {
+            AttachCalled.Raise(this, context);
+            base.OnAttach(context);
+        }
+
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            CreateWillBeCalled.Raise(this, savedInstanceState);
+            base.OnCreate(savedInstanceState);
+            CreateCalled.Raise(this, savedInstanceState);
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            CreateViewCalled.Raise(this, new MvxCreateViewParameters(inflater, container, savedInstanceState));
+            return base.OnCreateView(inflater, container, savedInstanceState);
+        }
+
+        public override void OnStart()
+        {
+            StartCalled.Raise(this);
+            base.OnStart();
+        }
+
+        public override void OnResume()
+        {
+            ResumeCalled.Raise(this);
+            base.OnResume();
+        }
+
+        public override void OnPause()
+        {
+            PauseCalled.Raise(this);
+            base.OnPause();
+        }
+
+        public override void OnStop()
+        {
+            StopCalled.Raise(this);
+            base.OnStop();
+        }
+
+        public override void OnDestroyView()
+        {
+            DestroyViewCalled.Raise(this);
+            base.OnDestroyView();
+        }
+
+        public override void OnDestroy()
+        {
+            DestroyCalled.Raise(this);
+            base.OnDestroy();
+        }
+
+        public override void OnDetach()
+        {
+            DetachCalled.Raise(this);
+            base.OnDetach();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCalled.Raise(this);
+            }
+            base.Dispose(disposing);
+        }
+
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
+    }
+}

--- a/MvvmCross.Android.Support/V14.Preference/MvxFragmentExtensions.cs
+++ b/MvvmCross.Android.Support/V14.Preference/MvxFragmentExtensions.cs
@@ -1,0 +1,112 @@
+// MvxFragmentExtensions.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+//
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using Android.App;
+using Android.Views;
+using MvvmCross.Binding.Droid.BindingContext;
+using MvvmCross.Core.ViewModels;
+using MvvmCross.Core.Views;
+using MvvmCross.Droid.Platform;
+using MvvmCross.Droid.Support.V14.EventSource;
+using MvvmCross.Droid.Views;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Exceptions;
+
+namespace MvvmCross.Droid.Support.V14
+{
+    public static class MvxFragmentExtensions
+    {
+        public static void AddEventListeners(this IMvxEventSourceFragment fragment)
+        {
+            if (fragment is IMvxFragmentView)
+            {
+                var adapter = new MvxBindingFragmentAdapter(fragment);
+            }
+        }
+
+        public static void OnCreate(this IMvxFragmentView fragmentView, IMvxBundle bundle, MvxViewModelRequest request = null)
+        {
+            if (fragmentView.ViewModel != null)
+            {
+                //TODO call MvxViewModelLoader.Reload when it's added in MvvmCross, tracked by #1165
+                //until then, we're going to re-run the viewmodel lifecycle here.
+                Views.MvxFragmentExtensions.RunViewModelLifecycle(fragmentView.ViewModel, bundle, request);
+
+                return;
+            }
+
+            var fragment = fragmentView.ToFragment();
+            if (fragment == null)
+                throw new MvxException($"{nameof(OnCreate)} called on an {nameof(IMvxFragmentView)} which is not an Android Fragment: {fragmentView}");
+
+            // as it is called during onCreate it is safe to assume that fragment has Activity attached.
+            var viewModelType = fragmentView.FindAssociatedViewModelType(fragment.Activity.GetType());
+            var view = fragmentView as IMvxView;
+
+            var cache = Mvx.Resolve<IMvxMultipleViewModelCache>();
+            var cached = cache.GetAndClear(viewModelType, fragmentView.UniqueImmutableCacheTag);
+
+            view.OnViewCreate(() => cached ?? fragmentView.LoadViewModel(bundle, fragment.Activity.GetType(), request));
+        }
+
+        public static Fragment ToFragment(this IMvxFragmentView fragmentView)
+        {
+            return fragmentView as Fragment;
+        }
+
+        public static void EnsureBindingContextIsSet(this IMvxFragmentView fragment, LayoutInflater inflater)
+        {
+            var actualFragment = fragment.ToFragment();
+            if (actualFragment == null)
+                throw new MvxException($"{nameof(EnsureBindingContextIsSet)} called on an {nameof(IMvxFragmentView)} which is not an Android Fragment: {fragment}");
+
+            if (fragment.BindingContext == null)
+            {
+                fragment.BindingContext = new MvxAndroidBindingContext(actualFragment.Activity,
+                    new MvxSimpleLayoutInflaterHolder(inflater),
+                    fragment.DataContext);
+            }
+            else
+            {
+                var androidContext = fragment.BindingContext as IMvxAndroidBindingContext;
+                if (androidContext != null)
+                    androidContext.LayoutInflaterHolder = new MvxSimpleLayoutInflaterHolder(inflater);
+            }
+        }
+
+        public static void EnsureBindingContextIsSet(this IMvxFragmentView fragment)
+        {
+            var actualFragment = fragment.ToFragment();
+            if (actualFragment == null)
+                throw new MvxException($"{nameof(EnsureBindingContextIsSet)} called on an {nameof(IMvxFragmentView)} which is not an Android Fragment: {fragment}");
+
+            if (fragment.BindingContext == null)
+            {
+                fragment.BindingContext = new MvxAndroidBindingContext(actualFragment.Activity,
+                    new MvxSimpleLayoutInflaterHolder(
+                        actualFragment.Activity.LayoutInflater),
+                    fragment.DataContext);
+            }
+            else
+            {
+                var androidContext = fragment.BindingContext as IMvxAndroidBindingContext;
+                if (androidContext != null)
+                    androidContext.LayoutInflaterHolder = new MvxSimpleLayoutInflaterHolder(actualFragment.Activity.LayoutInflater);
+            }
+        }
+
+        public static void EnsureSetupInitialized(this IMvxFragmentView fragmentView)
+        {
+            var fragment = fragmentView.ToFragment();
+            if (fragment == null)
+                throw new MvxException($"{nameof(EnsureSetupInitialized)} called on an {nameof(IMvxFragmentView)} which is not an Android Fragment: {fragmentView}");
+
+            var setupSingleton = MvxAndroidSetupSingleton.EnsureSingletonAvailable(fragment.Activity.ApplicationContext);
+            setupSingleton.EnsureInitialized();
+        }
+    }
+}

--- a/MvvmCross.Android.Support/V14.Preference/MvxPreferenceFragment.cs
+++ b/MvvmCross.Android.Support/V14.Preference/MvxPreferenceFragment.cs
@@ -2,7 +2,7 @@
 using Android.Runtime;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Core.ViewModels;
-using MvvmCross.Droid.Support.V4;
+using MvvmCross.Droid.Support.V14;
 using MvvmCross.Droid.Views;
 
 namespace MvvmCross.Droid.Support.V14.Preference


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
The class MvxPreferenceFragment throws an exception when it is created. The problem is the cross of MvvmCross.Droid.Support.V14 with MvvmCross.Droid.Support.V7

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?
Using the MvvmCross.Droid.Support.V14

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
