### PR TITLE
Rename test to tests to align with old nuget package and current naming

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -28,6 +28,7 @@
   
   <ItemGroup Condition="'$(IsLibraryProject)' == 'true'">
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.2.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(IsLibraryProject)' == 'true'">

--- a/MvvmCross.Android.Support/V7.AppCompat/MvvmCross.Droid.Support.V7.AppCompat.csproj
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvvmCross.Droid.Support.V7.AppCompat.csproj
@@ -25,10 +25,6 @@
     <ProjectReference Include="..\Design\MvvmCross.Droid.Support.Design.csproj" />
     <ProjectReference Include="..\Fragment\MvvmCross.Droid.Support.Fragment.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Resources\layouts\" />
-  </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 

--- a/MvvmCross.Tests/MvvmCross.Tests.csproj
+++ b/MvvmCross.Tests/MvvmCross.Tests.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>MvvmCross.Tests</AssemblyName>
+    <RootNamespace>MvvmCross.Tests</RootNamespace>
+    <Description></Description>
+    <PackageId>MvvmCross.Tests</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MvvmCross.Tests/MvxIoCSupportingTest.cs
+++ b/MvvmCross.Tests/MvxIoCSupportingTest.cs
@@ -9,7 +9,7 @@ using MvvmCross.Core;
 using MvvmCross.IoC;
 using MvvmCross.Logging;
 
-namespace MvvmCross.Test
+namespace MvvmCross.Tests
 {
     public class MvxIoCSupportingTest
     {

--- a/MvvmCross.Tests/MvxTestFixture.cs
+++ b/MvvmCross.Tests/MvxTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MvvmCross.Test
+namespace MvvmCross.Tests
 {
     public class MvxTestFixture : MvxIoCSupportingTest, IDisposable
     {

--- a/MvvmCross.Tests/MvxTestLog.cs
+++ b/MvvmCross.Tests/MvxTestLog.cs
@@ -10,7 +10,7 @@ using MvvmCross.Logging;
 
 [assembly: InternalsVisibleTo("MvvmCross.UnitTest")]
 
-namespace MvvmCross.Test
+namespace MvvmCross.Tests
 {
     internal static class MvxTestLog
     {

--- a/MvvmCross.Tests/TestLogProvider.cs
+++ b/MvvmCross.Tests/TestLogProvider.cs
@@ -14,7 +14,7 @@ using MvvmCross.Logging.LogProviders;
 
 [assembly: InternalsVisibleTo("MvvmCross.UnitTest")]
 
-namespace MvvmCross.Test
+namespace MvvmCross.Tests
 {
     internal sealed class TestLogProvider : MvxBaseLogProvider
     {

--- a/MvvmCross.sln
+++ b/MvvmCross.sln
@@ -38,9 +38,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross", "MvvmCross\MvvmCross.csproj", "{49F965F5-5824-4BBE-94EA-0178F848ABDB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross.Forms", "MvvmCross.Forms\MvvmCross.Forms.csproj", "{013BB2B2-8204-43BD-AA7B-E494007F0B94}"
-	ProjectSection(ProjectDependencies) = postProject
-		{FD67CBBC-4BAC-40D6-9F4C-28AAE6C8533E} = {FD67CBBC-4BAC-40D6-9F4C-28AAE6C8533E}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross.Plugin.Accelerometer", "MvvmCross.Plugins\Accelerometer\MvvmCross.Plugin.Accelerometer.csproj", "{E038C845-9ECD-42BC-89B3-627E374F7550}"
 EndProject

--- a/MvvmCross.sln
+++ b/MvvmCross.sln
@@ -38,6 +38,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross", "MvvmCross\MvvmCross.csproj", "{49F965F5-5824-4BBE-94EA-0178F848ABDB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross.Forms", "MvvmCross.Forms\MvvmCross.Forms.csproj", "{013BB2B2-8204-43BD-AA7B-E494007F0B94}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FD67CBBC-4BAC-40D6-9F4C-28AAE6C8533E} = {FD67CBBC-4BAC-40D6-9F4C-28AAE6C8533E}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross.Plugin.Accelerometer", "MvvmCross.Plugins\Accelerometer\MvvmCross.Plugin.Accelerometer.csproj", "{E038C845-9ECD-42BC-89B3-627E374F7550}"
 EndProject
@@ -113,7 +116,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground.Droid", "Project
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground.Forms.Droid", "Projects\Playground\Playground.Forms.Droid\Playground.Forms.Droid.csproj", "{A8A8B9B3-34FA-4769-AE81-4D80F9BDC3BB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross.Test", "MvvmCross.Test\MvvmCross.Test.csproj", "{8DFE6A59-AD7D-4916-ABF3-D2D1B0F55858}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvvmCross.Tests", "MvvmCross.Tests\MvvmCross.Tests.csproj", "{8DFE6A59-AD7D-4916-ABF3-D2D1B0F55858}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground.Forms.iOS", "Projects\Playground\Playground.Forms.iOS\Playground.Forms.iOS.csproj", "{344370AA-AC33-4E7B-8C82-67CEA99F45ED}"
 EndProject

--- a/MvvmCross/Logging/LogProviders/MvxBaseLogProvider.cs
+++ b/MvvmCross/Logging/LogProviders/MvxBaseLogProvider.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("MvvmCross.Test")]
+[assembly: InternalsVisibleTo("MvvmCross.Tests")]
 
 namespace MvvmCross.Logging.LogProviders
 {

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -14,10 +14,6 @@
     <Compile Remove="Resources\*.cs" />
   </ItemGroup>
   
-  <ItemGroup>
-       <PackageReference Include="Microsoft.CSharp" Version="4.4.1" PrivateAssets="All" />
-  </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <Compile Include="Platform\Netstandard\**\*.cs" />
   </ItemGroup>

--- a/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -159,6 +159,10 @@
       <Project>{fc0b3e3c-8b00-48fa-af93-981a45b2be4b}</Project>
       <Name>MvvmCross.Droid.Support.Fragment</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross.Android.Support\V7.AppCompat\MvvmCross.Droid.Support.V7.AppCompat.csproj">
+      <Project>{fd67cbbc-4bac-40d6-9f4c-28aae6c8533e}</Project>
+      <Name>MvvmCross.Droid.Support.V7.AppCompat</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\MvvmCross.Forms\MvvmCross.Forms.csproj">
       <Project>{013bb2b2-8204-43bd-aa7b-e494007f0b94}</Project>
       <Name>MvvmCross.Forms</Name>

--- a/Projects/Playground/Playground.Forms.iOS/Setup.cs
+++ b/Projects/Playground/Playground.Forms.iOS/Setup.cs
@@ -26,12 +26,5 @@ namespace Playground.Forms.iOS
         protected override MvxFormsApplication CreateFormsApplication() => new FormsApp();
 
         protected override IMvxApplication CreateApp() => new Core.App();
-
-        protected override void PerformBootstrapActions()
-        {
-            base.PerformBootstrapActions();
-
-            PluginLoader.Instance.EnsureLoaded();
-        }
     }
 }

--- a/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -169,6 +169,9 @@
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.1</Version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>11.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\JsonLocalization\MvvmCross.Plugin.JsonLocalization.csproj">

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using MvvmCross.Base;
 using Xunit;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using System.Linq;
 using MvvmCross.Exceptions;
 using MvvmCross.IoC;

--- a/UnitTests/MvvmCross.UnitTest/Binding/Binders/MvxSourceStepTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Binders/MvxSourceStepTests.cs
@@ -14,7 +14,7 @@ using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Combiners;
 using MvvmCross.Binding.Parse.PropertyPath;
 using MvvmCross.Converters;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Binders

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingConstructionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingConstructionTest.cs
@@ -13,7 +13,7 @@ using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Converters;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using Xunit;
 

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
@@ -10,7 +10,7 @@ using MvvmCross.Binding.Bindings.Source.Construction;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Binding.Mocks;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingValueConversionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingValueConversionTest.cs
@@ -12,7 +12,7 @@ using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Converters;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Binding.Mocks;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/Binding/ExpressionParse/MvxExpressionBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/ExpressionParse/MvxExpressionBindingTest.cs
@@ -14,7 +14,7 @@ using MvvmCross.Binding.Bindings;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.ExpressionParse;
 using MvvmCross.Converters;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.ExpressionParse

--- a/UnitTests/MvvmCross.UnitTest/Binding/ExtensionMethods/MakeSafeValueTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/ExtensionMethods/MakeSafeValueTest.cs
@@ -6,7 +6,7 @@ using System;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.Extensions;
 using MvvmCross.Converters;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.ExtensionMethods

--- a/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Lang/MvxLangBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Lang/MvxLangBindingTest.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Parse.Binding;
 using MvvmCross.Binding.Parse.Binding.Lang;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Parse.Binding.Lang

--- a/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/MvxBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/MvxBindingTest.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 ﻿using MvvmCross.Binding.Parse.Binding;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Parse.Binding

--- a/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Swiss/MvxBaseSwissBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Swiss/MvxBaseSwissBindingTest.cs
@@ -10,7 +10,7 @@ using MvvmCross.Binding;
 using MvvmCross.Binding.Parse.Binding;
 using MvvmCross.Binding.Parse.Binding.Swiss;
 using MvvmCross.Logging;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Parse.Binding.Swiss

--- a/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Swiss/MvxSwissBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Swiss/MvxSwissBindingTest.cs
@@ -5,7 +5,7 @@
 using MvvmCross.Binding.Parse.Binding;
 using MvvmCross.Binding.Parse.Binding.Swiss;
 using MvvmCross.Logging;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Parse.Binding.Swiss

--- a/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Swiss/MvxTibetBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Parse/Binding/Swiss/MvxTibetBindingTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using MvvmCross.Binding.Parse.Binding;
 using MvvmCross.Binding.Parse.Binding.Tibet;
 using MvvmCross.Logging;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Parse.Binding.Swiss

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MvvmCross.Base;
 using MvvmCross.Logging;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 

--- a/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
+++ b/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
@@ -13,8 +13,8 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/MvvmCross.UnitTest/MvxTestCollection.cs
+++ b/UnitTests/MvvmCross.UnitTest/MvxTestCollection.cs
@@ -1,4 +1,4 @@
-﻿using MvvmCross.Test;
+﻿using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest

--- a/UnitTests/MvvmCross.UnitTest/Navigation/NavigationServiceTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Navigation/NavigationServiceTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Moq;
  using MvvmCross.Core;
  using MvvmCross.Navigation;
- using MvvmCross.Test;
+ using MvvmCross.Tests;
  using MvvmCross.UnitTest.Mocks.Dispatchers;
  using MvvmCross.UnitTest.Mocks.ViewModels;
  using MvvmCross.ViewModels;

--- a/UnitTests/MvvmCross.UnitTest/Navigation/RoutingServiceTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Navigation/RoutingServiceTests.cs
@@ -10,7 +10,7 @@ using Moq;
 using MvvmCross.Core;
 using MvvmCross.Exceptions;
 using MvvmCross.Navigation;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.UnitTest.Mocks.ViewModels;

--- a/UnitTests/MvvmCross.UnitTest/Parse/MvxStringDictionaryTextSerializerTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Parse/MvxStringDictionaryTextSerializerTest.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using MvvmCross.Core.Parse.StringDictionary;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/Platform/MvxSimplePropertyDictionaryExtensionMethodsTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Platform/MvxSimplePropertyDictionaryExtensionMethodsTests.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using MvvmCross.Core;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Platform

--- a/UnitTests/MvvmCross.UnitTest/Platform/MvxStringToTypeParserTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Platform/MvxStringToTypeParserTest.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using MvvmCross.Core;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Platform

--- a/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelByNameLookupTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelByNameLookupTest.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelViewLookupBuilderTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelViewLookupBuilderTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.UnitTest.Mocks.TestViews;
 using MvvmCross.ViewModels;

--- a/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelViewTypeFinderTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelViewTypeFinderTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.UnitTest.Mocks.TestViews;
 using MvvmCross.ViewModels;

--- a/UnitTests/MvvmCross.UnitTest/Plugin/MvxPluginManagerTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Plugin/MvxPluginManagerTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using MvvmCross.Exceptions;
 using MvvmCross.Plugin;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Plugin;
 using Xunit;
 

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxBundleTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxBundleTest.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Linq;
 using MvvmCross.Core;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollectionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollectionTest.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Windows.Input;
 using MvvmCross.Base;
 using MvvmCross.Commands;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxDefaultViewModelLocatorTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxDefaultViewModelLocatorTest.cs
@@ -5,7 +5,7 @@
 using System;
 using MvvmCross.Core;
 using MvvmCross.Exceptions;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using MvvmCross.Base;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxObservableCollectionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxObservableCollectionTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using MvvmCross.Base;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.ViewModels;
 using Xunit;
 

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxSaveStateTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxSaveStateTest.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using MvvmCross.Core;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxViewModelLoaderTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxViewModelLoaderTest.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using Moq;
 using MvvmCross.Exceptions;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
 using Xunit;

--- a/UnitTests/Plugins.Color.UnitTest/ColorCollection.cs
+++ b/UnitTests/Plugins.Color.UnitTest/ColorCollection.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.Plugins.Color.UnitTest

--- a/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
+++ b/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins\Color\MvvmCross.Plugin.Color.csproj" />
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins.Color.UnitTest/MvxColorValueConverterTest.cs
+++ b/UnitTests/Plugins.Color.UnitTest/MvxColorValueConverterTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UI;
 using Xunit;
 

--- a/UnitTests/Plugins.Color.UnitTest/MvxRgbIntValueConverterTest.cs
+++ b/UnitTests/Plugins.Color.UnitTest/MvxRgbIntValueConverterTest.cs
@@ -4,7 +4,7 @@
 
 using System.Globalization;
 using MvvmCross.Plugin.Color;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.Plugins.Color.UnitTest

--- a/UnitTests/Plugins.Color.UnitTest/MvxRgbaValueConverterTest.cs
+++ b/UnitTests/Plugins.Color.UnitTest/MvxRgbaValueConverterTest.cs
@@ -4,7 +4,7 @@
 
 using System.Globalization;
 using MvvmCross.Plugin.Color;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.Plugins.Color.UnitTest

--- a/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins\JsonLocalization\MvvmCross.Plugin.JsonLocalization.csproj" />
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins.JsonLocalization.UnitTest/MvxDictionaryTextProviderTest.cs
+++ b/UnitTests/Plugins.JsonLocalization.UnitTest/MvxDictionaryTextProviderTest.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using MvvmCross.Plugins.JsonLocalization.UnitTest.TestClasses;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.Plugins.JsonLocalization.UnitTest

--- a/UnitTests/Plugins.Messenger.UnitTest/MessengerHubTest.cs
+++ b/UnitTests/Plugins.Messenger.UnitTest/MessengerHubTest.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using MvvmCross.Plugin.Messenger;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.Plugins.Messenger.UnitTest

--- a/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
+++ b/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins\Messenger\MvvmCross.Plugin.Messenger.csproj" />
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins.Network.UnitTest/MvvmCross.Plugins.Network.UnitTest.csproj
+++ b/UnitTests/Plugins.Network.UnitTest/MvvmCross.Plugins.Network.UnitTest.csproj
@@ -15,8 +15,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins\Json\MvvmCross.Plugin.Json.csproj" />
     <ProjectReference Include="..\..\MvvmCross.Plugins\Network\MvvmCross.Plugin.Network.csproj" />
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins.Network.UnitTest/RestCollection.cs
+++ b/UnitTests/Plugins.Network.UnitTest/RestCollection.cs
@@ -5,7 +5,7 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.Plugins.Network.UnitTest

--- a/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
+++ b/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins\ResourceLoader\MvvmCross.Plugin.ResourceLoader.csproj" />
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins\ResxLocalization\MvvmCross.Plugin.ResxLocalization.csproj" />
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins.Visibility/MvvmCross.Plugins.Visibility.UnitTest.csproj
+++ b/UnitTests/Plugins.Visibility/MvvmCross.Plugins.Visibility.UnitTest.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins\Visibility\MvvmCross.Plugin.Visibility.csproj" />
-    <ProjectReference Include="..\..\MvvmCross.Test\MvvmCross.Test.csproj" />
+    <ProjectReference Include="..\..\MvvmCross.Tests\MvvmCross.Tests.csproj" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />
   </ItemGroup>
 

--- a/UnitTests/Plugins.Visibility/VisibilityCollection.cs
+++ b/UnitTests/Plugins.Visibility/VisibilityCollection.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using Xunit;
 
 namespace MvvmCross.Plugins.Visibility.UnitTest

--- a/UnitTests/Plugins.Visibility/VisibilityValueConverterTest.cs
+++ b/UnitTests/Plugins.Visibility/VisibilityValueConverterTest.cs
@@ -4,7 +4,7 @@
 
 using System.Globalization;
 using MvvmCross.Plugin.Visibility;
-using MvvmCross.Test;
+using MvvmCross.Tests;
 using MvvmCross.UI;
 using Xunit;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Changes back the name from MvvmCross.Test to Tests.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

Yes for the beta, No for stable

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
