### PR TITLE
Updates "Requesting presentation changes" documentation for MvvmCross 6

### DIFF
--- a/docs/_documentation/fundamentals/view-presenters.md
+++ b/docs/_documentation/fundamentals/view-presenters.md
@@ -97,11 +97,11 @@ To add your own `MvxPresentationHint` you should follow these steps:
     }
     ```
 
-2. Override the method `CreatePresenter()` in the Setup class and register your custom hint in it. For example, on iOS:
+2. Override the method `CreateViewPresenter()` in the Setup class and register your custom hint in it. For example, on iOS:
     ```c#
-    protected override IMvxIosViewPresenter CreatePresenter()
+    protected override IMvxIosViewPresenter CreateViewPresenter()
     {
-        var presenter = base.CreatePresenter();
+        var presenter = base.CreateViewPresenter();
         presenter.AddPresentationHintHandler<MyCustomHint>(hint => HandleMyCustomHint(hint));
         return presenter;
     }
@@ -121,13 +121,13 @@ To add your own `MvxPresentationHint` you should follow these steps:
     ```
     **Now repeat steps 2 and 3 for each platform (if a platform should just ignore the MvxPresentationHint, it's not necessary to do anything).**
 
-4. Finally, make a call to the ChangePresentation method from a MvxViewModel or a MvxNavigatingObject when necessary:
+4. Finally, make a call to the ChangePresentation method from the IMvxNavigationService when necessary:
     ```c#
-    private void AMethod()
+    private async Task AMethodAsync()
     {
         // your code
 
-        ChangePresentation(new MyCustomHint("example"));
+        bool handled = await mvxNavigationService.ChangePresentation(new MyCustomHint("example"));
 
         // your code
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
docs update

### :arrow_heading_down: What is the current behavior?
The "Requesting presentation changes" documentation is out of date. I've made some adjustments so the documentation reflects the changes in MvvmCross 6:

1. The CreatePresenter methods were renamed to CreateViewPresenter.
2. The ChangePresentation method was moved from the MvxViewModel to IMvxNavigationService.

💀 The docs style guide link in this template points to a dead link. 💀

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop