### PR TITLE
Assure Xamarin's Current Application is set when Intiailize is called

### DIFF
--- a/MvvmCross.Forms/Platform/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platform/Android/Views/MvxFormsAppCompatActivity.cs
@@ -105,6 +105,11 @@ namespace MvvmCross.Forms.Platform.Android.Views
 
         public virtual void InitializeForms(Bundle bundle)
         {
+            if(null == global::Xamarin.Forms.Application.Current)
+            {
+                global::Xamarin.Forms.Application.Current = FormsApplication;
+            }
+
             if (FormsApplication.MainPage != null)
             {
                 global::Xamarin.Forms.Forms.Init(this, bundle, GetResourceAssembly());


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix For: https://github.com/MvvmCross/MvvmCross/issues/2622 and also makes https://github.com/MvvmCross/MvvmCross/issues/2624 possible.

### :arrow_heading_down: What is the current behavior?
The Application.Current Context is lost in the base implementation of `OnCreate` by Xamarin's Built in FormsActivity

### :new: What is the new behavior (if this is a feature change)?
If no Current Application is set, we will set it to be the current FormsApplication we have associated with the Activity

### :boom: Does this PR introduce a breaking change?
Shouldn't for Forms Applications unless people are detecting this edge case manually

### :bug: Recommendations for testing
Create an Xamarin Forms Application with Android that doesn't have a Splash Screen and its first page depends on Static Resources. This PR, should make the app work properly.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
