### PR TITLE
IMvxFormsViewPresenter in UWP sample

### DIFF
--- a/docs/_documentation/platform/forms/xamarin-forms.md
+++ b/docs/_documentation/platform/forms/xamarin-forms.md
@@ -190,7 +190,7 @@ public MainPage()
     InitializeComponent();
     SupportedOrientations = SupportedPageOrientation.PortraitOrLandscape;
 
-    var presenter = Mvx.Resolve<IMvxViewPresenter>() as MvxFormsWindowsUWPPagePresenter;
+    var presenter = Mvx.Resolve<IMvxFormsViewPresenter>() as MvxFormsWindowsUWPPagePresenter;
     LoadApplication(FormsApplication);
 }
 ```


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

**Docs update**
Fixed the `Mvx.Resolve` call on `MainPage` in UWP sample to use `IMvxFormsViewPresenter` instead of `IMvxViewPresenter`, because `IMvxFormsViewPresenter` is the one which is actually registered.

### :arrow_heading_down: What is the current behavior?

The current sample does not work out of the box and complains that the instance of `IMvxViewPresenter` is not registered.

### :new: What is the new behavior (if this is a feature change)?

Sample will now work as expected without throwing exception.

### :boom: Does this PR introduce a breaking change?

 No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
