### PR TITLE
MvxNotifyTask improvements

### DIFF
--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
@@ -26,7 +27,7 @@ namespace Playground.Core.ViewModels
 
             ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel, SampleModel>(new SampleModel { Message = "Hey", Value = 1.23m }));
 
-            ShowModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalViewModel>());
+            ShowModalCommand = new MvxAsyncCommand(Navigate);
 
             ShowModalNavCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
 
@@ -63,6 +64,21 @@ namespace Playground.Core.ViewModels
                                                            null);
         }
 
+        public override void ViewAppearing()
+        {
+            base.ViewAppearing();
+
+            MyTask = MvxNotifyTask.Create(
+                async () => 
+                {
+                    await Task.Delay(300);
+
+                    throw new System.Exception("Boom!");
+                }, exception => 
+                {
+                });
+        }
+        
         protected override void SaveStateToBundle(IMvxBundle bundle)
         {
             base.SaveStateToBundle(bundle);
@@ -76,6 +92,8 @@ namespace Playground.Core.ViewModels
 
             _counter = int.Parse(state.Data["MyKey"]);
         }
+
+        public MvxNotifyTask MyTask { get; set; }
 
         public IMvxAsyncCommand ShowChildCommand { get; private set; }
 
@@ -104,5 +122,16 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowBindingsViewCommand => new MvxAsyncCommand(async () => await _navigationService.Navigate<BindingsViewModel>());
 
         public IMvxAsyncCommand ShowCodeBehindViewCommand => new MvxAsyncCommand(async () => await _navigationService.Navigate<CodeBehindViewModel>());
+
+        private async Task Navigate()
+        {
+            try 
+            {
+                await _navigationService.Navigate<ModalViewModel>();
+            }
+            catch (System.Exception) 
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
1) When using `MvxNotifyTask` you can easily miss exceptions if you don't subscribe / check its properties.
2) When using `MvxNotifyTask` there's a chance (as with every async method) the code may run synchronously until the first `await` is called. If an exception happens on those lines, it won't be caught.

### :new: What is the new behavior (if this is a feature change)?
1) Added an optional callback `onException` to the static constructor, which the user can subscribe to.
2) Added a `Task.Yield()` sentence at the beginning of `MonitorTaskAsync`. As a result the call returns inmediately to the caller and all code is run in a different synchronization context. This is not recommended for normal `async/await`, but `MvxNotifyTask` is more special than that.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Playground and set some breakpoints on `RootViewModel`.

### :memo: Links to relevant issues/docs
/

### :thinking: Checklist before submitting

- [x] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
