### PR TITLE
Fixing issue with navigating back with result from master details

### DIFF
--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -436,7 +436,7 @@ namespace MvvmCross.Forms.Presenters
 
         public virtual bool CloseMasterDetailPage(IMvxViewModel viewModel, MvxMasterDetailPagePresentationAttribute attribute)
         {
-            var masterDetailHost = GetPageOfType<MvxMasterDetailPage>();
+            var masterDetailHost = GetPageOfType<MasterDetailPage>();
             switch (attribute.Position)
             {
                 case MasterDetailPosition.Root:

--- a/Projects/Playground/Playground.Core/ViewModels/MixedNavMasterDetailViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/MixedNavMasterDetailViewModel.cs
@@ -30,6 +30,7 @@ namespace Playground.Core.ViewModels
             Menu = new[] {
                 new MenuItem { Title = "Root", Description = "The root page", ViewModelType = typeof(MixedNavMasterRootContentViewModel) },
                 new MenuItem { Title = "Tabs", Description = "Tabbed detail page", ViewModelType = typeof(MixedNavTabsViewModel)},
+                new MenuItem { Title = "Result", Description = "Open detail page with result", ViewModelType = typeof(MixedNavResultDetailViewModel)},
             };
         }
 

--- a/Projects/Playground/Playground.Core/ViewModels/MixedNavResultDetailViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/MixedNavResultDetailViewModel.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class MixedNavResultDetailViewModel : MvxViewModel, IMvxViewModelResult<DetailResultResult>
+    {
+        private readonly IMvxNavigationService _navigationService;
+
+        public MixedNavResultDetailViewModel(IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService;
+            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this, DetailResultResult.Build()));
+        }
+
+
+        public IMvxAsyncCommand CloseViewModelCommand { get; private set; }
+        public TaskCompletionSource<object> CloseCompletionSource { get; set; }
+
+        public override void ViewDestroy(bool viewFinishing = true)
+        {
+            if (viewFinishing && CloseCompletionSource != null && !CloseCompletionSource.Task.IsCompleted && !CloseCompletionSource.Task.IsFaulted)
+                CloseCompletionSource?.TrySetCanceled();
+
+            base.ViewDestroy(viewFinishing);
+        }
+    }
+
+    public class DetailResultParams
+    {
+
+    }
+
+    public class DetailResultResult
+    {
+        public static DetailResultResult Build()
+        {
+            return new DetailResultResult();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Forms.UI/Pages/MixedNavResultDetailPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/MixedNavResultDetailPage.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<views:MvxContentPage 
+    x:TypeArguments="viewModels:MixedNavResultDetailViewModel"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:viewModels="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
+    xmlns:views="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
+    x:Class="Playground.Forms.Pages.MixedNavResultDetailPage">
+    <StackLayout>
+        <Button 
+            Text="Cerrar"
+            Command="{Binding CloseViewModelCommand}"/>
+    </StackLayout>
+</views:MvxContentPage>

--- a/Projects/Playground/Playground.Forms.UI/Pages/MixedNavResultDetailPage.xaml.cs
+++ b/Projects/Playground/Playground.Forms.UI/Pages/MixedNavResultDetailPage.xaml.cs
@@ -1,0 +1,17 @@
+﻿using MvvmCross.Forms.Presenters.Attributes;
+using MvvmCross.Forms.Views;
+using Playground.Core.ViewModels;
+using Xamarin.Forms.Xaml;
+
+namespace Playground.Forms.Pages
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    [MvxMasterDetailPagePresentation(Position = MasterDetailPosition.Detail, WrapInNavigationPage = true)]
+    public partial class MixedNavResultDetailPage : MvxContentPage<MixedNavResultDetailViewModel>
+    {
+        public MixedNavResultDetailPage()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Close from master details with result doesn't work 

### :new: What is the new behavior (if this is a feature change)?
Close from master details with result works

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Playground.Forms Droid

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
