### PR TITLE
Removed no longer relevant comment in MvxAppCompatSetup

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetup.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetup.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-using Android.Content;
 using Android.Support.V4.Widget;
 using Android.Support.V7.Widget;
 using MvvmCross.Binding.BindingContext;
@@ -26,9 +25,6 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 typeof(MvxSwipeRefreshLayout).Assembly
             };
 
-        /// <summary>
-        /// This is very important to override. The default view presenter does not know how to show fragments!
-        /// </summary>
         protected override IMvxAndroidViewPresenter CreateViewPresenter()
         {
             return new MvxAppCompatViewPresenter(AndroidViewAssemblies);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Outdated comment on `CreateViewPresenter` in `MvxAppCompatSetup `

### :new: What is the new behavior (if this is a feature change)?

Comment is gone

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

N/A

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
