### PR TITLE
 Removed redundant navigation in SplitRootViewModel

### DIFF
--- a/Projects/Playground/Playground.Core/ViewModels/SplitRootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/SplitRootViewModel.cs
@@ -17,30 +17,12 @@ namespace Playground.Core.ViewModels
         {
             _navigationService = navigationService;
 
-            ShowInitialMenuCommand = new MvxAsyncCommand(ShowInitialViewModel);
-            ShowDetailCommand = new MvxAsyncCommand(ShowDetailViewModel);
+            ShowInitialMenuCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitMasterViewModel>());
+            ShowDetailCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitDetailViewModel>());
         }
 
         public IMvxAsyncCommand ShowInitialMenuCommand { get; private set; }
 
         public IMvxAsyncCommand ShowDetailCommand { get; private set; }
-
-        public override void ViewAppeared()
-        {
-            MvxNotifyTask.Create(async () => {
-                await ShowInitialViewModel();
-                await ShowDetailViewModel();
-            });
-        }
-
-        private async Task ShowInitialViewModel()
-        {
-            await _navigationService.Navigate<SplitMasterViewModel>();
-        }
-
-        private async Task ShowDetailViewModel()
-        {
-            await _navigationService.Navigate<SplitDetailViewModel>();
-        }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Double request to NavigationService for opening the same views.

### :new: What is the new behavior (if this is a feature change)?
None

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
