### PR TITLE
Fixed issue #2515 where MvxObservableCollection.AddRange() reports wrong index

### DIFF
--- a/MvvmCross/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/ViewModels/MvxObservableCollection.cs
@@ -84,6 +84,7 @@ namespace MvvmCross.ViewModels
                 throw new ArgumentNullException(nameof(items));
             }
 
+            int startingIndex = this.Items.Count;
             var itemsList = items.ToList();
             using (SuppressEvents())
             {
@@ -93,7 +94,7 @@ namespace MvvmCross.ViewModels
                 }
             }
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList,this.Items.Count));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList, startingIndex));
         }
 
         /// <summary>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug Fix

### :arrow_heading_down: What is the current behavior?

The index is incorrectly reported when AddRange is called, which could cause issues with certain collections responding to NotifyCollectionChangedEventArgs events.  

### :new: What is the new behavior (if this is a feature change)?

MvxObservableCollection will stop reporting the wrong index

### :boom: Does this PR introduce a breaking change?

Not that I'm aware of, I've tested it against a MvxRecyclerView and haven't seen any regression in behavior.  Unless there is a custom control using the index parameter incorrectly, this should work as expected.

### :bug: Recommendations for testing

Bind a MvxRecyclerView to an MvxObservableCollection<T> and call AddRange multiple times and check the index being reported.

### :memo: Links to relevant issues/docs

Original Issue:
https://github.com/MvvmCross/MvvmCross/issues/2515

See this MSDN for details on how index parameter should be passed: https://msdn.microsoft.com/en-us/library/ms653208(v=vs.110).aspx

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
