### PR TITLE
allow only one fragment instatnce and example in playground

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -206,6 +206,16 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             MvxFragmentPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
+            // if AllowOnlyOneInstance is true, then return if fragment already exists
+            if (attribute.AllowOnlyOneInstance)
+            {
+                var fragmentName = FragmentJavaName(attribute.ViewType);
+                var fragment = (CurrentActivity as MvxAppCompatActivity)?.SupportFragmentManager.FindFragmentByTag(fragmentName);
+                
+                if (fragment != null && fragment.IsAdded)
+                    return;
+            }
+
             // if attribute has a Fragment Host, then show it as nested and return
             if (attribute.FragmentHostViewType != null)
             {

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,7 +27,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             int popExitAnimation = int.MinValue,
             int transitionStyle = int.MinValue,
             Type fragmentHostViewType = null,
-            bool isCacheableFragment = false
+            bool isCacheableFragment = false,
+            bool allowOnlyOneInstance = false
         )
         {
             ActivityHostViewModelType = activityHostViewModelType;
@@ -40,6 +41,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             TransitionStyle = transitionStyle;
             FragmentHostViewType = fragmentHostViewType;
             IsCacheableFragment = isCacheableFragment;
+            AllowOnlyOneInstance = allowOnlyOneInstance;
         }
 
         public MvxFragmentPresentationAttribute(
@@ -52,7 +54,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             string popExitAnimation = null,
             string transitionStyle = null,
             Type fragmentHostViewType = null,
-            bool isCacheableFragment = false
+            bool isCacheableFragment = false,
+            bool allowOnlyOneInstance = false
         )
         {
             var context = Mvx.Resolve<IMvxAndroidGlobals>().ApplicationContext;
@@ -67,6 +70,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             TransitionStyle = !string.IsNullOrEmpty(transitionStyle) ? context.Resources.GetIdentifier(transitionStyle, "style", context.PackageName) : int.MinValue;
             FragmentHostViewType = fragmentHostViewType;
             IsCacheableFragment = isCacheableFragment;
+            AllowOnlyOneInstance = allowOnlyOneInstance;
         }
 
         /// <summary>
@@ -89,6 +93,12 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
         /// Will add the Fragment to the FragmentManager backstack
         /// </summary>
         public bool AddToBackStack { get; set; } = DefaultAddToBackStack;
+
+        public static bool DefaultAllowOnlyOneInstance = false;
+        /// <summary>
+        /// Allow only one instance at a time. False by default.
+        /// </summary>
+        public bool AllowOnlyOneInstance { get; set; } = DefaultAllowOnlyOneInstance;
 
         public static int DefaultEnterAnimation = int.MinValue;
         /// <summary>

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -265,6 +265,16 @@ namespace MvvmCross.Platforms.Android.Presenters
             MvxFragmentPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
+            // if AllowOnlyOneInstance is true, then return if fragment already exists
+            if (attribute.AllowOnlyOneInstance)
+            {
+                var fragmentName = FragmentJavaName(attribute.ViewType);
+                var fragment = CurrentActivity.FragmentManager.FindFragmentByTag(fragmentName);
+                
+                if (fragment != null && fragment.IsAdded)
+                    return;
+            }
+
             // if attribute has a Fragment Host, then show it as nested and return
             if (attribute.FragmentHostViewType != null)
             {

--- a/Projects/Playground/Playground.Droid/Views/SplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Views/SplitDetailView.cs
@@ -15,7 +15,7 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Views
 {
-    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
+    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame, allowOnlyOneInstance: true)]
     [Register(nameof(SplitDetailView))]
     public class SplitDetailView : MvxFragment<SplitDetailViewModel>
     {

--- a/Projects/Playground/Playground.Droid/Views/SplitMasterView.cs
+++ b/Projects/Playground/Playground.Droid/Views/SplitMasterView.cs
@@ -20,12 +20,15 @@ namespace Playground.Droid.Views
     public class SplitMasterView : MvxFragment<SplitMasterViewModel>, NavigationView.IOnNavigationItemSelectedListener
     {
         private IMenuItem previousMenuItem;
+        private NavigationView _navigationView;
 
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             var ignore = base.OnCreateView(inflater, container, savedInstanceState);
 
             var view = this.BindingInflate(Resource.Layout.SplitMasterView, null);
+            _navigationView = view.FindViewById<NavigationView>(Resource.Id.navigation_view);
+            _navigationView.SetNavigationItemSelectedListener(this);
 
             return view;
         }
@@ -45,6 +48,7 @@ namespace Playground.Droid.Views
         private async Task Navigate(int itemId)
         {
             ((SplitRootView)Activity).DrawerLayout.CloseDrawers();
+            ((SplitRootView)Activity).ViewModel.ShowDetailCommand.Execute();
             await Task.Delay(TimeSpan.FromMilliseconds(250));
 
             //switch (itemId)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
There is no a flag to tell the presenter to only allow one instance of the fragment at a time.

### :new: What is the new behavior (if this is a feature change)?
`allowOnlyOneInstance` flag added to `MvxFragmentPresentationAttribute`

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
SplitView (master/detail) in Playground has an example

### :memo: Links to relevant issues/docs
fixes #2694 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
