### PR TITLE
Amended LinkerPleaseInclude (iOS) example

### DIFF
--- a/ContentFiles/iOS/LinkerPleaseInclude.cs
+++ b/ContentFiles/iOS/LinkerPleaseInclude.cs
@@ -38,6 +38,7 @@ namespace $YourNameSpace$
         {
             textField.Text = textField.Text + "";
             textField.EditingChanged += (sender, args) => { textField.Text = ""; };
+            textField.EditingDidEnd += (sender, args) => { textField.Text = ""; };
         }
 
         public void Include(UITextView textView)


### PR DESCRIPTION
Whereas MvxUITextFieldTextTargetBinding establishes a dependency on UITextField.EditingDidEnd, LinkerPleaseInclude for iOS must ensure the presence of UITextField.EditingDidEnd.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix.

### :arrow_heading_down: What is the current behavior?

MvxUITextFieldTextTargetBinding depends on the presence of UITextField.EditingDidEnd, which can be scrubbed by the linker.

### :new: What is the new behavior (if this is a feature change)?

The example of LinkerPleaseInclude for iOS is amended to ensure the presence of UITextField.EditingDidEnd.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

I encountered an error when attempting to bind a UITextField to a string in a ViewModel after upgrading from MvvmCross 5 to 6. A similar change in my own code base solve this problem.

### :memo: Links to relevant issues/docs

https://github.com/MvvmCross/MvvmCross/issues/2527