### PR TITLE
Fix moving items in the MvxRecyclerAdapter

### DIFF
--- a/MvvmCross.Android.Support/V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Android.Support/V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -259,12 +259,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                         break;
                     case NotifyCollectionChangedAction.Move:
                         for (int i = 0; i < e.NewItems.Count; i++)
-                        {
-                            var oldItem = e.OldItems[i];
-                            var newItem = e.NewItems[i];
-
-                            NotifyItemMoved(GetViewPosition(oldItem), GetViewPosition(newItem));
-                        }
+                            NotifyItemMoved(GetViewPosition(e.OldStartingIndex + i), GetViewPosition(e.NewStartingIndex + i));
                         break;
                     case NotifyCollectionChangedAction.Replace:
                         NotifyItemRangeChanged(GetViewPosition(e.NewStartingIndex), e.NewItems.Count);


### PR DESCRIPTION
When using NotifyCollectionChangedAction.Move:
  1. OldItems and NewItems are logically equivalent
  2. OldStartingIndex is the old item position
  3. NewStartingIndex is the new item position

This fixes animations during a move operation.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
Move operations don't animate and the UI doesn't refresh.  The user has to scroll to see the visual change.

### :new: What is the new behavior (if this is a feature change)?
Items now animate properly

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Generate a move from an observable collection (sorting is a good example).

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
