### PR TITLE
Helpers for testing RaiseCanExecuteChanged

### DIFF
--- a/MvvmCross.Tests/MvxUnitTestCommandExtensions.cs
+++ b/MvvmCross.Tests/MvxUnitTestCommandExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using MvvmCross.Commands;
+
+namespace MvvmCross.Tests
+{
+    public static class MvxUnitTestCommandExtensions
+    {
+        public static void ListenForRaiseCanExecuteChanged(this IMvxCommand command)
+        {
+            var helper = GetCommandHelper();
+            helper.WillCallRaisePropertyChangedFor(command);
+        }
+
+        public static bool RaisedCanExecuteChanged(this IMvxCommand command)
+        {
+            var helper = GetCommandHelper();
+            return helper.HasCalledRaisePropertyChangedFor(command);
+        }
+
+        private static MvxUnitTestCommandHelper GetCommandHelper()
+        {
+            if (Mvx.TryResolve<IMvxCommandHelper>(out IMvxCommandHelper helper))
+            {
+                if (helper != null && helper is MvxUnitTestCommandHelper)
+                {
+                    return (MvxUnitTestCommandHelper)helper;
+                }
+            }
+
+            helper = new MvxUnitTestCommandHelper();
+            Mvx.RegisterSingleton<IMvxCommandHelper>(helper);
+            return (MvxUnitTestCommandHelper)helper;
+        }
+    }
+}

--- a/MvvmCross.Tests/MvxUnitTestCommandHelper.cs
+++ b/MvvmCross.Tests/MvxUnitTestCommandHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using MvvmCross.Commands;
 
 namespace MvvmCross.Tests
@@ -17,29 +18,24 @@ namespace MvvmCross.Tests
 
         public bool HasCalledRaisePropertyChangedFor(object item)
         {
-            try
+            if(item != null && items.Any() && items.ContainsKey(item))
             {
                 return items[item] > 0;
             }
-            catch (Exception)
-            {
-                return false;
-            }
+
+            throw new Exception("This command is not registered for tracking RaiseCanExecuteChanged");
         }
 
-        public void RaiseCanExecuteChanged(object sender)
+        public void RaiseCanExecuteChanged(object item)
         {
-            try
+            if (items != null && items.Any() && items.ContainsKey(item))
             {
-                items[sender] += 1;
-            }
-            catch (Exception)
-            {
+                items[item] += 1;
             }
 
             if (CanExecuteChanged != null)
             {
-                CanExecuteChanged.Invoke(sender, new System.EventArgs());
+                CanExecuteChanged.Invoke(item, new System.EventArgs());
             }
         }
     }

--- a/MvvmCross.Tests/MvxUnitTestCommandHelper.cs
+++ b/MvvmCross.Tests/MvxUnitTestCommandHelper.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using MvvmCross.Commands;
+
+namespace MvvmCross.Tests
+{
+    public class MvxUnitTestCommandHelper : IMvxCommandHelper
+    {
+        public event EventHandler CanExecuteChanged;
+
+        private Dictionary<object, int> items = new Dictionary<object, int>();
+
+        public void WillCallRaisePropertyChangedFor(object item)
+        {
+            items.Add(item, 0);
+        }
+
+        public bool HasCalledRaisePropertyChangedFor(object item)
+        {
+            try
+            {
+                return items[item] > 0;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public void RaiseCanExecuteChanged(object sender)
+        {
+            try
+            {
+                items[sender] += 1;
+            }
+            catch (Exception)
+            {
+            }
+
+            if (CanExecuteChanged != null)
+            {
+                CanExecuteChanged.Invoke(sender, new System.EventArgs());
+            }
+        }
+    }
+}

--- a/UnitTests/MvvmCross.UnitTest/Helpers/MvxUnitTestCommandHelperTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Helpers/MvxUnitTestCommandHelperTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using MvvmCross.Commands;
+using MvvmCross.Tests;
+using Xunit;
+
+namespace MvvmCross.UnitTest.Helpers
+{
+    public class MvxUnitTestCommandHelperTests
+    {
+        [Fact]
+        public void Helper_Can_Construct_Test()
+        {
+            var helper = new MvxUnitTestCommandHelper();
+            Assert.IsType<MvxUnitTestCommandHelper>(helper);
+        }
+
+        [Fact]
+        public void Can_Add_Item_To_Helper_Test()
+        {
+            var helper = new MvxUnitTestCommandHelper();
+
+            var fakeCommand = new object { };
+
+            helper.WillCallRaisePropertyChangedFor(fakeCommand);
+
+            helper.RaiseCanExecuteChanged(fakeCommand);
+
+            Assert.True(helper.HasCalledRaisePropertyChangedFor(fakeCommand));
+        }
+
+        [Fact]
+        public void Testing_Unregistered_Item_Will_Throw_Test()
+        {
+            var helper = new MvxUnitTestCommandHelper();
+
+            var fakeCommand = new object { };
+
+            Action act = () => helper.HasCalledRaisePropertyChangedFor(fakeCommand);
+
+            Assert.Throws<Exception>(act);
+        }
+    }
+}

--- a/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
+++ b/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
@@ -21,5 +21,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   
+  <ItemGroup>
+    <Folder Include="Helpers\" />
+  </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
+++ b/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
@@ -20,9 +20,6 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Helpers\" />
-  </ItemGroup>
+   
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/docs/_documentation/fundamentals/testing.md
+++ b/docs/_documentation/fundamentals/testing.md
@@ -135,7 +135,7 @@ protected override void AdditionalSetup()
 
 ## Testing MvxCommand RaiseCanExecuteChanged
 
-It can be diffucult to test if a Mvx(Async)Command in a view model has raised the CanExecuteChanged property. MvxUnitTestCommandHelper can help testing this behaviour:
+It can be difficult to test if a Mvx(Async)Command in a view model has raised the CanExecuteChanged property. MvxUnitTestCommandHelper can help testing this behaviour:
 
 ```
 protected override void AdditionalSetup()

--- a/docs/_documentation/fundamentals/testing.md
+++ b/docs/_documentation/fundamentals/testing.md
@@ -148,8 +148,22 @@ protected override void AdditionalSetup()
 
 ```
 
-Example test:
+Property in ViewModel:
 
+```
+private SomeModel _someModel;
+public SomeModel SomeModel
+{
+	get => _someModel;
+	set 
+	{
+		SetProperty(ref _someModel, value);
+		SomeCommand.RaiseCanExecuteChanged();
+	}
+}
+```
+
+Example test:
 
 ```
 [Test]

--- a/docs/_documentation/fundamentals/testing.md
+++ b/docs/_documentation/fundamentals/testing.md
@@ -133,6 +133,38 @@ protected override void AdditionalSetup()
 }
 ```
 
+## Testing MvxCommand RaiseCanExecuteChanged
+
+It can be diffucult to test if a Mvx(Async)Command in a view model has raised the CanExecuteChanged property. MvxUnitTestCommandHelper can help testing this behaviour:
+
+```
+protected override void AdditionalSetup()
+{
+	MvvmCross.Core.MvxSingletonCache.Instance.Settings.AlwaysRaiseInpcOnUserInterfaceThread = false;
+	
+	var helper = new MvxUnitTestCommandHelper();
+	Ioc.RegisterSingleton<IMvxCommandHelper>(helper);
+}
+
+```
+
+Example test:
+
+
+```
+[Test]
+public void Valid_Model_Raises_CanExecute_Test()
+{
+	var vm = Ioc.IoCConstruct<InsertCategoryViewModel>();
+	vm.SomeCommand.ListenForRaiseCanExecuteChanged();
+	
+	vm.SomeModel = new SomeValidModel();
+	
+	Assert.AreEqual(vm.SomeCommand.RaisedCanExecuteChanged(), true);
+}
+
+```
+
 ## Links and other references
 
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds a helper and extension methods to make it possible to unit test the behaviour of RaiseCanExecuteChanged. 

### :arrow_heading_down: What is the current behavior?
Currently it is not possible to check (in a unit test) if CanExecuteChanged has been raised.

### :new: What is the new behavior (if this is a feature change)?
With the use of the helper (which is also documented in the Testing chapter of the MvvmCross documentation) it is possible to assert that CanExecuteChanged has been raised.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x ] All projects build
- [x ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x ] Rebased onto current develop
