### PR TITLE
Removing calls to base methods to prevent error

### DIFF
--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
@@ -49,6 +49,8 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
 
             instance.PlatformSetup<MvxFormsMacSetup>().FormsApplication.SendStart();
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
+
+            // Unlike most other overrides, this should be left here so that the base FormsApplicationDelegate override is called
             base.DidFinishLaunching(notification);
         }
 
@@ -85,7 +87,6 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
         public override void WillTerminate(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Closing);
-            base.WillTerminate(notification);
         }
 
         private void FireLifetimeChanged(MvxLifetimeEvent which)

--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -37,7 +37,6 @@ namespace MvvmCross.Platforms.Mac.Core
             RunAppStart(notification);
 
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
-            base.DidFinishLaunching(notification);
         }
 
         protected virtual void RunAppStart(object hint = null)
@@ -65,7 +64,6 @@ namespace MvvmCross.Platforms.Mac.Core
         public override void WillTerminate(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Closing);
-            base.WillTerminate(notification);
         }
 
         private void FireLifetimeChanged(MvxLifetimeEvent which)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Mac applications crash if DidFinishLaunching not overridden and base not called

### :new: What is the new behavior (if this is a feature change)?
Mac applications run

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run playground Mac sample

### :memo: Links to relevant issues/docs
This issue was previously closed but the fix didn't cover DidFinishLaunching
https://github.com/MvvmCross/MvvmCross/issues/2591

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
