### PR TITLE
Use legacy properties on the Android TimePicker for versions 5.1 and …

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Views/MvxTimePicker.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxTimePicker.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using Android.Content;
+using Android.OS;
 using Android.Runtime;
 using Android.Util;
 using Android.Widget;
@@ -39,7 +40,11 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         {
             get
             {
-                return new TimeSpan(Hour, Minute, 0);
+                if (Build.VERSION.SdkInt <= BuildVersionCodes.LollipopMr1)
+#pragma warning disable CS0618
+                    return new TimeSpan((int)CurrentHour, (int)CurrentMinute, 0);
+                else
+                    return new TimeSpan(Hour, Minute, 0);
             }
             set
             {
@@ -49,13 +54,28 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                     _initialized = true;
                 }
 
-                if (Hour != value.Hours)
+                if (Build.VERSION.SdkInt <= BuildVersionCodes.LollipopMr1)
                 {
-                    Hour = value.Hours;
+#pragma warning disable CS0618
+                    if ((int)CurrentHour != value.Hours)
+                    {
+                        CurrentHour = (Java.Lang.Integer)value.Hours;
+                    }
+                    if ((int)CurrentMinute != value.Minutes)
+                    {
+                        CurrentMinute = (Java.Lang.Integer)value.Minutes;
+                    }
                 }
-                if (Minute != value.Minutes)
+                else
                 {
-                    Minute = value.Minutes;
+                    if (Hour != value.Hours)
+                    {
+                        Hour = value.Hours;
+                    }
+                    if (Minute != value.Minutes)
+                    {
+                        Minute = value.Minutes;
+                    }
                 }
             }
         }


### PR DESCRIPTION
…lower.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes a compatibility issue with Android 5.1 and earlier.

### :arrow_heading_down: What is the current behavior?
MvxTimePicker doesn't bind correctly to the Android TimePicker.

### :new: What is the new behavior (if this is a feature change)?
This version check the Build Version in the Getter and Setter and sets/returns the correct property accordingly.

### :boom: Does this PR introduce a breaking change?
It shouldn't

### :bug: Recommendations for testing
Run the ApiExamples.Droid on a device that is running Android 5.1 or earlier.

### :memo: Links to relevant issues/docs
https://forums.xamarin.com/discussion/91890/error-setting-timepicker-hour-property-on-android

### :thinking: Checklist before submitting

- [ X] All projects build
- [X ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
