### PR TITLE
Update ContentFiles Referenced In Readme.txt To Use MVVMCross 6.x Namespaces (& Remove MvxTrace References)

### DIFF
--- a/ContentFiles/Android/LinkerPleaseInclude.cs
+++ b/ContentFiles/Android/LinkerPleaseInclude.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Specialized;
-using System.Windows.Input;
-using Android.App;
+﻿using Android.App;
 using Android.Views;
 using Android.Widget;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Navigation;
 using MvvmCross.ViewModels;
+using System;
+using System.Collections.Specialized;
+using System.Windows.Input;
 
 namespace $YourNameSpace$
 {

--- a/ContentFiles/Android/MainView.cs.pp
+++ b/ContentFiles/Android/MainView.cs.pp
@@ -1,6 +1,6 @@
 using Android.App;
 using Android.OS;
-using MvvmCross.Droid.Views;
+using MvvmCross.Platforms.Android.Views;
 
 namespace $rootnamespace$.Views
 {

--- a/ContentFiles/Android/Setup.cs.pp
+++ b/ContentFiles/Android/Setup.cs.pp
@@ -1,7 +1,6 @@
 using Android.Content;
-using MvvmCross.Droid.Platform;
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform.Platform;
+using MvvmCross.Platforms.Android.Core;
+using MvvmCross.ViewModels;
 
 namespace $rootnamespace$
 {
@@ -14,11 +13,6 @@ namespace $rootnamespace$
         protected override IMvxApplication CreateApp()
         {
             return new Core.App();
-        }
-
-        protected override IMvxTrace CreateDebugTrace()
-        {
-            return new DebugTrace();
         }
     }
 }

--- a/ContentFiles/Android/SplashScreen.cs.pp
+++ b/ContentFiles/Android/SplashScreen.cs.pp
@@ -1,6 +1,6 @@
 using Android.App;
 using Android.Content.PM;
-using MvvmCross.Droid.Views;
+using MvvmCross.Platforms.Android.Views;
 
 namespace $rootnamespace$
 {

--- a/ContentFiles/Android/_ Droid UI.txt
+++ b/ContentFiles/Android/_ Droid UI.txt
@@ -1,4 +1,4 @@
 The steps to get this Android UI working are:
 
-1. Add a reference to your Core PCL project
+1. Add a reference to your Core .NET Standard project
 2. Remove any old `MainLauncher` activities - eg Activity1 or MainActivity

--- a/ContentFiles/Core/App.cs.pp
+++ b/ContentFiles/Core/App.cs.pp
@@ -1,8 +1,8 @@
-using MvvmCross.Platform.IoC;
+using MvvmCross.IoC;
 
 namespace $rootnamespace$
 {
-    public class App : MvvmCross.Core.ViewModels.MvxApplication
+    public class App : MvvmCross.ViewModels.MvxApplication
     {
         public override void Initialize()
         {

--- a/ContentFiles/Core/MainViewModel.cs.pp
+++ b/ContentFiles/Core/MainViewModel.cs.pp
@@ -1,5 +1,5 @@
+using MvvmCross.ViewModels;
 using System.Threading.Tasks;
-using MvvmCross.Core.ViewModels;
 
 namespace $rootnamespace$.ViewModels
 {

--- a/ContentFiles/Forms/CoreContent/App.xaml.cs.pp
+++ b/ContentFiles/Forms/CoreContent/App.xaml.cs.pp
@@ -1,6 +1,6 @@
-﻿using MvvmCross.Core.ViewModels;
-using MvvmCross.Forms.Platform;
-using MvvmCross.Platform;
+﻿using MvvmCross;
+using MvvmCross.Forms.Core;
+using MvvmCross.ViewModels;
 using Xamarin.Forms;
 
 namespace $rootnamespace$.Core

--- a/ContentFiles/Forms/CoreContent/App.xaml.pp
+++ b/ContentFiles/Forms/CoreContent/App.xaml.pp
@@ -2,7 +2,7 @@
 <d:MvxFormsApplication xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="$rootnamespace$.Core.App" 
-    xmlns:d="clr-namespace:MvvmCross.Forms.Platform;assembly=MvvmCross.Forms.Platform">
+    xmlns:d="clr-namespace:MvvmCross.Forms.Core;assembly=MvvmCross.Forms">
 	<Application.Resources>
 		<!-- Application resource dictionary -->
 	</Application.Resources>

--- a/ContentFiles/Forms/CoreContent/CoreApp.cs.pp
+++ b/ContentFiles/Forms/CoreContent/CoreApp.cs.pp
@@ -1,5 +1,5 @@
-using MvvmCross.Platform.IoC;
-using MvvmCross.Core.ViewModels;
+using MvvmCross.IoC;
+using MvvmCross.ViewModels;
 
 namespace $rootnamespace$.Core
 {

--- a/ContentFiles/Forms/CoreContent/MainViewModel.cs.pp
+++ b/ContentFiles/Forms/CoreContent/MainViewModel.cs.pp
@@ -1,5 +1,5 @@
+using MvvmCross.ViewModels;
 using System.Threading.Tasks;
-using MvvmCross.Core.ViewModels;
 
 namespace $rootnamespace$.Core.ViewModels
 {

--- a/ContentFiles/Forms/CoreContent/_ Core.txt
+++ b/ContentFiles/Forms/CoreContent/_ Core.txt
@@ -1,24 +1,22 @@
 The steps to get this Core project working are:
 
-1. Ensure your PCL is targeting a profile compatible with the MvvmCross.Forms dependency i.e.: Profile111
+1. Add .Core to the name of the .NET Standard project.
 
-2. Add .Core to the name of the PCL project.
-
-3. Change the Build Action of the following files from 'Page' to 'Embedded Resource':
+2. Change the Build Action of the following files from 'Page' to 'Embedded Resource':
 
     * Core|Pages|MainPage.xaml
     * Core|App.xaml
 
-4. Delete the page that was created by Xamarin forms.
+3. Delete the page that was created by Xamarin forms.
 
 4. Add the MvvmCross Forms StarterPack package to the platform specific projects.
 
 5. In Android: Remove the MainActivity.cs.
 
-5. In the platform specific projects remove the reference to the core project and click ok. Then add the reference again.
+6. In the platform specific projects remove the reference to the core project and click ok. Then add the reference again.
    (This has to be done because the platform specific projects wont recognise the renamed core project)
 
-6. In Android: in SplachScreen.cs change the label property in the attribute to your app name. Is now "YourAppName".
+7. In Android: in SplachScreen.cs change the label property in the attribute to your app name. Is now "YourAppName".
 
 Note: It might be a good idea to manually remove the MvvmCross.Forms.StarterPack from the packages.config file,
       otherwise your files will be overwritten the next time you update your nugets. The ToDo folder can also

--- a/ContentFiles/Forms/DroidContent/FormsActivity.cs.pp
+++ b/ContentFiles/Forms/DroidContent/FormsActivity.cs.pp
@@ -1,9 +1,9 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using MvvmCross.Droid.Views;
-using MvvmCross.Forms.Droid.Views;
-using MvvmCross.Platform;
+using MvvmCross;
+using MvvmCross.Forms.Platforms.Android.Views;
+using MvvmCross.Platforms.Android.Views;
 
 namespace $rootnamespace$
 {

--- a/ContentFiles/Forms/DroidContent/Setup.cs.pp
+++ b/ContentFiles/Forms/DroidContent/Setup.cs.pp
@@ -1,11 +1,10 @@
 using Android.Content;
-using MvvmCross.Droid.Platform;
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform.Platform;
-using MvvmCross.Droid.Views;
-using MvvmCross.Forms.Platform;
-using MvvmCross.Forms.Droid.Platform;
-using MvvmCross.Forms.Droid;
+using MvvmCross.Forms.Core;
+using MvvmCross.Forms.Platforms.Android;
+using MvvmCross.Forms.Platforms.Android.Core;
+using MvvmCross.Platforms.Android.Core;
+using MvvmCross.Platforms.Android.Views;
+using MvvmCross.ViewModels;
 
 namespace $rootnamespace$
 {
@@ -23,11 +22,6 @@ namespace $rootnamespace$
         protected override IMvxApplication CreateApp()
         {
             return new Core.CoreApp();
-        }
-
-        protected override IMvxTrace CreateDebugTrace()
-        {
-            return new DebugTrace();
         }
     }
 }

--- a/ContentFiles/Forms/DroidContent/SplashScreen.cs.pp
+++ b/ContentFiles/Forms/DroidContent/SplashScreen.cs.pp
@@ -1,6 +1,6 @@
 using Android.App;
 using Android.Content.PM;
-using MvvmCross.Droid.Views;
+using MvvmCross.Platforms.Android.Views;
 
 namespace $rootnamespace$
 {

--- a/ContentFiles/Forms/iOSContent/AppDelegate.cs.pp
+++ b/ContentFiles/Forms/iOSContent/AppDelegate.cs.pp
@@ -1,7 +1,7 @@
 ﻿using Foundation;
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Forms.iOS;
-using MvvmCross.Platform;
+using MvvmCross;
+using MvvmCross.Forms.Platforms.Ios;
+using MvvmCross.ViewModels;
 using UIKit;
 
 namespace $rootnamespace$

--- a/ContentFiles/Forms/iOSContent/Setup.cs.pp
+++ b/ContentFiles/Forms/iOSContent/Setup.cs.pp
@@ -1,9 +1,8 @@
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Forms.iOS;
-using MvvmCross.Forms.iOS.Presenters;
-using MvvmCross.iOS.Platform;
-using MvvmCross.iOS.Views.Presenters;
-using MvvmCross.Platform.Platform;
+using MvvmCross.Forms.Platforms.Ios;
+using MvvmCross.Forms.Platforms.Ios.Presenters;
+using MvvmCross.Platforms.Ios.Core;
+using MvvmCross.Platforms.Ios.Presenters;
+using MvvmCross.ViewModels;
 using UIKit;
 
 namespace $rootnamespace$

--- a/ContentFiles/MacOS/AppDelegate.cs.txt.pp
+++ b/ContentFiles/MacOS/AppDelegate.cs.txt.pp
@@ -1,12 +1,12 @@
-using System;
 using AppKit;
 using CoreGraphics;
 using Foundation;
+using MvvmCross;
+using MvvmCross.Platforms.Mac.Core;
+using MvvmCross.Platforms.Mac.Presenters;
+using MvvmCross.ViewModels;
 using ObjCRuntime;
-using MvvmCross.Mac.Views.Presenters;
-using MvvmCross.Platform;
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Mac.Platform;
+using System;
 
 namespace $rootnamespace$
 {

--- a/ContentFiles/MacOS/MainView.cs.pp
+++ b/ContentFiles/MacOS/MainView.cs.pp
@@ -1,9 +1,9 @@
+using AppKit;
+using Foundation;
+using MvvmCross.Platforms.Mac.Binding.Views;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using AppKit;
-using Foundation;
-using MvvmCross.Binding.Mac.Views;
 
 namespace $rootnamespace$.Views
 {

--- a/ContentFiles/MacOS/MainViewController.cs.pp
+++ b/ContentFiles/MacOS/MainViewController.cs.pp
@@ -1,11 +1,11 @@
+using AppKit;
+using Foundation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using AppKit;
-using Foundation;
-using MvvmCross.Mac.Views;
 using MvvmCross.Binding.BindingContext;
-using MvvmCross.Core.ViewModels;
+using MvvmCross.Platforms.Mac.Views;
+using MvvmCross.ViewModels;
 
 namespace $rootnamespace$.Views
 {

--- a/ContentFiles/MacOS/Setup.cs.pp
+++ b/ContentFiles/MacOS/Setup.cs.pp
@@ -1,9 +1,8 @@
 using AppKit;
 using Foundation;
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Mac.Platform;
-using MvvmCross.Mac.Views.Presenters;
-using MvvmCross.Platform.Platform;
+using MvvmCross.Platforms.Mac.Core;
+using MvvmCross.Platforms.Mac.Presenters;
+using MvvmCross.ViewModels;
 
 namespace $rootnamespace$
 {
@@ -17,11 +16,6 @@ namespace $rootnamespace$
         protected override IMvxApplication CreateApp ()
         {
             return new Core.App();
-        }
-        
-        protected override IMvxTrace CreateDebugTrace()
-        {
-            return new DebugTrace();
         }
     }
 }

--- a/ContentFiles/MacOS/_ Mac UI.txt
+++ b/ContentFiles/MacOS/_ Mac UI.txt
@@ -2,7 +2,7 @@ NOTE
 - Use Xamarin Studio for this...
 
 0. Add a Xamarin.Mac Project
-1. Add a reference to your Core PCL project, e.g., <root>.Core
+1. Add a reference to your Core .NET Standard project, e.g., <root>.Core
 2. Right-click on the project and under Tools -> Edit File, then add <TargetFrameworkVersion>4.5</TargetFrameworkVersion> in the first PropertyGroup, this is needed to access PCLs using Profile 158
 3. Use nuget to add the MvvmCross.Mac package
 4. Verify the Setup.cs file (automatically created)
@@ -11,15 +11,15 @@ NOTE
 7. Create a Views folder and add a Cocao View and Controller, if the ViewModel is "FirstViewModel", recommended naming for the View is "FirstView"
 8. Edit FirstView.cs by adding the using statement below and changing the base type to MvxView
 
-        using MvvmCross.Binding.Mac.Views;
+        using MvvmCross.Platforms.Mac.Binding.Views;
 
         public partial class FirstView : MvxView
 
 9. Edit FirstViewController.cs by adding the using statements below, adding MvxViewFor and changing the base type to MvxViewController
 
-        using MvvmCross.Mac.Views;
+        using MvvmCross.Platforms.Mac.Views;
         using MvvmCross.Binding.BindingContext;
-        using MvvmCross.Core.ViewModels;
+        using MvvmCross.ViewModels;
         using <root>.Core.ViewModels;
 
         [MvxViewFor(typeof(FirstViewModel))]
@@ -46,4 +46,4 @@ Where this requires using's of:
 
     using <core>.Core.ViewModels;
     using MvvmCross.Binding.BindingContext;
-    using MvvmCross.Mac.Views;
+    using MvvmCross.Platforms.Mac.Views;

--- a/ContentFiles/Uwp/MainView.xaml.cs.pp
+++ b/ContentFiles/Uwp/MainView.xaml.cs.pp
@@ -1,4 +1,4 @@
-using MvvmCross.Uwp.Views;
+using MvvmCross.Platforms.Uap.Views;
 
 namespace $rootnamespace$.Views
 {

--- a/ContentFiles/Uwp/MainView.xaml.pp
+++ b/ContentFiles/Uwp/MainView.xaml.pp
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:views="using:MvvmCross.Uwp.Views"
+    xmlns:views="using:MvvmCross.Platforms.Uap.Views"
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemneBrush}">

--- a/ContentFiles/Uwp/Setup.cs.pp
+++ b/ContentFiles/Uwp/Setup.cs.pp
@@ -1,7 +1,5 @@
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform.Logging;
-using MvvmCross.Platform.Platform;
-using MvvmCross.Uwp.Platform;
+using MvvmCross.Platforms.Uap.Core;
+using MvvmCross.ViewModels;
 using Windows.UI.Xaml.Controls;
 
 namespace $rootnamespace$
@@ -15,16 +13,6 @@ namespace $rootnamespace$
         protected override IMvxApplication CreateApp()
         {
             return new Core.App();
-        }
-
-        protected override IMvxTrace CreateDebugTrace()
-        {
-            return new DebugTrace();
-        }
-
-        protected override MvxLogProviderType GetDefaultLogProviderType()
-        {
-            return MvxLogProviderType.None;
         }
     }
 }

--- a/ContentFiles/Uwp/_ UWP UI.txt
+++ b/ContentFiles/Uwp/_ UWP UI.txt
@@ -1,6 +1,6 @@
 The steps to get this UWP UI working are:
 
-1. Add a reference to your Core PCL project
+1. Add a reference to your Core .NET Standard project
 2. Change App.Xaml.cs so that it creates a 'new Setup(RootFrame)' during its OnLaunched:
 
         protected override void OnLaunched(LaunchActivatedEventArgs e)

--- a/ContentFiles/Wpf/App.Xaml.Mvx.cs.pp
+++ b/ContentFiles/Wpf/App.Xaml.Mvx.cs.pp
@@ -1,8 +1,8 @@
+using MvvmCross
+using MvvmCross.Platforms.Wpf.Views;
+using MvvmCross.ViewModels;
 using System;
 using System.Windows;
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform;
-using MvvmCross.Wpf.Views;
 
 namespace $rootnamespace$
 {

--- a/ContentFiles/Wpf/MainView.xaml.cs.pp
+++ b/ContentFiles/Wpf/MainView.xaml.cs.pp
@@ -1,4 +1,4 @@
-using MvvmCross.Wpf.Views;
+using MvvmCross.Platforms.Wpf.Views;
 
 namespace $rootnamespace$.Views
 {

--- a/ContentFiles/Wpf/MainView.xaml.pp
+++ b/ContentFiles/Wpf/MainView.xaml.pp
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:views="clr-namespace:MvvmCross.Wpf.Views;assembly=MvvmCross.Wpf"
+             xmlns:views="clr-namespace:MvvmCross.Platforms.Wpf.Views;assembly=MvvmCross"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>

--- a/ContentFiles/Wpf/Setup.cs.pp
+++ b/ContentFiles/Wpf/Setup.cs.pp
@@ -1,9 +1,8 @@
+using MvvmCross.Platforms.Wpf.Core;
+using MvvmCross.Platforms.Wpf.Views;
+using MvvmCross.ViewModels;
 using System.Windows.Controls;
 using System.Windows.Threading;
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform.Platform;
-using MvvmCross.Wpf.Platform;
-using MvvmCross.Wpf.Views;
 
 namespace $rootnamespace$
 {
@@ -18,11 +17,6 @@ namespace $rootnamespace$
         protected override IMvxApplication CreateApp()
         {
             return new Core.App();
-        }
-
-        protected override IMvxTrace CreateDebugTrace()
-        {
-            return new DebugTrace();
         }
     }
 }

--- a/ContentFiles/Wpf/_ Wpf UI.txt
+++ b/ContentFiles/Wpf/_ Wpf UI.txt
@@ -1,3 +1,3 @@
 The only step to get this Wpf .Net 4.5 UI working is:
 
-1. Add a reference to your Core PCL project
+1. Add a reference to your Core .NET Standard project

--- a/ContentFiles/iOS/AppDelegate.cs.txt.pp
+++ b/ContentFiles/iOS/AppDelegate.cs.txt.pp
@@ -1,7 +1,7 @@
-using MvvmCross.Core.ViewModels;
-using MvvmCross.iOS.Platform;
-using MvvmCross.Platform;
 using Foundation;
+using MvvmCross;
+using MvvmCross.Platforms.Ios.Core;
+using MvvmCross.ViewModels;
 using UIKit;
 
 namespace $rootnamespace$

--- a/ContentFiles/iOS/LinkerPleaseInclude.cs
+++ b/ContentFiles/iOS/LinkerPleaseInclude.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Specialized;
-using System.Windows.Input;
-using Foundation;
+﻿using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Views;
 using MvvmCross.ViewModels;
+using System;
+using System.Collections.Specialized;
+using System.Windows.Input;
 using UIKit;
 
 namespace $YourNameSpace$

--- a/ContentFiles/iOS/MainView.cs.pp
+++ b/ContentFiles/iOS/MainView.cs.pp
@@ -1,6 +1,6 @@
 using MvvmCross.Binding.BindingContext;
-using MvvmCross.iOS.Views;
-using MvvmCross.iOS.Views.Presenters.Attributes;
+using MvvmCross.Platforms.Ios.Presenters.Attributes;
+using MvvmCross.Platforms.Ios.Views;
 
 namespace $rootnamespace$.Views
 {

--- a/ContentFiles/iOS/Setup.cs.pp
+++ b/ContentFiles/iOS/Setup.cs.pp
@@ -1,7 +1,6 @@
-using MvvmCross.Core.ViewModels;
-using MvvmCross.iOS.Platform;
-using MvvmCross.iOS.Views.Presenters;
-using MvvmCross.Platform.Platform;
+using MvvmCross.Platforms.Ios.Core;
+using MvvmCross.Platforms.Ios.Presenters;
+using MvvmCross.ViewModels;
 using UIKit;
 
 namespace $rootnamespace$
@@ -21,11 +20,6 @@ namespace $rootnamespace$
         protected override IMvxApplication CreateApp()
         {
             return new Core.App();
-        }
-        
-        protected override IMvxTrace CreateDebugTrace()
-        {
-            return new DebugTrace();
         }
     }
 }

--- a/ContentFiles/iOS/_ iOS UI.txt
+++ b/ContentFiles/iOS/_ iOS UI.txt
@@ -1,4 +1,4 @@
 The steps to get this iOS UI working are:
 
-1. Add a reference to your Core PCL project
+1. Add a reference to your Core .NET Standard project
 2. Modify AppDelegate.cs to create the new Setup and to call the IMvxAppStart - there is sample code for this in AppDelegate.cs.txt

--- a/ContentFiles/tvOS/AppDelegate.cs.txt.pp
+++ b/ContentFiles/tvOS/AppDelegate.cs.txt.pp
@@ -1,12 +1,8 @@
-using MvvmCross.Core.ViewModels;
-using MvvmCross.iOS.Platform;
-using MvvmCross.Platform;
 using Foundation;
+using MvvmCross;
+using MvvmCross.Platforms.Tvos.Core;
+using MvvmCross.ViewModels;
 using UIKit;
-
-using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform;
-using MvvmCross.tvOS.Platform;
 
 namespace $rootnamespace$
 {

--- a/ContentFiles/tvOS/LinkerPleaseInclude.cs
+++ b/ContentFiles/tvOS/LinkerPleaseInclude.cs
@@ -1,14 +1,12 @@
+﻿using Foundation;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Navigation;
+using MvvmCross.Platforms.Tvos.Views;
+using MvvmCross.ViewModels;
 using System;
 using System.Collections.Specialized;
 using System.Windows.Input;
-
-using Foundation;
 using UIKit;
-
-using MvvmCross.Binding.BindingContext;
-using MvvmCross.tvOS.Views;
-using MvvmCross.Core.Navigation;
-using MvvmCross.Core.ViewModels;
 
 namespace $rootnamespace$
 {

--- a/ContentFiles/tvOS/MainView.cs.pp
+++ b/ContentFiles/tvOS/MainView.cs.pp
@@ -1,6 +1,6 @@
 using MvvmCross.Binding.BindingContext;
-using MvvmCross.tvOS.Views;
-using MvvmCross.tvOS.Views.Presenters.Attributes;
+using MvvmCross.Platforms.Tvos.Presenters.Attributes;
+using MvvmCross.Platforms.Tvos.Views;
 
 namespace $rootnamespace$.Views
 {

--- a/ContentFiles/tvOS/Setup.cs.pp
+++ b/ContentFiles/tvOS/Setup.cs.pp
@@ -1,7 +1,6 @@
-using MvvmCross.Core.ViewModels;
-using MvvmCross.tvOS.Platform;
-using MvvmCross.tvOS.Views.Presenters;
-using MvvmCross.Platform.Platform;
+using MvvmCross.Platforms.Tvos.Core;
+using MvvmCross.Platforms.Tvos.Presenters;
+using MvvmCross.ViewModels;
 using UIKit;
 
 namespace $rootnamespace$
@@ -21,11 +20,6 @@ namespace $rootnamespace$
         protected override IMvxApplication CreateApp()
         {
             return new Core.App();
-        }
-        
-        protected override IMvxTrace CreateDebugTrace()
-        {
-            return new DebugTrace();
         }
 
         protected override IMvxTvosViewPresenter CreatePresenter()

--- a/ContentFiles/tvOS/_ tvOSUI.txt
+++ b/ContentFiles/tvOS/_ tvOSUI.txt
@@ -1,4 +1,4 @@
 The steps to get this tvOS UI working are:
 
-1. Add a reference to your Core PCL project
+1. Add a reference to your Core .NET Standard project
 2. Modify AppDelegate.cs to create the new Setup and to call the IMvxAppStart - there is sample code for this in AppDelegate.cs.txt


### PR DESCRIPTION
Note: This is my first time submitting a pull request to an open source project on GitHub, I'm used to using VSTS with TFVC. Hopefully this is done right (forking the project, making changes and then sending a pull request).

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Documentation Update I think (considering these are referred to as sample files in the readme.txt, but are NuGet ContentFiles in reality, but not sure if they're still used as ContentFiles, since readme.txt also says no content files will be installed).

### :arrow_heading_down: What is the current behavior?
When you start a new MVVMCross 6.x project and the readme.txt file appears, there's a link to sample files (https://github.com/MvvmCross/MvvmCross/blob/develop/ContentFiles/) - however these files are out of date because they don't use the new MVVMCross 6.x namespaces. They also include references to MvxTrace, which is deleted in 6.x

### :new: What is the new behavior (if this is a feature change)?
The namespaces are now updated to use the new MVVMCross 6.x namespaces. The references to MvxTrace are also deleted.

### :boom: Does this PR introduce a breaking change?
Not if you're using MVVMCross 6.x (since this updates these files to match the MVVMCross 6.x documentation)

### :bug: Recommendations for testing
Copying and pasting these files into real MVVMCross projects and ensuring the namespaces all are found correctly.

One other thing to note: I think other changes will need to be made to these files with all the changes to Setup etc. that is shipping in MVVMCross 6.x, but I don't know enough about those changes yet to confidently update these files, so I'll just provide what I am confident with (namespace changes and obvious deletions)

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
