### PR TITLE
Apply default templates to MvxAppCompatSpinner

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/Widget/MvxAppCompatSpinner.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/Widget/MvxAppCompatSpinner.cs
@@ -36,8 +36,12 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Widget
         {
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
             var dropDownItemTemplateId = MvxAttributeHelpers.ReadDropDownListItemTemplateId(context, attrs);
-            adapter.ItemTemplateId = itemTemplateId;
-            adapter.DropDownItemTemplateId = dropDownItemTemplateId;
+
+            if (itemTemplateId > 0)
+                adapter.ItemTemplateId = itemTemplateId;
+            if (dropDownItemTemplateId > 0)
+                adapter.DropDownItemTemplateId = dropDownItemTemplateId;
+
             Adapter = adapter;
             ItemSelected += OnItemSelected;
         }


### PR DESCRIPTION
If the user does not specify template ids for the spinner
we need to make sure that the defaults are not overriden.

This brings `MvxAppCompatSpinner` in line with `MvxSpinner`.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
If an item template id or dropdown template id are not specified the program crashes with a ResourceNotFound exception.

### :new: What is the new behavior (if this is a feature change)?
Defaults are applied properly.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

Before this change this breaks in an AppCompat activity:
```
<MvxSpinner
                style="@style/Widget.AppCompat.Spinner.Underlined"
                android:id="@+id/sensor_sort"
                android:layout_width="wrap_content"
                android:layout_height="wrap_content"
                local:MvxBind="ItemsSource Whatever" />
```
### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X] All projects build
- [ X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X] Rebased onto current develop
