### PR TITLE
Making IMvxViewDispatcher async aware

### DIFF
--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -447,28 +447,28 @@ namespace MvvmCross.Navigation
             return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual Task<bool> ChangePresentation(MvxPresentationHint hint)
+        public virtual async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
             MvxLog.Instance.Trace("Requesting presentation change");
             var args = new ChangePresentationEventArgs(hint);
             OnBeforeChangePresentation(this, args);
 
-            var result = ViewDispatcher.ChangePresentation(hint);
+            var result = await ViewDispatcher.ChangePresentation(hint);
 
             args.Result = result;
             OnAfterChangePresentation(this, args);
 
-            return Task.FromResult(result);
+            return result;
         }
 
-        public virtual Task<bool> Close(IMvxViewModel viewModel)
+        public virtual async Task<bool> Close(IMvxViewModel viewModel)
         {
             var args = new NavigateEventArgs(viewModel);
             OnBeforeClose(this, args);
-            var close = ViewDispatcher.ChangePresentation(new MvxClosePresentationHint(viewModel));
+            var close = await ViewDispatcher.ChangePresentation(new MvxClosePresentationHint(viewModel));
             OnAfterClose(this, args);
 
-            return Task.FromResult(close);
+            return close;
         }
 
         public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result)

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidViewDispatcher.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidViewDispatcher.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross.Platforms.Android.Presenters;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
@@ -19,14 +20,16 @@ namespace MvvmCross.Platforms.Android.Views
             _presenter = presenter;
         }
 
-        public bool ShowViewModel(MvxViewModelRequest request)
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
-            return RequestMainThreadAction(() => _presenter.Show(request));
+            await ExecuteOnMainThreadAsync(() => _presenter.Show(request));
+            return true;
         }
 
-        public bool ChangePresentation(MvxPresentationHint hint)
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            return RequestMainThreadAction(() => _presenter.ChangePresentation(hint));
+            await ExecuteOnMainThreadAsync(() => _presenter.ChangePresentation(hint));
+            return true;
         }
     }
 }

--- a/MvvmCross/Platforms/Console/Views/MvxConsoleViewDispatcher.cs
+++ b/MvvmCross/Platforms/Console/Views/MvxConsoleViewDispatcher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Base;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
@@ -19,16 +20,18 @@ namespace MvvmCross.Platforms.Console.Views
             return true;
         }
 
-        public bool ShowViewModel(MvxViewModelRequest request)
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
             var navigation = Mvx.Resolve<IMvxConsoleNavigation>();
-            return RequestMainThreadAction(() => navigation.Show(request));
+            await ExecuteOnMainThreadAsync(() => navigation.Show(request));
+            return true;
         }
 
-        public bool ChangePresentation(MvxPresentationHint hint)
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
             var navigation = Mvx.Resolve<IMvxConsoleNavigation>();
-            return RequestMainThreadAction(() => navigation.ChangePresentation(hint));
+            await ExecuteOnMainThreadAsync(() => navigation.ChangePresentation(hint));
+            return true;
         }
     }
 }

--- a/MvvmCross/Platforms/Ios/Views/MvxIosViewDispatcher.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxIosViewDispatcher.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Logging;
 using MvvmCross.Platforms.Ios.Presenters;
 using MvvmCross.ViewModels;
@@ -20,19 +21,21 @@ namespace MvvmCross.Platforms.Ios.Views
             _presenter = presenter;
         }
 
-        public bool ShowViewModel(MvxViewModelRequest request)
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
             Action action = () =>
                 {
                     MvxLog.Instance.Trace("iOSNavigation", "Navigate requested");
                     _presenter.Show(request);
                 };
-            return RequestMainThreadAction(action);
+            await ExecuteOnMainThreadAsync(action);
+            return true;
         }
 
-        public bool ChangePresentation(MvxPresentationHint hint)
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            return RequestMainThreadAction(() => _presenter.ChangePresentation(hint));
+            await ExecuteOnMainThreadAsync(() => _presenter.ChangePresentation(hint));
+            return true;
         }
     }
 }

--- a/MvvmCross/Platforms/Mac/Views/MvxMacViewDispatcher.cs
+++ b/MvvmCross/Platforms/Mac/Views/MvxMacViewDispatcher.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Logging;
 using MvvmCross.Platforms.Mac.Presenters;
 using MvvmCross.ViewModels;
@@ -21,24 +22,26 @@ namespace MvvmCross.Platforms.Mac.Views
             _presenter = presenter;
         }
 
-        public bool ShowViewModel(MvxViewModelRequest request)
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
             Action action = () =>
             {
                 MvxLog.Instance.Trace("MacNavigation", "Navigate requested");
                 _presenter.Show(request);
             };
-            return RequestMainThreadAction(action);
+            await ExecuteOnMainThreadAsync(action);
+            return true;
         }
 
-        public bool ChangePresentation(MvxPresentationHint hint)
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
             Action action = () =>
                                 {
                                     MvxLog.Instance.Trace("MacNavigation", "Change presentation requested");
                                     _presenter.ChangePresentation(hint);
                                 };
-            return RequestMainThreadAction(action);
+            await ExecuteOnMainThreadAsync(action);
+            return true;
         }
     }
 }

--- a/MvvmCross/Platforms/Tvos/Views/MvxTvosViewDispatcher.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxTvosViewDispatcher.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Logging;
 using MvvmCross.Platforms.Tvos.Presenters;
 using MvvmCross.ViewModels;
@@ -20,19 +21,21 @@ namespace MvvmCross.Platforms.Tvos.Views
             _presenter = presenter;
         }
 
-        public bool ShowViewModel(MvxViewModelRequest request)
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
             Action action = () =>
                 {
                     MvxLog.Instance.Trace("tvOSNavigation", "Navigate requested");
                     _presenter.Show(request);
                 };
-            return RequestMainThreadAction(action);
+            await ExecuteOnMainThreadAsync(action);
+            return true;
         }
 
-        public bool ChangePresentation(MvxPresentationHint hint)
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            return RequestMainThreadAction(() => _presenter.ChangePresentation(hint));
+            await ExecuteOnMainThreadAsync(() => _presenter.ChangePresentation(hint));
+            return true;
         }
     }
 }

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsViewDispatcher.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsViewDispatcher.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross.Platforms.Uap.Presenters;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
@@ -19,14 +20,16 @@ namespace MvvmCross.Platforms.Uap.Views
             _presenter = presenter;
         }
 
-        public bool ShowViewModel(MvxViewModelRequest request)
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
-            return RequestMainThreadAction(() => _presenter.Show(request));
+            await ExecuteOnMainThreadAsync(() => _presenter.Show(request));
+            return true;
         }
 
-        public bool ChangePresentation(MvxPresentationHint hint)
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            return RequestMainThreadAction(() => _presenter.ChangePresentation(hint));
+            await ExecuteOnMainThreadAsync(() => _presenter.ChangePresentation(hint));
+            return true;
         }
     }
 }

--- a/MvvmCross/Platforms/Wpf/Views/MvxWpfViewDispatcher.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWpfViewDispatcher.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using System.Windows.Threading;
 using MvvmCross.Platforms.Wpf.Presenters;
 using MvvmCross.ViewModels;
@@ -20,14 +21,16 @@ namespace MvvmCross.Platforms.Wpf.Views
             _presenter = presenter;
         }
 
-        public bool ShowViewModel(MvxViewModelRequest request)
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
-            return RequestMainThreadAction(() => _presenter.Show(request));
+            await ExecuteOnMainThreadAsync(() => _presenter.Show(request));
+            return true;
         }
 
-        public bool ChangePresentation(MvxPresentationHint hint)
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            return RequestMainThreadAction(() => _presenter.ChangePresentation(hint));
+            await ExecuteOnMainThreadAsync(() => _presenter.ChangePresentation(hint));
+            return true;
         }
     }
 }

--- a/MvvmCross/Views/IMvxViewDispatcher.cs
+++ b/MvvmCross/Views/IMvxViewDispatcher.cs
@@ -2,15 +2,16 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross.Base;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Views
 {
-    public interface IMvxViewDispatcher : IMvxMainThreadDispatcher, IMvxMainThreadAsyncDispatcher
+    public interface IMvxViewDispatcher : IMvxMainThreadAsyncDispatcher, IMvxMainThreadDispatcher
     {
-        bool ShowViewModel(MvxViewModelRequest request);
+        Task<bool> ShowViewModel(MvxViewModelRequest request);
 
-        bool ChangePresentation(MvxPresentationHint hint);
+        Task<bool> ChangePresentation(MvxPresentationHint hint);
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
@@ -37,7 +37,7 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
             }
         }
 
-        public virtual bool ShowViewModel(MvxViewModelRequest request)
+        public virtual Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
             var debugString = $"ShowViewModel: '{request.ViewModelType.Name}' ";
             if (request.ParameterValues != null)
@@ -47,13 +47,13 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
             MvxTestLog.Instance.Log(MvxLogLevel.Debug, () => debugString);
 
             Requests.Add(request);
-            return true;
+            return Task.FromResult(true);
         }
 
-        public virtual bool ChangePresentation(MvxPresentationHint hint)
+        public virtual Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
             Hints.Add(hint);
-            return true;
+            return Task.FromResult(true);
         }
 
         public Task ExecuteOnMainThreadAsync(Action action, bool maskExceptions = true)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
ViewDispatcher methods are fire-and-forget (see issue https://github.com/MvvmCross/MvvmCross/issues/2740 for example of where this is a problem)

### :new: What is the new behavior (if this is a feature change)?
ViewDispatcher methods are async aware and can be awaited

### :boom: Does this PR introduce a breaking change?
Yes - changes to IMvxViewDispatcher

### :bug: Recommendations for testing
Run playground apps

### :memo: Links to relevant issues/docs
Deprecated PR: https://github.com/MvvmCross/MvvmCross/pull/2749
Issue: https://github.com/MvvmCross/MvvmCross/issues/2740

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
