### PR TITLE
Improving Forms Android support for setup

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -15,7 +15,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
     public abstract class MvxSplashScreenAppCompatActivity
         : MvxAppCompatActivity, IMvxSetupMonitor
     {
-        private const int NoContent = 0;
+        protected const int NoContent = 0;
 
         private readonly int _resourceId;
 
@@ -29,6 +29,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected MvxSplashScreenAppCompatActivity(int resourceId = NoContent)
         {
+            RegisterSetup();
             _resourceId = resourceId;
         }
 
@@ -81,6 +82,24 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 return;
 
             RunAppStart(_bundle);
+        }
+
+        protected virtual void RegisterSetup()
+        {
+        }
+    }
+
+    public abstract class MvxSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenAppCompatActivity
+            where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
+            where TApplication : IMvxApplication, new()
+    {
+        protected MvxSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)
+        {
+        }
+
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
         }
     }
 }

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
@@ -11,6 +11,7 @@ using Android.Views;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Core;
 using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Forms.Platforms.Android.Core;
 using MvvmCross.Forms.Platforms.Android.Views.Base;
 using MvvmCross.Forms.Presenters;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -28,6 +29,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
         protected MvxFormsAppCompatActivity()
         {
+            RegisterSetup();
             BindingContext = new MvxAndroidBindingContext(this, this);
             this.AddEventListeners();
         }
@@ -112,7 +114,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
             InitializeForms(bundle);
 
             var startup = Mvx.Resolve<IMvxAppStart>();
-            if(!startup.IsStarted)
+            if (!startup.IsStarted)
                 startup.Start(GetAppStartHint(bundle));
 
             InitializeApplication();
@@ -194,6 +196,10 @@ namespace MvvmCross.Forms.Platforms.Android.Views
             var view = MvxAppCompatActivityHelper.OnCreateView(parent, name, context, attrs);
             return view ?? base.OnCreateView(parent, name, context, attrs);
         }
+
+        protected virtual void RegisterSetup()
+        {
+        }
     }
 
     public class MvxFormsAppCompatActivity<TViewModel>
@@ -204,6 +210,29 @@ namespace MvvmCross.Forms.Platforms.Android.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
+        }
+    }
+
+    public abstract class MvxFormsAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxFormsAppCompatActivity
+    where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
+    where TApplication : IMvxApplication, new()
+    where TFormsApplication : Application, new()
+    {
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
+        }
+    }
+
+    public abstract class MvxFormsAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication, TViewModel> : MvxFormsAppCompatActivity<TViewModel>
+    where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
+    where TApplication : IMvxApplication, new()
+    where TFormsApplication : Application, new()
+         where TViewModel : class, IMvxViewModel
+    {
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
         }
     }
 }

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
@@ -3,13 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using System.Threading.Tasks;
 using Android.Content;
 using Android.OS;
 using Android.Views;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Core;
-using MvvmCross.Forms.Core;
+using MvvmCross.Forms.Platforms.Android.Core;
 using MvvmCross.Forms.Platforms.Android.Views.Base;
 using MvvmCross.Forms.Presenters;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -27,6 +26,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
         protected MvxFormsApplicationActivity()
         {
+            RegisterSetup();
             BindingContext = new MvxAndroidBindingContext(this, this);
             this.AddEventListeners();
         }
@@ -186,6 +186,10 @@ namespace MvvmCross.Forms.Platforms.Android.Views
                 base.OnBackPressed();
             }
         }
+
+        protected virtual void RegisterSetup()
+        {
+        }
     }
 
     public class MvxFormsApplicationActivity<TViewModel>
@@ -196,6 +200,29 @@ namespace MvvmCross.Forms.Platforms.Android.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
+        }
+    }
+
+    public abstract class MvxFormsApplicationActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxFormsApplicationActivity
+    where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
+    where TApplication : IMvxApplication, new()
+    where TFormsApplication : Application, new()
+    {
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
+        }
+    }
+
+    public abstract class MvxFormsApplicationActivity<TMvxAndroidSetup, TApplication, TFormsApplication, TViewModel> : MvxFormsApplicationActivity<TViewModel>
+    where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
+    where TApplication : IMvxApplication, new()
+    where TFormsApplication : Application, new()
+         where TViewModel : class, IMvxViewModel
+    {
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
         }
     }
 }

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Core;
+using MvvmCross.Forms.Platforms.Android.Core;
+using MvvmCross.Platforms.Android.Views;
+using MvvmCross.ViewModels;
+using Xamarin.Forms;
+
+namespace MvvmCross.Forms.Platforms.Android.Views
+{
+    public abstract class MvxFormsSplashScreenActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenActivity
+            where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
+            where TApplication : IMvxApplication, new()
+            where TFormsApplication : Application, new()
+    {
+        protected MvxFormsSplashScreenActivity(int resourceId = NoContent) : base(resourceId)
+        {
+        }
+
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
+        }
+    }
+}

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenAppCompatActivity.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Core;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Forms.Platforms.Android.Core;
+using MvvmCross.ViewModels;
+using Xamarin.Forms;
+
+namespace MvvmCross.Forms.Platforms.Android.Views
+{
+    public abstract class MvxFormsSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenAppCompatActivity
+            where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
+            where TApplication : IMvxApplication, new()
+            where TFormsApplication : Application, new()
+    {
+        protected MvxFormsSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)
+        {
+        }
+
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
+        }
+    }
+}

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -15,7 +15,7 @@ namespace MvvmCross.Platforms.Android.Views
     public abstract class MvxSplashScreenActivity
         : MvxActivity, IMvxSetupMonitor
     {
-        private const int NoContent = 0;
+        protected const int NoContent = 0;
 
         private readonly int _resourceId;
 
@@ -29,6 +29,7 @@ namespace MvvmCross.Platforms.Android.Views
 
         protected MvxSplashScreenActivity(int resourceId = NoContent)
         {
+            RegisterSetup();
             _resourceId = resourceId;
         }
 
@@ -81,6 +82,24 @@ namespace MvvmCross.Platforms.Android.Views
                 return;
 
             RunAppStart(_bundle);
+        }
+
+        protected virtual void RegisterSetup()
+        {
+        }
+    }
+
+    public abstract class MvxSplashScreenActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenActivity
+            where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
+            where TApplication : IMvxApplication, new()
+    {
+        protected MvxSplashScreenActivity(int resourceId = NoContent) : base(resourceId)
+        {
+        }
+
+        protected override void RegisterSetup()
+        {
+            this.RegisterSetupType<TMvxAndroidSetup>();
         }
     }
 }

--- a/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
+++ b/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
@@ -6,8 +6,10 @@ using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using MvvmCross.Core;
+using MvvmCross.Forms.Platforms.Android.Core;
 using MvvmCross.Forms.Platforms.Android.Views;
 using Playground.Core.ViewModels;
+using Playground.Forms.UI;
 
 namespace Playground.Forms.Droid
 {
@@ -15,17 +17,13 @@ namespace Playground.Forms.Droid
         Label = "Playground.Forms",
         Icon = "@mipmap/icon",
         Theme = "@style/AppTheme",
-        //MainLauncher = true, // No Splash Screen: Uncomment this lines if removing splash screen
+        // MainLauncher = true, // No Splash Screen: Uncomment this lines if removing splash screen
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation,
         LaunchMode = LaunchMode.SingleTask)]
-    public class MainActivity : MvxFormsAppCompatActivity<MainViewModel>
+    public class MainActivity : MvxFormsAppCompatActivity <MainViewModel>
+    // No Splash Screen: use this base instead
+    // MvxFormsAppCompatActivity<Setup, Core.App, FormsApp, MainViewModel>
     {
-        // No Splash Screen: uncomment this constructor
-        // public MainActivity() : base()
-        // {
-        //     this.RegisterSetupType<Setup>();
-        // }
-
         protected override void OnCreate(Bundle bundle)
         {
             TabLayoutResource = Resource.Layout.Tabbar;

--- a/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
+++ b/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
@@ -6,7 +6,9 @@ using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using MvvmCross.Core;
+using MvvmCross.Forms.Platforms.Android.Views;
 using MvvmCross.Platforms.Android.Views;
+using Playground.Forms.UI;
 
 namespace Playground.Forms.Droid
 {
@@ -18,14 +20,8 @@ namespace Playground.Forms.Droid
         , Theme = "@style/AppTheme.Splash"
         , NoHistory = true
         , ScreenOrientation = ScreenOrientation.Portrait)]
-    public class SplashScreen : MvxSplashScreenActivity
+    public class SplashScreen : MvxFormsSplashScreenActivity<Setup, Core.App, FormsApp>
     {
-        public SplashScreen()
-            : base(Resource.Layout.SplashScreen)
-        {
-            this.RegisterSetupType<Setup>();
-        }
-
         protected override void RunAppStart(Bundle bundle)
         {
             StartActivity(typeof(MainActivity));


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently Android Forms requires explicit call to register setup

### :new: What is the new behavior (if this is a feature change)?
Use the generic splash or activity classes to automatically register setup class

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
