### PR TITLE
Fixes #2736

### DIFF
--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SplashScreen.cs" />
     <Compile Include="Setup.cs" />
+    <Compile Include="Views\Base\BaseSplitDetailView.cs" />
     <Compile Include="Views\CollectionView.cs" />
     <Compile Include="Views\DictionaryBindingView.cs" />
     <Compile Include="Views\RootView.cs" />
@@ -107,6 +108,9 @@
       <SubType>Designer</SubType>
     </AndroidResource>
     <AndroidResource Include="Resources\layout\ItemListSharedElementsTemplate.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include="Resources\layout\SplitDetailNavView.axml">
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>

--- a/Projects/Playground/Playground.Droid/Resources/layout/SplitDetailNavView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/SplitDetailNavView.axml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#880000">
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+      <android.support.v7.widget.Toolbar
+          android:id="@+id/toolbar"
+          android:layout_width="match_parent"
+          android:layout_height="?attr/actionBarSize"
+          android:background="?attr/colorPrimary"
+          local:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+    </android.support.design.widget.AppBarLayout>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="I'm a detail navigation page" />
+    <Button
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:text="Main Menu"
+        local:MvxBind="Click MainMenuCommand" />
+    <Button
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:text="Close"
+        local:MvxBind="Click CloseCommand" />
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/values/styles.xml
+++ b/Projects/Playground/Playground.Droid/Resources/values/styles.xml
@@ -35,5 +35,6 @@
 		parent="AppTheme.Base">
 		<item name="android:statusBarColor">@color/colorPrimaryDark</item>
 		<item name="android:windowNoTitle">true</item>
+    <item name="android:windowBackground">@color/colorAccent</item>
 	</style>
 </resources>

--- a/Projects/Playground/Playground.Droid/Resources/values/styles.xml
+++ b/Projects/Playground/Playground.Droid/Resources/values/styles.xml
@@ -35,6 +35,6 @@
 		parent="AppTheme.Base">
 		<item name="android:statusBarColor">@color/colorPrimaryDark</item>
 		<item name="android:windowNoTitle">true</item>
-    <item name="android:windowBackground">@color/colorAccent</item>
+		<item name="android:windowBackground">@color/colorAccent</item>
 	</style>
 </resources>

--- a/Projects/Playground/Playground.Droid/Views/Base/BaseSplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Views/Base/BaseSplitDetailView.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.Content.Res;
+using Android.OS;
+using Android.Support.V7.Widget;
+using Android.Views;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.ViewModels;
+
+namespace Playground.Droid.Views.Base
+{
+    public abstract class BaseSplitDetailView<TViewModel> : MvxFragment<TViewModel> where TViewModel : class, IMvxViewModel
+    {
+        protected SplitRootView BaseActivity => (SplitRootView)Activity;
+        protected Toolbar _toolbar;
+        protected MvxActionBarDrawerToggle _drawerToggle;
+
+        protected abstract int FragmentLayoutId { get; }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(FragmentLayoutId, null);
+
+            _toolbar = view.FindViewById<Toolbar>(Resource.Id.toolbar);
+            if (_toolbar != null)
+            {
+                BaseActivity.SetSupportActionBar(_toolbar);
+                BaseActivity.SupportActionBar.SetDisplayHomeAsUpEnabled(true);
+
+                _drawerToggle = new MvxActionBarDrawerToggle(
+                    Activity,                               // host Activity
+                    BaseActivity.DrawerLayout,              // DrawerLayout object
+                    _toolbar,                               // nav drawer icon to replace 'Up' caret
+                    Resource.String.drawer_open,            // "open drawer" description
+                    Resource.String.drawer_close            // "close drawer" description
+                );
+                BaseActivity.DrawerLayout.AddDrawerListener(_drawerToggle);
+                _drawerToggle.DrawerIndicatorEnabled = true;
+            }
+
+            return view;
+        }
+
+        public override void OnConfigurationChanged(Configuration newConfig)
+        {
+            base.OnConfigurationChanged(newConfig);
+            if (_toolbar != null)
+                _drawerToggle.OnConfigurationChanged(newConfig);
+        }
+
+        public override void OnActivityCreated(Bundle savedInstanceState)
+        {
+            base.OnActivityCreated(savedInstanceState);
+            if (_toolbar != null)
+                _drawerToggle.SyncState();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Views/SplitDetailNavView.cs
+++ b/Projects/Playground/Playground.Droid/Views/SplitDetailNavView.cs
@@ -2,27 +2,17 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
 using Android.Runtime;
-using Android.Views;
-using MvvmCross.Droid.Support.V4;
-using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
+using Playground.Droid.Views.Base;
 
 namespace Playground.Droid.Views
 {
-    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
+    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame, AddToBackStack = true)]
     [Register(nameof(SplitDetailNavView))]
-    public class SplitDetailNavView : MvxFragment<SplitDetailNavViewModel>
+    public class SplitDetailNavView : BaseSplitDetailView<SplitDetailNavViewModel>
     {
-        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
-        {
-            base.OnCreateView(inflater, container, savedInstanceState);
-
-            var view = this.BindingInflate(Resource.Layout.SplitDetailView, null);
-
-            return view;
-        }
+        protected override int FragmentLayoutId => Resource.Layout.SplitDetailNavView;
     }
 }

--- a/Projects/Playground/Playground.Droid/Views/SplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Views/SplitDetailView.cs
@@ -2,66 +2,17 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.Content.Res;
-using Android.OS;
 using Android.Runtime;
-using Android.Support.V7.Widget;
-using Android.Views;
-using MvvmCross.Droid.Support.V4;
-using MvvmCross.Droid.Support.V7.AppCompat;
-using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
+using Playground.Droid.Views.Base;
 
 namespace Playground.Droid.Views
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
     [Register(nameof(SplitDetailView))]
-    public class SplitDetailView : MvxFragment<SplitDetailViewModel>
+    public class SplitDetailView : BaseSplitDetailView<SplitDetailViewModel>
     {
-        public SplitRootView BaseActivity => (SplitRootView)Activity;
-
-        private Toolbar _toolbar;
-        private MvxActionBarDrawerToggle _drawerToggle;
-
-        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
-        {
-            base.OnCreateView(inflater, container, savedInstanceState);
-
-            var view = this.BindingInflate(Resource.Layout.SplitDetailView, null);
-
-            _toolbar = view.FindViewById<Toolbar>(Resource.Id.toolbar);
-            if (_toolbar != null)
-            {
-                BaseActivity.SetSupportActionBar(_toolbar);
-                BaseActivity.SupportActionBar.SetDisplayHomeAsUpEnabled(true);
-
-                _drawerToggle = new MvxActionBarDrawerToggle(
-                    Activity,                               // host Activity
-                    BaseActivity.DrawerLayout,  // DrawerLayout object
-                    _toolbar,                               // nav drawer icon to replace 'Up' caret
-                    Resource.String.drawer_open,            // "open drawer" description
-                    Resource.String.drawer_close            // "close drawer" description
-                );
-                BaseActivity.DrawerLayout.AddDrawerListener(_drawerToggle);
-                _drawerToggle.DrawerIndicatorEnabled = true;
-            }
-
-            return view;
-        }
-
-        public override void OnConfigurationChanged(Configuration newConfig)
-        {
-            base.OnConfigurationChanged(newConfig);
-            if (_toolbar != null)
-                _drawerToggle.OnConfigurationChanged(newConfig);
-        }
-
-        public override void OnActivityCreated(Bundle savedInstanceState)
-        {
-            base.OnActivityCreated(savedInstanceState);
-            if (_toolbar != null)
-                _drawerToggle.SyncState();
-        }
+        protected override int FragmentLayoutId => Resource.Layout.SplitDetailView;
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix (Playground.Droid)

### :arrow_heading_down: What is the current behavior?
In Playground.Droid, opening the Master/Detail then clicking "SHOW CHILD" isn't implemented.

### :new: What is the new behavior (if this is a feature change)?

1. Added a new AXML layout for SplitDetailNavView based on the one in the Forms.Droid project. Note: clicking "MAIN MENU" doesn't work, but that's outside of the scope of this PR.
2. I added a new `BaseSplitDetailView` abstract class since 99% of the code would be duplicated between SplitDetailView and SplitDetailNavView.
3. Unrelated but nice - I fixed the white screen displayed before the splash screen starts up.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Start the Playground.Droid project, click "SHOW MASTER/DETAIL" then click "SHOW CHILD". Play around with the back button while navigating between the views.

### :memo: Links to relevant issues/docs
#2736 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
