### PR TITLE
Fix duplicated entry for SplitView attribute on iOS ViewPresenter

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -139,21 +139,32 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowMasterSplitViewController(viewController, (MvxSplitViewPresentationAttribute)attribute, request);
-                    },
-                    CloseAction = (viewModel, attribute) => CloseMasterSplitViewController(viewModel, (MvxSplitViewPresentationAttribute)attribute)
-                });
+                        var splitAttribute = (MvxSplitViewPresentationAttribute)attribute;
+                        switch (splitAttribute.Position)
+                        {
+                            case MasterDetailPosition.Master:
+                                ShowMasterSplitViewController(viewController, splitAttribute, request);
+                                break;
 
-            AttributeTypesToActionsDictionary.Add(
-                typeof(MvxSplitViewPresentationAttribute),
-                new MvxPresentationAttributeAction
-                {
-                    ShowAction = (viewType, attribute, request) =>
-                    {
-                        var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowDetailSplitViewController(viewController, (MvxSplitViewPresentationAttribute)attribute, request);
+                            case MasterDetailPosition.Detail:
+                                ShowDetailSplitViewController(viewController, splitAttribute, request);
+                                break;
+                        }
                     },
-                    CloseAction = (viewModel, attribute) => CloseDetailSplitViewController(viewModel, (MvxSplitViewPresentationAttribute)attribute)
+                    CloseAction = (viewModel, attribute) =>
+                    {
+                        var splitAttribute = (MvxSplitViewPresentationAttribute)attribute;
+                        switch (splitAttribute.Position)
+                        {
+                            case MasterDetailPosition.Master:
+                                return CloseMasterSplitViewController(viewModel, splitAttribute);
+
+                            case MasterDetailPosition.Detail:
+                            default:
+                                return CloseDetailSplitViewController(viewModel, splitAttribute);
+                        }
+                        
+                    }
                 });
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MvxSplitViewPresentationAttribute is registered twice.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Playground.iOS

### :memo: Links to relevant issues/docs
Previous PR: #2767 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
