### PR TITLE
Update Acr.UserDialogs link

### DIFF
--- a/docs/_documentation/plugins/3rd-party-plugins.md
+++ b/docs/_documentation/plugins/3rd-party-plugins.md
@@ -8,7 +8,7 @@ On this page you can find MvvmCross plugins that are made by 3rd parties. Feel f
 
 Plugin | Summary | Platforms | Link
 --- | --- | --- | ---
-ACR MvvmCross User Dialogs | A cross platform library that allows you to call for standard user dialogs from a shared/portable library. | Android, iOS, Windows Phone 8.0, UWP | [Nuget](https://www.nuget.org/packages/Acr.MvvmCross.Plugins.UserDialogs/)
+ACR User Dialogs | A cross platform library that allows you to call for standard user dialogs from a shared/portable library. | Android, iOS, Windows Phone 8.0, UWP | [Github](https://github.com/aritchie/userdialogs#mvvmcross)
 Pushwoosh plugin for MvvmCross | MvvmCross plugin that wraps the native Pushwoosh SDK | Android, iOS | [Nuget](https://www.nuget.org/packages/SoToGo.Plugins.Pushwoosh/)
 Infinite Scroll Plugin | Infinite Scrolling/Incremental Scrolling for lists | Android, iOS, UWP | [Github](https://github.com/HBSequence/Sequence.Plugins)
 Bluetooth LE Plugin | Use bluetooth low energy | Android, iOS | [Nuget](https://www.nuget.org/packages/MvvmCross.Plugin.BLE/)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs Update

### :arrow_heading_down: What is the current behavior?
The link to Acr.UserDialogs was pointing to a deprecated project

### :new: What is the new behavior (if this is a feature change)?
No New Behaviour

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Forms:
`Mvx.RegisterSingleton(() => UserDialogs.Instance)`

Android:
`UserDialogs.Init(() => Mvx.Resolve<IMvxAndroidCurrentTopActivity>().Activity)`

### :memo: Links to relevant issues/docs
https://www.nuget.org/packages/Acr.MvvmCross.Plugins.UserDialogs/
*This library is deprecated.  Please use Acr.UserDialogs directly*

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
