### PR TITLE
SplashScreenAppCompat should use AppCompatSetup

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -90,7 +90,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
     }
 
     public abstract class MvxSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenAppCompatActivity
-            where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
+            where TMvxAndroidSetup : MvxAppCompatSetup<TApplication>, new()
             where TApplication : IMvxApplication, new()
     {
         protected MvxSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
You cannot create a MvxSplashScreenAppCompatActivity derived class using MvxAppCompatSetup as required from Support v7 AppCompat package.

### :new: What is the new behavior (if this is a feature change)?

The MvxSplashScreenAppCompatActivity is now using the right setup class.

### :boom: Does this PR introduce a breaking change?

Maybe. If someone is using MvxAndroidSetup as generic param, it'll break. But the application 'll not work as expected, as target bindings for AppCompat type of views, aren't being properly registered and
 bindings 'll not work.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

https://github.com/MvvmCross/MvvmCross/blob/620bd145baab24ad07f2ad8d332412b6356dbc31/MvvmCross.Android.Support/V7.AppCompat/README.md

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
