### PR TITLE
Binding types fix

### DIFF
--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
@@ -8,14 +8,14 @@ using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.Binding.Bindings.Target
 {
-    public class MvxEventNameTargetBinding : MvxTargetBinding
+    public class MvxEventNameTargetBinding<TTarget> : MvxTargetBinding where TTarget : class
     {
         private readonly bool _useEventArgsAsCommandParameter;
         private readonly IDisposable _eventSubscription;
 
         private ICommand _currentCommand;
 
-        public MvxEventNameTargetBinding(object target, string targetEventName, bool useEventArgsAsCommandParameter = true) : base(target)
+        public MvxEventNameTargetBinding(TTarget target, string targetEventName, bool useEventArgsAsCommandParameter = true) : base(target)
         {
             _useEventArgsAsCommandParameter = useEventArgsAsCommandParameter;
             _eventSubscription = target.WeakSubscribe(targetEventName, HandleEvent);

--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
@@ -8,17 +8,17 @@ using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.Binding.Bindings.Target
 {
-    public class MvxEventNameTargetBinding<TEventArgs> : MvxTargetBinding
+    public class MvxEventNameTargetBinding<TTarget, TEventArgs> : MvxTargetBinding where TTarget : class
     {
         private readonly bool _useEventArgsAsCommandParameter;
         private readonly IDisposable _eventSubscription;
 
         private ICommand _currentCommand;
 
-        public MvxEventNameTargetBinding(object target, string targetEventName, bool useEventArgsAsCommandParameter = true) : base(target)
+        public MvxEventNameTargetBinding(TTarget target, string targetEventName, bool useEventArgsAsCommandParameter = true) : base(target)
         {
             _useEventArgsAsCommandParameter = useEventArgsAsCommandParameter;
-            _eventSubscription = target.WeakSubscribe<object, TEventArgs>(targetEventName, HandleEvent);
+            _eventSubscription = target.WeakSubscribe<TTarget, TEventArgs>(targetEventName, HandleEvent);
         }
 
         public override Type TargetType { get; } = typeof(ICommand);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Weak subscription couldn't find event info, because it uses typeof instead of GetType

### :new: What is the new behavior (if this is a feature change)?
Now you implicitly passing view type in generic constructor, so binding goes normal

### :boom: Does this PR introduce a breaking change?
No. It's fixes EventName bindings which were not used before in projects

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
