### PR TITLE
Make sure Forms is loaded when not using a splashscreen

### DIFF
--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
@@ -108,11 +108,13 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
         protected virtual void RunAppStart(Bundle bundle)
         {
+            InitializeForms(bundle);
+
             var startup = Mvx.Resolve<IMvxAppStart>();
             if(!startup.IsStarted)
                 startup.Start(GetAppStartHint(bundle));
 
-            InitializeForms(bundle);
+            InitializeApplication();
         }
 
         protected virtual object GetAppStartHint(object hint = null)
@@ -131,7 +133,10 @@ namespace MvvmCross.Forms.Platforms.Android.Views
             {
                 Xamarin.Forms.Application.Current = FormsApplication;
             }
+        }
 
+        public virtual void InitializeApplication()
+        {
             LoadApplication(FormsApplication);
         }
 

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
@@ -106,11 +106,13 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
         protected virtual void RunAppStart(Bundle bundle)
         {
+            InitializeForms(bundle);
+
             var startup = Mvx.Resolve<IMvxAppStart>();
             if (!startup.IsStarted)
                 startup.Start(GetAppStartHint(bundle));
 
-            InitializeForms(bundle);
+            InitializeApplication();
         }
 
         protected virtual object GetAppStartHint(object hint = null)
@@ -129,7 +131,10 @@ namespace MvvmCross.Forms.Platforms.Android.Views
             {
                 Xamarin.Forms.Application.Current = FormsApplication;
             }
+        }
 
+        public virtual void InitializeApplication()
+        {
             LoadApplication(FormsApplication);
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix

### :arrow_heading_down: What is the current behavior?

When not using a splashscreen and your first view uses a static resource the app crashes

### :new: What is the new behavior (if this is a feature change)?

It's fixed

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2622

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
