### PR TITLE
Added Margin target binding for Android

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
@@ -193,6 +193,23 @@ namespace MvvmCross.Platforms.Android.Binding
             registry.RegisterCustomBindingFactory<TwoStatePreference>(
                 MvxAndroidPropertyBinding.TwoStatePreference_Checked,
                 preference => new MvxTwoStatePreferenceCheckedTargetBinding(preference));
+
+            var allMargins = new[]
+            {
+                MvxAndroidPropertyBinding.View_Margin,
+                MvxAndroidPropertyBinding.View_MarginLeft,
+                MvxAndroidPropertyBinding.View_MarginRight,
+                MvxAndroidPropertyBinding.View_MarginTop,
+                MvxAndroidPropertyBinding.View_MarginBottom,
+                MvxAndroidPropertyBinding.View_MarginStart,
+                MvxAndroidPropertyBinding.View_MarginEnd
+            };
+
+            foreach(var margin in allMargins)
+            {
+                registry.RegisterCustomBindingFactory<View>(
+                    margin, view => new MvxViewMarginTargetBinding(view, margin));
+            }
         }
 
         protected override void FillDefaultBindingNames(IMvxBindingNameRegistry registry)

--- a/MvvmCross/Platforms/Android/Binding/MvxAndroidPropertyBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxAndroidPropertyBinding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -34,5 +34,13 @@ namespace MvvmCross.Platforms.Android.Binding
         public const string EditTextPreference_Text = "Text";
         public const string ListPreference_Value = "Value";
         public const string TwoStatePreference_Checked = "Checked";
+
+        public const string View_Margin = "Margin";
+        public const string View_MarginLeft = "MarginLeft";
+        public const string View_MarginRight = "MarginRight";
+        public const string View_MarginTop = "MarginTop";
+        public const string View_MarginBottom = "MarginBottom";
+        public const string View_MarginStart = "MarginStart";
+        public const string View_MarginEnd = "MarginEnd";
     }
 }

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Android.Content.Res;
+using Android.Views;
+using MvvmCross.Binding;
+
+namespace MvvmCross.Platforms.Android.Binding.Target
+{
+    public class MvxViewMarginTargetBinding : MvxAndroidTargetBinding
+    {
+        private string _whichMargin;
+
+        public MvxViewMarginTargetBinding(View target, string whichMargin) : base(target)
+        {
+            if (whichMargin == null) throw new ArgumentNullException(nameof(whichMargin));
+            _whichMargin = whichMargin;
+        }
+
+        public override Type TargetType => typeof(int);
+        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            var view = target as View;
+            if (view == null) return;
+
+            var layoutParameters = view.LayoutParameters as ViewGroup.MarginLayoutParams;
+            if (layoutParameters == null) return;
+
+            var dpMargin = (int)value;
+            var pxMargin = DpToPx(dpMargin);
+
+            switch (_whichMargin)
+            {
+                case MvxAndroidPropertyBinding.View_Margin:
+                    layoutParameters.SetMargins(pxMargin, pxMargin, pxMargin, pxMargin);
+                    break;
+                case MvxAndroidPropertyBinding.View_MarginLeft:
+                    layoutParameters.LeftMargin = pxMargin;
+                    break;
+                case MvxAndroidPropertyBinding.View_MarginRight:
+                    layoutParameters.RightMargin = pxMargin;
+                    break;
+                case MvxAndroidPropertyBinding.View_MarginTop:
+                    layoutParameters.TopMargin = pxMargin;
+                    break;
+                case MvxAndroidPropertyBinding.View_MarginBottom:
+                    layoutParameters.BottomMargin = pxMargin;
+                    break;
+                case MvxAndroidPropertyBinding.View_MarginEnd:
+                    layoutParameters.MarginEnd = pxMargin;
+                    break;
+                case MvxAndroidPropertyBinding.View_MarginStart:
+                    layoutParameters.MarginStart = pxMargin;
+                    break;
+            }
+        }
+
+        private int DpToPx(int dp)
+            => (int)(dp * Resources.System.DisplayMetrics.Density);
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
No way to bind Margins on Android Layouts

### :new: What is the new behavior (if this is a feature change)?
You can bind:
* Margin (binds all margins to same value)
* MarginLeft
* MarginRight
* MarginTop
* MarginBottom
* MarginStart
* MarginEnd

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Try binding a margin

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
