### PR TITLE
Using IActivatedEventArgs in UWP

### DIFF
--- a/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
@@ -48,7 +48,7 @@ namespace MvvmCross.Forms.Platform.Uap.Core
             {
                 if (_formsApplication == null)
                 {
-                    Xamarin.Forms.Forms.Init(ActivatedEventArgs);
+                    Xamarin.Forms.Forms.Init(ActivationArguments);
                     _formsApplication = _formsApplication ?? CreateFormsApplication();
                 }
                 return _formsApplication;

--- a/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
@@ -21,15 +21,14 @@ using MvvmCross.Platform.Uap.Presenters;
 namespace MvvmCross.Forms.Platform.Uap.Core
 {
     public abstract class MvxFormsWindowsSetup : MvxWindowsSetup
-    {
-        private readonly IActivatedEventArgs _activatedEventArgs;
+    {        
         private List<Assembly> _viewAssemblies;
         private MvxFormsApplication _formsApplication;
 
         protected MvxFormsWindowsSetup(XamlControls.Frame rootFrame, IActivatedEventArgs e)
-            : base(rootFrame)
+            : base(rootFrame, e)
         {
-            _activatedEventArgs = e;
+
         }
 
         protected override IEnumerable<Assembly> GetViewAssemblies()
@@ -49,7 +48,7 @@ namespace MvvmCross.Forms.Platform.Uap.Core
             {
                 if (_formsApplication == null)
                 {
-                    Xamarin.Forms.Forms.Init(_activatedEventArgs);
+                    Xamarin.Forms.Forms.Init(ActivatedEventArgs);
                     _formsApplication = _formsApplication ?? CreateFormsApplication();
                 }
                 return _formsApplication;

--- a/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
@@ -22,24 +22,19 @@ namespace MvvmCross.Forms.Platform.Uap.Core
 {
     public abstract class MvxFormsWindowsSetup : MvxWindowsSetup
     {
-        private readonly LaunchActivatedEventArgs _launchActivatedEventArgs;
+        private readonly IActivatedEventArgs _activatedEventArgs;
         private List<Assembly> _viewAssemblies;
         private MvxFormsApplication _formsApplication;
 
-        protected MvxFormsWindowsSetup(XamlControls.Frame rootFrame, LaunchActivatedEventArgs e)
+        protected MvxFormsWindowsSetup(XamlControls.Frame rootFrame, IActivatedEventArgs e)
             : base(rootFrame)
         {
-            _launchActivatedEventArgs = e;
+            _activatedEventArgs = e;
         }
 
         protected override IEnumerable<Assembly> GetViewAssemblies()
         {
-            if (_viewAssemblies == null)
-            {
-                _viewAssemblies = new List<Assembly>(base.GetViewAssemblies());
-            }
-
-            return _viewAssemblies;
+            return _viewAssemblies ?? (_viewAssemblies = new List<Assembly>(base.GetViewAssemblies()));
         }
 
         protected override void InitializeApp(IMvxPluginManager pluginManager, IMvxApplication app)
@@ -54,7 +49,7 @@ namespace MvvmCross.Forms.Platform.Uap.Core
             {
                 if (_formsApplication == null)
                 {
-                    Xamarin.Forms.Forms.Init(_launchActivatedEventArgs);
+                    Xamarin.Forms.Forms.Init(_activatedEventArgs);
                     _formsApplication = _formsApplication ?? CreateFormsApplication();
                 }
                 return _formsApplication;

--- a/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
@@ -28,7 +28,6 @@ namespace MvvmCross.Forms.Platform.Uap.Core
         protected MvxFormsWindowsSetup(XamlControls.Frame rootFrame, IActivatedEventArgs e)
             : base(rootFrame, e)
         {
-
         }
 
         protected override IEnumerable<Assembly> GetViewAssemblies()

--- a/MvvmCross/Platform/Uap/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platform/Uap/Core/MvxWindowsSetup.cs
@@ -2,14 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Windows.UI.Xaml.Controls;
-using MvvmCross.Binding.Bindings.Target.Construction;
-using MvvmCross.Binding.BindingContext;
-using MvvmCross.Binding;
-using MvvmCross.Binding.Binders;
-using System;
-using System.Reflection;
 using MvvmCross.Converters;
 using MvvmCross.Exceptions;
 using MvvmCross.Plugins;
@@ -20,6 +12,7 @@ using MvvmCross.Platform.Uap.Views;
 using MvvmCross.Platform.Uap.Views.Suspension;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
+using Windows.ApplicationModel.Activation;
 
 namespace MvvmCross.Platform.Uap.Core
 {
@@ -29,6 +22,12 @@ namespace MvvmCross.Platform.Uap.Core
         private readonly IMvxWindowsFrame _rootFrame;
         private readonly string _suspensionManagerSessionStateKey;
         private IMvxWindowsViewPresenter _presenter;
+
+        protected MvxWindowsSetup(Frame rootFrame, IActivatedEventArgs activatedEventArgs,
+            string suspensionManagerSessionStateKey = null) : this(rootFrame, suspensionManagerSessionStateKey)
+        {
+            ActivatedEventArgs = activatedEventArgs;
+        }
 
         protected MvxWindowsSetup(Frame rootFrame, string suspensionManagerSessionStateKey = null)
             : this(new MvxWrappedFrame(rootFrame))
@@ -150,7 +149,9 @@ namespace MvvmCross.Platform.Uap.Core
             // this base class does nothing
         }
 
-        protected virtual List<Type> ValueConverterHolders => new List<Type>();
+        protected IActivatedEventArgs ActivatedEventArgs { get; }
+
+        protected virtual List<Type> ValueConverterHolders => new List<Type>();        
 
         protected virtual IEnumerable<Assembly> ValueConverterAssemblies
         {
@@ -161,7 +162,7 @@ namespace MvvmCross.Platform.Uap.Core
                 toReturn.AddRange(GetViewAssemblies());
                 return toReturn;
             }
-        }
+        }       
 
         protected virtual MvxBindingBuilder CreateBindingBuilder()
         {

--- a/MvvmCross/Platform/Uap/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platform/Uap/Core/MvxWindowsSetup.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platform.Uap.Core
         protected MvxWindowsSetup(Frame rootFrame, IActivatedEventArgs activatedEventArgs,
             string suspensionManagerSessionStateKey = null) : this(rootFrame, suspensionManagerSessionStateKey)
         {
-            ActivatedEventArgs = activatedEventArgs;
+            ActivationArguments = activatedEventArgs;
         }
 
         protected MvxWindowsSetup(Frame rootFrame, string suspensionManagerSessionStateKey = null)
@@ -149,7 +149,7 @@ namespace MvvmCross.Platform.Uap.Core
             // this base class does nothing
         }
 
-        protected IActivatedEventArgs ActivatedEventArgs { get; }
+        protected IActivatedEventArgs ActivationArguments { get; }
 
         protected virtual List<Type> ValueConverterHolders => new List<Type>();        
 

--- a/MvvmCross/Platform/Uap/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platform/Uap/Core/MvxWindowsSetup.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 using MvvmCross.Converters;
 using MvvmCross.Exceptions;
 using MvvmCross.Plugins;
@@ -13,6 +16,11 @@ using MvvmCross.Platform.Uap.Views.Suspension;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 using Windows.ApplicationModel.Activation;
+using Windows.UI.Xaml.Controls;
+using MvvmCross.Binding;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Binders;
 
 namespace MvvmCross.Platform.Uap.Core
 {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

**New feature**
This PR switches the `LaunchActivatedEventArgs` class in the constructor of `MvxFormsWindowsSetup` class for the more general `IActivatedEventArgs` interface.

The app can be launched in many **other ways than just by direct launch** (URI, File association, etc.), and instead of `LaunchActivatedEventArgs` you then have an instance of different class implementing `IActivatedEventArgs` and can't therefore create `MvxFormsWindowsSetup` instance.

Internally, `MvxFormsWindowsSetup` calls `Xamarin.Forms.Forms.Init` method, which expects an instance of `IActivatedEventArgs` and doesn't require an instance of `LaunchActivatedEventArgs` specifically.

### :arrow_heading_down: What is the current behavior?

The `MvxFormsWindowsSetup` constructor requires an instance of `LaunchActivatedEventArgs`.

### :new: What is the new behavior (if this is a feature change)?

The `MvxFormsWindowsSetup` constructor expects a more general instance of `IActivatedEventArgs`.

### :boom: Does this PR introduce a breaking change?

No, because `LaunchActivatedEventArgs` implements `IActivatedEventArgs`, the new interface is just more permissive and allows other activation types like URI, File, Search and many others.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

[IActivatedEventArgs in Docs](https://docs.microsoft.com/en-us/uwp/api/Windows.ApplicationModel.Activation.IActivatedEventArgs).

[LaunchActivatedEventArgs in Docs](https://docs.microsoft.com/en-us/uwp/api/Windows.ApplicationModel.Activation.LaunchActivatedEventArgs).

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
