### PR TITLE
Find resource type based on Android.Runtime.ResourceDesignerAttribute

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAppResourceTypeFinder.cs
+++ b/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAppResourceTypeFinder.cs
@@ -1,22 +1,37 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
+using System.Reflection;
 using MvvmCross.Exceptions;
 
 namespace MvvmCross.Platforms.Android.Binding.ResourceHelpers
 {
     public class MvxAppResourceTypeFinder : IMvxAppResourceTypeFinder
     {
+        private Type FindResourceType(Assembly assembly)
+        {
+            var att =
+                assembly.CustomAttributes.FirstOrDefault(ca =>
+                    ca.AttributeType.FullName == "Android.Runtime.ResourceDesignerAttribute");
+
+            if (att != null)
+            {
+                var resourceType = assembly.GetTypes().FirstOrDefault(
+                    t => t.FullName == (string)att.ConstructorArguments.First().Value);
+                return resourceType;
+            }
+            return null;
+        }
+
         public Type Find()
         {
             var setup = Mvx.Resolve<IMvxAndroidGlobals>();
-            var resourceTypeName = setup.ExecutableNamespace + ".Resource";
-            var resourceType = setup.ExecutableAssembly.GetType(resourceTypeName);
+            var resourceType = FindResourceType(setup.ExecutableAssembly);
             if (resourceType == null)
-                throw new MvxException("Unable to find resource type - " + resourceTypeName +
-                                       ". Please check if your setup class is in your application's root namespace.");
+                throw new MvxException("Unable to find resource type. Please check if your setup class is in your application's root namespace.");
             return resourceType;
         }
     }

--- a/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAppResourceTypeFinder.cs
+++ b/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAppResourceTypeFinder.cs
@@ -19,9 +19,8 @@ namespace MvvmCross.Platforms.Android.Binding.ResourceHelpers
 
             if (att != null)
             {
-                var resourceType = assembly.GetTypes().FirstOrDefault(
-                    t => t.FullName == (string)att.ConstructorArguments.First().Value);
-                return resourceType;
+                var typeName = (string)att.ConstructorArguments.First().Value;
+                return assembly.GetType(typeName);
             }
             return null;
         }

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -23,6 +23,7 @@ using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 using MvvmCross.Presenters;
+using System.Linq;
 
 namespace MvvmCross.Platforms.Android.Core
 {
@@ -39,9 +40,7 @@ namespace MvvmCross.Platforms.Android.Core
 
         #region IMvxAndroidGlobals Members
 
-        public virtual string ExecutableNamespace => GetType().Namespace;
-
-        public virtual Assembly ExecutableAssembly => GetType().Assembly;
+        public virtual Assembly ExecutableAssembly => ViewAssemblies.FirstOrDefault() ?? GetType().Assembly;
 
         public Context ApplicationContext => _applicationContext;
 

--- a/MvvmCross/Platforms/Android/IMvxAndroidGlobals.cs
+++ b/MvvmCross/Platforms/Android/IMvxAndroidGlobals.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,7 +9,6 @@ namespace MvvmCross.Platforms.Android
 {
     public interface IMvxAndroidGlobals
     {
-        string ExecutableNamespace { get; }
         Assembly ExecutableAssembly { get; }
         Context ApplicationContext { get; }
     }


### PR DESCRIPTION
instead of using hardcoded name for resource type. Fixes #2772

I haven't tested this code. I haven't even compiled it (couldn't build on OSX) :) It looks right to me though.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixes #2772 - The resource type name can be defined by the user, it might not be "Resource"

### :arrow_heading_down: What is the current behavior?

Can't use MvvmCross with F#

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#2772 
https://github.com/xamarin/xamarin-android/issues/1513#issuecomment-379391085

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
https://github.com/xamarin/xamarin-android/issues/1513#issuecomment-379391085