### PR TITLE
Fix that change presentation add handler is ignored in forms

### DIFF
--- a/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Views/MvxFormsPagePresenter.cs
@@ -205,7 +205,7 @@ namespace MvvmCross.Forms.Views
                 return;
             }
 
-            base.ChangePresentation(hint);
+            PlatformPresenter.ChangePresentation(hint);
 
 #if DEBUG // Only showing this when debugging MVX
             MvxFormsLog.Instance.Trace(FormsApplication.Hierarchy());


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Custom hints are ignored because they are added to a different presenter.

### :new: What is the new behavior (if this is a feature change)?

It works now

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2589

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
