### PR TITLE
[WIP] Add support for async startup

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatApplication.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatApplication.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 {
     public abstract class MvxAppCompatApplication<TMvxAndroidSetup, TApplication> : MvxAndroidApplication
   where TMvxAndroidSetup : MvxAppCompatSetup<TApplication>, new()
-  where TApplication : IMvxApplication, new()
+  where TApplication : class, IMvxApplication, new()
     {
         public MvxAppCompatApplication() : base()
         {

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetup.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetup.cs
@@ -44,9 +44,9 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
     }
 
     public class MvxAppCompatSetup<TApplication> : MvxAppCompatSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Android.OS;
 using Android.Support.Design.Widget;
 using Android.Support.V4.App;
@@ -162,7 +163,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             Show(hostViewModelRequest);
         }
 
-        protected override void ShowFragment(Type view,
+        protected override Task<bool> ShowFragment(Type view,
             MvxFragmentPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
@@ -171,7 +172,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             {
                 ShowNestedFragment(view, attribute, request);
 
-                return;
+                return Task.FromResult(true);
             }
 
             // if there is no Activity host associated, assume is the current activity
@@ -193,6 +194,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
                 PerformShowFragmentTransaction(CurrentFragmentManager, attribute, request);
             }
+            return Task.FromResult(true);
         }
 
         protected override void ShowNestedFragment(Type view, MvxFragmentPresentationAttribute attribute, MvxViewModelRequest request)
@@ -315,7 +317,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         }
 
-        protected override void ShowDialogFragment(Type view,
+        protected override Task<bool> ShowDialogFragment(Type view,
            MvxDialogFragmentPresentationAttribute attribute,
            MvxViewModelRequest request)
         {
@@ -352,9 +354,10 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             dialog.Show(ft, fragmentName);
 
             OnFragmentChanged(ft, dialog, attribute, request);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowViewPagerFragment(
+        protected virtual Task<bool> ShowViewPagerFragment(
             Type view,
             MvxViewPagerFragmentPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -412,9 +415,10 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 else
                     throw new MvxException("ViewPager not found");
             }
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowTabLayout(
+        protected virtual Task<bool> ShowTabLayout(
             Type view,
             MvxTabLayoutPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -429,11 +433,12 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             }
             else
                 throw new MvxException("ViewPager or TabLayout not found");
+            return Task.FromResult(true);
         }
         #endregion
 
         #region Close implementations
-        protected override bool CloseFragmentDialog(IMvxViewModel viewModel, MvxDialogFragmentPresentationAttribute attribute)
+        protected override async Task<bool> CloseFragmentDialog(IMvxViewModel viewModel, MvxDialogFragmentPresentationAttribute attribute)
         {
             string tag = FragmentJavaName(attribute.ViewType);
             var toClose = CurrentFragmentManager.FindFragmentByTag(tag);
@@ -445,7 +450,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             return false;
         }
 
-        protected virtual bool CloseViewPagerFragment(IMvxViewModel viewModel, MvxViewPagerFragmentPresentationAttribute attribute)
+        protected virtual async Task<bool> CloseViewPagerFragment(IMvxViewModel viewModel, MvxViewPagerFragmentPresentationAttribute attribute)
         {
             var viewPager = CurrentActivity.FindViewById<ViewPager>(attribute.ViewPagerResourceId);
             if (viewPager?.Adapter is MvxCachingFragmentStatePagerAdapter adapter)
@@ -477,7 +482,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             return true;
         }
 
-        protected override bool CloseFragment(IMvxViewModel viewModel, MvxFragmentPresentationAttribute attribute)
+        protected override async Task<bool> CloseFragment(IMvxViewModel viewModel, MvxFragmentPresentationAttribute attribute)
         {
             // try to close nested fragment first
             if (attribute.FragmentHostViewType != null)

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -91,7 +91,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
     public abstract class MvxSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenAppCompatActivity
             where TMvxAndroidSetup : MvxAppCompatSetup<TApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
     {
         protected MvxSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)
         {

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
@@ -76,12 +77,19 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             base.OnPause();
         }
 
-        public virtual void InitializationComplete()
+        public virtual async Task InitializationComplete()
         {
             if (!_isResumed)
                 return;
 
-            RunAppStart(_bundle);
+            await RunAppStartAsync(_bundle);
+        }
+
+        protected virtual async Task RunAppStartAsync(Bundle bundle)
+        {
+            var startup = Mvx.Resolve<IMvxAppStart>();
+            if (!startup.IsStarted)
+                await startup.StartAsync(GetAppStartHint(bundle));
         }
 
         protected virtual void RegisterSetup()

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -90,7 +90,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
     }
 
     public abstract class MvxSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenAppCompatActivity
-            where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
+            where TMvxAndroidSetup : MvxAppCompatSetup<TApplication>, new()
             where TApplication : IMvxApplication, new()
     {
         protected MvxSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)

--- a/MvvmCross.Forms/MvvmCross.Forms.csproj
+++ b/MvvmCross.Forms/MvvmCross.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid81;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid81</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid81;tizen40;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid81;tizen40</TargetFrameworks>
     <AssemblyName>MvvmCross.Forms</AssemblyName>
     <RootNamespace>MvvmCross.Forms</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.
@@ -81,7 +81,10 @@ This package contains MvvmCross to use with Xamarin.Forms</Description>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">
     <Compile Include="Platforms\Tizen\**\*.cs" />
     <Compile Include="Platforms\Xamarin-common\**\*.cs" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" />
+    <PackageReference Include="Tizen.NET" Version="4.0.0">
+      <ExcludeAssets>Runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms.Platform.Tizen" Version="2.5.0.280555" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
+++ b/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
@@ -131,7 +131,7 @@ namespace MvvmCross.Forms.Platforms.Android.Core
     }
 
     public class MvxFormsAndroidSetup<TApplication, TFormsApplication> : MvxFormsAndroidSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -146,6 +146,6 @@ namespace MvvmCross.Forms.Platforms.Android.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Android/Presenters/MvxFormsAndroidViewPresenter.cs
+++ b/MvvmCross.Forms/Platforms/Android/Presenters/MvxFormsAndroidViewPresenter.cs
@@ -12,6 +12,7 @@ using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 using MvvmCross.Forms.Platforms.Android.Views;
 using Xamarin.Forms;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Forms.Platforms.Android.Presenters
 {
@@ -22,13 +23,7 @@ namespace MvvmCross.Forms.Platforms.Android.Presenters
         {
             FormsApplication = formsApplication ?? throw new ArgumentNullException(nameof(formsApplication), "MvxFormsApplication cannot be null");
         }
-
-        private Application _formsApplication;
-        public Application FormsApplication
-        {
-            get { return _formsApplication; }
-            set { _formsApplication = value; }
-        }
+        public Application FormsApplication { get; set; }
 
         private IMvxFormsPagePresenter _formsPagePresenter;
         public virtual IMvxFormsPagePresenter FormsPagePresenter
@@ -42,9 +37,9 @@ namespace MvvmCross.Forms.Platforms.Android.Presenters
             set { _formsPagePresenter = value; }
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
-            FormsPagePresenter.Show(request);
+            return FormsPagePresenter.Show(request);
         }
 
         public override void RegisterAttributeTypes()
@@ -53,15 +48,15 @@ namespace MvvmCross.Forms.Platforms.Android.Presenters
             FormsPagePresenter.RegisterAttributeTypes();
         }
 
-        public override void ChangePresentation(MvxPresentationHint hint)
+        public override async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            FormsPagePresenter.ChangePresentation(hint);
-            base.ChangePresentation(hint);
+            await FormsPagePresenter.ChangePresentation(hint);
+            return await base.ChangePresentation(hint);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            FormsPagePresenter.Close(viewModel);
+            return FormsPagePresenter.Close(viewModel);
         }
 
         public virtual bool ShowPlatformHost(Type hostViewModel = null)

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
@@ -215,7 +215,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxFormsAppCompatActivity
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()
@@ -226,7 +226,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication, TViewModel> : MvxFormsAppCompatActivity<TViewModel>
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
          where TViewModel : class, IMvxViewModel
     {

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
@@ -205,7 +205,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsApplicationActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxFormsApplicationActivity
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()
@@ -216,7 +216,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsApplicationActivity<TMvxAndroidSetup, TApplication, TFormsApplication, TViewModel> : MvxFormsApplicationActivity<TViewModel>
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
          where TViewModel : class, IMvxViewModel
     {

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 {
     public abstract class MvxFormsSplashScreenActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenActivity
             where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
             where TFormsApplication : Application, new()
     {
         protected MvxFormsSplashScreenActivity(int resourceId = NoContent) : base(resourceId)

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenAppCompatActivity.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 {
     public abstract class MvxFormsSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenAppCompatActivity
             where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
             where TFormsApplication : Application, new()
     {
         protected MvxFormsSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)

--- a/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsApplicationDelegate.cs
@@ -106,7 +106,7 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
 
     public abstract class MvxFormsApplicationDelegate<TMvxIosSetup, TApplication, TFormsApplication> : MvxFormsApplicationDelegate
         where TMvxIosSetup : MvxFormsIosSetup<TApplication, TFormsApplication>, new()
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()

--- a/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsIosSetup.cs
+++ b/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsIosSetup.cs
@@ -116,7 +116,7 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
     }
 
     public class MvxFormsIosSetup<TApplication, TFormsApplication> : MvxFormsIosSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -131,6 +131,6 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Ios/Presenters/MvxFormsIosViewPresenter.cs
+++ b/MvvmCross.Forms/Platforms/Ios/Presenters/MvxFormsIosViewPresenter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Forms.Core;
 using MvvmCross.Forms.Presenters;
 using MvvmCross.Logging;
@@ -41,12 +42,13 @@ namespace MvvmCross.Forms.Platforms.Ios.Presenters
             set { _formsPagePresenter = value; }
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override async Task<bool> Show(MvxViewModelRequest request)
         {
-            FormsPagePresenter.Show(request);
+            if (!await FormsPagePresenter.Show(request)) return false;
 
             if (_window.RootViewController == null)
                 SetWindowRootViewController(FormsApplication.MainPage.CreateViewController());
+            return true;
         }
 
         public override void RegisterAttributeTypes()
@@ -55,15 +57,15 @@ namespace MvvmCross.Forms.Platforms.Ios.Presenters
             FormsPagePresenter.RegisterAttributeTypes();
         }
 
-        public override void ChangePresentation(MvxPresentationHint hint)
+        public override async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            FormsPagePresenter.ChangePresentation(hint);
-            base.ChangePresentation(hint);
+            if (!await FormsPagePresenter.ChangePresentation(hint)) return false;
+            return await base.ChangePresentation(hint);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            FormsPagePresenter.Close(viewModel);
+            return FormsPagePresenter.Close(viewModel);
         }
 
         public virtual bool ShowPlatformHost(Type hostViewModel = null)

--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
@@ -49,6 +49,8 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
 
             instance.PlatformSetup<MvxFormsMacSetup>().FormsApplication.SendStart();
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
+
+            // Unlike most other overrides, this should be left here so that the base FormsApplicationDelegate override is called
             base.DidFinishLaunching(notification);
         }
 
@@ -85,7 +87,6 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
         public override void WillTerminate(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Closing);
-            base.WillTerminate(notification);
         }
 
         private void FireLifetimeChanged(MvxLifetimeEvent which)

--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
@@ -103,7 +103,7 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
 
     public abstract class MvxFormsApplicationDelegate<TMvxMacSetup, TApplication, TFormsApplication> : MvxFormsApplicationDelegate
     where TMvxMacSetup : MvxFormsMacSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()

--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsMacSetup.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsMacSetup.cs
@@ -116,7 +116,7 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
     }
 
     public class MvxFormsMacSetup<TApplication, TFormsApplication> : MvxFormsMacSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -131,6 +131,6 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Mac/Presenters/MvxFormsMacViewPresenter.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Presenters/MvxFormsMacViewPresenter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using AppKit;
 using MvvmCross.Forms.Core;
 using MvvmCross.Forms.Presenters;
@@ -41,9 +42,9 @@ namespace MvvmCross.Forms.Platforms.Mac.Presenters
             set { _formsPagePresenter = value; }
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
-            FormsPagePresenter.Show(request);
+            return FormsPagePresenter.Show(request);
         }
 
         public override void RegisterAttributeTypes()
@@ -53,15 +54,15 @@ namespace MvvmCross.Forms.Platforms.Mac.Presenters
             FormsPagePresenter.RegisterAttributeTypes();
         }
 
-        public override void ChangePresentation(MvxPresentationHint hint)
+        public override async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            FormsPagePresenter.ChangePresentation(hint);
-            base.ChangePresentation(hint);
+            if (!await FormsPagePresenter.ChangePresentation(hint)) return false;
+            return await base.ChangePresentation(hint);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            FormsPagePresenter.Close(viewModel);
+            return FormsPagePresenter.Close(viewModel);
         }
 
         public virtual bool ShowPlatformHost(Type hostViewModel = null)

--- a/MvvmCross.Forms/Platforms/Tizen/Bindings/MvxFormsTizenBindingBuilder.cs
+++ b/MvvmCross.Forms/Platforms/Tizen/Bindings/MvxFormsTizenBindingBuilder.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Forms.Bindings;
+using MvvmCross.Platforms.Tizen.Binding;
+
+namespace MvvmCross.Forms.Platforms.Tizen.Bindings
+{
+    public class MvxFormsTizenBindingBuilder : MvxTizenBindingBuilder
+    {
+        public MvxFormsTizenBindingBuilder()
+        {
+        }
+
+        public override void DoRegistration()
+        {
+            base.DoRegistration();
+            InitializeBindingCreator();
+        }
+
+        protected override IMvxTargetBindingFactoryRegistry CreateTargetBindingRegistry()
+        {
+            return new MvxFormsTargetBindingFactoryRegistry();
+        }
+
+        private void InitializeBindingCreator()
+        {
+            var creator = CreateBindingCreator();
+            Mvx.RegisterSingleton(creator);
+        }
+
+        protected virtual IMvxBindingCreator CreateBindingCreator()
+        {
+            return new MvxFormsBindingCreator();
+        }
+    }
+}

--- a/MvvmCross.Forms/Platforms/Tizen/Core/MvxFormsTizenSetup.cs
+++ b/MvvmCross.Forms/Platforms/Tizen/Core/MvxFormsTizenSetup.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Binding;
+using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Forms.Presenters;
+using MvvmCross.Localization;
+using System.Collections.Generic;
+using System.Reflection;
+using MvvmCross.Forms.Core;
+using MvvmCross.Forms.Platforms.Tizen.Bindings;
+using MvvmCross.Platforms.Tizen.Core;
+using MvvmCross.Platforms.Tizen.Presenters;
+using MvvmCross.Plugin;
+using MvvmCross.ViewModels;
+using MvvmCross.Forms.Platforms.Tizen.Presenters;
+using Xamarin.Forms;
+using System.Linq;
+
+namespace MvvmCross.Forms.Platforms.Tizen.Core
+{
+    public abstract class MvxFormsTizenSetup : MvxTizenSetup, IMvxFormsSetup
+    {
+        private List<Assembly> _viewAssemblies;
+        private Application _formsApplication;
+
+        public override IEnumerable<Assembly> GetViewAssemblies()
+        {
+            if (_viewAssemblies == null)
+            {
+                _viewAssemblies = new List<Assembly>(base.GetViewAssemblies());
+            }
+
+            return _viewAssemblies;
+        }
+
+        protected override void InitializeIoC()
+        {
+            base.InitializeIoC();
+            Mvx.RegisterSingleton<IMvxFormsSetup>(this);
+        }
+
+        protected override void InitializeApp(IMvxPluginManager pluginManager, IMvxApplication app)
+        {
+            base.InitializeApp(pluginManager, app);
+            _viewAssemblies.AddRange(GetViewModelAssemblies());
+        }
+
+        public virtual Application FormsApplication
+        {
+            get
+            {
+                if (!Xamarin.Forms.Platform.Tizen.Forms.IsInitialized)
+                    Xamarin.Forms.Platform.Tizen.Forms.Init(CoreApplication);
+                if (_formsApplication == null)
+                {
+                    _formsApplication = CreateFormsApplication();
+                }
+                if (Application.Current != _formsApplication)
+                {
+                    Application.Current = _formsApplication;
+                }
+                return _formsApplication;
+            }
+        }
+
+        protected abstract Application CreateFormsApplication();
+
+        protected virtual IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
+        {
+            var formsPagePresenter = new MvxFormsPagePresenter(viewPresenter);
+            Mvx.RegisterSingleton(formsPagePresenter);
+            return formsPagePresenter;
+        }
+
+        protected override IMvxTizenViewPresenter CreateViewPresenter()
+        {
+            var presenter = new MvxFormsTizenViewPresenter(FormsApplication);
+            Mvx.RegisterSingleton<IMvxFormsViewPresenter>(presenter);
+            presenter.FormsPagePresenter = CreateFormsPagePresenter(presenter);
+            return presenter;
+        }
+
+        protected override IEnumerable<Assembly> ValueConverterAssemblies
+        {
+            get
+            {
+                var toReturn = new List<Assembly>(base.ValueConverterAssemblies)
+                {
+                    typeof(MvxLanguageConverter).Assembly
+                };
+                return toReturn;
+            }
+        }
+
+        protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+        {
+            MvxFormsSetupHelper.FillTargetFactories(registry);
+            base.FillTargetFactories(registry);
+        }
+
+        protected override void FillBindingNames(Binding.BindingContext.IMvxBindingNameRegistry registry)
+        {
+            MvxFormsSetupHelper.FillBindingNames(registry);
+            base.FillBindingNames(registry);
+        }
+
+        protected override MvxBindingBuilder CreateBindingBuilder() => new MvxFormsTizenBindingBuilder();
+
+        protected override IMvxNameMapping CreateViewToViewModelNaming()
+        {
+            return new MvxPostfixAwareViewToViewModelNameMapping("View", "Page");
+        }
+    }
+
+    public class MvxFormsTizenSetup<TApplication, TFormsApplication> : MvxFormsTizenSetup
+        where TApplication : class, IMvxApplication, new()
+        where TFormsApplication : Application, new()
+    {
+        public override IEnumerable<Assembly> GetViewAssemblies()
+        {
+            return new List<Assembly>(base.GetViewAssemblies().Union(new[] { typeof(TFormsApplication).GetTypeInfo().Assembly }));
+        }
+
+        public override IEnumerable<Assembly> GetViewModelAssemblies()
+        {
+            return new[] { typeof(TApplication).GetTypeInfo().Assembly };
+        }
+
+        protected override Application CreateFormsApplication() => new TFormsApplication();
+
+        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+    }
+}

--- a/MvvmCross.Forms/Platforms/Tizen/Presenters/MvxFormsTizenViewPresenter.cs
+++ b/MvvmCross.Forms/Platforms/Tizen/Presenters/MvxFormsTizenViewPresenter.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using MvvmCross.Forms.Core;
+using MvvmCross.Forms.Presenters;
+using MvvmCross.Logging;
+using MvvmCross.Platforms.Tizen.Presenters;
+using MvvmCross.ViewModels;
+using Xamarin.Forms;
+
+namespace MvvmCross.Forms.Platforms.Tizen.Presenters
+{
+    public class MvxFormsTizenViewPresenter
+        : MvxTizenViewPresenter
+        , IMvxFormsViewPresenter
+    {
+        public MvxFormsTizenViewPresenter(Application formsApplication) : base ()
+        {
+            FormsApplication = formsApplication ?? throw new ArgumentNullException(nameof(formsApplication), "MvxFormsApplication cannot be null");
+        }
+
+        private Application _formsApplication;
+        public Application FormsApplication
+        {
+            get { return _formsApplication; }
+            set { _formsApplication = value; }
+        }
+
+        private IMvxFormsPagePresenter _formsPagePresenter;
+        public virtual IMvxFormsPagePresenter FormsPagePresenter
+        {
+            get
+            {
+                if (_formsPagePresenter == null)
+                    throw new ArgumentNullException(nameof(FormsPagePresenter), "IMvxFormsPagePresenter cannot be null. Set the value in CreateViewPresenter in the setup.");
+                return _formsPagePresenter;
+            }
+            set { _formsPagePresenter = value; }
+        }
+
+        public override void Show(MvxViewModelRequest request)
+        {
+            FormsPagePresenter.Show(request);
+        }
+
+        public override void RegisterAttributeTypes()
+        {
+            base.RegisterAttributeTypes();
+            FormsPagePresenter.RegisterAttributeTypes();
+        }
+
+        public override void ChangePresentation(MvxPresentationHint hint)
+        {
+            FormsPagePresenter.ChangePresentation(hint);
+            base.ChangePresentation(hint);
+        }
+
+        public override void Close(IMvxViewModel viewModel)
+        {
+            FormsPagePresenter.Close(viewModel);
+        }
+
+        public virtual bool ShowPlatformHost(Type hostViewModel = null)
+        {
+            MvxFormsLog.Instance.Trace($"Showing of native host View in Forms is not supported.");
+            return false;
+        }
+
+        public virtual bool ClosePlatformViews()
+        {
+            return true;
+        }
+    }
+}

--- a/MvvmCross.Forms/Platforms/Tizen/Presenters/MvxFormsTizenViewPresenter.cs
+++ b/MvvmCross.Forms/Platforms/Tizen/Presenters/MvxFormsTizenViewPresenter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Forms.Core;
 using MvvmCross.Forms.Presenters;
 using MvvmCross.Logging;
@@ -40,9 +41,9 @@ namespace MvvmCross.Forms.Platforms.Tizen.Presenters
             set { _formsPagePresenter = value; }
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
-            FormsPagePresenter.Show(request);
+            return FormsPagePresenter.Show(request);
         }
 
         public override void RegisterAttributeTypes()
@@ -51,15 +52,15 @@ namespace MvvmCross.Forms.Platforms.Tizen.Presenters
             FormsPagePresenter.RegisterAttributeTypes();
         }
 
-        public override void ChangePresentation(MvxPresentationHint hint)
+        public override Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
             FormsPagePresenter.ChangePresentation(hint);
-            base.ChangePresentation(hint);
+            return base.ChangePresentation(hint);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            FormsPagePresenter.Close(viewModel);
+            return FormsPagePresenter.Close(viewModel);
         }
 
         public virtual bool ShowPlatformHost(Type hostViewModel = null)

--- a/MvvmCross.Forms/Platforms/Tizen/Views/MvxProgram.cs
+++ b/MvvmCross.Forms/Platforms/Tizen/Views/MvxProgram.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MvvmCross.Forms.Presenters;
+using MvvmCross.Platforms.Tizen.Core;
+using Xamarin.Forms;
+
+namespace MvvmCross.Forms.Platforms.Tizen.Views
+{
+    public class MvxProgram : global::Xamarin.Forms.Platform.Tizen.FormsApplication
+    {
+        private Application _formsApplication;
+        protected Application FormsApplication
+        {
+            get
+            {
+                if (_formsApplication == null)
+                {
+                    var formsPresenter = Mvx.Resolve<IMvxFormsViewPresenter>();
+                    _formsApplication = formsPresenter.FormsApplication;
+                }
+
+                return _formsApplication;
+            }
+        }
+
+        private static global::Xamarin.Forms.Platform.Tizen.FormsApplication _application;
+        protected static global::Xamarin.Forms.Platform.Tizen.FormsApplication Application
+        {
+            get
+            {
+                if (_application == null)
+                {
+                    _application = new MvxProgram();
+                }
+
+                return _application;
+            }
+        }
+
+        protected override void OnCreate()
+        {
+            base.OnCreate();
+
+            var setup = MvxTizenSetupSingleton.EnsureSingletonAvailable(Application);
+            setup.EnsureInitialized();
+
+            LoadApplication(FormsApplication);
+        }
+
+        static void Main(string[] args)
+        {
+            global::Xamarin.Forms.Platform.Tizen.Forms.Init(Application);
+            Application.Run(args);
+        }
+    }
+}

--- a/MvvmCross.Forms/Platforms/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Core/MvxFormsWindowsSetup.cs
@@ -98,7 +98,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Core
     }
 
     public class MvxFormsWindowsSetup<TApplication, TFormsApplication> : MvxFormsWindowsSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()        
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -113,6 +113,6 @@ namespace MvvmCross.Forms.Platforms.Uap.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Uap/Presenters/MvxFormsUwpViewPresenter.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Presenters/MvxFormsUwpViewPresenter.cs
@@ -10,6 +10,7 @@ using MvvmCross.Platforms.Uap.Presenters;
 using MvvmCross.Platforms.Uap.Views;
 using MvvmCross.ViewModels;
 using Xamarin.Forms;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Forms.Platforms.Uap.Presenters
 {
@@ -51,20 +52,20 @@ namespace MvvmCross.Forms.Platforms.Uap.Presenters
             FormsPagePresenter.RegisterAttributeTypes();
         }
 
-        public override void ChangePresentation(MvxPresentationHint hint)
+        public override async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            FormsPagePresenter.ChangePresentation(hint);
-            base.ChangePresentation(hint);
+            if (!await FormsPagePresenter.ChangePresentation(hint)) return false;
+            return await base.ChangePresentation(hint);
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
-            FormsPagePresenter.Show(request);
+            return FormsPagePresenter.Show(request);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            FormsPagePresenter.Close(viewModel);
+            return FormsPagePresenter.Close(viewModel);
         }
 
         public virtual bool ShowPlatformHost(Type hostViewModel = null)

--- a/MvvmCross.Forms/Platforms/Uap/Views/MvxWindowsApplication.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Views/MvxWindowsApplication.cs
@@ -39,7 +39,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Views
 
     public abstract class MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication> : MvxWindowsApplication
        where TMvxUapSetup : MvxFormsWindowsSetup<TApplication, TFormsApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         protected abstract override Type HostWindowsPageType();
@@ -52,7 +52,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Views
 
     public class MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication, THostPageType> : MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication>
        where TMvxUapSetup : MvxFormsWindowsSetup<TApplication, TFormsApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
         where THostPageType : MvxFormsWindowsPage
     {

--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -31,7 +32,6 @@ namespace MvvmCross.Forms.Presenters
         public MvxFormsPagePresenter(IMvxFormsViewPresenter platformPresenter)
         {
             PlatformPresenter = platformPresenter;
-            AttributeTypesToActionsDictionary = platformPresenter.AttributeTypesToActionsDictionary;
         }
 
         protected IMvxFormsViewPresenter PlatformPresenter { get; }
@@ -39,8 +39,9 @@ namespace MvvmCross.Forms.Presenters
         private Application _formsApplication;
         public Application FormsApplication
         {
-            get {
-                if(_formsApplication == null)
+            get
+            {
+                if (_formsApplication == null)
                     _formsApplication = PlatformPresenter.FormsApplication;
                 return _formsApplication;
             }
@@ -69,7 +70,7 @@ namespace MvvmCross.Forms.Presenters
                 if (_viewsContainer == null)
                     _viewsContainer = PlatformPresenter.ViewsContainer;
                 return base.ViewsContainer;
-            } 
+            }
             set => base.ViewsContainer = value;
         }
 
@@ -82,6 +83,19 @@ namespace MvvmCross.Forms.Presenters
                 return base.ViewModelTypeFinder;
             }
             set => base.ViewModelTypeFinder = value;
+        }
+
+        public override Dictionary<Type, MvxPresentationAttributeAction> AttributeTypesToActionsDictionary
+        {
+            get
+            {
+                if (_attributeTypesActionsDictionary == null)
+                {
+                    _attributeTypesActionsDictionary = PlatformPresenter.AttributeTypesToActionsDictionary;
+                }
+                return _attributeTypesActionsDictionary;
+            }
+            set => base.AttributeTypesToActionsDictionary = value;
         }
 
         public virtual Page CreatePage(Type viewType, MvxViewModelRequest request, MvxBasePresentationAttribute attribute)

--- a/MvvmCross/Base/MvxDictionaryExtensions.cs
+++ b/MvvmCross/Base/MvxDictionaryExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace MvvmCross.Platform.ExtensionMethods
+{
+	public static class MvxObjectExtensions
+	{
+		public static IDictionary<string, object> ToPropertyDictionary(this object input)
+		{
+			if (input == null)
+				return new Dictionary<string, object>();
+
+			if (input is IDictionary<string, object>)
+				return (IDictionary<string, object>)input;
+
+			var propertyInfos = from property in input.GetType()
+													  .GetProperties(BindingFlags.Instance | BindingFlags.Public |
+																	 BindingFlags.FlattenHierarchy)
+								where property.CanRead
+								select property;
+
+			var dictionary = new Dictionary<string, object>();
+			foreach (var propertyInfo in propertyInfos)
+			{
+				dictionary[propertyInfo.Name] = propertyInfo.GetValue(input);
+			}
+			return dictionary;
+		}
+	}
+}

--- a/MvvmCross/Base/MvxDictionaryExtensions.cs
+++ b/MvvmCross/Base/MvxDictionaryExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
-namespace MvvmCross.Platform.ExtensionMethods
+namespace MvvmCross.Base
 {
-	public static class MvxObjectExtensions
-	{
+	public static class MvxDictionaryExtensions
+    {
 		public static IDictionary<string, object> ToPropertyDictionary(this object input)
 		{
 			if (input == null)

--- a/MvvmCross/Core/IMvxSetupMonitor.cs
+++ b/MvvmCross/Core/IMvxSetupMonitor.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+
 namespace MvvmCross.Core
 {
     public interface IMvxSetupMonitor
     {
-        void InitializationComplete();
+        Task InitializationComplete();
     }
 }

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -484,9 +484,9 @@ namespace MvvmCross.Core
     }
 
     public abstract class MvxSetup<TApplication> : MvxSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Exceptions/MvxException.cs
+++ b/MvvmCross/Exceptions/MvxException.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace MvvmCross.Exceptions
 {
-    // Officially exception should support serialisation, but we don't add it here - mainly because of
-    // serialization limits in PCLs
+    [Serializable]
     public class MvxException : Exception
     {
         public MvxException()
@@ -30,5 +30,13 @@ namespace MvvmCross.Exceptions
             : base(string.Format(messageFormat, formatArguments), innerException)
         {
         }
+
+        public MvxException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected MvxException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }        
     }
 }

--- a/MvvmCross/Exceptions/MvxIoCResolveException.cs
+++ b/MvvmCross/Exceptions/MvxIoCResolveException.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace MvvmCross.Exceptions
 {
-    // Officially exception should support serialisation, but we don't add it here - mainly because of
-    // serialization limits in PCLs
+    [Serializable]
     public class MvxIoCResolveException : MvxException
     {
         public MvxIoCResolveException()
@@ -30,5 +30,13 @@ namespace MvvmCross.Exceptions
             : base(innerException, messageFormat, formatArguments)
         {
         }
+
+        public MvxIoCResolveException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected MvxIoCResolveException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }        
     }
 }

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -19,6 +19,11 @@ namespace MvvmCross.IoC
 
         object Resolve(Type type);
 
+        bool TryResolve<T>(out T resolved)
+            where T : class;
+
+        bool TryResolve(Type type, out object resolved);
+
         T Create<T>()
             where T : class;
 
@@ -28,11 +33,6 @@ namespace MvvmCross.IoC
             where T : class;
 
         object GetSingleton(Type type);
-
-        bool TryResolve<T>(out T resolved)
-            where T : class;
-
-        bool TryResolve(Type type, out object resolved);
 
         void RegisterType<TFrom, TTo>()
             where TFrom : class
@@ -67,7 +67,9 @@ namespace MvvmCross.IoC
         T IoCConstruct<T>(params object[] arguments)
             where T : class;
 
-        object IoCConstruct(Type type, IDictionary<string, object> arguments = null);
+        object IoCConstruct(Type type);
+
+        object IoCConstruct(Type type, IDictionary<string, object> arguments);
 
         object IoCConstruct(Type type, object arguments);
 

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -58,17 +58,20 @@ namespace MvvmCross.IoC
         T IoCConstruct<T>()
             where T : class;
 
-        object IoCConstruct(Type type);
-
         T IoCConstruct<T>(IDictionary<string, object> arguments)
             where T : class;
 
         T IoCConstruct<T>(object arguments)
             where T : class;
 
-        object IoCConstruct(Type type, IDictionary<string, object> arguments);
+        T IoCConstruct<T>(params object[] arguments)
+            where T : class;
+
+        object IoCConstruct(Type type, IDictionary<string, object> arguments = null);
 
         object IoCConstruct(Type type, object arguments);
+
+        object IoCConstruct(Type type, params object[] arguments);
 
         void CallbackWhenRegistered<T>(Action action);
 

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 namespace MvvmCross.IoC
 {
@@ -58,6 +59,16 @@ namespace MvvmCross.IoC
             where T : class;
 
         object IoCConstruct(Type type);
+
+        T IoCConstruct<T>(IDictionary<string, object> arguments)
+            where T : class;
+
+        T IoCConstruct<T>(object arguments)
+            where T : class;
+
+        object IoCConstruct(Type type, IDictionary<string, object> arguments);
+
+        object IoCConstruct(Type type, object arguments);
 
         void CallbackWhenRegistered<T>(Action action);
 

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -398,7 +398,7 @@ namespace MvvmCross.IoC
             return IoCConstruct(type, selectedConstructor, arguments);
         }
 
-        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments= null)
+        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments = null)
         {
             var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public);
             var firstConstructor = constructors.FirstOrDefault();
@@ -407,7 +407,7 @@ namespace MvvmCross.IoC
                 throw new MvxIoCResolveException("Failed to find constructor for type {0}", type.FullName);
 
             var parameters = GetIoCParameterValues(type, firstConstructor, arguments);
-            return IoCConstruct(type, firstConstructor, arguments.ToArray());
+            return IoCConstruct(type, firstConstructor, parameters.ToArray());
         }
 
         protected virtual object IoCConstruct(Type type, ConstructorInfo constructor, object[] arguments)

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -358,6 +358,11 @@ namespace MvvmCross.IoC
             InternalSetResolver(interfaceType, new ConstructingSingletonResolver(theConstructor));
         }
 
+        public object IoCConstruct(Type type)
+        {
+            return IoCConstruct(type, default(IDictionary<string, object>));
+        }
+
         public T IoCConstruct<T>()
             where T : class
         {
@@ -398,7 +403,7 @@ namespace MvvmCross.IoC
             return IoCConstruct(type, selectedConstructor, arguments);
         }
 
-        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments = null)
+        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments)
         {
             var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public);
             var firstConstructor = constructors.FirstOrDefault();

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -349,8 +349,7 @@ namespace MvvmCross.IoC
         public void RegisterSingleton<TInterface>(Func<TInterface> theConstructor)
             where TInterface : class
         {
-#warning when the MonoTouch/Droid code fully supports CoVariance (Contra?) then we can change this)
-            RegisterSingleton(typeof(TInterface), () => (object)theConstructor());
+            RegisterSingleton(typeof(TInterface), theConstructor);
         }
 
         public void RegisterSingleton(Type interfaceType, Func<object> theConstructor)

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -41,5 +41,16 @@ namespace MvvmCross.IoC
         {
             ioc.RegisterSingleton(type, constructor);
         }
+
+        public static void RegisterType<TType>(this IMvxIoCProvider ioc)
+            where TType : class
+        {
+            ioc.RegisterType<TType, TType>();
+        }
+
+        public static void RegisterType(this IMvxIoCProvider ioc, Type tType)
+        {
+            ioc.RegisterType(tType, tType);
+        }
     }
 }

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MvvmCross.IoC
+{
+    public static class MvxIoCContainerExtensions
+    {
+        public static void CallbackWhenRegistered<T>(this IMvxIoCProvider ioc, Action<T> action)
+            where T : class
+        {
+            Action simpleAction = () =>
+            {
+                var t = ioc.Resolve<T>();
+                action(t);
+            };
+            ioc.CallbackWhenRegistered<T>(simpleAction);
+        }
+
+        public static void ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            ioc.RegisterSingleton<TInterface>(ioc.IoCConstruct<TType>());
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            ioc.RegisterSingleton<TInterface>(() => ioc.IoCConstruct<TType>());
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface>(this IMvxIoCProvider ioc, Func<TInterface> constructor)
+            where TInterface : class
+        {
+            ioc.RegisterSingleton<TInterface>(constructor);
+        }
+
+        public static void LazyConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, Func<object> constructor)
+        {
+            ioc.RegisterSingleton(type, constructor);
+        }
+    }
+}

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -163,7 +163,7 @@ namespace MvvmCross.IoC
             return _provider.IoCConstruct<T>(arguments);
         }
 
-        public object IoCConstruct(Type type, IDictionary<string, object> arguments)
+        public object IoCConstruct(Type type, IDictionary<string, object> arguments = null)
         {
             return _provider.IoCConstruct(type, arguments);
         }

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -153,6 +153,11 @@ namespace MvvmCross.IoC
             return _provider.IoCConstruct<T>(arguments);
         }
 
+        public T IoCConstruct<T>(params object[] arguments) where T : class
+        {
+            return _provider.IoCConstruct<T>(arguments);
+        }
+
         public T IoCConstruct<T>(object arguments) where T : class
         {
             return _provider.IoCConstruct<T>(arguments);
@@ -164,6 +169,11 @@ namespace MvvmCross.IoC
         }
 
         public object IoCConstruct(Type type, object arguments)
+        {
+            return _provider.IoCConstruct(type, arguments);
+        }
+
+        public object IoCConstruct(Type type, params object[] arguments)
         {
             return _provider.IoCConstruct(type, arguments);
         }

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using MvvmCross.Base;
 
 namespace MvvmCross.IoC
@@ -145,6 +146,26 @@ namespace MvvmCross.IoC
         public virtual object IoCConstruct(Type type)
         {
             return _provider.IoCConstruct(type);
+        }
+
+        public T IoCConstruct<T>(IDictionary<string, object> arguments) where T : class
+        {
+            return _provider.IoCConstruct<T>(arguments);
+        }
+
+        public T IoCConstruct<T>(object arguments) where T : class
+        {
+            return _provider.IoCConstruct<T>(arguments);
+        }
+
+        public object IoCConstruct(Type type, IDictionary<string, object> arguments)
+        {
+            return _provider.IoCConstruct(type, arguments);
+        }
+
+        public object IoCConstruct(Type type, object arguments)
+        {
+            return _provider.IoCConstruct(type, arguments);
         }
 
         public void CallbackWhenRegistered<T>(Action action)

--- a/MvvmCross/IoC/MvxLazySingletonCreator.cs
+++ b/MvvmCross/IoC/MvxLazySingletonCreator.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.IoC
 
                 lock (_lockObject)
                 {
-                    _instance = _instance ?? Mvx.IocConstruct(_type);
+                    _instance = _instance ?? Mvx.IoCConstruct(_type);
                     return _instance;
                 }
             }

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -170,7 +170,7 @@ namespace MvvmCross.IoC
                 if (!pair.ServiceTypes.Any())
                     continue;
 
-                var instance = Mvx.IocConstruct(pair.ImplementationType);
+                var instance = Mvx.IoCConstruct(pair.ImplementationType);
                 foreach (var serviceType in pair.ServiceTypes)
                 {
                     Mvx.RegisterSingleton(serviceType, instance);

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -70,6 +70,8 @@ This package contains the 'Core' libraries for MvvmCross</Description>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">
     <Compile Include="Platforms\Tizen\**\*.cs" />
     <Compile Include="Platforms\Xamarin-common\**\*.cs" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" />
+    <PackageReference Include="Tizen.NET" Version="4.0.0">
+        <ExcludeAssets>Runtime</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/MvvmCross/Mvx.cs
+++ b/MvvmCross/Mvx.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using MvvmCross.Base;
 using MvvmCross.IoC;
 
@@ -63,6 +64,12 @@ namespace MvvmCross
             return ioc.Create<T>();
         }
 
+        public static object Create(Type type)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.Create(type);
+        }
+
         public static T GetSingleton<T>()
             where T : class
         {
@@ -70,59 +77,10 @@ namespace MvvmCross
             return ioc.GetSingleton<T>();
         }
 
-        public static void RegisterSingleton<TInterface>(Func<TInterface> serviceConstructor)
-            where TInterface : class
+        public static object GetSingleton(Type type)
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(serviceConstructor);
-        }
-
-        public static void RegisterSingleton(Type tInterface, Func<object> serviceConstructor)
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(tInterface, serviceConstructor);
-        }
-
-        public static void RegisterSingleton<TInterface>(TInterface service)
-            where TInterface : class
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(service);
-        }
-
-        public static void RegisterSingleton(Type tInterface, object service)
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(tInterface, service);
-        }
-
-        public static void ConstructAndRegisterSingleton<TInterface, TType>()
-            where TInterface : class
-            where TType : TInterface
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton<TInterface>(IocConstruct<TType>());
-        }
-
-        public static void LazyConstructAndRegisterSingleton<TInterface, TType>()
-            where TInterface : class
-            where TType : TInterface
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton<TInterface>(() => IocConstruct<TType>());
-        }
-
-        public static void LazyConstructAndRegisterSingleton<TInterface>(Func<TInterface> constructor)
-            where TInterface : class
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton<TInterface>(constructor);
-        }
-
-        public static void LazyConstructAndRegisterSingleton(Type type, Func<object> constructor)
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(type, constructor);
+            return ioc.GetSingleton(type);
         }
 
         public static void RegisterType<TInterface, TType>()
@@ -152,29 +110,91 @@ namespace MvvmCross
             ioc.RegisterType(tInterface, tType);
         }
 
-        public static T IocConstruct<T>()
+        public static void RegisterSingleton<TInterface>(Func<TInterface> serviceConstructor)
+            where TInterface : class
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            return (T)ioc.IoCConstruct(typeof(T));
+            ioc.RegisterSingleton(serviceConstructor);
         }
 
-        public static object IocConstruct(Type t)
+        public static void RegisterSingleton(Type tInterface, Func<object> serviceConstructor)
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            return ioc.IoCConstruct(t);
+            ioc.RegisterSingleton(tInterface, serviceConstructor);
+        }
+
+        public static void RegisterSingleton<TInterface>(TInterface service)
+            where TInterface : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterSingleton(service);
+        }
+
+        public static void RegisterSingleton(Type tInterface, object service)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterSingleton(tInterface, service);
+        }
+
+        public static T IoCConstruct<T>()
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>();
+        }
+
+        public static T IoCConstruct<T>(IDictionary<string, object> arguments)
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>(arguments);
+        }
+
+        public static T IoCConstruct<T>(object arguments)
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>(arguments);
+        }
+
+        public static T IoCConstruct<T>(params object[] arguments)
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>(arguments);
+        }
+
+        public static object IoCConstruct(Type type)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type);
+        }
+
+        public static object IoCConstruct(Type type, IDictionary<string, object> arguments)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type, arguments);
+        }
+
+        public static object IoCConstruct(Type type, object arguments)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type, arguments);
+        }
+
+        public static object IoCConstruct(Type type, params object[] arguments)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type, arguments);
         }
 
         public static void CallbackWhenRegistered<T>(Action<T> action)
             where T : class
         {
-            Action simpleAction = () =>
-                {
-                    var t = Resolve<T>();
-                    action(t);
-                };
-            CallbackWhenRegistered<T>(simpleAction);
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.CallbackWhenRegistered<T>(action);
         }
-        
+
         public static void CallbackWhenRegistered<T>(Action action)
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
@@ -185,6 +205,41 @@ namespace MvvmCross
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
             ioc.CallbackWhenRegistered(type, action);
+        }
+
+        public static void ConstructAndRegisterSingleton<TInterface, TType>()
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.ConstructAndRegisterSingleton<TInterface, TType>();
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface, TType>()
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.LazyConstructAndRegisterSingleton<TInterface, TType>();
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface>(Func<TInterface> constructor)
+            where TInterface : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.LazyConstructAndRegisterSingleton<TInterface>(constructor);
+        }
+
+        public static void LazyConstructAndRegisterSingleton(Type type, Func<object> constructor)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.LazyConstructAndRegisterSingleton(type, constructor);
+        }
+
+        public static IMvxIoCProvider CreateChildContainer()
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.CreateChildContainer();
         }
     }
 }

--- a/MvvmCross/Mvx.cs
+++ b/MvvmCross/Mvx.cs
@@ -83,6 +83,13 @@ namespace MvvmCross
             return ioc.GetSingleton(type);
         }
 
+        public static void RegisterType<TType>()
+            where TType : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterType<TType>();
+        }
+
         public static void RegisterType<TInterface, TType>()
             where TInterface : class
             where TType : class, TInterface
@@ -96,6 +103,12 @@ namespace MvvmCross
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
             ioc.RegisterType(constructor);
+        }
+
+        public static void RegisterType(Type tType)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterType(tType);
         }
 
         public static void RegisterType(Type type, Func<object> constructor)

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -151,7 +151,7 @@ namespace MvvmCross.Navigation
 
             if(viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
             {
-                var facade = (IMvxNavigationFacade)Mvx.IocConstruct(viewModelType);
+                var facade = (IMvxNavigationFacade)Mvx.IoCConstruct(viewModelType);
 
                 try
                 {
@@ -207,7 +207,7 @@ namespace MvvmCross.Navigation
 
             if(viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
             {
-                var facade = (IMvxNavigationFacade)Mvx.IocConstruct(viewModelType);
+                var facade = (IMvxNavigationFacade)Mvx.IoCConstruct(viewModelType);
 
                 try
                 {

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -38,13 +38,9 @@ namespace MvvmCross.Platforms.Android.Core
             _applicationContext = applicationContext;
         }
 
-        #region IMvxAndroidGlobals Members
-
         public virtual Assembly ExecutableAssembly => ViewAssemblies.FirstOrDefault() ?? GetType().Assembly;
 
         public Context ApplicationContext => _applicationContext;
-
-        #endregion IMvxAndroidGlobals Members
 
         protected override void InitializePlatformServices()
         {

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -264,9 +264,9 @@ namespace MvvmCross.Platforms.Android.Core
     }
 
     public class MvxAndroidSetup<TApplication> : MvxAndroidSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidApplication.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidApplication.cs
@@ -34,7 +34,7 @@ namespace MvvmCross.Platforms.Android.Views
 
     public abstract class MvxAndroidApplication<TMvxAndroidSetup, TApplication> : MvxAndroidApplication
       where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
-      where TApplication : IMvxApplication, new()
+      where TApplication : class, IMvxApplication, new()
     {
         public MvxAndroidApplication() : base()
         {

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -91,7 +91,7 @@ namespace MvvmCross.Platforms.Android.Views
 
     public abstract class MvxSplashScreenActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenActivity
             where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
     {
         protected MvxSplashScreenActivity(int resourceId = NoContent) : base(resourceId)
         {

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
@@ -76,12 +77,19 @@ namespace MvvmCross.Platforms.Android.Views
             base.OnPause();
         }
 
-        public virtual void InitializationComplete()
+        public virtual async Task InitializationComplete()
         {
             if (!_isResumed)
                 return;
 
-            RunAppStart(_bundle);
+            await RunAppStartAsync(_bundle);
+        }
+
+        protected virtual async Task RunAppStartAsync(Bundle bundle)
+        {
+            var startup = Mvx.Resolve<IMvxAppStart>();
+            if (!startup.IsStarted)
+                await startup.StartAsync(GetAppStartHint(bundle));
         }
 
         protected virtual void RegisterSetup()

--- a/MvvmCross/Platforms/Console/Core/MvxConsoleSetup.cs
+++ b/MvvmCross/Platforms/Console/Core/MvxConsoleSetup.cs
@@ -51,9 +51,9 @@ namespace MvvmCross.Platforms.Console.Core
     }
 
     public class MvxConsoleSetup<TApplication> : MvxConsoleSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Console/Views/IMvxConsoleNavigation.cs
+++ b/MvvmCross/Platforms/Console/Views/IMvxConsoleNavigation.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross.Presenters;
 
 namespace MvvmCross.Platforms.Console.Views
@@ -9,7 +10,7 @@ namespace MvvmCross.Platforms.Console.Views
     public interface IMvxConsoleNavigation
         : IMvxViewPresenter
     {
-        void GoBack();
+        Task<bool> GoBack();
 
         void RemoveBackEntry();
 

--- a/MvvmCross/Platforms/Console/Views/MvxBaseConsoleContainer.cs
+++ b/MvvmCross/Platforms/Console/Views/MvxBaseConsoleContainer.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MvvmCross.Logging;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
@@ -13,40 +14,41 @@ namespace MvvmCross.Platforms.Console.Views
     public abstract class MvxBaseConsoleContainer
         : MvxViewsContainer, IMvxConsoleNavigation
     {
-        private readonly Dictionary<Type, Func<MvxPresentationHint, bool>> _presentationHintHandlers = new Dictionary<Type, Func<MvxPresentationHint, bool>>();
+        private readonly Dictionary<Type, Func<MvxPresentationHint, Task<bool>>> _presentationHintHandlers = new Dictionary<Type, Func<MvxPresentationHint, Task<bool>>>();
 
-        public void AddPresentationHintHandler<THint>(Func<THint, bool> action) where THint : MvxPresentationHint
+        public void AddPresentationHintHandler<THint>(Func<THint, Task<bool>> action) where THint : MvxPresentationHint
         {
             _presentationHintHandlers[typeof(THint)] = hint => action((THint)hint);
         }
 
-        protected bool HandlePresentationChange(MvxPresentationHint hint)
+        protected async Task<bool> HandlePresentationChange(MvxPresentationHint hint)
         {
-            Func<MvxPresentationHint, bool> handler;
+            Func<MvxPresentationHint, Task<bool>> handler;
 
             if (_presentationHintHandlers.TryGetValue(hint.GetType(), out handler))
             {
-                if (handler(hint)) return true;
+                return await handler(hint);
             }
 
             return false;
         }
 
-        public abstract void Show(MvxViewModelRequest request);
+        public abstract Task<bool> Show(MvxViewModelRequest request);
 
-        public abstract void GoBack();
+        public abstract Task<bool> GoBack();
 
         public abstract void RemoveBackEntry();
 
         public abstract bool CanGoBack();
 
-        public virtual void ChangePresentation(MvxPresentationHint hint)
+        public virtual async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            if (HandlePresentationChange(hint)) return;
+            if (await HandlePresentationChange(hint)) return true;
 
             MvxLog.Instance.Warn("Hint ignored {0}", hint.GetType().Name);
+            return false;
         }
 
-        public abstract void Close(IMvxViewModel toClose);
+        public abstract Task<bool> Close(IMvxViewModel toClose);
     }
 }

--- a/MvvmCross/Platforms/Console/Views/MvxConsoleContainer.cs
+++ b/MvvmCross/Platforms/Console/Views/MvxConsoleContainer.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
 using MvvmCross.Presenters.Hints;
@@ -16,7 +17,7 @@ namespace MvvmCross.Platforms.Console.Views
     {
         private readonly Stack<MvxViewModelRequest> _navigationStack = new Stack<MvxViewModelRequest>();
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
             lock (this)
             {
@@ -33,48 +34,49 @@ namespace MvvmCross.Platforms.Console.Views
                 Mvx.Resolve<IMvxConsoleCurrentView>().CurrentView = view;
                 _navigationStack.Push(request);
             }
+            return Task.FromResult(true);
         }
 
-        public override void ChangePresentation(MvxPresentationHint hint)
+        public override async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            if (HandlePresentationChange(hint)) return;
+            if (await HandlePresentationChange(hint)) return true;
 
             if (hint is MvxClosePresentationHint)
             {
-                Close((hint as MvxClosePresentationHint).ViewModelToClose);
-                return;
+                return await Close((hint as MvxClosePresentationHint).ViewModelToClose);
             }
 
             MvxLog.Instance.Warn("Hint ignored {0}", hint.GetType().Name);
+            return false;
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
             var currentView = Mvx.Resolve<IMvxConsoleCurrentView>().CurrentView;
 
             if (currentView == null)
             {
                 MvxLog.Instance.Warn("Ignoring close for viewmodel - rootframe has no current page");
-                return;
+                return Task.FromResult(true);
             }
 
             if (currentView.ViewModel != viewModel)
             {
                 MvxLog.Instance.Warn("Ignoring close for viewmodel - rootframe's current page is not the view for the requested viewmodel");
-                return;
+                return Task.FromResult(true);
             }
 
-            GoBack();
+            return GoBack();
         }
 
-        public override void GoBack()
+        public override Task<bool> GoBack()
         {
             lock (this)
             {
                 if (!CanGoBack())
                 {
                     System.Console.WriteLine("Back not possible");
-                    return;
+                    return Task.FromResult(true);
                 }
 
                 // pop off the current view
@@ -84,7 +86,7 @@ namespace MvvmCross.Platforms.Console.Views
                 var backTo = _navigationStack.Pop();
 
                 // re-display the view
-                Show(backTo);
+                return Show(backTo);
             }
         }
 

--- a/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
@@ -79,7 +79,7 @@ namespace MvvmCross.Platforms.Ios.Core
 
     public abstract class MvxApplicationDelegate<TMvxIosSetup, TApplication> : MvxApplicationDelegate
        where TMvxIosSetup : MvxIosSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
@@ -171,9 +171,9 @@ namespace MvvmCross.Platforms.Ios.Core
     }
 
     public class MvxIosSetup<TApplication> : MvxIosSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -14,6 +14,7 @@ using MvvmCross.ViewModels;
 using MvvmCross.Presenters;
 using UIKit;
 using MvvmCross.Presenters.Attributes;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Platforms.Ios.Presenters
 {
@@ -90,7 +91,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowRootViewController(viewController, (MvxRootPresentationAttribute)attribute, request);
+                        return ShowRootViewController(viewController, (MvxRootPresentationAttribute)attribute, request);
                     },
                     CloseAction = (viewModel, attribute) => CloseRootViewController(viewModel, (MvxRootPresentationAttribute)attribute)
                 });
@@ -102,7 +103,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowChildViewController(viewController, (MvxChildPresentationAttribute)attribute, request);
+                        return ShowChildViewController(viewController, (MvxChildPresentationAttribute)attribute, request);
                     },
                     CloseAction = (viewModel, attribute) => CloseChildViewController(viewModel, (MvxChildPresentationAttribute)attribute)
                 });
@@ -114,7 +115,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowTabViewController(viewController, (MvxTabPresentationAttribute)attribute, request);
+                        return ShowTabViewController(viewController, (MvxTabPresentationAttribute)attribute, request);
                     },
                     CloseAction = (viewModel, attribute) => CloseTabViewController(viewModel, (MvxTabPresentationAttribute)attribute)
                 });
@@ -127,7 +128,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowModalViewController(viewController, (MvxModalPresentationAttribute)attribute, request);
+                        return ShowModalViewController(viewController, (MvxModalPresentationAttribute)attribute, request);
                     },
                     CloseAction = (viewModel, attribute) => CloseModalViewController(viewModel, (MvxModalPresentationAttribute)attribute)
                 });
@@ -143,13 +144,12 @@ namespace MvvmCross.Platforms.Ios.Presenters
                         switch (splitAttribute.Position)
                         {
                             case MasterDetailPosition.Master:
-                                ShowMasterSplitViewController(viewController, splitAttribute, request);
-                                break;
+                                return ShowMasterSplitViewController(viewController, splitAttribute, request);
 
                             case MasterDetailPosition.Detail:
-                                ShowDetailSplitViewController(viewController, splitAttribute, request);
-                                break;
+                                return ShowDetailSplitViewController(viewController, splitAttribute, request);
                         }
+                        return Task.FromResult(true);
                     },
                     CloseAction = (viewModel, attribute) =>
                     {
@@ -163,12 +163,12 @@ namespace MvvmCross.Platforms.Ios.Presenters
                             default:
                                 return CloseDetailSplitViewController(viewModel, splitAttribute);
                         }
-                        
+
                     }
                 });
         }
 
-        protected virtual void ShowRootViewController(
+        protected virtual async Task<bool> ShowRootViewController(
             UIViewController viewController,
             MvxRootPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -181,10 +181,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 // set root
                 SetupWindowRootNavigation(viewController, attribute);
 
-                CloseModalViewControllers();
-                CloseSplitViewController();
+                if (!await CloseModalViewControllers()) return false;
+                if (!await CloseSplitViewController()) return false;
 
-                return;
+                return true;
             }
 
             // check if viewController is a SplitViewController
@@ -195,18 +195,19 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 // set root
                 SetupWindowRootNavigation(viewController, attribute);
 
-                CloseModalViewControllers();
-                CloseTabBarViewController();
+                if (!await CloseModalViewControllers()) return false;
+                if (!await CloseTabBarViewController()) return false;
 
-                return;
+                return true;
             }
 
             // set root initiating stack navigation or just a plain controller
             SetupWindowRootNavigation(viewController, attribute);
 
-            CloseModalViewControllers();
-            CloseTabBarViewController();
-            CloseSplitViewController();
+            if (!await CloseModalViewControllers()) return false;
+            if (!await CloseTabBarViewController()) return false;
+            if (!await CloseSplitViewController()) return false;
+            return true;
         }
 
         protected void SetupWindowRootNavigation(UIViewController viewController, MvxRootPresentationAttribute attribute)
@@ -225,7 +226,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             }
         }
 
-        protected virtual void ShowChildViewController(
+        protected virtual Task<bool> ShowChildViewController(
             UIViewController viewController,
             MvxChildPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -239,7 +240,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 {
                     PushViewControllerIntoStack(modalNavController, viewController, attribute);
 
-                    return;
+                    return Task.FromResult(true); 
                 }
                 else
                 {
@@ -249,19 +250,19 @@ namespace MvvmCross.Platforms.Ios.Presenters
 
             if (TabBarViewController != null && TabBarViewController.ShowChildView(viewController))
             {
-                return;
+                return Task.FromResult(true);
             }
 
             if (MasterNavigationController != null)
             {
                 PushViewControllerIntoStack(MasterNavigationController, viewController, attribute);
-                return;
+                return Task.FromResult(true);
             }
 
             throw new MvxException($"Trying to show View type: {viewController.GetType().Name} as child, but there is no current stack!");
         }
 
-        protected virtual void ShowTabViewController(
+        protected virtual Task<bool> ShowTabViewController(
             UIViewController viewController,
             MvxTabPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -282,9 +283,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
             TabBarViewController.ShowTabView(
                 viewController,
                 attribute);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowModalViewController(
+        protected virtual Task<bool> ShowModalViewController(
             UIViewController viewController,
             MvxModalPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -309,9 +311,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 null);
 
             ModalViewControllers.Add(viewController);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowMasterSplitViewController(
+        protected virtual Task<bool> ShowMasterSplitViewController(
             UIViewController viewController,
             MvxSplitViewPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -320,9 +323,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 throw new MvxException("Trying to show a master page without a SplitViewController, this is not possible!");
 
             SplitViewController.ShowMasterView(viewController, attribute);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowDetailSplitViewController(
+        protected virtual Task<bool> ShowDetailSplitViewController(
             UIViewController viewController,
             MvxSplitViewPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -331,16 +335,17 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 throw new MvxException("Trying to show a detail page without a SplitViewController, this is not possible!");
 
             SplitViewController.ShowDetailView(viewController, attribute);
+            return Task.FromResult(true);
         }
 
-        protected virtual bool CloseRootViewController(IMvxViewModel viewModel, MvxRootPresentationAttribute attribute)
+        protected virtual Task<bool> CloseRootViewController(IMvxViewModel viewModel, MvxRootPresentationAttribute attribute)
         {
             MvxLog.Instance.Warn($"Ignored attempt to close the window root (ViewModel type: {viewModel.GetType().Name}");
 
-            return false;
+            return Task.FromResult(false);
         }
 
-        protected virtual bool CloseChildViewController(IMvxViewModel viewModel, MvxChildPresentationAttribute attribute)
+        protected virtual Task<bool> CloseChildViewController(IMvxViewModel viewModel, MvxChildPresentationAttribute attribute)
         {
             // if there are modals presented
             if (ModalViewControllers.Any())
@@ -348,59 +353,58 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 foreach (var modalNav in ModalViewControllers.Where(v => v is UINavigationController))
                 {
                     if (TryCloseViewControllerInsideStack((UINavigationController)modalNav, viewModel, attribute))
-                        return true;
+                        return Task.FromResult(true);
                 }
             }
 
             //if the current root is a TabBarViewController, delegate close responsibility to it
             if (TabBarViewController != null && TabBarViewController.CloseChildViewModel(viewModel))
-                return true;
+                return Task.FromResult(true);
 
             if (SplitViewController != null && SplitViewController.CloseChildViewModel(viewModel, attribute))
-                return true;
+                return Task.FromResult(true);
 
             // if the current root is a NavigationController, close it in the stack
             if (MasterNavigationController != null && TryCloseViewControllerInsideStack(MasterNavigationController, viewModel, attribute))
-                return true;
+                return Task.FromResult(true);
 
-            return false;
+            return Task.FromResult(false);
         }
 
-        protected virtual bool CloseTabViewController(IMvxViewModel viewModel, MvxTabPresentationAttribute attribute)
+        protected virtual Task<bool> CloseTabViewController(IMvxViewModel viewModel, MvxTabPresentationAttribute attribute)
         {
             if (TabBarViewController != null && TabBarViewController.CloseTabViewModel(viewModel))
-                return true;
+                return Task.FromResult(true);
 
-            return false;
+            return Task.FromResult(false);
         }
 
-        protected virtual bool CloseMasterSplitViewController(IMvxViewModel viewModel, MvxSplitViewPresentationAttribute attribute)
+        protected virtual Task<bool> CloseMasterSplitViewController(IMvxViewModel viewModel, MvxSplitViewPresentationAttribute attribute)
         {
             if (SplitViewController != null && SplitViewController.CloseChildViewModel(viewModel, attribute))
-                return true;
+                return Task.FromResult(true);
 
-            return true;
+            return Task.FromResult(true);
         }
 
-        protected virtual bool CloseDetailSplitViewController(IMvxViewModel viewModel, MvxSplitViewPresentationAttribute attribute)
+        protected virtual Task<bool> CloseDetailSplitViewController(IMvxViewModel viewModel, MvxSplitViewPresentationAttribute attribute)
         {
             if (SplitViewController != null && SplitViewController.CloseChildViewModel(viewModel, attribute))
-                return true;
+                return Task.FromResult(true);
 
-            return true;
+            return Task.FromResult(false);
         }
 
-        protected virtual bool CloseModalViewController(IMvxViewModel toClose, MvxModalPresentationAttribute attribute)
+        protected virtual Task<bool> CloseModalViewController(IMvxViewModel toClose, MvxModalPresentationAttribute attribute)
         {
             if (ModalViewControllers == null || !ModalViewControllers.Any())
-                return false;
+                return Task.FromResult(false);
 
             // check for plain modals
             var modalToClose = ModalViewControllers.FirstOrDefault(v => v is IMvxIosView && v.GetIMvxIosView().ViewModel == toClose);
             if (modalToClose != null)
             {
-                CloseModalViewController(modalToClose, attribute);
-                return true;
+                return CloseModalViewController(modalToClose, attribute);
             }
 
             // check for modal navigation stacks
@@ -416,11 +420,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
             }
             if (controllerToClose != null)
             {
-                CloseModalViewController(controllerToClose, attribute);
-                return true;
+                return CloseModalViewController(controllerToClose, attribute);
             }
 
-            return false;
+            return Task.FromResult(false);
         }
 
         protected virtual bool TryCloseViewControllerInsideStack(UINavigationController navController, IMvxViewModel toClose, MvxChildPresentationAttribute attribute)
@@ -473,10 +476,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
             MasterNavigationController = null;
         }
 
-        public virtual void CloseModalViewController(UIViewController viewController, MvxModalPresentationAttribute attribute)
+        public virtual Task<bool> CloseModalViewController(UIViewController viewController, MvxModalPresentationAttribute attribute)
         {
             if (viewController == null)
-                return;
+                return Task.FromResult(true);
 
             if (viewController is UINavigationController modalNavController)
             {
@@ -486,20 +489,22 @@ namespace MvvmCross.Platforms.Ios.Presenters
 
             viewController.DismissViewController(attribute.Animated, null);
             ModalViewControllers.Remove(viewController);
+            return Task.FromResult(true);
         }
 
-        public virtual void CloseModalViewControllers()
+        public virtual async Task<bool> CloseModalViewControllers()
         {
             while (ModalViewControllers.Any())
             {
-                CloseModalViewController(ModalViewControllers.LastOrDefault(), new MvxModalPresentationAttribute());
+                if (!(await CloseModalViewController(ModalViewControllers.LastOrDefault(), new MvxModalPresentationAttribute()))) return false;
             }
+            return true;
         }
 
-        public virtual void CloseTabBarViewController()
+        public virtual Task<bool> CloseTabBarViewController()
         {
             if (TabBarViewController == null)
-                return;
+                return Task.FromResult(true);
 
             if (TabBarViewController is UITabBarController tabsController
                 && tabsController.ViewControllers != null)
@@ -508,12 +513,13 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     item.DidMoveToParentViewController(null);
             }
             TabBarViewController = null;
+            return Task.FromResult(true);
         }
 
-        protected virtual void CloseSplitViewController()
+        protected virtual Task<bool> CloseSplitViewController()
         {
             if (SplitViewController == null)
-                return;
+                return Task.FromResult(true);
 
             if (SplitViewController is UISplitViewController splitController
                && splitController.ViewControllers != null)
@@ -522,6 +528,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     item.DidMoveToParentViewController(null);
             }
             SplitViewController = null;
+            return Task.FromResult(true);
         }
 
         protected void RemoveWindowSubviews()
@@ -530,9 +537,9 @@ namespace MvvmCross.Platforms.Ios.Presenters
                 v.RemoveFromSuperview();
         }
 
-        public virtual void ShowModalViewController(UIViewController viewController, bool animated)
+        public virtual Task<bool> ShowModalViewController(UIViewController viewController, bool animated)
         {
-            ShowModalViewController(viewController, new MvxModalPresentationAttribute { Animated = animated }, null);
+            return ShowModalViewController(viewController, new MvxModalPresentationAttribute { Animated = animated }, null);
         }
 
         protected virtual void SetWindowRootViewController(UIViewController controller, MvxRootPresentationAttribute attribute = null)

--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -80,7 +80,7 @@ namespace MvvmCross.Platforms.Mac.Core
 
     public class MvxApplicationDelegate<TMvxMacSetup, TApplication> : MvxApplicationDelegate
    where TMvxMacSetup : MvxMacSetup<TApplication>, new()
-   where TApplication : IMvxApplication, new()
+   where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -37,7 +37,6 @@ namespace MvvmCross.Platforms.Mac.Core
             RunAppStart(notification);
 
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
-            base.DidFinishLaunching(notification);
         }
 
         protected virtual void RunAppStart(object hint = null)
@@ -65,7 +64,6 @@ namespace MvvmCross.Platforms.Mac.Core
         public override void WillTerminate(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Closing);
-            base.WillTerminate(notification);
         }
 
         private void FireLifetimeChanged(MvxLifetimeEvent which)

--- a/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
@@ -177,9 +177,9 @@ namespace MvvmCross.Platforms.Mac.Core
     }
 
     public class MvxMacSetup<TApplication> : MvxMacSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,6 +14,7 @@ using MvvmCross.Platforms.Mac.Views;
 using MvvmCross.ViewModels;
 using MvvmCross.Presenters;
 using MvvmCross.Presenters.Attributes;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Platforms.Mac.Presenters
 {
@@ -75,13 +76,9 @@ namespace MvvmCross.Platforms.Mac.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (NSViewController)this.CreateViewControllerFor(request);
-                        ShowWindowViewController(viewController, (MvxWindowPresentationAttribute)attribute, request);
+                        return ShowWindowViewController(viewController, (MvxWindowPresentationAttribute)attribute, request);
                     },
-                    CloseAction = (viewModel, attribute) =>
-                    {
-                        Close(viewModel);
-                        return true;
-                    }
+                    CloseAction = (viewModel, attribute) => Close(viewModel)
                 });
 
             AttributeTypesToActionsDictionary.Add(
@@ -91,13 +88,9 @@ namespace MvvmCross.Platforms.Mac.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (NSViewController)this.CreateViewControllerFor(request);
-                        ShowContentViewController(viewController, (MvxContentPresentationAttribute)attribute, request);
+                        return ShowContentViewController(viewController, (MvxContentPresentationAttribute)attribute, request);
                     },
-                    CloseAction = (viewModel, attribute) =>
-                    {
-                        Close(viewModel);
-                        return true;
-                    }
+                    CloseAction = (viewModel, attribute) => Close(viewModel)
                 });
 
             AttributeTypesToActionsDictionary.Add(
@@ -107,13 +100,9 @@ namespace MvvmCross.Platforms.Mac.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (NSViewController)this.CreateViewControllerFor(request);
-                        ShowModalViewController(viewController, (MvxModalPresentationAttribute)attribute, request);
+                        return ShowModalViewController(viewController, (MvxModalPresentationAttribute)attribute, request);
                     },
-                    CloseAction = (viewModel, attribute) =>
-                    {
-                        Close(viewModel);
-                        return true;
-                    }
+                    CloseAction = (viewModel, attribute) => Close(viewModel)
                 });
 
             AttributeTypesToActionsDictionary.Add(
@@ -123,13 +112,9 @@ namespace MvvmCross.Platforms.Mac.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (NSViewController)this.CreateViewControllerFor(request);
-                        ShowSheetViewController(viewController, (MvxSheetPresentationAttribute)attribute, request);
+                        return ShowSheetViewController(viewController, (MvxSheetPresentationAttribute)attribute, request);
                     },
-                    CloseAction = (viewModel, attribute) =>
-                    {
-                        Close(viewModel);
-                        return true;
-                    }
+                    CloseAction = (viewModel, attribute) => Close(viewModel)
                 });
 
             AttributeTypesToActionsDictionary.Add(
@@ -139,22 +124,18 @@ namespace MvvmCross.Platforms.Mac.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (NSViewController)this.CreateViewControllerFor(request);
-                        ShowTabViewController(viewController, (MvxTabPresentationAttribute)attribute, request);
+                        return ShowTabViewController(viewController, (MvxTabPresentationAttribute)attribute, request);
                     },
-                    CloseAction = (viewModel, attribute) =>
-                    {
-                        Close(viewModel);
-                        return true;
-                    }
+                    CloseAction = (viewModel, attribute) => Close(viewModel)
                 });
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            return GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
-        protected virtual void ShowWindowViewController(
+        protected virtual Task<bool> ShowWindowViewController(
             NSViewController viewController,
             MvxWindowPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -192,6 +173,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
             window.ContentView = viewController.View;
             window.ContentViewController = viewController;
             windowController.ShowWindow(null);
+            return Task.FromResult(true);
         }
 
         protected virtual void UpdateWindow(MvxWindowPresentationAttribute attribute, NSWindow window)
@@ -247,7 +229,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
             return windowController;
         }
 
-        protected virtual void ShowContentViewController(
+        protected virtual Task<bool> ShowContentViewController(
             NSViewController viewController,
             MvxContentPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -259,9 +241,10 @@ namespace MvvmCross.Platforms.Mac.Presenters
 
             window.ContentView = viewController.View;
             window.ContentViewController = viewController;
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowModalViewController(
+        protected virtual Task<bool> ShowModalViewController(
             NSViewController viewController,
             MvxModalPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -269,9 +252,10 @@ namespace MvvmCross.Platforms.Mac.Presenters
             var window = Windows.FirstOrDefault(w => w.Identifier == attribute.WindowIdentifier) ?? Windows.Last();
 
             window.ContentViewController.PresentViewControllerAsModalWindow(viewController);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowSheetViewController(
+        protected virtual Task<bool> ShowSheetViewController(
             NSViewController viewController,
             MvxSheetPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -279,9 +263,10 @@ namespace MvvmCross.Platforms.Mac.Presenters
             var window = Windows.FirstOrDefault(w => w.Identifier == attribute.WindowIdentifier) ?? Windows.Last();
 
             window.ContentViewController.PresentViewControllerAsSheet(viewController);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowTabViewController(
+        protected virtual Task<bool> ShowTabViewController(
             NSViewController viewController,
             MvxTabPresentationAttribute attribute,
             MvxViewModelRequest request)
@@ -293,9 +278,10 @@ namespace MvvmCross.Platforms.Mac.Presenters
                 throw new MvxException($"trying to display a tab but there is no TabViewController! View type: {viewController.GetType()}");
 
             tabViewController.ShowTabView(viewController, attribute.TabTitle);
+            return Task.FromResult(true);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
             var currentWindows = Windows;
             for (int i = currentWindows.Count - 1; i >= 0; i--)
@@ -312,14 +298,14 @@ namespace MvvmCross.Platforms.Mac.Presenters
                     if (modal != null)
                     {
                         window.ContentViewController.DismissViewController(modal);
-                        return;
+                        return Task.FromResult(true);
                     }
                 }
                 // if toClose is a tab
                 var tabViewController = window.ContentViewController as IMvxTabViewController;
                 if (tabViewController != null && tabViewController.CloseTabView(viewModel))
                 {
-                    return;
+                    return Task.FromResult(true);
                 }
 
                 // toClose is a content
@@ -327,9 +313,10 @@ namespace MvvmCross.Platforms.Mac.Presenters
                 if (controller != null && controller.ViewModel == viewModel)
                 {
                     window.Close();
-                    return;
+                    return Task.FromResult(true);
                 }
             }
+            return Task.FromResult(true);
         }
 
         protected virtual MvxWindowController CreateWindowController(NSWindow window)

--- a/MvvmCross/Platforms/Tizen/Binding/MvxTizenBindingBuilder.cs
+++ b/MvvmCross/Platforms/Tizen/Binding/MvxTizenBindingBuilder.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using MvvmCross.Base;
+using MvvmCross.Converters;
+using MvvmCross.Binding;
+using MvvmCross.Binding.Binders;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Binding.Bindings.Target.Construction;
+
+namespace MvvmCross.Platforms.Tizen.Binding
+{
+    public class MvxTizenBindingBuilder
+        : MvxBindingBuilder
+    {
+        private readonly Action<IMvxTargetBindingFactoryRegistry> _fillRegistryAction;
+        private readonly Action<IMvxValueConverterRegistry> _fillValueConvertersAction;
+        private readonly Action<IMvxAutoValueConverters> _fillAutoValueConvertersAction;
+        private readonly Action<IMvxBindingNameRegistry> _fillBindingNamesAction;
+
+        public MvxTizenBindingBuilder(Action<IMvxTargetBindingFactoryRegistry> fillRegistryAction = null,
+                                    Action<IMvxValueConverterRegistry> fillValueConvertersAction = null,
+                                    Action<IMvxAutoValueConverters> fillAutoValueConvertersAction = null,
+                                    Action<IMvxBindingNameRegistry> fillBindingNamesAction = null)
+        {
+            _fillRegistryAction = fillRegistryAction;
+            _fillValueConvertersAction = fillValueConvertersAction;
+            _fillAutoValueConvertersAction = fillAutoValueConvertersAction;
+            _fillBindingNamesAction = fillBindingNamesAction;
+        }
+
+        protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+        {
+            base.FillTargetFactories(registry);
+
+            //TODO: Add targets
+
+            _fillRegistryAction?.Invoke(registry);
+        }
+
+        protected override void FillValueConverters(IMvxValueConverterRegistry registry)
+        {
+            base.FillValueConverters(registry);
+
+            _fillValueConvertersAction?.Invoke(registry);
+        }
+
+        protected override void FillAutoValueConverters(IMvxAutoValueConverters autoValueConverters)
+        {
+            base.FillAutoValueConverters(autoValueConverters);
+
+            _fillAutoValueConvertersAction?.Invoke(autoValueConverters);
+        }
+
+        protected override void FillDefaultBindingNames(IMvxBindingNameRegistry registry)
+        {
+            base.FillDefaultBindingNames(registry);
+
+            //TODO: Add default names
+
+            _fillBindingNamesAction?.Invoke(registry);
+        }
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Binding/MvxTizenPropertyBinding.cs
+++ b/MvvmCross/Platforms/Tizen/Binding/MvxTizenPropertyBinding.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.Platforms.Tizen.Binding
+{
+    internal static class MvxTizenPropertyBinding
+    {
+        
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Binding/MvxTizenPropertyBindingExtensions.cs
+++ b/MvvmCross/Platforms/Tizen/Binding/MvxTizenPropertyBindingExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.Platforms.Tizen.Binding
+{
+    public static class MvxTizenPropertyBindingExtensions
+    {
+
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Core/IMvxTizenSetup.cs
+++ b/MvvmCross/Platforms/Tizen/Core/IMvxTizenSetup.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MvvmCross.Core;
+using Tizen.Applications;
+
+namespace MvvmCross.Platforms.Tizen.Core
+{
+    public interface IMvxTizenSetup : IMvxSetup
+    {
+        void PlatformInitialize(CoreApplication coreApplication);
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
+++ b/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
@@ -139,7 +139,7 @@ namespace MvvmCross.Platforms.Tizen.Core
     public class MvxTizenSetup<TApplication> : MvxTizenSetup
         where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
+++ b/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
@@ -1,0 +1,149 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using MvvmCross.Binding;
+using MvvmCross.Binding.Binders;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Converters;
+using MvvmCross.Core;
+using MvvmCross.Platforms.Tizen.Binding;
+using MvvmCross.Platforms.Tizen.Presenters;
+using MvvmCross.Platforms.Tizen.Views;
+using MvvmCross.Presenters;
+using MvvmCross.ViewModels;
+using MvvmCross.Views;
+using Tizen.Applications;
+
+namespace MvvmCross.Platforms.Tizen.Core
+{
+    public abstract class MvxTizenSetup
+        : MvxSetup, IMvxTizenSetup
+    {
+        protected CoreApplication CoreApplication { get; private set; }
+
+        public virtual void PlatformInitialize(CoreApplication coreApplication)
+        {
+            CoreApplication = coreApplication;
+        }
+
+        private IMvxTizenViewPresenter _presenter;
+        protected IMvxTizenViewPresenter Presenter
+        {
+            get
+            {
+                _presenter = _presenter ?? CreateViewPresenter();
+                return _presenter;
+            }
+        }
+
+        protected override void InitializePlatformServices()
+        {
+            RegisterPresenter();
+            base.InitializePlatformServices();
+        }
+
+        protected sealed override IMvxViewsContainer CreateViewsContainer()
+        {
+            var container = CreateTizenViewsContainer();
+            Mvx.RegisterSingleton(container);
+            return container;
+        }
+
+        protected virtual IMvxTizenViewsContainer CreateTizenViewsContainer()
+        {
+            return new MvxTizenViewsContainer();
+        }
+
+        protected virtual IMvxTizenViewPresenter CreateViewPresenter()
+        {
+            return new MvxTizenViewPresenter();
+        }
+
+        protected virtual void RegisterPresenter()
+        {
+            var presenter = Presenter;
+            Mvx.RegisterSingleton(presenter);
+            Mvx.RegisterSingleton<IMvxViewPresenter>(presenter);
+        }
+
+        protected override void InitializeLastChance()
+        {
+            InitializeBindingBuilder();
+            base.InitializeLastChance();
+        }
+
+        protected virtual void InitializeBindingBuilder()
+        {
+            RegisterBindingBuilderCallbacks();
+            var bindingBuilder = CreateBindingBuilder();
+            bindingBuilder.DoRegistration();
+        }
+
+        protected virtual void RegisterBindingBuilderCallbacks()
+        {
+            Mvx.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            Mvx.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
+            Mvx.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
+        }
+
+        protected virtual MvxBindingBuilder CreateBindingBuilder()
+        {
+            return new MvxTizenBindingBuilder();
+        }
+
+        protected override IMvxViewDispatcher CreateViewDispatcher()
+        {
+            return new MvxTizenViewDispatcher(Presenter);
+        }
+
+        protected override IMvxNameMapping CreateViewToViewModelNaming()
+        {
+            return new MvxPostfixAwareViewToViewModelNameMapping("View");
+        }
+
+        protected virtual void FillBindingNames(IMvxBindingNameRegistry registry)
+        {
+            // this base class does nothing
+        }
+
+        protected virtual void FillValueConverters(IMvxValueConverterRegistry registry)
+        {
+            registry.Fill(ValueConverterAssemblies);
+            registry.Fill(ValueConverterHolders);
+        }
+
+        protected virtual List<Type> ValueConverterHolders => new List<Type>();
+
+        protected virtual IEnumerable<Assembly> ValueConverterAssemblies
+        {
+            get
+            {
+                var toReturn = new List<Assembly>();
+                toReturn.AddRange(GetViewModelAssemblies());
+                toReturn.AddRange(GetViewAssemblies());
+                return toReturn;
+            }
+        }
+
+        protected virtual void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+        {
+            // this base class does nothing
+        }
+    }
+
+    public class MvxTizenSetup<TApplication> : MvxTizenSetup
+        where TApplication : class, IMvxApplication, new()
+    {
+        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+
+        public override IEnumerable<Assembly> GetViewModelAssemblies()
+        {
+            return new[] { typeof(TApplication).GetTypeInfo().Assembly };
+        }
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Core/MvxTizenSetupSingleton.cs
+++ b/MvvmCross/Platforms/Tizen/Core/MvxTizenSetupSingleton.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Core;
+using Tizen.Applications;
+
+namespace MvvmCross.Platforms.Tizen.Core
+{
+    public class MvxTizenSetupSingleton
+        : MvxSetupSingleton
+    {
+        public static MvxTizenSetupSingleton EnsureSingletonAvailable(CoreApplication coreApplication)
+        {
+            var instance = EnsureSingletonAvailable<MvxTizenSetupSingleton>();
+            instance.PlatformSetup<MvxTizenSetup>()?.PlatformInitialize(coreApplication);
+            return instance;
+        }
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Presenters/IMvxTizenViewPresenter.cs
+++ b/MvvmCross/Platforms/Tizen/Presenters/IMvxTizenViewPresenter.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Presenters;
+
+namespace MvvmCross.Platforms.Tizen.Presenters
+{
+    public interface IMvxTizenViewPresenter
+        : IMvxViewPresenter
+    {
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Presenters/MvxTizenViewPresenter.cs
+++ b/MvvmCross/Platforms/Tizen/Presenters/MvxTizenViewPresenter.cs
@@ -1,0 +1,23 @@
+﻿
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using MvvmCross.Presenters;
+using MvvmCross.Presenters.Attributes;
+
+namespace MvvmCross.Platforms.Tizen.Presenters
+{
+    public class MvxTizenViewPresenter : MvxAttributeViewPresenter, IMvxTizenViewPresenter
+    {
+        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
+        {
+            return null;
+        }
+
+        public override void RegisterAttributeTypes()
+        {
+        }
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Views/IMvxTizenViewsContainer.cs
+++ b/MvvmCross/Platforms/Tizen/Views/IMvxTizenViewsContainer.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Views;
+
+namespace MvvmCross.Platforms.Tizen.Views
+{
+    public interface IMvxTizenViewsContainer
+        : IMvxViewsContainer
+    {
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Views/MvxTizenMainThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Tizen/Views/MvxTizenMainThreadDispatcher.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MvvmCross.Base;
+using Tizen.Applications;
+
+namespace MvvmCross.Platforms.Tizen.Views
+{
+    public class MvxTizenMainThreadDispatcher : MvxMainThreadAsyncDispatcher
+    {
+        public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
+        {
+            //TODO: implement
+            return true;
+        }
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Views/MvxTizenViewDispatcher.cs
+++ b/MvvmCross/Platforms/Tizen/Views/MvxTizenViewDispatcher.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using MvvmCross.Logging;
+using MvvmCross.Platforms.Tizen.Presenters;
+using MvvmCross.ViewModels;
+using MvvmCross.Views;
+
+namespace MvvmCross.Platforms.Tizen.Views
+{
+    public class MvxTizenViewDispatcher
+        : MvxTizenMainThreadDispatcher, IMvxViewDispatcher
+    {
+        private readonly IMvxTizenViewPresenter _presenter;
+
+        public MvxTizenViewDispatcher(IMvxTizenViewPresenter presenter)
+        {
+            _presenter = presenter;
+        }
+
+        public async Task<bool> ShowViewModel(MvxViewModelRequest request)
+        {
+            Action action = () =>
+            {
+                MvxLog.Instance.Trace("TizenNavigation", "Navigate requested");
+                _presenter.Show(request);
+            };
+            await ExecuteOnMainThreadAsync(action);
+            return true;
+        }
+
+        public async Task<bool> ChangePresentation(MvxPresentationHint hint)
+        {
+            await ExecuteOnMainThreadAsync(() => _presenter.ChangePresentation(hint));
+            return true;
+        }
+    }
+}

--- a/MvvmCross/Platforms/Tizen/Views/MvxTizenViewsContainer.cs
+++ b/MvvmCross/Platforms/Tizen/Views/MvxTizenViewsContainer.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using MvvmCross.Exceptions;
+using MvvmCross.ViewModels;
+using MvvmCross.Views;
+
+namespace MvvmCross.Platforms.Tizen.Views
+{
+    public class MvxTizenViewsContainer
+        : MvxViewsContainer
+        , IMvxTizenViewsContainer
+    {
+        public MvxViewModelRequest CurrentRequest { get; private set; }
+    }
+}

--- a/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Platforms.Tvos.Core
 
     public abstract class MvxApplicationDelegate<TMvxTvosSetup, TApplication> : MvxApplicationDelegate
        where TMvxTvosSetup : MvxTvosSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
@@ -174,9 +174,9 @@ namespace MvvmCross.Platforms.Tvos.Core
     }
 
     public class MvxTvosSetup<TApplication> : MvxTvosSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Tvos/Presenters/MvxTvosViewPresenter.cs
+++ b/MvvmCross/Platforms/Tvos/Presenters/MvxTvosViewPresenter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,6 +14,7 @@ using MvvmCross.ViewModels;
 using MvvmCross.Presenters;
 using UIKit;
 using MvvmCross.Presenters.Attributes;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Platforms.Tvos.Presenters
 {
@@ -103,7 +104,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowRootViewController(viewController,
+                        return ShowRootViewController(viewController,
                                                (MvxRootPresentationAttribute)attribute,
                                                request);
                     },
@@ -118,7 +119,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                   ShowAction = (viewType, attribute, request) =>
                   {
                       var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                      ShowChildViewController(viewController,
+                      return ShowChildViewController(viewController,
                                               (MvxChildPresentationAttribute)attribute,
                                               request);
                   },
@@ -134,7 +135,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                     ShowAction = (viewType, attribute, request) =>
                     {
                         var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                        ShowTabViewController(viewController,
+                        return ShowTabViewController(viewController,
                                               (MvxTabPresentationAttribute)attribute,
                                               request);
                     },
@@ -149,7 +150,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                   ShowAction = (viewType, attribute, request) =>
                   {
                       var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                      ShowModalViewController(viewController, (MvxModalPresentationAttribute)attribute, request);
+                      return ShowModalViewController(viewController, (MvxModalPresentationAttribute)attribute, request);
                   },
                   CloseAction = (viewModel, attribute) => CloseModalViewController(viewModel, (MvxModalPresentationAttribute)attribute)
               });
@@ -161,43 +162,43 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                   ShowAction = (viewType, attribute, request) =>
                   {
                       var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                      ShowMasterDetailSplitViewController(viewController, (MvxMasterDetailPresentationAttribute)attribute, request);
+                      return ShowMasterDetailSplitViewController(viewController, (MvxMasterDetailPresentationAttribute)attribute, request);
                   },
                   CloseAction = (viewModel, attribute) => CloseMasterSplitViewController(viewModel, (MvxMasterDetailPresentationAttribute)attribute)
               });
         }
 
-        protected virtual bool CloseRootViewController(IMvxViewModel viewModel,
+        protected virtual Task<bool> CloseRootViewController(IMvxViewModel viewModel,
                                      MvxRootPresentationAttribute attribute)
         {
             MvxLog.Instance.Warn($"Ignored attempt to close the window root (ViewModel type: {viewModel.GetType().Name}");
-            return false;
+            return Task.FromResult(false);
         }
 
-        protected virtual bool CloseChildViewController(IMvxViewModel viewModel, MvxChildPresentationAttribute attribute)
+        protected virtual Task<bool> CloseChildViewController(IMvxViewModel viewModel, MvxChildPresentationAttribute attribute)
         {
             if (ModalViewControllers.Any())
             {
                 foreach (var navController in ModalViewControllers.Where(v => v is UINavigationController))
                 {
                     if (TryCloseViewControllerInsideStack((UINavigationController)navController, viewModel))
-                        return true;
+                        return Task.FromResult(true);
                 }
             }
 
             if (TabBarViewController != null && TabBarViewController.CloseChildViewModel(viewModel))
-                return true;
+                return Task.FromResult(true);
 
             if (MasterNavigationController != null && TryCloseViewControllerInsideStack(MasterNavigationController, viewModel))
-                return true;
+                return Task.FromResult(true);
 
-            return false;
+            return Task.FromResult(false);
         }
 
-        public void CloseTabBarViewController()
+        public Task<bool> CloseTabBarViewController()
         {
             if (TabBarViewController == null)
-                return;
+                return Task.FromResult(true);
 
             if (TabBarViewController is UITabBarController tabController
                && tabController.ViewControllers != null)
@@ -207,24 +208,25 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             }
 
             TabBarViewController = null;
+            return Task.FromResult(true);
         }
 
-        protected virtual bool CloseTabViewController(IMvxViewModel viewModel,
+        protected virtual Task<bool> CloseTabViewController(IMvxViewModel viewModel,
                                     MvxTabPresentationAttribute attribute)
         {
             if (TabBarViewController != null && TabBarViewController.CloseTabViewModel(viewModel))
-                return true;
+                return Task.FromResult(true);
 
-            return false;
+            return Task.FromResult(false);
         }
 
-        protected virtual bool CloseModalViewController(IMvxViewModel viewModel,
+        protected virtual Task<bool> CloseModalViewController(IMvxViewModel viewModel,
                                                         MvxModalPresentationAttribute attribute)
         {
             return CloseModalViewController(viewModel);
         }
 
-        protected virtual bool CloseModalViewController(IMvxViewModel viewModel)
+        protected virtual async Task<bool> CloseModalViewController(IMvxViewModel viewModel)
         {
             if (ModalViewControllers == null || !ModalViewControllers.Any())
                 return false;
@@ -233,8 +235,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                 .FirstOrDefault(v => v is IMvxTvosView && v.GetIMvxTvosView().ViewModel == viewModel);
             if (modal != null)
             {
-                CloseModalViewController(modal);
-                return true;
+                return await CloseModalViewController(modal);
             }
 
             UIViewController viewController = null;
@@ -249,17 +250,16 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             }
             if (viewController != null)
             {
-                CloseModalViewController(viewController);
-                return true;
+                return await CloseModalViewController(viewController);
             }
 
             return false;
         }
 
-        protected virtual void CloseModalViewController(UIViewController viewController)
+        protected virtual Task<bool> CloseModalViewController(UIViewController viewController)
         {
             if (viewController == null)
-                return;
+                return Task.FromResult(true);
 
             if (viewController is UINavigationController navController)
             {
@@ -269,47 +269,50 @@ namespace MvvmCross.Platforms.Tvos.Presenters
 
             viewController.DismissViewController(true, null);
             ModalViewControllers.Remove(viewController);
+            return Task.FromResult(true);
         }
 
-        public virtual void CloseModalViewController()
+        public virtual Task<bool> CloseModalViewController()
         {
             MasterNavigationController.PopViewController(true);
+            return Task.FromResult(true);
         }
 
-        protected void CloseMasterNavigationController()
+        protected Task<bool> CloseMasterNavigationController()
         {
             if (MasterNavigationController == null)
-                return;
+                return Task.FromResult(true);
             if (MasterNavigationController.ViewControllers != null)
             {
                 foreach (var v in MasterNavigationController.ViewControllers)
                     v.DidMoveToParentViewController(null);
             }
             MasterNavigationController = null;
+            return Task.FromResult(true);
         }
 
-        protected virtual bool CloseMasterSplitViewController(IMvxViewModel viewModel, MvxMasterDetailPresentationAttribute attribute)
+        protected virtual async Task<bool> CloseMasterSplitViewController(IMvxViewModel viewModel, MvxMasterDetailPresentationAttribute attribute)
         {
             if (SplitViewController != null &&
                 attribute.Position != MasterDetailPosition.Root &&
-                CloseChildViewModel(viewModel))
+                await CloseChildViewModel(viewModel))
                 return true;
             else if (attribute.Position == MasterDetailPosition.Root)
                 return false;
             return true;
         }
 
-        protected virtual bool CloseDetailSplitViewController(IMvxViewModel viewModel, MvxMasterDetailPresentationAttribute attribute)
+        protected virtual async Task<bool> CloseDetailSplitViewController(IMvxViewModel viewModel, MvxMasterDetailPresentationAttribute attribute)
         {
-            if (SplitViewController != null && CloseChildViewModel(viewModel))
+            if (SplitViewController != null && await CloseChildViewModel(viewModel))
                 return true;
             return true;
         }
 
-        public virtual bool CloseChildViewModel(IMvxViewModel viewModel)
+        public virtual Task<bool> CloseChildViewModel(IMvxViewModel viewModel)
         {
             if (!SplitViewController.ViewControllers.Any())
-                return false;
+                return Task.FromResult(false);
 
             var toClose = SplitViewController.ViewControllers.ToList()
                                          .Select(v => v.GetIMvxTvosView())
@@ -319,16 +322,16 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                 var newStack = SplitViewController.ViewControllers.Where(v => v.GetIMvxTvosView() != toClose);
                 SplitViewController.ViewControllers = newStack.ToArray();
 
-                return true;
+                return Task.FromResult(true);
             }
 
-            return false;
+            return Task.FromResult(false);
         }
 
-        protected void CloseSplitViewController()
+        protected Task<bool> CloseSplitViewController()
         {
             if (SplitViewController == null)
-                return;
+                return Task.FromResult(true);
 
             if (SplitViewController is UISplitViewController splitController
                && splitController.ViewControllers != null)
@@ -337,21 +340,22 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                     item.DidMoveToParentViewController(null);
             }
             SplitViewController = null;
+            return Task.FromResult(true);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute)
+            return GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute)
                 .CloseAction.Invoke(viewModel, attribute);
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute)
+            return GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute)
                 .ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
-        protected virtual void ShowRootViewController(UIViewController viewController,
+        protected virtual async Task<bool> ShowRootViewController(UIViewController viewController,
                                            MvxRootPresentationAttribute attribute,
                                            MvxViewModelRequest request)
         {
@@ -360,22 +364,21 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                 //NOTE clean up must be done first incase we are enbedding into a navigation controller
                 //before setting the tab view controller, otherwise this will reset the view stack and your tab
                 //controller will be null. 
-                SetupWindowRootNavigation(viewController, attribute);
+                await SetupWindowRootNavigation(viewController, attribute);
                 this.TabBarViewController = (IMvxTabBarViewController)viewController;
 
-                CloseModalViewControllers();
-
-                return;
+                return await CloseModalViewControllers();
             }
 
-            SetupWindowRootNavigation(viewController, attribute);
+            await SetupWindowRootNavigation(viewController, attribute);
 
-            CloseModalViewControllers();
-            CloseTabBarViewController();
-            CloseSplitViewController();
+            if(!(await CloseModalViewControllers()))return false;
+            if(!(await CloseTabBarViewController()))return false;
+            if(!(await CloseSplitViewController()))return false;
+            return true;
         }
 
-        protected virtual void ShowChildViewController(UIViewController viewController,
+        protected virtual Task<bool> ShowChildViewController(UIViewController viewController,
                                                         MvxChildPresentationAttribute attribute,
                                                         MvxViewModelRequest request)
         {
@@ -387,7 +390,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                 if (ModalViewControllers.LastOrDefault() is UINavigationController navigationController)
                 {
                     PushViewControllerIntoStack(navigationController, viewController, attribute.Animated);
-                    return;
+                    return Task.FromResult(true);
                 }
                 else
                 {
@@ -397,19 +400,19 @@ namespace MvvmCross.Platforms.Tvos.Presenters
 
             if (TabBarViewController != null && TabBarViewController.ShowChildView(viewController))
             {
-                return;
+                return Task.FromResult(true);
             }
 
             if (MasterNavigationController != null)
             {
                 PushViewControllerIntoStack(MasterNavigationController, viewController, attribute.Animated);
-                return;
+                return Task.FromResult(true);
             }
 
             throw new MvxException($"Trying to show View type: {viewController.GetType().Name} as child, but there is no current stack!");
         }
 
-        protected virtual void ShowModalViewController(UIViewController viewController,
+        protected virtual Task<bool> ShowModalViewController(UIViewController viewController,
                                                        MvxModalPresentationAttribute attribute,
                                                        MvxViewModelRequest request)
         {
@@ -433,9 +436,10 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                 null);
 
             ModalViewControllers.Add(viewController);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowTabViewController(UIViewController viewController,
+        protected virtual Task<bool> ShowTabViewController(UIViewController viewController,
                                            MvxTabPresentationAttribute attribute,
                                            MvxViewModelRequest request)
         {
@@ -455,47 +459,49 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             TabBarViewController.ShowTabView(
                 viewController,
                 attribute);
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowMasterDetailSplitViewController(
+        protected virtual async Task<bool> ShowMasterDetailSplitViewController(
           UIViewController viewController,
             MvxMasterDetailPresentationAttribute attribute,
           MvxViewModelRequest request)
         {
             if (SplitViewController != null && attribute.Position == MasterDetailPosition.Master)
             {
-                ShowMasterView(viewController, attribute.WrapInNavigationController);
+                return await ShowMasterView(viewController, attribute.WrapInNavigationController);
             }
             else if (SplitViewController != null && attribute.Position == MasterDetailPosition.Detail)
             {
-                ShowDetailView(viewController, attribute.WrapInNavigationController);
+                return await ShowDetailView(viewController, attribute.WrapInNavigationController);
             }
             else if (viewController is MvxSplitViewController && attribute.Position == MasterDetailPosition.Root)
             {
                 SplitViewController = (MvxSplitViewController)viewController;
 
                 // set root
-                SetupSplitViewWindowRootNavigation(viewController, attribute);
+                await SetupSplitViewWindowRootNavigation(viewController, attribute);
 
-                CloseModalViewControllers();
-                CloseTabBarViewController();
-                return;
+                await CloseModalViewControllers();
+                await CloseTabBarViewController();
             }
             else
             {
                 throw new MvxException("Trying to show a master page without a SplitViewController, this is not possible!");
             }
+            return true;
         }
 
-        public virtual void ShowDetailView(UIViewController viewController, bool wrapInNavigationController)
+        public virtual Task<bool> ShowDetailView(UIViewController viewController, bool wrapInNavigationController)
         {
             viewController = wrapInNavigationController ?
                 new MvxNavigationController(viewController) : viewController;
 
             SplitViewController.ShowDetailViewController(viewController, SplitViewController);
+            return Task.FromResult(true);
         }
 
-        public virtual void ShowMasterView(UIViewController viewController, bool wrapInNavigationController)
+        public virtual Task<bool> ShowMasterView(UIViewController viewController, bool wrapInNavigationController)
         {
             var stack = SplitViewController.ViewControllers.ToList();
 
@@ -508,16 +514,16 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             stack.Insert(0, viewController);
 
             SplitViewController.ViewControllers = stack.ToArray();
+            return Task.FromResult(true);
         }
-        public bool PresentModalViewController(UIViewController viewController, bool animated)
+        public Task<bool> PresentModalViewController(UIViewController viewController, bool animated)
         {
-            ShowModalViewController(viewController, new MvxModalPresentationAttribute { Animated = animated }, null);
-            return true;
+            return ShowModalViewController(viewController, new MvxModalPresentationAttribute { Animated = animated }, null);
         }
 
-        public virtual void CloseTopModalViewController()
+        public virtual Task<bool> CloseTopModalViewController()
         {
-            CloseModalViewController(ModalViewControllers?.Last());
+            return CloseModalViewController(ModalViewControllers?.Last());
         }
 
         protected virtual void PushViewControllerIntoStack(UINavigationController navigationController, UIViewController viewController, bool animated)
@@ -528,7 +534,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                 TabBarViewController = tabBarController;
         }
 
-        protected void SetupWindowRootNavigation(UIViewController viewController,
+        protected Task<bool> SetupWindowRootNavigation(UIViewController viewController,
                                                  MvxRootPresentationAttribute attribute)
         {
             if (attribute.WrapInNavigationController)
@@ -539,12 +545,12 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             else
             {
                 SetWindowRootViewController(viewController);
-                CloseMasterNavigationController();
+                return CloseMasterNavigationController();
             }
-
+            return Task.FromResult(true);
         }
 
-        protected void SetupSplitViewWindowRootNavigation(UIViewController viewController,
+        protected Task<bool> SetupSplitViewWindowRootNavigation(UIViewController viewController,
                                                MvxMasterDetailPresentationAttribute attribute)
         {
             if (attribute.WrapInNavigationController)
@@ -555,9 +561,9 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             else
             {
                 SetWindowRootViewController(viewController);
-                CloseMasterNavigationController();
+                return CloseMasterNavigationController();
             }
-
+            return Task.FromResult(true);
         }
 
         protected virtual void SetWindowRootViewController(UIViewController controller)
@@ -597,12 +603,13 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             return new MvxNavigationController(viewController);
         }
 
-        protected void CloseModalViewControllers()
+        protected async Task<bool> CloseModalViewControllers()
         {
             while (ModalViewControllers.Any())
             {
-                CloseModalViewController(ModalViewControllers.LastOrDefault());
+                if(!(await CloseModalViewController(ModalViewControllers.LastOrDefault())))return false;
             }
+            return true;
         }
 
     }

--- a/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
@@ -187,13 +187,13 @@ namespace MvvmCross.Platforms.Uap.Core
     }
 
     public class MvxWindowsSetup<TApplication> : MvxWindowsSetup
-         where TApplication : IMvxApplication, new()
+         where TApplication : class, IMvxApplication, new()
     {
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {
             return new[] { typeof(TApplication).GetTypeInfo().Assembly };
         }
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross/Platforms/Uap/Presenters/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Platforms/Uap/Presenters/MvxWindowsViewPresenter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,6 +14,7 @@ using MvvmCross.ViewModels;
 using MvvmCross.Presenters;
 using MvvmCross.Views;
 using MvvmCross.Presenters.Attributes;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Platforms.Uap.Presenters
 {
@@ -63,14 +64,14 @@ namespace MvvmCross.Platforms.Uap.Presenters
         }
 
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
-            GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+            return GetPresentationAttributeAction(request, out MvxBasePresentationAttribute attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
+            return GetPresentationAttributeAction(new MvxViewModelInstanceRequest(viewModel), out MvxBasePresentationAttribute attribute).CloseAction.Invoke(viewModel, attribute);
         }
 
         protected virtual async void BackButtonOnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)
@@ -112,7 +113,7 @@ namespace MvvmCross.Platforms.Uap.Presenters
                 _rootFrame.CanGoBack ? AppViewBackButtonVisibility.Visible : AppViewBackButtonVisibility.Collapsed;
         }
 
-        protected virtual void ShowSplitView(Type viewType, MvxSplitViewPresentationAttribute attribute, MvxViewModelRequest request)
+        protected virtual Task<bool> ShowSplitView(Type viewType, MvxSplitViewPresentationAttribute attribute, MvxViewModelRequest request)
         {
             var viewsContainer = Mvx.Resolve<IMvxViewsContainer>();
 
@@ -121,7 +122,7 @@ namespace MvvmCross.Platforms.Uap.Presenters
                 var splitView = currentPage.Content.FindControl<SplitView>();
                 if (splitView == null)
                 {
-                    return;
+                    return Task.FromResult(true);
                 }
 
                 if (attribute.Position == SplitPanePosition.Content)
@@ -147,14 +148,15 @@ namespace MvvmCross.Platforms.Uap.Presenters
                     nestedFrame.Navigate(viewType, requestText);
                 }
             }
+            return Task.FromResult(true);
         }
 
-        protected virtual bool CloseSplitView(IMvxViewModel viewModel, MvxSplitViewPresentationAttribute attribute)
+        protected virtual Task<bool> CloseSplitView(IMvxViewModel viewModel, MvxSplitViewPresentationAttribute attribute)
         {
             return ClosePage(viewModel, attribute);
         }
 
-        protected virtual void ShowRegionView(Type viewType, MvxRegionPresentationAttribute attribute, MvxViewModelRequest request)
+        protected virtual Task<bool> ShowRegionView(Type viewType, MvxRegionPresentationAttribute attribute, MvxViewModelRequest request)
         {
             if (viewType.HasRegionAttribute())
             {
@@ -165,12 +167,13 @@ namespace MvvmCross.Platforms.Uap.Presenters
                 if (containerView != null)
                 {
                     containerView.Navigate(viewType, requestText);
-                    return;
+                    return Task.FromResult(true);
                 }
             }
+            return Task.FromResult(true);
         }
 
-        protected virtual bool CloseRegionView(IMvxViewModel viewModel, MvxRegionPresentationAttribute attribute)
+        protected virtual Task<bool> CloseRegionView(IMvxViewModel viewModel, MvxRegionPresentationAttribute attribute)
         {
             var viewFinder = Mvx.Resolve<IMvxViewsContainer>();
             var viewType = viewFinder.GetViewType(viewModel.GetType());
@@ -184,42 +187,42 @@ namespace MvvmCross.Platforms.Uap.Presenters
                 if (containerView.CanGoBack)
                 {
                     containerView.GoBack();
-                    return true;
+                    return Task.FromResult(true);
                 }
             }
 
             return ClosePage(viewModel, attribute);
         }
 
-        protected virtual bool ClosePage(IMvxViewModel viewModel, MvxBasePresentationAttribute attribute)
+        protected virtual Task<bool> ClosePage(IMvxViewModel viewModel, MvxBasePresentationAttribute attribute)
         {
             var currentView = _rootFrame.Content as IMvxView;
             if (currentView == null)
             {
                 MvxLog.Instance.Warn("Ignoring close for viewmodel - rootframe has no current page");
-                return false;
+                return Task.FromResult(false);
             }
 
             if (currentView.ViewModel != viewModel)
             {
                 MvxLog.Instance.Warn("Ignoring close for viewmodel - rootframe's current page is not the view for the requested viewmodel");
-                return false;
+                return Task.FromResult(false);
             }
 
             if (!_rootFrame.CanGoBack)
             {
                 MvxLog.Instance.Warn("Ignoring close for viewmodel - rootframe refuses to go back");
-                return false;
+                return Task.FromResult(false);
             }
 
             _rootFrame.GoBack();
 
             HandleBackButtonVisibility();
 
-            return true;
+            return Task.FromResult(true);
         }
 
-        protected virtual void ShowPage(Type viewType, MvxBasePresentationAttribute attribute, MvxViewModelRequest request)
+        protected virtual Task<bool> ShowPage(Type viewType, MvxBasePresentationAttribute attribute, MvxViewModelRequest request)
         {
             try
             {
@@ -229,11 +232,13 @@ namespace MvvmCross.Platforms.Uap.Presenters
                 _rootFrame.Navigate(viewType, requestText); //Frame won't allow serialization of it's nav-state if it gets a non-simple type as a nav param
 
                 HandleBackButtonVisibility();
+                return Task.FromResult(true);
             }
             catch (Exception exception)
             {
                 MvxLog.Instance.Trace("Error seen during navigation request to {0} - error {1}", request.ViewModelType.Name,
                     exception.ToLongString());
+                return Task.FromResult(false);
             }
         }
     }

--- a/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
@@ -152,7 +152,7 @@ namespace MvvmCross.Platforms.Uap.Views
 
     public class MvxApplication<TMvxUapSetup, TApplication> : MvxApplication
        where TMvxUapSetup : MvxWindowsSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
+++ b/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
@@ -91,9 +91,9 @@ namespace MvvmCross.Platforms.Wpf.Core
     }
 
     public class MvxWpfSetup<TApplication> : MvxWpfSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
@@ -40,7 +40,7 @@ namespace MvvmCross.Platforms.Wpf.Views
 
     public class MvxApplication<TMvxWpfSetup, TApplication> : MvxApplication
        where TMvxWpfSetup : MvxWpfSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Presenters/IMvxViewPresenter.cs
+++ b/MvvmCross/Presenters/IMvxViewPresenter.cs
@@ -3,18 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Presenters
 {
     public interface IMvxViewPresenter
     {
-        void Show(MvxViewModelRequest request);
+        Task<bool> Show(MvxViewModelRequest request);
 
-        void ChangePresentation(MvxPresentationHint hint);
+        Task<bool> ChangePresentation(MvxPresentationHint hint);
 
-        void AddPresentationHintHandler<THint>(Func<THint, bool> action) where THint : MvxPresentationHint;
+        void AddPresentationHintHandler<THint>(Func<THint, Task<bool>> action) where THint : MvxPresentationHint;
 
-        void Close(IMvxViewModel toClose);
+        Task<bool> Close(IMvxViewModel toClose);
     }
 }

--- a/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
+++ b/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MvvmCross.Logging;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.Presenters.Hints;
@@ -151,20 +152,20 @@ namespace MvvmCross.Presenters
             throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
         }
 
-        public override void ChangePresentation(MvxPresentationHint hint)
+        public override async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            if (HandlePresentationChange(hint)) return;
+            if (await HandlePresentationChange(hint)) return true;
 
             if (hint is MvxClosePresentationHint presentationHint)
             {
-                Close(presentationHint.ViewModelToClose);
-                return;
+                return await Close(presentationHint.ViewModelToClose);
             }
 
             MvxLog.Instance.Warn("Hint ignored {0}", hint.GetType().Name);
+            return false;
         }
 
-        public override void Close(IMvxViewModel viewModel)
+        public override Task<bool> Close(IMvxViewModel viewModel)
         {
             var attribute = GetPresentationAttribute(new MvxViewModelInstanceRequest(viewModel));
             var attributeType = attribute.GetType();
@@ -178,14 +179,13 @@ namespace MvvmCross.Presenters
                     throw new NullReferenceException($"attributeAction.CloseAction is null for attribute: {attributeType.Name}");
                 }
 
-                attributeAction.CloseAction.Invoke(viewModel, attribute);
-                return;
+                return attributeAction.CloseAction.Invoke(viewModel, attribute);
             }
 
             throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");
         }
 
-        public override void Show(MvxViewModelRequest request)
+        public override Task<bool> Show(MvxViewModelRequest request)
         {
             var attribute = GetPresentationAttribute(request);
             attribute.ViewModelType = request.ViewModelType;
@@ -200,8 +200,7 @@ namespace MvvmCross.Presenters
                     throw new NullReferenceException($"attributeAction.ShowAction is null for attribute: {attributeType.Name}");
                 }
 
-                attributeAction.ShowAction.Invoke(attribute.ViewType, attribute, request);
-                return;
+                return attributeAction.ShowAction.Invoke(attribute.ViewType, attribute, request);
             }
 
             throw new KeyNotFoundException($"The type {attributeType.Name} is not configured in the presenter dictionary");

--- a/MvvmCross/Presenters/MvxPresentationAttributeAction.cs
+++ b/MvvmCross/Presenters/MvxPresentationAttributeAction.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
 
@@ -10,8 +11,8 @@ namespace MvvmCross.Presenters
 {
     public class MvxPresentationAttributeAction
     {
-        public Action<Type, MvxBasePresentationAttribute, MvxViewModelRequest> ShowAction { get; set; }
+        public Func<Type, MvxBasePresentationAttribute, MvxViewModelRequest, Task<bool>> ShowAction { get; set; }
 
-        public Func<IMvxViewModel, MvxBasePresentationAttribute, bool> CloseAction { get; set; }
+        public Func<IMvxViewModel, MvxBasePresentationAttribute, Task<bool>> CloseAction { get; set; }
     }
 }

--- a/MvvmCross/Presenters/MvxViewPresenter.cs
+++ b/MvvmCross/Presenters/MvxViewPresenter.cs
@@ -4,35 +4,36 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Presenters
 {
     public abstract class MvxViewPresenter : IMvxViewPresenter
     {
-        private readonly Dictionary<Type, Func<MvxPresentationHint, bool>> _presentationHintHandlers = new Dictionary<Type, Func<MvxPresentationHint, bool>>();
+        private readonly Dictionary<Type, Func<MvxPresentationHint, Task<bool>>> _presentationHintHandlers = new Dictionary<Type, Func<MvxPresentationHint, Task<bool>>>();
 
-        public void AddPresentationHintHandler<THint>(Func<THint, bool> action) where THint : MvxPresentationHint
+        public void AddPresentationHintHandler<THint>(Func<THint, Task<bool>> action) where THint : MvxPresentationHint
         {
             _presentationHintHandlers[typeof(THint)] = hint => action((THint)hint);
         }
 
-        protected bool HandlePresentationChange(MvxPresentationHint hint)
+        protected Task<bool> HandlePresentationChange(MvxPresentationHint hint)
         {
-            Func<MvxPresentationHint, bool> handler;
+            Func<MvxPresentationHint, Task<bool>> handler;
 
             if (_presentationHintHandlers.TryGetValue(hint.GetType(), out handler))
             {
-                if (handler(hint)) return true;
+                return handler(hint);
             }
 
-            return false;
+            return Task.FromResult(false);
         }
 
-        public abstract void Show(MvxViewModelRequest request);
+        public abstract Task<bool> Show(MvxViewModelRequest request);
 
-        public abstract void ChangePresentation(MvxPresentationHint hint);
+        public abstract Task<bool> ChangePresentation(MvxPresentationHint hint);
 
-        public abstract void Close(IMvxViewModel viewModel);
+        public abstract Task<bool> Close(IMvxViewModel viewModel);
     }
 }

--- a/MvvmCross/ViewModels/IMvxAppStart.cs
+++ b/MvvmCross/ViewModels/IMvxAppStart.cs
@@ -2,11 +2,15 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+
 namespace MvvmCross.ViewModels
 {
     public interface IMvxAppStart
     {
         void Start(object hint = null);
+
+        Task StartAsync(object hint = null);
 
         bool IsStarted { get; }
 

--- a/MvvmCross/ViewModels/IMvxApplication.cs
+++ b/MvvmCross/ViewModels/IMvxApplication.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross.Plugin;
 
 namespace MvvmCross.ViewModels
@@ -12,7 +13,7 @@ namespace MvvmCross.ViewModels
 
         void Initialize();
 
-        void Startup(object hint);
+        Task Startup(object hint);
 
         void Reset();
     }

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using MvvmCross.IoC;
 using MvvmCross.Plugin;
 
@@ -45,9 +46,10 @@ namespace MvvmCross.ViewModels
         /// Any initialization steps that need to be done on the UI thread
         /// </summary>
         /// <param name="hint"></param>
-        public virtual void Startup(object hint)
+        public virtual Task Startup(object hint)
         {
             // do nothing
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -66,7 +66,7 @@ namespace MvvmCross.ViewModels
         }
 
         protected void RegisterCustomAppStart<TMvxAppStart>()
-            where TMvxAppStart : IMvxAppStart
+            where TMvxAppStart : class, IMvxAppStart
         {
             Mvx.ConstructAndRegisterSingleton<IMvxAppStart, TMvxAppStart>();
         }

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -36,7 +36,7 @@ namespace MvvmCross.ViewModels
             IMvxViewModel viewModel;
             try
             {
-                viewModel = (IMvxViewModel)Mvx.IocConstruct(viewModelType);
+                viewModel = (IMvxViewModel)Mvx.IoCConstruct(viewModelType);
             }
             catch(Exception exception)
             {
@@ -56,7 +56,7 @@ namespace MvvmCross.ViewModels
             IMvxViewModel<TParameter> viewModel;
             try
             {
-                viewModel = (IMvxViewModel<TParameter>)Mvx.IocConstruct(viewModelType);
+                viewModel = (IMvxViewModel<TParameter>)Mvx.IoCConstruct(viewModelType);
             }
             catch(Exception exception)
             {

--- a/Projects/Playground/Playground.Core/App.cs
+++ b/Projects/Playground/Playground.Core/App.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross;
 using MvvmCross.IoC;
 using MvvmCross.Localization;
@@ -33,9 +34,9 @@ namespace Playground.Core
         /// Do any UI bound startup actions here
         /// </summary>
         /// <param name="hint"></param>
-        public override void Startup(object hint)
+        public override Task Startup(object hint)
         {
-            base.Startup(hint);
+            return base.Startup(hint);
         }
 
         /// <summary>

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -63,6 +63,9 @@ namespace Playground.Core.ViewModels
         {
             await base.Initialize();
 
+            // Uncomment this to demonstrate use of StartAsync for async first navigation
+            // await Task.Delay(5000);
+
             _mvxViewModelLoader.LoadViewModel<SampleModel>(MvxViewModelRequest.GetDefaultRequest(typeof(ChildViewModel)),
                                                            new SampleModel { Message = "From locator", Value = 2 },
                                                            null);

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -562,6 +562,21 @@ namespace MvvmCross.UnitTest.Base
             Assert.Equal(enabled, d.Enabled);
         }
 
+        [Fact]
+        public void IocConstruct_WithMultipleTypedArguments_ThrowsFailedToFindCtor()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var subtitle = "The subtitle";
+            var enabled = true;
+
+            Assert.Throws<MvxIoCResolveException>(() => {
+                var d = instance.IoCConstruct<D>(title, subtitle, enabled);
+            });
+        }
+
         // TODO - there are so many tests we could and should do here!
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -90,12 +90,21 @@ namespace MvvmCross.UnitTest.Base
             public string Title { get; }
             public string Subtitle { get; }
             public string Description { get; }
+            public int Amount { get; }
+            public bool Enabled { get; }
 
             public D(string title, string subtitle, string description)
             {
                 Title = title;
                 Subtitle = subtitle;
                 Description = description;
+            }
+
+            public D(string title, int amount, bool enabled)
+            {
+                Title = title;
+                Amount = amount;
+                Enabled = enabled;
             }
         }
 
@@ -534,6 +543,23 @@ namespace MvvmCross.UnitTest.Base
             Assert.Equal(title, d.Title);
             Assert.Equal(subtitle, d.Subtitle);
             Assert.Equal(description, d.Description);
+        }
+
+        [Fact]
+        public void IocConstruct_WithMultipleTypedArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var amount = 5;
+            var enabled = true;
+
+            var d = instance.IoCConstruct<D>(title, amount, enabled);
+
+            Assert.Equal(title, d.Title);
+            Assert.Equal(amount, d.Amount);
+            Assert.Equal(enabled, d.Enabled);
         }
 
         // TODO - there are so many tests we could and should do here!

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -85,6 +85,20 @@ namespace MvvmCross.UnitTest.Base
             }
         }
 
+        public class D
+        {
+            public string Title { get; }
+            public string Subtitle { get; }
+            public string Description { get; }
+
+            public D(string title, string subtitle, string description)
+            {
+                Title = title;
+                Subtitle = subtitle;
+                Description = description;
+            }
+        }
+
         public class COdd : IC
         {
             public static bool FirstTime = true;
@@ -456,6 +470,71 @@ namespace MvvmCross.UnitTest.Base
         }
 
         #endregion
+
+        [Fact]
+        public void IocConstruct_WithDictionaryArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var c = new C2();
+            var arguments = new Dictionary<string, object>
+            {
+                ["c"] = c
+            };
+            instance.IoCConstruct<B>(arguments);
+        }
+
+        [Fact]
+        public void IocConstruct_WithAnonymousTypeArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var c = new C2();
+            instance.IoCConstruct<B>(new { c });
+        }
+
+        [Fact]
+        public void IocConstruct_WithMultipleDictionaryArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var subtitle = "The subtitle";
+            var description = "The description";
+
+            var arguments = new Dictionary<string, object>
+            {
+                ["title"] = title,
+                ["subtitle"] = subtitle,
+                ["description"] = description
+            };
+            var d = instance.IoCConstruct<D>(arguments);
+
+            Assert.Equal(title, d.Title);
+            Assert.Equal(subtitle, d.Subtitle);
+            Assert.Equal(description, d.Description);
+        }
+
+        [Fact]
+        public void IocConstruct_WithMultipleAnonymousArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var subtitle = "The subtitle";
+            var description = "The description";
+
+            var arguments = new { title, subtitle, description };
+            var d = instance.IoCConstruct<D>(arguments);
+
+            Assert.Equal(title, d.Title);
+            Assert.Equal(subtitle, d.Subtitle);
+            Assert.Equal(description, d.Description);
+        }
 
         // TODO - there are so many tests we could and should do here!
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently the built in MvxAppStart only supports a synchronous startup. In cases where a splash screen is used, it should be possible to use an async startup which would allow the Initialize method to do long running actions. Currently this is achieved by overriding the default MvxAppStart.

### :new: What is the new behavior (if this is a feature change)?
Added support for StartAsync into IMvxAppStart
Altered SplashScreen (Android only) to make use of StartAsync
TODO: Add equivalent splash screen view to other platforms to show how this could work

### :boom: Does this PR introduce a breaking change?
Yes - some interfaces now return Task where previously was void

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting
Follow up PR to: https://github.com/MvvmCross/MvvmCross/pull/2784
In response to Issue: https://github.com/MvvmCross/MvvmCross/issues/2829

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
Note: This needs to be rebased onto v6.1 after PR 2784 has been merged
