### PR TITLE
Fixing startup issue where ioc isn't initialized

### DIFF
--- a/MvvmCross/Core/Core/Platform/MvxSetup.cs
+++ b/MvvmCross/Core/Core/Platform/MvxSetup.cs
@@ -1,4 +1,4 @@
-// MvxSetup.cs
+﻿// MvxSetup.cs
 
 // MvvmCross is licensed using Microsoft Public License (Ms-PL)
 // Contributions and inspirations noted in readme.md and license.txt
@@ -46,9 +46,9 @@ namespace MvvmCross.Core.Platform
                 throw new MvxException("Cannot start primary - as state already {0}", State);
             }
             State = MvxSetupState.InitializingPrimary;
+            InitializeIoC();
             InitializeLoggingServices();
             SetupLog.Trace("Setup: Primary start");
-            InitializeIoC();
             State = MvxSetupState.InitializedPrimary;
             if (State != MvxSetupState.InitializedPrimary)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
On startup logging is being setup before IoC which causes an exception

### :new: What is the new behavior (if this is a feature change)?
Logging is setup after IoC

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [  x ] Rebased onto current develop
