### PR TITLE
Rename Android NativeColor method for consistency

### DIFF
--- a/MvvmCross.Plugins/Color/Platform/Android/MvxAndroidColor.cs
+++ b/MvvmCross.Plugins/Color/Platform/Android/MvxAndroidColor.cs
@@ -15,10 +15,10 @@ namespace MvvmCross.Plugins.Color.Droid
     {
         public object ToNative(MvxColor mvxColor)
         {
-            return ToAndroidColor(mvxColor);
+            return ToNativeColor(mvxColor);
         }
 
-        public Android.Graphics.Color ToAndroidColor(MvxColor mvxColor)
+        public Android.Graphics.Color ToNativeColor(MvxColor mvxColor)
         {
             return new Android.Graphics.Color(mvxColor.R, mvxColor.G, mvxColor.B, mvxColor.A);
         }

--- a/MvvmCross.Plugins/Color/Platform/Android/MvxColorExtensions.cs
+++ b/MvvmCross.Plugins/Color/Platform/Android/MvxColorExtensions.cs
@@ -13,9 +13,9 @@ namespace MvvmCross.Plugins.Color.Droid
     {
         private static readonly MvxAndroidColor _mvxNativeColor = new MvxAndroidColor();
 
-        public static Android.Graphics.Color ToAndroidColor(this MvxColor color)
+        public static Android.Graphics.Color ToNativeColor(this MvxColor color)
         {
-            return _mvxNativeColor.ToAndroidColor(color);
+            return _mvxNativeColor.ToNativeColor(color);
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Renaming

### :arrow_heading_down: What is the current behavior?
All extension methods that convert an MvxColor into a platform color are called `ToNativeColor`, except for Droid's.

### :new: What is the new behavior (if this is a feature change)?
Droid method is renamed

### :boom: Does this PR introduce a breaking change?
It does, yes. Peeps will have to change the method name. 
This is by no means hard to fix and adds consistency.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
