### PR TITLE
Add missing license to SelectedItemRecyclerAdapter

### DIFF
--- a/Projects/Playground/Playground.Droid/Adapter/SelectedItemRecyclerAdapter.cs
+++ b/Projects/Playground/Playground.Droid/Adapter/SelectedItemRecyclerAdapter.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using Android.Support.V4.View;
 using Android.Support.V7.Widget;
 using Android.Views;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Missing license on `SelectedItemRecyclerAdapter` in playground

### :new: What is the new behavior (if this is a feature change)?

File now has license

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

n/a

### :memo: Links to relevant issues/docs

n/a

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
