### PR TITLE
Updates RegisterAttribute to match new Mvx 6 namespaces

### DIFF
--- a/MvvmCross/Platform/Android/Binding/Views/MvxAutoCompleteTextView.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxAutoCompleteTextView.cs
@@ -12,7 +12,7 @@ using MvvmCross.Binding.Attributes;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxAutoCompleteTextView")]
+    [Register("mvvmcross.platform.android.binding.views.MvxAutoCompleteTextView")]
     public class MvxAutoCompleteTextView
         : AutoCompleteTextView
     {

--- a/MvvmCross/Platform/Android/Binding/Views/MvxDatePicker.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxDatePicker.cs
@@ -10,7 +10,7 @@ using Android.Widget;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxDatePicker")]
+    [Register("mvvmcross.platform.android.binding.views.MvxDatePicker")]
     public class MvxDatePicker
         : DatePicker
         , DatePicker.IOnDateChangedListener

--- a/MvvmCross/Platform/Android/Binding/Views/MvxExpandableListView.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxExpandableListView.cs
@@ -13,7 +13,7 @@ using MvvmCross.Binding.Attributes;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxExpandableListView")]
+    [Register("mvvmcross.platform.android.binding.views.MvxExpandableListView")]
     public class MvxExpandableListView : ExpandableListView
     {
         private bool _groupClickOverloaded;

--- a/MvvmCross/Platform/Android/Binding/Views/MvxFrameControl.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxFrameControl.cs
@@ -16,7 +16,7 @@ using MvvmCross.Platform.Android.Binding.BindingContext;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxFrameControl")]
+    [Register("mvvmcross.platform.android.binding.views.MvxFrameControl")]
     public class MvxFrameControl
         : FrameLayout, IMvxBindingContextOwner
     {

--- a/MvvmCross/Platform/Android/Binding/Views/MvxGridView.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxGridView.cs
@@ -13,7 +13,7 @@ using MvvmCross.Binding.Attributes;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxGridView")]
+    [Register("mvvmcross.platform.android.binding.views.MvxGridView")]
     public class MvxGridView
         : GridView
     {

--- a/MvvmCross/Platform/Android/Binding/Views/MvxImageView.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxImageView.cs
@@ -15,7 +15,7 @@ using MvvmCross.Platform.Android.Binding.ResourceHelpers;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxImageView")]
+    [Register("mvvmcross.platform.android.binding.views.MvxImageView")]
     public class MvxImageView
         : ImageView
     {

--- a/MvvmCross/Platform/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxLayoutInflater.cs
@@ -38,7 +38,7 @@ namespace MvvmCross.Platform.Android.Binding.Views
     /// Heavily based on Calligraphy's CalligraphyLayoutInflater
     /// See: https://github.com/chrisjenx/Calligraphy/blob/master/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java" />
     /// </summary>
-    [Register("mvvmcross.binding.droid.views.MvxLayoutInflater")]
+    [Register("mvvmcross.platform.android.binding.views.MvxLayoutInflater")]
     public class MvxLayoutInflater : LayoutInflater
     {
         public class MvxBindingVisitor

--- a/MvvmCross/Platform/Android/Binding/Views/MvxLinearLayout.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxLinearLayout.cs
@@ -16,7 +16,7 @@ using MvvmCross.Binding.BindingContext;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxLinearLayout")]
+    [Register("mvvmcross.platform.android.binding.views.MvxLinearLayout")]
     public class MvxLinearLayout
         : LinearLayout, IMvxWithChangeAdapter
     {

--- a/MvvmCross/Platform/Android/Binding/Views/MvxListItemView.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxListItemView.cs
@@ -12,7 +12,7 @@ using Object = Java.Lang.Object;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxListItemView")]
+    [Register("mvvmcross.platform.android.binding.views.MvxListItemView")]
     public class MvxListItemView : Object, IMvxListItemView, 
         IMvxBindingContextOwner, View.IOnAttachStateChangeListener
     {

--- a/MvvmCross/Platform/Android/Binding/Views/MvxListView.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxListView.cs
@@ -13,7 +13,7 @@ using MvvmCross.Binding.Attributes;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxListView")]
+    [Register("mvvmcross.platform.android.binding.views.MvxListView")]
     public class MvxListView
         : ListView
     {

--- a/MvvmCross/Platform/Android/Binding/Views/MvxRadioGroup.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxRadioGroup.cs
@@ -17,7 +17,7 @@ using MvvmCross.Binding.BindingContext;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxRadioGroup")]
+    [Register("mvvmcross.platform.android.binding.views.MvxRadioGroup")]
     public class MvxRadioGroup : RadioGroup, IMvxWithChangeAdapter
     {
         public MvxRadioGroup(Context context, IAttributeSet attrs)

--- a/MvvmCross/Platform/Android/Binding/Views/MvxSimpleListItemView.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxSimpleListItemView.cs
@@ -9,7 +9,7 @@ using Android.Widget;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxSimpleListItemView")]
+    [Register("mvvmcross.platform.android.binding.views.MvxSimpleListItemView")]
     public class MvxSimpleListItemView : MvxListItemView
     {
         public MvxSimpleListItemView(Context context, IMvxLayoutInflaterHolder layoutInflaterHolder, 

--- a/MvvmCross/Platform/Android/Binding/Views/MvxSpinner.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxSpinner.cs
@@ -13,7 +13,7 @@ using MvvmCross.Binding.Attributes;
 
 namespace MvvmCross.Platform.Android.Binding.Views
 {
-    [Register("mvvmcross.binding.droid.views.MvxSpinner")]
+    [Register("mvvmcross.platform.android.binding.views.MvxSpinner")]
     public class MvxSpinner : Spinner
     {
         public MvxSpinner(Context context, IAttributeSet attrs)

--- a/MvvmCross/Platform/Android/Binding/Views/MvxTimePicker.cs
+++ b/MvvmCross/Platform/Android/Binding/Views/MvxTimePicker.cs
@@ -13,7 +13,7 @@ namespace MvvmCross.Platform.Android.Binding.Views
     // Special thanks for this file to Emi - https://github.com/eMi-/mvvmcross_datepicker_timepicker
     // Code used under Creative Commons with attribution
     // See also http://stackoverflow.com/questions/14829521/bind-timepicker-datepicker-mvvmcross-mono-for-android
-    [Register("mvvmcross.binding.droid.views.MvxTimePicker")]
+    [Register("mvvmcross.platform.android.binding.views.MvxTimePicker")]
     public class MvxTimePicker
         : TimePicker
         , TimePicker.IOnTimeChangedListener

--- a/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourceDialogFragment.cs
+++ b/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourceDialogFragment.cs
@@ -12,7 +12,7 @@ using MvvmCross.Base;
 
 namespace MvvmCross.Platform.Android.Views.Fragments.EventSource
 {
-    [Register("mvvmcross.droid.fragments.eventsource.MvxEventSourceDialogFragment")]
+    [Register("mvvmcross.platform.android.views.fragments.eventsource.MvxEventSourceDialogFragment")]
     public class MvxEventSourceDialogFragment
         : DialogFragment
         , IMvxEventSourceFragment

--- a/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourceFragment.cs
+++ b/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourceFragment.cs
@@ -12,7 +12,7 @@ using MvvmCross.Base;
 
 namespace MvvmCross.Platform.Android.Views.Fragments.EventSource
 {
-    [Register("mvvmcross.droid.fragments.eventsource.MvxEventSourceFragment")]
+    [Register("mvvmcross.platform.android.views.fragments.eventsource.MvxEventSourceFragment")]
     public class MvxEventSourceFragment
         : Fragment
         , IMvxEventSourceFragment

--- a/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -12,7 +12,7 @@ using MvvmCross.Base;
 
 namespace MvvmCross.Platform.Android.Views.Fragments.EventSource
 {
-    [Register("mvvmcross.droid.fragments.eventsource.MvxEventSourceListFragment")]
+    [Register("mvvmcross.platform.android.views.fragments.eventsource.MvxEventSourceListFragment")]
     public class MvxEventSourceListFragment
         : ListFragment
         , IMvxEventSourceFragment

--- a/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourcePreferenceFragment.cs
+++ b/MvvmCross/Platform/Android/Views/Fragments/EventSource/MvxEventSourcePreferenceFragment.cs
@@ -13,7 +13,7 @@ using MvvmCross.Base;
 
 namespace MvvmCross.Platform.Android.Views.Fragments.EventSource
 {
-    [Register("mvvmcross.droid.fragments.eventsource.MvxEventSourcePreferenceFragment")]
+    [Register("mvvmcross.platform.android.views.fragments.eventsource.MvxEventSourcePreferenceFragment")]
     public abstract class MvxEventSourcePreferenceFragment : PreferenceFragment
     , IMvxEventSourceFragment
     {

--- a/MvvmCross/Platform/Android/Views/Fragments/MvxDialogFragment.cs
+++ b/MvvmCross/Platform/Android/Views/Fragments/MvxDialogFragment.cs
@@ -11,7 +11,7 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platform.Android.Views.Fragments
 {
-    [Register("mvvmcross.droid.fragments.MvxDialogFragment")]
+    [Register("mvvmcross.platform.android.views.fragments.MvxDialogFragment")]
     public abstract class MvxDialogFragment
         : MvxEventSourceDialogFragment, IMvxFragmentView
     {

--- a/MvvmCross/Platform/Android/Views/Fragments/MvxFragment.cs
+++ b/MvvmCross/Platform/Android/Views/Fragments/MvxFragment.cs
@@ -11,7 +11,7 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platform.Android.Views.Fragments
 {
-    [Register("mvvmcross.droid.fragments.MvxFragment")]
+    [Register("mvvmcross.platform.android.views.fragments.MvxFragment")]
     public class MvxFragment
         : MvxEventSourceFragment
         , IMvxFragmentView

--- a/MvvmCross/Platform/Android/Views/Fragments/MvxPreferenceFragment.cs
+++ b/MvvmCross/Platform/Android/Views/Fragments/MvxPreferenceFragment.cs
@@ -11,7 +11,7 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platform.Android.Views.Fragments
 {
-    [Register("mvvmcross.droid.fragments.MvxPreferenceFragment")]
+    [Register("mvvmcross.platform.android.views.fragments.MvxPreferenceFragment")]
     public abstract class MvxPreferenceFragment : MvxEventSourcePreferenceFragment, IMvxFragmentView
     {
         protected MvxPreferenceFragment()

--- a/MvvmCross/Platform/Android/Views/MvxActivity.cs
+++ b/MvvmCross/Platform/Android/Views/MvxActivity.cs
@@ -17,7 +17,7 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platform.Android.Views
 {
-    [Register("mvvmcross.droid.views.MvxActivity")]
+    [Register("mvvmcross.platform.android.views.MvxActivity")]
     public abstract class MvxActivity
         : MvxEventSourceActivity
         , IMvxAndroidView

--- a/MvvmCross/Platform/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platform/Android/Views/MvxSplashScreenActivity.cs
@@ -10,7 +10,7 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platform.Android.Views
 {
-    [Register("mvvmcross.droid.views.MvxSplashScreenActivity")]
+    [Register("mvvmcross.platform.android.views.MvxSplashScreenActivity")]
     public abstract class MvxSplashScreenActivity
         : MvxActivity, IMvxAndroidSplashScreenActivity
     {

--- a/MvvmCross/Platform/Android/Views/MvxTabActivity.cs
+++ b/MvvmCross/Platform/Android/Views/MvxTabActivity.cs
@@ -17,7 +17,7 @@ using MvvmCross.ViewModels;
 namespace MvvmCross.Platform.Android.Views
 {
     [Obsolete("TabActivity is obsolete. Use ViewPager + Indicator or any other Activity with Toolbar support.")]
-    [Register("mvvmcross.droid.views.MvxTabActivity")]
+    [Register("mvvmcross.platform.android.views.MvxTabActivity")]
     public abstract class MvxTabActivity
         : MvxEventSourceTabActivity, IMvxAndroidView, IMvxChildViewModelOwner
     {

--- a/MvvmCross/Platform/Android/Views/MvxTabsFragmentActivity.cs
+++ b/MvvmCross/Platform/Android/Views/MvxTabsFragmentActivity.cs
@@ -19,7 +19,7 @@ using Object = Java.Lang.Object;
 
 namespace MvvmCross.Platform.Android.Views
 {
-    [Register("mvvmcross.droid.views.MvxTabsFragmentActivity")]
+    [Register("mvvmcross.platform.android.views.MvxTabsFragmentActivity")]
     public abstract class MvxTabsFragmentActivity
         : MvxActivity, TabHost.IOnTabChangeListener
     {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix related to Mvx6 when using ProGuard in release configuration.

### :arrow_heading_down: What is the current behavior?
The `[Register]` on some of the Android views is not reflecting the new namespace.

### :new: What is the new behavior (if this is a feature change)?
I've updated the `[Register]` to match the new Mvx 6 namespace.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#2688 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
