### PR TITLE
Fix inheritance for MvxBaseSplitViewController class with constraint

### DIFF
--- a/MvvmCross/Platform/iOS/Views/MvxBaseSplitViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxBaseSplitViewController.cs
@@ -87,7 +87,7 @@ namespace MvvmCross.iOS.Views
         }
     }
 
-    public class MvxBaseSplitViewController<TViewModel> : MvxViewController, IMvxIosView<TViewModel>
+    public class MvxBaseSplitViewController<TViewModel> : MvxBaseSplitViewController, IMvxIosView<TViewModel>
         where TViewModel : class, IMvxViewModel
     {
         public MvxBaseSplitViewController()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
`MvxBaseSplitViewController<TViewModel> : MvxViewController`

### :new: What is the new behavior (if this is a feature change)?
`MvxBaseSplitViewController<TViewModel> : MvxBaseSplitViewController`

### :boom: Does this PR introduce a breaking change?
Probably, but it was broken.

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
/

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Nuspec files were updated (when applicable)
- [X] Rebased onto current develop
