### PR TITLE
MvxBaseTableViewSource: Fix wrong height for xib based cells 

### DIFF
--- a/MvvmCross/Platform/Ios/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platform/Ios/Binding/Views/MvxBaseTableViewSource.cs
@@ -103,14 +103,22 @@ namespace MvvmCross.Platform.Ios.Binding.Views
             var item = GetItemAt(indexPath);
             var cell = GetOrCreateCellFor(tableView, indexPath, item);
 
-            var bindable = cell as IMvxBindable;
-
-            if (bindable != null)
+            if (cell is IMvxBindable bindable)
             {
                 var bindingContext = bindable.BindingContext as MvxTaskBasedBindingContext;
-                if (bindingContext != null && _tableView.RowHeight == UITableView.AutomaticDimension)
+
+                var isTaskBasedBindingContextAndHasAutomaticDimension = bindingContext != null && TableView.RowHeight == UITableView.AutomaticDimension;
+
+                // RunSynchronously must be called before DataContext is set
+                if (isTaskBasedBindingContextAndHasAutomaticDimension)
                     bindingContext.RunSynchronously = true;
+
                 bindable.DataContext = item;
+
+                // If AutomaticDimension is used, xib based cells need to re-layout everything after bindings are applied
+                // otherwise the cell height will be wrong
+                if (isTaskBasedBindingContextAndHasAutomaticDimension)
+                    cell.LayoutIfNeeded();
             }
 
             return cell;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Xib based cells have wrong height when `UITableView.AutomaticDimension` is used. The issue only happens on the first rows and is gone after you scroll the list and come back.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Unfortunately I found the issue / tested the fix on one of my apps. If necessary I could add something to Playground.iOS.

### :memo: Links to relevant issues/docs
Fixes #2057.

### :thinking: Checklist before submitting

- [ ] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
