### PR TITLE
Improve the IMvxPluginManager interface

### DIFF
--- a/MvvmCross.Plugins/FieldBinding/Plugin.cs
+++ b/MvvmCross.Plugins/FieldBinding/Plugin.cs
@@ -10,14 +10,9 @@ namespace MvvmCross.Plugin.FieldBinding
     [Preserve(AllMembers = true)]
     public class Plugin : IMvxPlugin
     {
-        private bool _loaded;
-
         public void Load()
         {
-            if (_loaded) return;
-
             Mvx.CallbackWhenRegistered<IMvxSourceBindingFactoryExtensionHost>(OnHostRegistered);
-            _loaded = true;
         }
 
         private void OnHostRegistered(IMvxSourceBindingFactoryExtensionHost host)

--- a/MvvmCross.Plugins/Json/Plugin.cs
+++ b/MvvmCross.Plugins/Json/Plugin.cs
@@ -12,15 +12,10 @@ namespace MvvmCross.Plugin.Json
     [Preserve(AllMembers = true)]
     public class Plugin : IMvxConfigurablePlugin
     {
-        private bool _loaded;
         private MvxJsonConfiguration _configuration;
 
         public void Load()
         {
-            if (_loaded)
-                return;
-
-            _loaded = true;
             Mvx.RegisterType<IMvxJsonConverter, MvxJsonConverter>();
             var configuration = _configuration ?? MvxJsonConfiguration.Default;
 
@@ -32,12 +27,6 @@ namespace MvvmCross.Plugin.Json
 
         public void Configure(IMvxPluginConfiguration configuration)
         {
-            if (_loaded)
-            {
-                MvxPluginLog.Instance.Error("Error - Configure called for Json Plugin after the plugin is already loaded");
-                return;
-            }
-
             if (configuration != null && !(configuration is MvxJsonConfiguration))
             {
                 throw new MvxException("You must configure the Json plugin with MvxJsonConfiguration - but supplied {0}", configuration.GetType().Name);

--- a/MvvmCross.Plugins/Messenger/Plugin.cs
+++ b/MvvmCross.Plugins/Messenger/Plugin.cs
@@ -7,14 +7,9 @@ namespace MvvmCross.Plugin.Messenger
     [Preserve(AllMembers = true)]
     public class Plugin : IMvxPlugin
     {
-        private bool _loaded;
-
         public void Load()
         {
-            if (_loaded) return;
-
             Mvx.RegisterSingleton<IMvxMessenger>(new MvxMessengerHub());
-            _loaded = true;
         }
     }
 }

--- a/MvvmCross.Plugins/MethodBinding/Plugin.cs
+++ b/MvvmCross.Plugins/MethodBinding/Plugin.cs
@@ -10,14 +10,9 @@ namespace MvvmCross.Plugin.MethodBinding
     [Preserve(AllMembers = true)]
     public class Plugin : IMvxPlugin
     {
-        private bool _loaded;
-
         public void Load()
         {
-            if (_loaded) return;
-
             Mvx.CallbackWhenRegistered<IMvxSourceBindingFactoryExtensionHost>(OnHostRegistered);
-            _loaded = true;
         }
 
         private void OnHostRegistered(IMvxSourceBindingFactoryExtensionHost host)

--- a/MvvmCross/Plugin/IMvxPluginManager.cs
+++ b/MvvmCross/Plugin/IMvxPluginManager.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 namespace MvvmCross.Plugin
 {
@@ -10,16 +11,18 @@ namespace MvvmCross.Plugin
     {
         Func<Type, IMvxPluginConfiguration> ConfigurationSource { get; }
 
+        IEnumerable<Type> LoadedPlugins { get; }
+
         bool IsPluginLoaded(Type type);
 
         bool IsPluginLoaded<TPlugin>() where TPlugin : IMvxPlugin;
 
-        void EnsurePluginLoaded(Type type);
+        void EnsurePluginLoaded(Type type, bool forceLoad = false);
         
-        void EnsurePluginLoaded<TPlugin>() where TPlugin : IMvxPlugin;
+        void EnsurePluginLoaded<TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin;
 
-        bool TryEnsurePluginLoaded(Type type);
+        bool TryEnsurePluginLoaded(Type type, bool forceLoad = false);
         
-        bool TryEnsurePluginLoaded<TPlugin>() where TPlugin : IMvxPlugin;
+        bool TryEnsurePluginLoaded<TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin;
      }
 }

--- a/MvvmCross/Plugin/MvxPluginManager.cs
+++ b/MvvmCross/Plugin/MvxPluginManager.cs
@@ -15,19 +15,21 @@ namespace MvvmCross.Plugin
 
         public Func<Type, IMvxPluginConfiguration> ConfigurationSource { get; }
 
+        public IEnumerable<Type> LoadedPlugins => _loadedPlugins;
+
         public MvxPluginManager(Func<Type, IMvxPluginConfiguration> configurationSource)
         {
             ConfigurationSource = configurationSource;
         }
 
-        public void EnsurePluginLoaded<TPlugin>() where TPlugin : IMvxPlugin
+        public void EnsurePluginLoaded<TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin
         {
-            EnsurePluginLoaded(typeof(TPlugin));
+            EnsurePluginLoaded(typeof(TPlugin), forceLoad);
         }
 
-        public virtual void EnsurePluginLoaded(Type type)
+        public virtual void EnsurePluginLoaded(Type type, bool forceLoad = false)
         {
-            if (IsPluginLoaded(type)) return;
+            if (forceLoad == false && IsPluginLoaded(type)) return;
             
             var plugin = Activator.CreateInstance(type) as IMvxPlugin;
             if (plugin == null)
@@ -57,14 +59,14 @@ namespace MvvmCross.Plugin
             }
         }
 
-        public bool TryEnsurePluginLoaded<TPlugin>() where TPlugin : IMvxPlugin 
-            => TryEnsurePluginLoaded(typeof(TPlugin));
+        public bool TryEnsurePluginLoaded<TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin 
+            => TryEnsurePluginLoaded(typeof(TPlugin), forceLoad);
 
-        public bool TryEnsurePluginLoaded(Type type)
+        public bool TryEnsurePluginLoaded(Type type, bool forceLoad = false)
         {
             try
             {
-                EnsurePluginLoaded(type);
+                EnsurePluginLoaded(type, forceLoad);
                 return true;
             }
             catch (Exception ex)

--- a/UnitTests/MvvmCross.UnitTest/Core/MvxSetupTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Core/MvxSetupTests.cs
@@ -48,7 +48,7 @@ namespace MvvmCross.UnitTest.Core
                 SetupUnderTest.Object.LoadPlugins(PluginManager.Object);
 
                 PluginManager
-                    .Verify(manager => manager.EnsurePluginLoaded(It.IsAny<Type>()), Times.Exactly(6));
+                    .Verify(manager => manager.EnsurePluginLoaded(It.IsAny<Type>(), It.IsAny<bool>()), Times.Exactly(10));
             }
         }
     }

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Plugin/PluginMocks.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Plugin/PluginMocks.cs
@@ -67,4 +67,48 @@ namespace MvvmCross.UnitTest.Mocks.Plugin
             LoadCount++;
         }
     }
+
+    [MvxPlugin]
+    public class PluginMock7 : IMvxPlugin
+    {
+        public static int LoadCount { get; private set; }
+
+        public void Load()
+        {
+            LoadCount++;
+        }
+    }
+
+    [MvxPlugin]
+    public class PluginMock8 : IMvxPlugin
+    {
+        public static int LoadCount { get; private set; }
+
+        public void Load()
+        {
+            LoadCount++;
+        }
+    }
+
+    [MvxPlugin]
+    public class PluginMock9 : IMvxPlugin
+    {
+        public static int LoadCount { get; private set; }
+
+        public void Load()
+        {
+            LoadCount++;
+        }
+    }
+
+    [MvxPlugin]
+    public class PluginMock10 : IMvxPlugin
+    {
+        public static int LoadCount { get; private set; }
+
+        public void Load()
+        {
+            LoadCount++;
+        }
+    }
 }

--- a/UnitTests/MvvmCross.UnitTest/Plugin/MvxPluginManagerTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Plugin/MvxPluginManagerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using MvvmCross.Exceptions;
 using MvvmCross.Plugin;
 using MvvmCross.Test;
@@ -47,13 +48,24 @@ namespace MvvmCross.UnitTest.Plugin
             }
 
             [Fact]
+            public void CallsLoadTwiceIfYouPassTheForceLoadParameter()
+            {
+                var type = typeof(PluginMock7);
+
+                PluginManager.EnsurePluginLoaded(type);
+                PluginManager.EnsurePluginLoaded(type, true);
+
+                Assert.Equal(PluginMock7.LoadCount, 2);
+            }
+
+            [Fact]
             public void ThrowsIfTheTypeIsNotAValidIMvxPlugin()
             {
                 var type = typeof(Int32);
 
                 Action callingEnsurePluginLoadedWithInvalidType =
-                    () =>  PluginManager.EnsurePluginLoaded(type);
-                
+                    () => PluginManager.EnsurePluginLoaded(type);
+
                 Assert.Throws<MvxException>(callingEnsurePluginLoadedWithInvalidType);
             }
         }
@@ -105,6 +117,17 @@ namespace MvvmCross.UnitTest.Plugin
             }
 
             [Fact]
+            public void CallsLoadTwiceIfYouPassTheForceLoadParameter()
+            {
+                var type = typeof(PluginMock8);
+
+                PluginManager.TryEnsurePluginLoaded(type);
+                PluginManager.TryEnsurePluginLoaded(type, true);
+
+                Assert.Equal(PluginMock8.LoadCount, 2);
+            }
+
+            [Fact]
             public void DoesNotThrowsIfTheTypeIsNotAValidIMvxPlugin()
             {
                 var type = typeof(Int32);
@@ -112,6 +135,21 @@ namespace MvvmCross.UnitTest.Plugin
                 var isLoaded = PluginManager.TryEnsurePluginLoaded(type);
 
                 Assert.False(isLoaded);
+            }
+        }
+
+        public class TheLoadedPluginsProperty : MvxPluginManagerTest
+        {
+            [Fact]
+            public void ReturnsAListOfAllLoadedPlugins()
+            {
+                var typesToLoad = new[] { typeof(PluginMock9), typeof(PluginMock10) };
+                foreach (var type in typesToLoad)
+                {
+                    PluginManager.EnsurePluginLoaded(type);
+                }
+
+                Assert.Equal(PluginManager.LoadedPlugins.Count(), 2);
             }
         }
     }

--- a/docs/_documentation/plugins/getting-started.md
+++ b/docs/_documentation/plugins/getting-started.md
@@ -12,6 +12,6 @@ Starting from version 6.0, plugin development has become much simpler. All you h
 
 That's all! In your Plugin's `Load` method you should include all IoC registration/initialization. This method will be called automatically during the app's Setup.
 
-Please note that the `Load` method should care only about registering the appropriate classes and initialize the adequate services. It should not hold state nor try to be smart about initialization; This is the job of the `IMvxPluginManager`. 
-
 If your service has platform independent and platform specific services that need to be registered, you can have multiple classes annotated with the `MvxPluginAttribute`. There's no restriction on how many classes can have the attribute on a given assembly.
+
+Please note that the `Load` method should care *exclusively* about registering the appropriate classes and initializing the adequate services. It should not hold state nor try to be smart about initialization/caching; This is the job of the `IMvxPluginManager`. It's very important to follow this rule because, when testing code, one can reliably use the `IMvxPluginManager` methods to reload whatever plugins the tested class depends on (using `forceLoad = true`).


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Plugins cache themselves and there's no way for one to force the reloading of a plugin.

### :new: What is the new behavior (if this is a feature change)?
Plugins can be reloaded using the `forceLoad` parameter. Also, I added a property to expose the loaded plugins

### :boom: Does this PR introduce a breaking change?
Yes; One needs to add the optional params and the new property to any overload of `IMvxPluginManager`. This is really minor, though, since the interface has changed a lot already

### :memo: Links to relevant issues/docs
Closes #1782

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
