### PR TITLE
#2718 Ensure that existing fragment info's VM instance is used whenev…

### DIFF
--- a/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
@@ -20,6 +20,7 @@ namespace MvvmCross.Droid.Support.V4
     public class MvxFragmentPagerAdapter : FragmentPagerAdapter
     {
         private readonly Context _context;
+
         public IEnumerable<MvxViewPagerFragmentInfo> Fragments { get; private set; }
 
         public override int Count => Fragments.Count();
@@ -45,8 +46,10 @@ namespace MvvmCross.Droid.Support.V4
             {
                 fragInfo.CachedFragment = Fragment.Instantiate(_context, FragmentJavaName(fragInfo.FragmentType));
 
-                var request = new MvxViewModelRequest(fragInfo.ViewModelType, null, null);
-                ((IMvxView)fragInfo.CachedFragment).ViewModel = Mvx.Resolve<IMvxViewModelLoader>().LoadViewModel(request, null);
+                var fragmentAsView = (IMvxView) fragInfo.CachedFragment;
+
+                fragmentAsView.ViewModel = fragInfo.ViewModel ?? Mvx.Resolve<IMvxViewModelLoader>()
+                    .LoadViewModel(new MvxViewModelRequest(fragInfo.ViewModelType, null, null), null);
             }
 
             return fragInfo.CachedFragment;

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
@@ -46,8 +46,10 @@ namespace MvvmCross.Droid.Support.V4
             {
                 fragInfo.CachedFragment = Fragment.Instantiate(_context, FragmentJavaName(fragInfo.FragmentType));
 
-                var request = new MvxViewModelRequest (fragInfo.ViewModelType, null, null);
-                ((IMvxView)fragInfo.CachedFragment).ViewModel = Mvx.Resolve<IMvxViewModelLoader>().LoadViewModel(request, null);
+                var fragmentAsView = (IMvxView)fragInfo.CachedFragment;
+
+                fragmentAsView.ViewModel = fragInfo.ViewModel ?? Mvx.Resolve<IMvxViewModelLoader>()
+                    .LoadViewModel(new MvxViewModelRequest(fragInfo.ViewModelType, null, null), null);
             }
 
             return fragInfo.CachedFragment;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

#2718 fixed

### :arrow_heading_down: What is the current behavior?

The adapter always tries to resolve the view model for the fragment from the resolver, even when the view model cannot be directly resolved and was manually supplied inside fragment info. This leads to crashes

### :new: What is the new behavior (if this is a feature change)?

Use the fragment info's existing view model instance whenever possible

### :boom: Does this PR introduce a breaking change?

Not that I know of.

### :bug: Recommendations for testing

See the scenario to reproduce in the bug.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
