### PR TITLE
Adding support for custom renderer assemblies to MvxFormsWindowsSetup

### DIFF
--- a/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
@@ -30,6 +30,11 @@ namespace MvvmCross.Forms.Platform.Uap.Core
         {
         }
 
+        /// <summary>
+        /// Override to provide list of assemblies to search for views. 
+        /// Additionally for UWP .NET Native compilation include the assemblies containing custom controls and renderers to be passed to <see cref="Xamarin.Forms.Forms.Init" /> method. 
+        /// </summary>
+        /// <returns>Custom view and renderer assemblies</returns>
         protected override IEnumerable<Assembly> GetViewAssemblies()
         {
             return _viewAssemblies ?? (_viewAssemblies = new List<Assembly>(base.GetViewAssemblies()));
@@ -41,23 +46,13 @@ namespace MvvmCross.Forms.Platform.Uap.Core
             _viewAssemblies.AddRange(GetViewModelAssemblies());
         }
 
-        /// <summary>
-        /// For UWP .NET Native compilation, you have to tell Xamarin.Forms which assemblies it should scan for custom controls and renderers.  
-        /// Override to provide the list of renderer assemblies that will be passed as the second argument of Xamarin.Forms.Forms.Init method.
-        /// </summary>
-        /// <returns>List of custom renderer assemblies</returns>
-        public virtual IEnumerable<Assembly> GetRendererAssemblies()
-        {
-            return null;
-        }
-
         public MvxFormsApplication FormsApplication
         {
             get
             {
                 if (_formsApplication == null)
                 {
-                    Xamarin.Forms.Forms.Init(ActivationArguments, GetRendererAssemblies());
+                    Xamarin.Forms.Forms.Init(ActivationArguments, GetViewAssemblies());
                     _formsApplication = _formsApplication ?? CreateFormsApplication();
                 }
                 return _formsApplication;

--- a/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platform/Uap/Core/MvxFormsWindowsSetup.cs
@@ -41,13 +41,23 @@ namespace MvvmCross.Forms.Platform.Uap.Core
             _viewAssemblies.AddRange(GetViewModelAssemblies());
         }
 
+        /// <summary>
+        /// For UWP .NET Native compilation, you have to tell Xamarin.Forms which assemblies it should scan for custom controls and renderers.  
+        /// Override to provide the list of renderer assemblies that will be passed as the second argument of Xamarin.Forms.Forms.Init method.
+        /// </summary>
+        /// <returns>List of custom renderer assemblies</returns>
+        public virtual IEnumerable<Assembly> GetRendererAssemblies()
+        {
+            return null;
+        }
+
         public MvxFormsApplication FormsApplication
         {
             get
             {
                 if (_formsApplication == null)
                 {
-                    Xamarin.Forms.Forms.Init(ActivationArguments);
+                    Xamarin.Forms.Forms.Init(ActivationArguments, GetRendererAssemblies());
                     _formsApplication = _formsApplication ?? CreateFormsApplication();
                 }
                 return _formsApplication;

--- a/docs/_documentation/platform/xamarin.forms/xamarin-forms.md
+++ b/docs/_documentation/platform/xamarin.forms/xamarin-forms.md
@@ -195,14 +195,7 @@ public MainPage()
 }
 ```
 
-Since MvvmCross 6.0 you can provide secondary view renderer assemblies to the Xamarin.Forms initialization so that the framework is able to find them in Release mode with .NET Native compilation. Override the `GetRendererAssemblies` method of the `MvxFormsWindowsSetup` to do so:
-
-```c#
-public override IEnumerable<Assembly> GetRendererAssemblies()
-{
-    return new[] { typeof(SecondaryLibrary.Renderers.MyRenderer).GetTypeInfo().Assembly };
-}
-```
+If you use secondary assemblies for your custom control and renderers, since MvvmCross 6.0 you should also return them  from the `GetViewAssemblies` method override, as the view assemblies are passed in to the Xamarin.Forms initialization so that the framework is able to find them in Release mode with .NET Native compilation.
 
 # Bindings
 

--- a/docs/_documentation/platform/xamarin.forms/xamarin-forms.md
+++ b/docs/_documentation/platform/xamarin.forms/xamarin-forms.md
@@ -195,6 +195,15 @@ public MainPage()
 }
 ```
 
+Since MvvmCross 6.0 you can provide secondary view renderer assemblies to the Xamarin.Forms initialization so that the framework is able to find them in Release mode with .NET Native compilation. Override the `GetRendererAssemblies` method of the `MvxFormsWindowsSetup` to do so:
+
+```c#
+public override IEnumerable<Assembly> GetRendererAssemblies()
+{
+    return new[] { typeof(SecondaryLibrary.Renderers.MyRenderer).GetTypeInfo().Assembly };
+}
+```
+
 # Bindings
 
 You can use the MvvmCross binding syntax just like you would do in a native Xamarin project. For more information see the [Bindings](https://www.mvvmcross.com/documentation/fundamentals/data-binding) documentation.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

**Feature**

When Xamarin.Forms UWP projects are built in Release mode, .NET Native compilation is used and that causes problems when there are secondary assemblies with Xamarin.Forms `ViewRenderers`.

Developers can provide the additional renderer assemblies in similar manner to `ViewAssemblies` - by overriding the new `GetRendererAssemblies` method in `MvxFormsWindowsSetup`.

### :arrow_heading_down: What is the current behavior?

The `Xamarin.Forms.Forms.Init` method is called with only the `IActivatedEventArgs` parameter.

### :new: What is the new behavior (if this is a feature change)?

`Xamarin.Forms.Forms.Init` method is called with the optional `rendererAssemblies` parameter which is necessary to make view renderers in secondary assemblies to be successfully discovered by Xamarin.Forms in UWP Release mode.

### :boom: Does this PR introduce a breaking change?

No, the parameter is optional, by default the `GetRendererAssemblies` method returns `null` which is the default value for the parameter.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Discussed for example [here](https://forums.xamarin.com/discussion/73132/map-doesnt-work-in-release-mode-uwp) on Xamarin Forums

Also the default cross-platform template for Xamarin.Forms mentions this in a comment.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
