### PR TITLE
ItemTemplateId added to IMvxTemplateSelector

### DIFF
--- a/MvvmCross.Android.Support/V7.RecyclerView/AttributeHelpers/MvxRecyclerViewAttributeExtensions.cs
+++ b/MvvmCross.Android.Support/V7.RecyclerView/AttributeHelpers/MvxRecyclerViewAttributeExtensions.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView.AttributeHelpers
             return className;
         }
             
-        public static IMvxTemplateSelector BuildItemTemplateSelector(Context context, IAttributeSet attrs)
+        public static IMvxTemplateSelector BuildItemTemplateSelector(Context context, IAttributeSet attrs, int itemTemplateId)
         {
             var templateSelectorClassName = ReadRecyclerViewItemTemplateSelectorClassName(context, attrs);
             var type = Type.GetType(templateSelectorClassName);
@@ -73,7 +73,12 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView.AttributeHelpers
                 throw new InvalidOperationException(message);
             }
 
-            return Activator.CreateInstance(type) as IMvxTemplateSelector;
+            var templateSelector = Activator.CreateInstance(type) as IMvxTemplateSelector;
+
+            if (itemTemplateId != 0 && templateSelector != null)
+                    templateSelector.ItemTemplateId = itemTemplateId;
+
+            return templateSelector;
         }
 
         private static bool areBindingResourcesInitialized = false;

--- a/MvvmCross.Android.Support/V7.RecyclerView/ItemTemplates/IMvxTemplateSelector.cs
+++ b/MvvmCross.Android.Support/V7.RecyclerView/ItemTemplates/IMvxTemplateSelector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,6 +6,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView.ItemTemplates
 {
     public interface IMvxTemplateSelector
     {
+        int ItemTemplateId { get; set; }
         int GetItemViewType(object forItemObject);
 
         int GetItemLayoutId(int fromViewType);

--- a/MvvmCross.Android.Support/V7.RecyclerView/ItemTemplates/MvxTemplateSelector.cs
+++ b/MvvmCross.Android.Support/V7.RecyclerView/ItemTemplates/MvxTemplateSelector.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,6 +6,8 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView.ItemTemplates
 {
     public abstract class MvxTemplateSelector<TItem> : IMvxTemplateSelector where TItem : class
     {
+        public int ItemTemplateId { get; set; }
+
         public int GetItemViewType(object forItemObject)
         {
             return SelectItemViewType(forItemObject as TItem);

--- a/MvvmCross.Android.Support/V7.RecyclerView/MvxRecyclerView.cs
+++ b/MvvmCross.Android.Support/V7.RecyclerView/MvxRecyclerView.cs
@@ -50,7 +50,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                 SetLayoutManager(new MvxGuardedLinearLayoutManager(context));
 
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
-            var itemTemplateSelector = MvxRecyclerViewAttributeExtensions.BuildItemTemplateSelector(context, attrs);
+            var itemTemplateSelector = MvxRecyclerViewAttributeExtensions.BuildItemTemplateSelector(context, attrs, itemTemplateId);
 
             adapter.ItemTemplateSelector = itemTemplateSelector;
             Adapter = adapter;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature request

### :arrow_heading_down: What is the current behavior?
There is no `ItemTemplateId` in TemplateSelector if set in xml

### :new: What is the new behavior (if this is a feature change)?
`ItemTemplateId` added as requested in #2422 

### :boom: Does this PR introduce a breaking change?
Yes. Extends IMvxTemplateSelector by ItemTemplateId

### :bug: Recommendations for testing
add `local:MvxItemTemplate` and `local:MvxTemplateSelector` in axml

### :memo: Links to relevant issues/docs
fixes #2422 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
