### PR TITLE
Allow more than 5 childs in MoreNavigationController

### DIFF
--- a/MvvmCross/Platform/Tvos/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platform/Tvos/Views/MvxTabBarViewController.cs
@@ -77,12 +77,6 @@ namespace MvvmCross.Platform.Tvos.Views
 
         public virtual bool ShowChildView(UIViewController viewController)
         {
-            if (SelectedIndex > 5) // when more menu item is currently visible, selected index has value higher than 5
-            {
-                MoreNavigationController.PushViewController(viewController, true);
-                return true;
-            }
-
             var navigationController = SelectedViewController as UINavigationController;
 
             // if the current selected ViewController is not a NavigationController, then a child cannot be shown
@@ -97,17 +91,6 @@ namespace MvvmCross.Platform.Tvos.Views
 
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
-            if (SelectedIndex > 5 && MoreNavigationController?.ViewControllers?.Any() ?? false)
-            {
-                var lastViewController = (MoreNavigationController.ViewControllers.Last()).GetIMvxTvosView();
-
-                if (lastViewController != null && lastViewController.ViewModel == viewModel)
-                {
-                    MoreNavigationController.PopViewController(true);
-                    return true;
-                }
-            }
-
             if (SelectedViewController is UINavigationController navController
                 && navController.ViewControllers != null
                 && navController.ViewControllers.Any())

--- a/MvvmCross/Platform/Tvos/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platform/Tvos/Views/MvxTabBarViewController.cs
@@ -77,6 +77,12 @@ namespace MvvmCross.Platform.Tvos.Views
 
         public virtual bool ShowChildView(UIViewController viewController)
         {
+            if (MoreNavigationController?.ViewControllers?.Any() ?? false) 
+            {
+                MoreNavigationController.PushViewController(viewController, true);
+                return true;
+            }
+
             var navigationController = SelectedViewController as UINavigationController;
 
             // if the current selected ViewController is not a NavigationController, then a child cannot be shown
@@ -91,6 +97,17 @@ namespace MvvmCross.Platform.Tvos.Views
 
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
+            if (MoreNavigationController?.ViewControllers?.Any() ?? false)
+            {
+                var lastViewController = (MoreNavigationController.ViewControllers.Last()).GetIMvxTvosView();
+
+                if (lastViewController != null && lastViewController.ViewModel == viewModel)
+                {
+                    MoreNavigationController.PopViewController(true);
+                    return true;
+                }
+            }
+
             if (SelectedViewController is UINavigationController navController
                 && navController.ViewControllers != null
                 && navController.ViewControllers.Any())

--- a/MvvmCross/Platform/Tvos/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platform/Tvos/Views/MvxTabBarViewController.cs
@@ -77,7 +77,7 @@ namespace MvvmCross.Platform.Tvos.Views
 
         public virtual bool ShowChildView(UIViewController viewController)
         {
-            if (MoreNavigationController?.ViewControllers?.Any() ?? false) 
+            if (SelectedIndex > 5) // when more menu item is currently visible, selected index has value higher than 5
             {
                 MoreNavigationController.PushViewController(viewController, true);
                 return true;
@@ -97,7 +97,7 @@ namespace MvvmCross.Platform.Tvos.Views
 
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
-            if (MoreNavigationController?.ViewControllers?.Any() ?? false)
+            if (SelectedIndex > 5 && MoreNavigationController?.ViewControllers?.Any() ?? false)
             {
                 var lastViewController = (MoreNavigationController.ViewControllers.Last()).GetIMvxTvosView();
 

--- a/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using MvvmCross.Platform.Ios.Presenters;
 using MvvmCross.Platform.Ios.Presenters.Attributes;
-using MvvmCross.iOS.Views;
 using MvvmCross.ViewModels;
 using UIKit;
 

--- a/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Platform.Ios.Views
 
         public virtual bool ShowChildView(UIViewController viewController)
         {
-            if (MoreNavigationController?.ViewControllers?.Any() ?? false) 
+            if (SelectedIndex > 5) // when more menu item is currently visible, selected index has value higher than 5
             {
                 MoreNavigationController.PushViewController(viewController, true);
                 return true;
@@ -104,7 +104,7 @@ namespace MvvmCross.Platform.Ios.Views
 
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
-            if (MoreNavigationController?.ViewControllers?.Any() ?? false)
+            if (SelectedIndex > 5 && MoreNavigationController?.ViewControllers?.Any() ?? false)
             {
                 var lastViewController = (MoreNavigationController.ViewControllers.Last()).GetIMvxIosView();
 

--- a/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
@@ -103,7 +103,7 @@ namespace MvvmCross.Platform.Ios.Views
 
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
-            if (SelectedIndex > 5 && MoreNavigationController?.ViewControllers?.Any() ?? false)
+            if (SelectedIndex > 5 && (MoreNavigationController?.ViewControllers?.Any() ?? false))
             {
                 var lastViewController = (MoreNavigationController.ViewControllers.Last()).GetIMvxIosView();
 

--- a/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platform/iOS/Views/MvxTabBarViewController.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MvvmCross.Platform.Ios.Presenters;
 using MvvmCross.Platform.Ios.Presenters.Attributes;
+using MvvmCross.iOS.Views;
 using MvvmCross.ViewModels;
 using UIKit;
 
@@ -77,6 +78,12 @@ namespace MvvmCross.Platform.Ios.Views
 
         public virtual bool ShowChildView(UIViewController viewController)
         {
+            if (MoreNavigationController?.ViewControllers?.Any() ?? false) 
+            {
+                MoreNavigationController.PushViewController(viewController, true);
+                return true;
+            }
+
             var navigationController = SelectedViewController as UINavigationController;
 
             // if the current selected ViewController is not a NavigationController, then a child cannot be shown
@@ -97,6 +104,17 @@ namespace MvvmCross.Platform.Ios.Views
 
         public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
         {
+            if (MoreNavigationController?.ViewControllers?.Any() ?? false)
+            {
+                var lastViewController = (MoreNavigationController.ViewControllers.Last()).GetIMvxIosView();
+
+                if (lastViewController != null && lastViewController.ViewModel == viewModel)
+                {
+                    MoreNavigationController.PopViewController(true);
+                    return true;
+                }
+            }
+
             if (SelectedViewController is UINavigationController navController
                 && navController.ViewControllers != null
                 && navController.ViewControllers.Any())


### PR DESCRIPTION
Previously, MvxTabBarViewController did not take care of MoreNavigationController and more than 5 tabs case.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)


### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop