### PR TITLE
MvxAppStart: Add non-generic version

### DIFF
--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -3,25 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using System.Threading.Tasks;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
 
 namespace MvvmCross.ViewModels
 {
-    public class MvxAppStart<TViewModel>
-        : IMvxAppStart
-        where TViewModel : IMvxViewModel
+    public abstract class MvxAppStart : IMvxAppStart
     {
-        protected readonly IMvxNavigationService NavigationService;
-
         private int startHasCommenced;
-
-        public MvxAppStart(IMvxNavigationService navigationService)
-        {
-            NavigationService = navigationService;
-        }
         
         public void Start(object hint = null)
         {
@@ -29,6 +19,31 @@ namespace MvvmCross.ViewModels
             if (Interlocked.CompareExchange(ref startHasCommenced, 1, 0) == 1)
                 return;
 
+            Startup(hint);
+        }
+
+        protected abstract void Startup(object hint = null);
+
+        public virtual bool IsStarted => startHasCommenced != 0;
+
+        public virtual void ResetStart()
+        {
+            Interlocked.Exchange(ref startHasCommenced, 0);
+        }
+    }
+
+    public class MvxAppStart<TViewModel> : MvxAppStart
+        where TViewModel : IMvxViewModel
+    {
+        protected readonly IMvxNavigationService NavigationService;
+        
+        public MvxAppStart(IMvxNavigationService navigationService)
+        {
+            NavigationService = navigationService;
+        }
+
+        protected override void Startup(object hint = null)
+        {
             if (hint != null)
             {
                 MvxLog.Instance.Trace("Hint ignored in default MvxAppStart");
@@ -42,13 +57,6 @@ namespace MvvmCross.ViewModels
             {
                 throw exception.MvxWrap("Problem navigating to ViewModel {0}", typeof(TViewModel).Name);
             } 
-        }
-
-        public bool IsStarted => startHasCommenced != 0;
-
-        public void ResetStart()
-        {
-            Interlocked.Exchange(ref startHasCommenced, 0);
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code improvement

### :arrow_heading_down: What is the current behavior?
Since all the Setup infrastructure has changed, not there's some code that needs to be placed in AppStart to ensure everything works fine.
The problem is that if an app implements its own MvxAppStart, that code needs to be copied/pasted or adequated on the app, because there's no base class to extend from.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed. I added a non-generic version of MvxAppStart and applied inheritance.

### :boom: Does this PR introduce a breaking change?
It depends... but I'd say yes (although it's not this PR which breaks, this was caused by the PR which improved all the Setup stuff).
I needed to add a new method, which is wrapped in the classic `Start`. 

Apps upgrading to 6.0 will need to change the inheritance of their custom AppStart to be `MvxAppStart` instead of `IMvxAppStart` and also modify `Start` to `Startup`.

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
