### PR TITLE
Added generic versions of MvxApplication for WPF and UWP

### DIFF
--- a/MvvmCross.Forms/Platforms/Uap/Views/MvxWindowsApplication.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Views/MvxWindowsApplication.cs
@@ -4,11 +4,14 @@
 
 using System;
 using System.Threading.Tasks;
+using MvvmCross.Core;
+using MvvmCross.Forms.Platforms.Uap.Core;
 using MvvmCross.Forms.Views.Base;
 using MvvmCross.Platforms.Uap.Core;
 using MvvmCross.Platforms.Uap.Views;
 using MvvmCross.ViewModels;
 using Windows.ApplicationModel.Activation;
+using Xamarin.Forms;
 
 namespace MvvmCross.Forms.Platforms.Uap.Views
 {
@@ -21,7 +24,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Views
             if (RootFrame?.Content == null)
             {
                 MvxWindowsSetupSingleton.EnsureSingletonAvailable(RootFrame, activationArgs, nameof(Suspend)).EnsureInitialized();
-                
+
                 var startup = Mvx.Resolve<IMvxAppStart>();
                 if (!startup.IsStarted)
                     startup.Start(GetAppStartHint(activationArgs));
@@ -31,6 +34,31 @@ namespace MvvmCross.Forms.Platforms.Uap.Views
             }
             else
                 base.RunAppStart(activationArgs);
+        }
+    }
+
+    public abstract class MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication> : MvxWindowsApplication
+       where TMvxUapSetup : MvxFormsWindowsSetup<TApplication, TFormsApplication>, new()
+       where TApplication : IMvxApplication, new()
+        where TFormsApplication : Application, new()
+    {
+        protected abstract override Type HostWindowsPageType();
+
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxUapSetup>();
+        }
+    }
+
+    public class MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication, THostPageType> : MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication>
+       where TMvxUapSetup : MvxFormsWindowsSetup<TApplication, TFormsApplication>, new()
+       where TApplication : IMvxApplication, new()
+        where TFormsApplication : Application, new()
+        where THostPageType : MvxFormsWindowsPage
+    {
+        protected override Type HostWindowsPageType()
+        {
+            return typeof(THostPageType);
         }
     }
 }

--- a/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
@@ -149,4 +149,14 @@ namespace MvvmCross.Platforms.Uap.Views
         {
         }
     }
+
+    public class MvxApplication<TMvxUapSetup, TApplication> : MvxApplication
+       where TMvxUapSetup : MvxWindowsSetup<TApplication>, new()
+       where TApplication : IMvxApplication, new()
+    {
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxUapSetup>();
+        }
+    }
 }

--- a/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using MvvmCross.Core;
 using MvvmCross.Platforms.Wpf.Core;
 using MvvmCross.ViewModels;
 
@@ -34,6 +35,16 @@ namespace MvvmCross.Platforms.Wpf.Views
 
         protected virtual void RegisterSetup()
         {
+        }
+    }
+
+    public class MvxApplication<TMvxWpfSetup, TApplication> : MvxApplication
+       where TMvxWpfSetup : MvxWpfSetup<TApplication>, new()
+       where TApplication : IMvxApplication, new()
+    {
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxWpfSetup>();
         }
     }
 }

--- a/Projects/Playground/Playground.Forms.Uwp/App.xaml
+++ b/Projects/Playground/Playground.Forms.Uwp/App.xaml
@@ -1,7 +1,8 @@
-﻿<mvx:MvxWindowsApplication x:Class="Playground.Forms.Uwp.App"
+﻿<local:PlaygroundApp x:Class="Playground.Forms.Uwp.App"
                            xmlns:mvx="using:MvvmCross.Forms.Platforms.Uap.Views"
                            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                            xmlns:local="using:Playground.Forms.Uwp"
                            RequestedTheme="Light">
 
-</mvx:MvxWindowsApplication>
+</local:PlaygroundApp>

--- a/Projects/Playground/Playground.Forms.Uwp/App.xaml.cs
+++ b/Projects/Playground/Playground.Forms.Uwp/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using MvvmCross.Core;
 using MvvmCross.Forms.Platforms.Uap.Core;
+using MvvmCross.Forms.Platforms.Uap.Views;
 using MvvmCross.Platforms.Uap.Core;
 using Playground.Forms.UI;
 
@@ -12,15 +13,9 @@ namespace Playground.Forms.Uwp
         {
             InitializeComponent();
         }
+    }
 
-        protected override Type HostWindowsPageType()
-        {
-            return typeof(MainPage);
-        }
-
-        protected override void RegisterSetup()
-        {
-            this.RegisterSetupType<MvxFormsWindowsSetup<Core.App, FormsApp>>();
-        }
+    public abstract class PlaygroundApp : MvxWindowsApplication<MvxFormsWindowsSetup<Core.App, FormsApp>, Core.App, FormsApp, MainPage>
+    {
     }
 }

--- a/Projects/Playground/Playground.Uwp/App.xaml
+++ b/Projects/Playground/Playground.Uwp/App.xaml
@@ -4,5 +4,7 @@
                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                         xmlns:local="using:Playground.Uwp"
                         RequestedTheme="Light">
-
+    <Application.Resources>
+        <x:String x:Key="WelcomeText">Hello World!</x:String>
+    </Application.Resources>
 </local:PlaygroundApp>

--- a/Projects/Playground/Playground.Uwp/App.xaml
+++ b/Projects/Playground/Playground.Uwp/App.xaml
@@ -1,8 +1,8 @@
-﻿<mvx:MvxApplication x:Class="Playground.Uwp.App"
+﻿<local:PlaygroundApp x:Class="Playground.Uwp.App"
                         xmlns:mvx="using:MvvmCross.Platforms.Uap.Views"
                         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                         xmlns:local="using:Playground.Uwp"
                         RequestedTheme="Light">
 
-</mvx:MvxApplication>
+</local:PlaygroundApp>

--- a/Projects/Playground/Playground.Uwp/App.xaml.cs
+++ b/Projects/Playground/Playground.Uwp/App.xaml.cs
@@ -4,11 +4,16 @@ using MvvmCross.Platforms.Uap.Views;
 
 namespace Playground.Uwp
 {
-    public sealed partial class App : MvxApplication<MvxWindowsSetup<Core.App>, Core.App>
+    public sealed partial class App : PlaygroundApp
     {
         public App()
         {
             InitializeComponent();
         }
+    }
+
+    public class PlaygroundApp : MvxApplication<MvxWindowsSetup<Core.App>, Core.App>
+    {
+
     }
 }

--- a/Projects/Playground/Playground.Uwp/App.xaml.cs
+++ b/Projects/Playground/Playground.Uwp/App.xaml.cs
@@ -1,10 +1,9 @@
-﻿using MvvmCross.Core;
-using MvvmCross.Platforms.Uap.Core;
+﻿using MvvmCross.Platforms.Uap.Core;
 using MvvmCross.Platforms.Uap.Views;
 
 namespace Playground.Uwp
 {
-    public sealed partial class App : PlaygroundApp
+    public sealed partial class App
     {
         public App()
         {
@@ -12,8 +11,7 @@ namespace Playground.Uwp
         }
     }
 
-    public class PlaygroundApp : MvxApplication<MvxWindowsSetup<Core.App>, Core.App>
+    public abstract class PlaygroundApp : MvxApplication<MvxWindowsSetup<Core.App>, Core.App>
     {
-
     }
 }

--- a/Projects/Playground/Playground.Uwp/App.xaml.cs
+++ b/Projects/Playground/Playground.Uwp/App.xaml.cs
@@ -4,16 +4,11 @@ using MvvmCross.Platforms.Uap.Views;
 
 namespace Playground.Uwp
 {
-    public sealed partial class App : MvxApplication
+    public sealed partial class App : MvxApplication<MvxWindowsSetup<Core.App>, Core.App>
     {
         public App()
         {
             InitializeComponent();
-        }
-
-        protected override void RegisterSetup()
-        {
-            this.RegisterSetupType<MvxWindowsSetup<Core.App>>();
         }
     }
 }

--- a/Projects/Playground/Playground.Uwp/Views/RootView.xaml
+++ b/Projects/Playground/Playground.Uwp/Views/RootView.xaml
@@ -6,6 +6,7 @@
                       xmlns:views="using:MvvmCross.Platforms.Uap.Views"
                       mc:Ignorable="d">
     <StackPanel>
+        <TextBlock Text="{StaticResource WelcomeText}" />
         <Button Content="Show Child (Stack Navigation)"
                 Command="{Binding ShowChildCommand}"
                 Margin="5"

--- a/Projects/Playground/Playground.Wpf/App.xaml.cs
+++ b/Projects/Playground/Playground.Wpf/App.xaml.cs
@@ -4,11 +4,7 @@ using MvvmCross.Platforms.Wpf.Views;
 
 namespace Playground.Wpf
 {
-    public partial class App : MvxApplication
+    public partial class App : MvxApplication<MvxWpfSetup<Core.App>, Core.App>
     {
-        protected override void RegisterSetup()
-        {
-            this.RegisterSetupType<MvxWpfSetup<Core.App>>();
-        }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Probably a feature, or a fix?

### :arrow_heading_down: What is the current behavior?
Classes with generic versions on most platforms. But UWP and WPF are missing

### :new: What is the new behavior (if this is a feature change)?
Above is fixed.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
Previous PR: #2668 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
