### PR TITLE
[iOS] Update UITextField binding when editing did end (Text Replacement fix)

### DIFF
--- a/MvvmCross/Platform/Ios/Binding/Target/MvxUITextFieldTextTargetBinding.cs
+++ b/MvvmCross/Platform/Ios/Binding/Target/MvxUITextFieldTextTargetBinding.cs
@@ -15,7 +15,8 @@ namespace MvvmCross.Platform.Ios.Binding.Target
     {
         protected UITextField View => Target as UITextField;
 
-        private IDisposable _subscription;
+        private IDisposable _subscriptionChanged;
+        private IDisposable _subscriptionEndEditing;
 
         public MvxUITextFieldTextTargetBinding(UITextField target)
             : base(target)
@@ -42,7 +43,8 @@ namespace MvvmCross.Platform.Ios.Binding.Target
                 return;
             }
 
-            _subscription = target.WeakSubscribe(nameof(target.EditingChanged), HandleEditTextValueChanged);
+            _subscriptionChanged = target.WeakSubscribe(nameof(target.EditingChanged), HandleEditTextValueChanged);
+            _subscriptionEndEditing = target.WeakSubscribe(nameof(target.EditingDidEnd), HandleEditTextValueChanged);
         }
 
         public override Type TargetType => typeof(string);
@@ -63,8 +65,11 @@ namespace MvvmCross.Platform.Ios.Binding.Target
             base.Dispose(isDisposing);
             if (!isDisposing) return;
 
-            _subscription?.Dispose();
-            _subscription = null;
+            _subscriptionChanged?.Dispose();
+            _subscriptionChanged = null;
+
+            _subscriptionEndEditing?.Dispose();
+            _subscriptionEndEditing = null;
         }
 
         public string CurrentText


### PR DESCRIPTION
This change ensures that binding updated on both `EditingChanged` and `EditingDidEnd` events.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix

### :arrow_heading_down: What is the current behavior?
Whenever iOS **Text Replacement** activated, a bound property is not updated 

### :new: What is the new behavior (if this is a feature change)?
Bound property updated both:

- on text typo
- on Text Replacement activation (during control focus lost)

### :boom: Does this PR introduce a breaking change?
Technically, previously binding updated only during the typo and didn't update on focus lost.
Now there is an additional binding update on focus lost.
If somebody relies on the fact, that UITextField focus lost doesn't update binding - then this might be a breaking change for that users.
Otherwise, I feel like this change contains more benefits.

### :bug: Recommendations for testing
See #2681 for reproduce description

### :memo: Links to relevant issues/docs
#2681 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop