### PR TITLE
Add a playground page to test whether MvxContentViews load their view models

### DIFF
--- a/Projects/Playground/Playground.Core/ViewModels/ChildContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/ChildContentViewModel.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class ChildContentViewModel : MvxViewModel
+    {
+        private string _test;
+
+        public string Test
+        {
+            get { return _test; }
+            private set { SetProperty(ref _test, value); }
+        }
+
+        public override async Task Initialize()
+        {
+            Test = "Bound Text";
+            await Task.Yield();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/ParentContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/ParentContentViewModel.cs
@@ -1,0 +1,8 @@
+﻿using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class ParentContentViewModel : MvxViewModel
+    {
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -123,6 +123,8 @@ namespace Playground.Core.ViewModels
 
         public IMvxAsyncCommand ShowCodeBehindViewCommand => new MvxAsyncCommand(async () => await _navigationService.Navigate<CodeBehindViewModel>());
 
+        public IMvxAsyncCommand ShowContentViewCommand => new MvxAsyncCommand(async () => await _navigationService.Navigate<ParentContentViewModel>());
+
         private async Task Navigate()
         {
             try 

--- a/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views1:MvxContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Playground.Forms.UI.Views;assembly=Playground.Forms.UI"
+             xmlns:views1="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
+             xmlns:viewModels="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
+             x:Class="Playground.Forms.UI.Pages.ParentContentPage" x:TypeArguments="viewModels:ParentContentViewModel">
+    <ContentPage.Content>
+        <StackLayout>
+            <views:ChildContentView />
+        </StackLayout>
+    </ContentPage.Content>
+</views1:MvxContentPage>

--- a/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml.cs
+++ b/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿using MvvmCross.Forms.Views;
+using Playground.Core.ViewModels;
+using Xamarin.Forms.Xaml;
+
+namespace Playground.Forms.UI.Pages
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class ParentContentPage : MvxContentPage<ParentContentViewModel>
+	{
+		public ParentContentPage()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
@@ -17,6 +17,7 @@
                 <Button Text="Show Tabs" mvx:Bi.nd="Command ShowTabsCommand"/>
                 <Button Text="Show Master/Detail" mvx:Bi.nd="Command ShowSplitCommand"/>
                 <Button Text="Show Mixed Navigation" mvx:Bi.nd="Command ShowMixedNavigationCommand"/>
+                <Button Text="Show Content View" mvx:Bi.nd="Command ShowContentViewCommand"/>
                 <Label Text="Native views" />
                 <Button Text="Show Native Page" mvx:Bi.nd="Command ShowNativeCommand"/>
                 <Button Text="Show Override" mvx:Bi.nd="Command ShowOverrideAttributeCommand"/>

--- a/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
+++ b/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
@@ -17,4 +17,13 @@
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="Pages\ParentContentPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Views\ChildContentView.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/Projects/Playground/Playground.Forms.UI/Views/ChildContentView.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Views/ChildContentView.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<views:MvxContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
+             xmlns:viewModels="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
+             x:Class="Playground.Forms.UI.Views.ChildContentView" x:TypeArguments="viewModels:ChildContentViewModel">
+  <ContentView.Content>
+      <StackLayout>
+          <Label Text="Static Text" />
+          <Label Text="{Binding Test}" />
+      </StackLayout>
+  </ContentView.Content>
+</views:MvxContentView>

--- a/Projects/Playground/Playground.Forms.UI/Views/ChildContentView.xaml.cs
+++ b/Projects/Playground/Playground.Forms.UI/Views/ChildContentView.xaml.cs
@@ -1,0 +1,15 @@
+﻿using MvvmCross.Forms.Views;
+using Playground.Core.ViewModels;
+using Xamarin.Forms.Xaml;
+
+namespace Playground.Forms.UI.Views
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class ChildContentView : MvxContentView<ChildContentViewModel>
+	{
+		public ChildContentView()
+		{
+			InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
@martijn00 Here is the PR you requested to test whether MvxContentViews automatically load and initialize their view models. Based on this, they don't appear to do so. Please let me know if I'm doing something wrong.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds a page to the playground to test whether content views automatically load and initialize their corresponding view model.

### :arrow_heading_down: What is the current behavior?
The test page doesn't exist in the playground.

### :new: What is the new behavior (if this is a feature change)?
The test page is available in the playground.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Launch the Playground.Forms.* project. On the root page, under "Forms views," tap "Show Content View." The content view page contains two labels, one with static text that reads "Static Text," the other with bound text that should read "Bound Text." Confirm whether both labels' text appears properly, or just the static text. (For me, I only see "Static Text", not "Bound Text".

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
