### PR TITLE
Fixing crash on UWP in Release due to plugin

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -291,12 +291,23 @@ namespace MvvmCross.Core
                 AppDomain.CurrentDomain
                     .GetAssemblies()
                     .AsParallel()
-                    .Where(AssemblyReferencesMvvmCross);
+                    .Where(asmb=> AssemblyReferencesMvvmCross(asmb, mvvmCrossAssemblyName));
 
             return pluginAssemblies;
 
-            bool AssemblyReferencesMvvmCross(Assembly assembly)
-                => assembly.GetReferencedAssemblies().Any(a => a.Name == mvvmCrossAssemblyName);
+
+        }
+
+        private bool AssemblyReferencesMvvmCross(Assembly assembly, string mvvmCrossAssemblyName)
+        {
+            try
+            {
+                return assembly.GetReferencedAssemblies().Any(a => a.Name == mvvmCrossAssemblyName);
+            }
+            catch(Exception ex)
+            {
+                return true;
+            }
         }
 
         public virtual void LoadPlugins(IMvxPluginManager pluginManager)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix


### Comments
Currently the plugin model uses reflection to look for plugin attributes, which is always going to be slow. Given issues such as this, I suggest we move away from this model to one where plugins need to be explicitly referenced by the head projects and/or core library.


### :arrow_heading_down: What is the current behavior?
UWP crashes when attempting to load plugins in Release (ie with .NET Native compile)

### :new: What is the new behavior (if this is a feature change)?
UWP no longer crashes

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2842

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop

