### PR TITLE
Reverts IsXamarinForms changes in Playground

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -35,8 +35,4 @@
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(IsLibraryProject)' == 'true'">
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
   </ItemGroup>
-
-  <ItemGroup Condition="'$(IsXamarinForms)' == 'true'">
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
-  </ItemGroup>
 </Project>

--- a/Directory.build.targets
+++ b/Directory.build.targets
@@ -38,4 +38,6 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('uap')) and '$(IsLibraryProject)' == 'true' ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.8" />
   </ItemGroup>
+
+  <Import Project="XamarinForms.targets" Condition="'$(IsXamarinForms)' == 'true'"/>
 </Project>

--- a/Projects/Directory.build.props
+++ b/Projects/Directory.build.props
@@ -12,10 +12,5 @@
 
     <Platform>AnyCPU</Platform>
     <DebugType>full</DebugType>
-    <IsXamarinForms>$(MSBuildProjectName.Contains('.Forms'))</IsXamarinForms>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(IsXamarinForms)' == 'true'">
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
-  </ItemGroup>
 </Project>

--- a/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -157,6 +157,7 @@
     <PackageReference Include="Xamarin.Build.Download">
       <Version>0.4.9</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross.Android.Support\Design\MvvmCross.Droid.Support.Design.csproj">

--- a/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -157,7 +157,6 @@
     <PackageReference Include="Xamarin.Build.Download">
       <Version>0.4.9</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross.Android.Support\Design\MvvmCross.Droid.Support.Design.csproj">
@@ -201,5 +200,6 @@
       <Name>Playground.Forms.UI</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.Mac/Playground.Forms.Mac.csproj
+++ b/Projects/Playground/Playground.Forms.Mac/Playground.Forms.Mac.csproj
@@ -120,10 +120,6 @@
       <Name>Playground.Forms.UI</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>2.5.0.280555</Version>
-    </PackageReference>
-  </ItemGroup>
+  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
+++ b/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
+  </ItemGroup>
+
 </Project>

--- a/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
+++ b/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
@@ -13,8 +13,5 @@
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
-  </ItemGroup>
-
+  <Import Project="..\..\..\XamarinForms.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -142,6 +142,7 @@
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.1</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />

--- a/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -142,7 +142,6 @@
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />
@@ -177,6 +176,7 @@
       <Name>Playground.Forms.UI</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
+++ b/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
@@ -125,5 +125,8 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
+++ b/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
@@ -125,8 +125,6 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
-  </ItemGroup>
+  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
+++ b/Projects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
@@ -156,8 +156,6 @@
     <BundleResource Include="Resources\MvvmCross%402x.png" />
     <BundleResource Include="Resources\MvvmCross%403x.png" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
-  </ItemGroup>
+  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
+++ b/Projects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
@@ -156,5 +156,8 @@
     <BundleResource Include="Resources\MvvmCross%402x.png" />
     <BundleResource Include="Resources\MvvmCross%403x.png" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/XamarinForms.targets
+++ b/XamarinForms.targets
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.280555" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
<PackageReference/> to Xamarin.Forms is incorrectly being added to Playground.Droid.

### :new: What is the new behavior (if this is a feature change)?
<PackageReference/> to Xamarin.Forms is no longer being added to Playground.Droid.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Rebuild and verify there is no longer a NuGet dependency to Xamarin.Forms in Playground.Droid.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
