### PR TITLE
Plugin loading on references of core assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,135 @@
 # Change Log
 
+## [6.0.1](https://github.com/MvvmCross/MvvmCross/tree/6.0.1) (2018-04-29)
+[Full Changelog](https://github.com/MvvmCross/MvvmCross/compare/6.0.0...6.0.1)
+
+**Fixed bugs:**
+
+- SplashScreenAppCompat should use AppCompatSetup [\#2821](https://github.com/MvvmCross/MvvmCross/pull/2821) ([drungrin](https://github.com/drungrin))
+
+**Closed issues:**
+
+- Calling async method on ViewModel.Initialize never ends and InitializeTask properties never got updated [\#2829](https://github.com/MvvmCross/MvvmCross/issues/2829)
+- RunAppStart isn't called in Xamarin Form - Android project [\#2813](https://github.com/MvvmCross/MvvmCross/issues/2813)
+- Error when using the Initialize event in a view model since upgrade to Version 6.0 [\#2808](https://github.com/MvvmCross/MvvmCross/issues/2808)
+- MvvmCross.Platforms.Android namespace missing from MvvmCross 6.0.0 package [\#2807](https://github.com/MvvmCross/MvvmCross/issues/2807)
+- Documentation request [\#2806](https://github.com/MvvmCross/MvvmCross/issues/2806)
+- MvxFormsIosSetup.CreateViewPresenter called too soon? [\#2802](https://github.com/MvvmCross/MvvmCross/issues/2802)
+- Resource.Layout' does not contain a definition for '\[ViewName\]' [\#2801](https://github.com/MvvmCross/MvvmCross/issues/2801)
+
+**Merged pull requests:**
+
+- Small docs fix, renamed to correct method in the events mapping table. [\#2834](https://github.com/MvvmCross/MvvmCross/pull/2834) ([agoransson](https://github.com/agoransson))
+- Update Getting-Started and MvvmCross-Overview docs [\#2822](https://github.com/MvvmCross/MvvmCross/pull/2822) ([nmilcoff](https://github.com/nmilcoff))
+- Fixing crash when running Android Forms Playground [\#2820](https://github.com/MvvmCross/MvvmCross/pull/2820) ([nickrandolph](https://github.com/nickrandolph))
+- Removing calls to base methods to prevent error [\#2819](https://github.com/MvvmCross/MvvmCross/pull/2819) ([nickrandolph](https://github.com/nickrandolph))
+- Allow options to be supplied to IocConstruct [\#2814](https://github.com/MvvmCross/MvvmCross/pull/2814) ([martijn00](https://github.com/martijn00))
+- Bugfix/fix playground wpf setup [\#2811](https://github.com/MvvmCross/MvvmCross/pull/2811) ([Cheesebaron](https://github.com/Cheesebaron))
+- Android margin extensions method bind and binding docs updates [\#2809](https://github.com/MvvmCross/MvvmCross/pull/2809) ([Plac3hold3r](https://github.com/Plac3hold3r))
+- Update Acr.UserDialogs link [\#2805](https://github.com/MvvmCross/MvvmCross/pull/2805) ([vatsalyagoel](https://github.com/vatsalyagoel))
+- Make it easier to override the Forms Page presenter [\#2803](https://github.com/MvvmCross/MvvmCross/pull/2803) ([martijn00](https://github.com/martijn00))
+- Implement basic infrastructure for Tizen and Tizen.Forms [\#2669](https://github.com/MvvmCross/MvvmCross/pull/2669) ([martijn00](https://github.com/martijn00))
+
 ## [6.0.0](https://github.com/MvvmCross/MvvmCross/tree/6.0.0) (2018-04-14)
 [Full Changelog](https://github.com/MvvmCross/MvvmCross/compare/6.0.0-beta8...6.0.0)
 
 **Fixed bugs:**
 
-- Playground.Droid creates multiple instances of RootViewModel [\#2782](https://github.com/MvvmCross/MvvmCross/issues/2782)
 - MvvmCross doesn't work with F\# Android app resources [\#2772](https://github.com/MvvmCross/MvvmCross/issues/2772)
-- Xamarin Forms Images is not shown on Android when using mvvmcross [\#2770](https://github.com/MvvmCross/MvvmCross/issues/2770)
 - UWP Photo chooser distorts photo on windows phone [\#2588](https://github.com/MvvmCross/MvvmCross/issues/2588)
+- Playground.Droid creates multiple instances of RootViewModel [\#2782](https://github.com/MvvmCross/MvvmCross/issues/2782)
+- Xamarin Forms Images is not shown on Android when using mvvmcross [\#2770](https://github.com/MvvmCross/MvvmCross/issues/2770)
+- Crash when Close Viewmodel With Result using MasterDetail [\#2757](https://github.com/MvvmCross/MvvmCross/issues/2757)
+- Playground SheetView crashes Android application [\#2722](https://github.com/MvvmCross/MvvmCross/issues/2722)
+- Android app hangs on SplashScreen [\#2721](https://github.com/MvvmCross/MvvmCross/issues/2721)
+- MvxViewPagerAdapter and MvxStateViewPagerAdapter ignore the presence of view model instance inside MvxViewPagerFragmentInfo [\#2718](https://github.com/MvvmCross/MvvmCross/issues/2718)
+- RegisterAttribute doesn't always match the new MvvmCross 6 namespace [\#2688](https://github.com/MvvmCross/MvvmCross/issues/2688)
+- App didn't show the right view after add SplashScreen on WPF [\#2684](https://github.com/MvvmCross/MvvmCross/issues/2684)
+- \[iOS\] Text Replacement does not apply change through the binding [\#2681](https://github.com/MvvmCross/MvvmCross/issues/2681)
+- Language files are not loaded in iOS project [\#2678](https://github.com/MvvmCross/MvvmCross/issues/2678)
+- Lack of Initialization from MvxSplashScreenActivity causes App start from external Intent \(ie, Uri routing\) to fail in Forms app [\#2624](https://github.com/MvvmCross/MvvmCross/issues/2624)
+- Xamarin.Forms Android - First page cannot reference Application level StaticResources [\#2622](https://github.com/MvvmCross/MvvmCross/issues/2622)
+- PluginLoaders not found for platform specific plugins [\#2611](https://github.com/MvvmCross/MvvmCross/issues/2611)
+- Child View Presentation does not work when using More Tabs \(more than five tabs\) \[iOS\]  [\#2609](https://github.com/MvvmCross/MvvmCross/issues/2609)
+- Fragment close does not work if fragment presentation attribute has backstack set to false [\#2600](https://github.com/MvvmCross/MvvmCross/issues/2600)
+- Sometimes open the app and then it crashes [\#2599](https://github.com/MvvmCross/MvvmCross/issues/2599)
+- Platform.Mac startup exception Foundation.You\_Should\_Not\_Call\_base\_In\_This\_Method [\#2591](https://github.com/MvvmCross/MvvmCross/issues/2591)
+- Custom Presentation Hint Handler is ignored [\#2589](https://github.com/MvvmCross/MvvmCross/issues/2589)
+- MvxAppStart swallows exceptions [\#2586](https://github.com/MvvmCross/MvvmCross/issues/2586)
+- MvvmCross.Forms cannot replace app's MainPage [\#2577](https://github.com/MvvmCross/MvvmCross/issues/2577)
+- UITextview binding - missing source event info in MvxWeakEventSubscription Parameter name: sourceEventInfo [\#2543](https://github.com/MvvmCross/MvvmCross/issues/2543)
+- MvxBottomSheetDialogFragment OnDestroy does not consider finsished parameter [\#2525](https://github.com/MvvmCross/MvvmCross/issues/2525)
+- MvxObservableCollection reports wrong index when doing AddRange [\#2515](https://github.com/MvvmCross/MvvmCross/issues/2515)
+- UITextView target binding fails when subscribing to changes [\#2484](https://github.com/MvvmCross/MvvmCross/issues/2484)
+- MvxWindowsPage cannot navigate to MvxContentPage [\#2466](https://github.com/MvvmCross/MvvmCross/issues/2466)
+- Status Bar Style jumps back to default after navigation \(iOS\) [\#2463](https://github.com/MvvmCross/MvvmCross/issues/2463)
+- UISwitch binding doesn't work [\#2462](https://github.com/MvvmCross/MvvmCross/issues/2462)
+- RegisterNavigationServiceAppStart vs RegisterAppStart [\#2447](https://github.com/MvvmCross/MvvmCross/issues/2447)
+- MvxExpandableListView GroupClick binding replaces group expanding functionality [\#2408](https://github.com/MvvmCross/MvvmCross/issues/2408)
+- MvxAppCompatDialogFragment Attempt to invoke virtual method on a null object reference [\#2378](https://github.com/MvvmCross/MvvmCross/issues/2378)
+- 'System.TypeInitializationException' In 'MvvmCross.Core.Platform.LogProviders.ConsoleLogProvider' On UWP Projects [\#2333](https://github.com/MvvmCross/MvvmCross/issues/2333)
+- Inconsistent PCL profile for PictureChooser [\#2295](https://github.com/MvvmCross/MvvmCross/issues/2295)
+- Adjusting the resolution of the resource assembly [\#2777](https://github.com/MvvmCross/MvvmCross/pull/2777) ([nickrandolph](https://github.com/nickrandolph))
 - Fixing issue with CurrentActivity being null in Playground.Droid [\#2775](https://github.com/MvvmCross/MvvmCross/pull/2775) ([nickrandolph](https://github.com/nickrandolph))
 - Find resource type based on Android.Runtime.ResourceDesignerAttribute [\#2774](https://github.com/MvvmCross/MvvmCross/pull/2774) ([nosami](https://github.com/nosami))
+- Make show and close of iOS views respect Animated [\#2767](https://github.com/MvvmCross/MvvmCross/pull/2767) ([martijn00](https://github.com/martijn00))
+- MvxUISliderValueTargetBinding: Add missing return [\#2750](https://github.com/MvvmCross/MvvmCross/pull/2750) ([nmilcoff](https://github.com/nmilcoff))
+- Fixes \#2722 [\#2730](https://github.com/MvvmCross/MvvmCross/pull/2730) ([tbalcom](https://github.com/tbalcom))
+- Make sure Forms is loaded when not using a splashscreen [\#2729](https://github.com/MvvmCross/MvvmCross/pull/2729) ([martijn00](https://github.com/martijn00))
+- Android add MvxViewVodelRequest to fragment forward life cycle events [\#2728](https://github.com/MvvmCross/MvvmCross/pull/2728) ([Plac3hold3r](https://github.com/Plac3hold3r))
+- Android Dialogs: Fix close & do not keep references to instances [\#2711](https://github.com/MvvmCross/MvvmCross/pull/2711) ([nmilcoff](https://github.com/nmilcoff))
+- Improvements & register fix for Visibility / Messenger / PictureChooser plugins [\#2704](https://github.com/MvvmCross/MvvmCross/pull/2704) ([nmilcoff](https://github.com/nmilcoff))
+- Fix moving items in the MvxRecyclerAdapter [\#2664](https://github.com/MvvmCross/MvvmCross/pull/2664) ([kjeremy](https://github.com/kjeremy))
+- MvxBaseTableViewSource: Fix wrong height for xib based cells  [\#2644](https://github.com/MvvmCross/MvvmCross/pull/2644) ([nmilcoff](https://github.com/nmilcoff))
+- Apply default templates to MvxAppCompatSpinner [\#2640](https://github.com/MvvmCross/MvvmCross/pull/2640) ([kjeremy](https://github.com/kjeremy))
+- Binding types fix [\#2632](https://github.com/MvvmCross/MvvmCross/pull/2632) ([Saratsin](https://github.com/Saratsin))
+- Fixed issue \#2515 where MvxObservableCollection.AddRange\(\) reports wrong index [\#2614](https://github.com/MvvmCross/MvvmCross/pull/2614) ([Strifex](https://github.com/Strifex))
+-  \#2600 no backstack fragment close does not work hotfix [\#2601](https://github.com/MvvmCross/MvvmCross/pull/2601) ([thefex](https://github.com/thefex))
+- Fix that change presentation add handler is ignored in forms [\#2592](https://github.com/MvvmCross/MvvmCross/pull/2592) ([martijn00](https://github.com/martijn00))
+- Fix inheritance for MvxBaseSplitViewController class with constraint [\#2564](https://github.com/MvvmCross/MvvmCross/pull/2564) ([nmilcoff](https://github.com/nmilcoff))
+- Fixing Android attributes [\#2529](https://github.com/MvvmCross/MvvmCross/pull/2529) ([nickrandolph](https://github.com/nickrandolph))
+- MvxBottomSheetDialogFragment: Fix OnDestroy [\#2526](https://github.com/MvvmCross/MvvmCross/pull/2526) ([nmilcoff](https://github.com/nmilcoff))
+- Improve implementation of IMvxAndroidCurrentTopActivity [\#2513](https://github.com/MvvmCross/MvvmCross/pull/2513) ([nmilcoff](https://github.com/nmilcoff))
+-  Make Mvx...Cell inherit from IMvxCell instead of IMvxElement [\#2511](https://github.com/MvvmCross/MvvmCross/pull/2511) ([mubold](https://github.com/mubold))
+- Fix MvxTabBarViewController.CloseTab: Pick correct ViewController [\#2506](https://github.com/MvvmCross/MvvmCross/pull/2506) ([nmilcoff](https://github.com/nmilcoff))
+- Switch parameters in MvxException so that first exception is InnerException [\#2504](https://github.com/MvvmCross/MvvmCross/pull/2504) ([mubold](https://github.com/mubold))
+- MvxNavigationServiceAppStart: Don't swallow exceptions [\#2471](https://github.com/MvvmCross/MvvmCross/pull/2471) ([nmilcoff](https://github.com/nmilcoff))
 
 **Closed issues:**
 
 - Generic UWP views break compiled bindings [\#2653](https://github.com/MvvmCross/MvvmCross/issues/2653)
+- Attribute "MvxBind" has already been defined [\#2800](https://github.com/MvvmCross/MvvmCross/issues/2800)
+- WPF Support Missing From MvvmCross 6.0.0 [\#2796](https://github.com/MvvmCross/MvvmCross/issues/2796)
+- \[iOS\] Using VS AppCenter "AppCenter.Start" while MvxApplication.Initialize results in deadlock since MVX 6 beta7 [\#2745](https://github.com/MvvmCross/MvvmCross/issues/2745)
+- WPF Presenter documentation is out of date [\#2743](https://github.com/MvvmCross/MvvmCross/issues/2743)
+- NuGet package descriptions are missing from csproj files [\#2742](https://github.com/MvvmCross/MvvmCross/issues/2742)
+- Need an example of custom activity transitions [\#2659](https://github.com/MvvmCross/MvvmCross/issues/2659)
+- -	Skipping DigitalWorkReport.Droid.Resource.String.fab\_scroll\_shrink\_grow\_autohide\_behavior [\#2645](https://github.com/MvvmCross/MvvmCross/issues/2645)
+- MvvmCross.Plugins.Location.Fused.Droid.Plugin does not load [\#2637](https://github.com/MvvmCross/MvvmCross/issues/2637)
+- Cleanup "Sidebar" plugin [\#2626](https://github.com/MvvmCross/MvvmCross/issues/2626)
+- MvvmCross.Forms version out of sync with Xamarin.Forms Tutorial [\#2620](https://github.com/MvvmCross/MvvmCross/issues/2620)
+- Navigation service: ChangePresentation should be async [\#2602](https://github.com/MvvmCross/MvvmCross/issues/2602)
+- OnCreate is called after first ContentPage [\#2549](https://github.com/MvvmCross/MvvmCross/issues/2549)
+- \[Android\] Inconsistency with MvxRecyclerView vs. MvxListView & MvxSpinner [\#2544](https://github.com/MvvmCross/MvvmCross/issues/2544)
+- Remove usage of MvxTrace from code [\#2541](https://github.com/MvvmCross/MvvmCross/issues/2541)
+- Switch NUnit tests to XUnit [\#2540](https://github.com/MvvmCross/MvvmCross/issues/2540)
+- Inconsistency between MvxCommand\<T\> and MvxAsyncCommand\<T\> implementing IMvxCommand [\#2520](https://github.com/MvvmCross/MvvmCross/issues/2520)
+- MvxFormsApplication Start, Sleep and Resume gets not called on iOS [\#2512](https://github.com/MvvmCross/MvvmCross/issues/2512)
+- Reason why app crashed MvxSetup.InitializePrimary\(\) called from void? [\#2508](https://github.com/MvvmCross/MvvmCross/issues/2508)
+- Documentation missing for Xamarin.Forms ViewPresenter  [\#2497](https://github.com/MvvmCross/MvvmCross/issues/2497)
+- Feature request: Broader fragment usage [\#2495](https://github.com/MvvmCross/MvvmCross/issues/2495)
+- Remove IMvxIosModalHost [\#2475](https://github.com/MvvmCross/MvvmCross/issues/2475)
+- The new logger infrastructure should not send null messages to IMvxLog [\#2437](https://github.com/MvvmCross/MvvmCross/issues/2437)
+- \[Android\] \[MvxRecyclerView\] MvxTemplateSelector\<TItem\> missing ItemTemplateId issue [\#2422](https://github.com/MvvmCross/MvvmCross/issues/2422)
 
 **Merged pull requests:**
 
+- Update 2018-4-14-mvvmcross-6.0.0-release.md [\#2799](https://github.com/MvvmCross/MvvmCross/pull/2799) ([fedemkr](https://github.com/fedemkr))
 - Making it easier to override creation of injected pages [\#2793](https://github.com/MvvmCross/MvvmCross/pull/2793) ([nickrandolph](https://github.com/nickrandolph))
 - Improving Forms Android support for setup [\#2790](https://github.com/MvvmCross/MvvmCross/pull/2790) ([nickrandolph](https://github.com/nickrandolph))
 - Split out WPF [\#2789](https://github.com/MvvmCross/MvvmCross/pull/2789) ([martijn00](https://github.com/martijn00))
 - Update 3rd-party-plugins.md [\#2788](https://github.com/MvvmCross/MvvmCross/pull/2788) ([vurf](https://github.com/vurf))
 - Bugfix/aapt error workaround [\#2787](https://github.com/MvvmCross/MvvmCross/pull/2787) ([Cheesebaron](https://github.com/Cheesebaron))
-
-## [6.0.0-beta8](https://github.com/MvvmCross/MvvmCross/tree/6.0.0-beta8) (2018-04-10)
-[Full Changelog](https://github.com/MvvmCross/MvvmCross/compare/6.0.0-beta7...6.0.0-beta8)
-
-**Fixed bugs:**
-
-- Crash when Close Viewmodel With Result using MasterDetail [\#2757](https://github.com/MvvmCross/MvvmCross/issues/2757)
-- Adjusting the resolution of the resource assembly [\#2777](https://github.com/MvvmCross/MvvmCross/pull/2777) ([nickrandolph](https://github.com/nickrandolph))
-- Make show and close of iOS views respect Animated [\#2767](https://github.com/MvvmCross/MvvmCross/pull/2767) ([martijn00](https://github.com/martijn00))
-- MvxUISliderValueTargetBinding: Add missing return [\#2750](https://github.com/MvvmCross/MvvmCross/pull/2750) ([nmilcoff](https://github.com/nmilcoff))
-
-**Closed issues:**
-
-- ViewControllers animation can't be disabled for VM Navigate\(\) / Close\(\) [\#2762](https://github.com/MvvmCross/MvvmCross/issues/2762)
-- \[iOS\] Using VS AppCenter "AppCenter.Start" while MvxApplication.Initialize results in deadlock since MVX 6 beta7 [\#2745](https://github.com/MvvmCross/MvvmCross/issues/2745)
-- WPF Presenter documentation is out of date [\#2743](https://github.com/MvvmCross/MvvmCross/issues/2743)
-- NuGet package descriptions are missing from csproj files [\#2742](https://github.com/MvvmCross/MvvmCross/issues/2742)
-
-**Merged pull requests:**
-
 - Added Margin target binding for Android [\#2780](https://github.com/MvvmCross/MvvmCross/pull/2780) ([Cheesebaron](https://github.com/Cheesebaron))
 - Fix duplicated entry for SplitView attribute on iOS ViewPresenter [\#2779](https://github.com/MvvmCross/MvvmCross/pull/2779) ([nmilcoff](https://github.com/nmilcoff))
 - Update json.md [\#2778](https://github.com/MvvmCross/MvvmCross/pull/2778) ([dawidstefaniak](https://github.com/dawidstefaniak))

--- a/ContentFiles/iOS/LinkerPleaseInclude.cs
+++ b/ContentFiles/iOS/LinkerPleaseInclude.cs
@@ -38,6 +38,7 @@ namespace $YourNameSpace$
         {
             textField.Text = textField.Text + "";
             textField.EditingChanged += (sender, args) => { textField.Text = ""; };
+            textField.EditingDidEnd += (sender, args) => { textField.Text = ""; };
         }
 
         public void Include(UITextView textView)

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
-    <PackageLicenseUrl>http://opensource.org/licenses/ms-pl</PackageLicenseUrl>
+    <PackageLicenseUrl>https://opensource.org/licenses/ms-pl</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MvvmCross</PackageProjectUrl>
     <PackageIconUrl>http://i.imgur.com/Baucn8c.png</PackageIconUrl>
     <Authors>.NET Foundation and Contributors</Authors>

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatApplication.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatApplication.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 {
     public abstract class MvxAppCompatApplication<TMvxAndroidSetup, TApplication> : MvxAndroidApplication
   where TMvxAndroidSetup : MvxAppCompatSetup<TApplication>, new()
-  where TApplication : IMvxApplication, new()
+  where TApplication : class, IMvxApplication, new()
     {
         public MvxAppCompatApplication() : base()
         {

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetup.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetup.cs
@@ -44,9 +44,9 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
     }
 
     public class MvxAppCompatSetup<TApplication> : MvxAppCompatSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -91,7 +91,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
     public abstract class MvxSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenAppCompatActivity
             where TMvxAndroidSetup : MvxAppCompatSetup<TApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
     {
         protected MvxSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)
         {

--- a/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
+++ b/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
@@ -131,7 +131,7 @@ namespace MvvmCross.Forms.Platforms.Android.Core
     }
 
     public class MvxFormsAndroidSetup<TApplication, TFormsApplication> : MvxFormsAndroidSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -146,6 +146,6 @@ namespace MvvmCross.Forms.Platforms.Android.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
@@ -215,7 +215,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxFormsAppCompatActivity
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()
@@ -226,7 +226,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication, TViewModel> : MvxFormsAppCompatActivity<TViewModel>
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
          where TViewModel : class, IMvxViewModel
     {

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
@@ -205,7 +205,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsApplicationActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxFormsApplicationActivity
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()
@@ -216,7 +216,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
     public abstract class MvxFormsApplicationActivity<TMvxAndroidSetup, TApplication, TFormsApplication, TViewModel> : MvxFormsApplicationActivity<TViewModel>
     where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
          where TViewModel : class, IMvxViewModel
     {

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 {
     public abstract class MvxFormsSplashScreenActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenActivity
             where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
             where TFormsApplication : Application, new()
     {
         protected MvxFormsSplashScreenActivity(int resourceId = NoContent) : base(resourceId)

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenAppCompatActivity.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 {
     public abstract class MvxFormsSplashScreenAppCompatActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenAppCompatActivity
             where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
             where TFormsApplication : Application, new()
     {
         protected MvxFormsSplashScreenAppCompatActivity(int resourceId = NoContent) : base(resourceId)

--- a/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsApplicationDelegate.cs
@@ -106,7 +106,7 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
 
     public abstract class MvxFormsApplicationDelegate<TMvxIosSetup, TApplication, TFormsApplication> : MvxFormsApplicationDelegate
         where TMvxIosSetup : MvxFormsIosSetup<TApplication, TFormsApplication>, new()
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()

--- a/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsIosSetup.cs
+++ b/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsIosSetup.cs
@@ -116,7 +116,7 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
     }
 
     public class MvxFormsIosSetup<TApplication, TFormsApplication> : MvxFormsIosSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -131,6 +131,6 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
@@ -103,7 +103,7 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
 
     public abstract class MvxFormsApplicationDelegate<TMvxMacSetup, TApplication, TFormsApplication> : MvxFormsApplicationDelegate
     where TMvxMacSetup : MvxFormsMacSetup<TApplication, TFormsApplication>, new()
-    where TApplication : IMvxApplication, new()
+    where TApplication : class, IMvxApplication, new()
     where TFormsApplication : Application, new()
     {
         protected override void RegisterSetup()

--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsMacSetup.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsMacSetup.cs
@@ -116,7 +116,7 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
     }
 
     public class MvxFormsMacSetup<TApplication, TFormsApplication> : MvxFormsMacSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -131,6 +131,6 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Core/MvxFormsWindowsSetup.cs
@@ -98,7 +98,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Core
     }
 
     public class MvxFormsWindowsSetup<TApplication, TFormsApplication> : MvxFormsWindowsSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()        
     {
         public override IEnumerable<Assembly> GetViewAssemblies()
@@ -113,6 +113,6 @@ namespace MvvmCross.Forms.Platforms.Uap.Core
 
         protected override Application CreateFormsApplication() => new TFormsApplication();
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross.Forms/Platforms/Uap/Views/MvxWindowsApplication.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Views/MvxWindowsApplication.cs
@@ -39,7 +39,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Views
 
     public abstract class MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication> : MvxWindowsApplication
        where TMvxUapSetup : MvxFormsWindowsSetup<TApplication, TFormsApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
     {
         protected abstract override Type HostWindowsPageType();
@@ -52,7 +52,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Views
 
     public class MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication, THostPageType> : MvxWindowsApplication<TMvxUapSetup, TApplication, TFormsApplication>
        where TMvxUapSetup : MvxFormsWindowsSetup<TApplication, TFormsApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
         where TFormsApplication : Application, new()
         where THostPageType : MvxFormsWindowsPage
     {

--- a/MvvmCross/Base/MvxDictionaryExtensions.cs
+++ b/MvvmCross/Base/MvxDictionaryExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace MvvmCross.Platform.ExtensionMethods
+{
+	public static class MvxObjectExtensions
+	{
+		public static IDictionary<string, object> ToPropertyDictionary(this object input)
+		{
+			if (input == null)
+				return new Dictionary<string, object>();
+
+			if (input is IDictionary<string, object>)
+				return (IDictionary<string, object>)input;
+
+			var propertyInfos = from property in input.GetType()
+													  .GetProperties(BindingFlags.Instance | BindingFlags.Public |
+																	 BindingFlags.FlattenHierarchy)
+								where property.CanRead
+								select property;
+
+			var dictionary = new Dictionary<string, object>();
+			foreach (var propertyInfo in propertyInfos)
+			{
+				dictionary[propertyInfo.Name] = propertyInfo.GetValue(input);
+			}
+			return dictionary;
+		}
+	}
+}

--- a/MvvmCross/Base/MvxDictionaryExtensions.cs
+++ b/MvvmCross/Base/MvxDictionaryExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
-namespace MvvmCross.Platform.ExtensionMethods
+namespace MvvmCross.Base
 {
-	public static class MvxObjectExtensions
-	{
+	public static class MvxDictionaryExtensions
+    {
 		public static IDictionary<string, object> ToPropertyDictionary(this object input)
 		{
 			if (input == null)

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -293,8 +293,6 @@ namespace MvvmCross.Core
                     .Where(asmb=> AssemblyReferencesMvvmCross(asmb, mvvmCrossAssemblyName));
 
             return pluginAssemblies;
-
-
         }
 
         protected virtual IEnumerable<Assembly> LoadAllReferencedAssemblies(Assembly assembly)
@@ -304,7 +302,7 @@ namespace MvvmCross.Core
             return loadedAssemblies;
         }
 
-        private static void LoadReferencedAssemblies(Assembly assembly, ISet<Assembly> loadedAssemblies)
+        private stat void LoadReferencedAssemblies(Assembly assembly, ISet<Assembly> loadedAssemblies)
         {
             foreach (var referencedAssembly in assembly.GetReferencedAssemblies())
             {

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -302,7 +302,7 @@ namespace MvvmCross.Core
             return loadedAssemblies;
         }
 
-        private stat void LoadReferencedAssemblies(Assembly assembly, ISet<Assembly> loadedAssemblies)
+        private void LoadReferencedAssemblies(Assembly assembly, ISet<Assembly> loadedAssemblies)
         {
             foreach (var referencedAssembly in assembly.GetReferencedAssemblies())
             {

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -291,12 +291,23 @@ namespace MvvmCross.Core
                 AppDomain.CurrentDomain
                     .GetAssemblies()
                     .AsParallel()
-                    .Where(AssemblyReferencesMvvmCross);
+                    .Where(asmb=> AssemblyReferencesMvvmCross(asmb, mvvmCrossAssemblyName));
 
             return pluginAssemblies;
 
-            bool AssemblyReferencesMvvmCross(Assembly assembly)
-                => assembly.GetReferencedAssemblies().Any(a => a.Name == mvvmCrossAssemblyName);
+
+        }
+
+        private bool AssemblyReferencesMvvmCross(Assembly assembly, string mvvmCrossAssemblyName)
+        {
+            try
+            {
+                return assembly.GetReferencedAssemblies().Any(a => a.Name == mvvmCrossAssemblyName);
+            }
+            catch(Exception ex)
+            {
+                return true;
+            }
         }
 
         public virtual void LoadPlugins(IMvxPluginManager pluginManager)

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -484,9 +484,9 @@ namespace MvvmCross.Core
     }
 
     public abstract class MvxSetup<TApplication> : MvxSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Exceptions/MvxException.cs
+++ b/MvvmCross/Exceptions/MvxException.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace MvvmCross.Exceptions
 {
-    // Officially exception should support serialisation, but we don't add it here - mainly because of
-    // serialization limits in PCLs
+    [Serializable]
     public class MvxException : Exception
     {
         public MvxException()
@@ -30,5 +30,13 @@ namespace MvvmCross.Exceptions
             : base(string.Format(messageFormat, formatArguments), innerException)
         {
         }
+
+        public MvxException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected MvxException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }        
     }
 }

--- a/MvvmCross/Exceptions/MvxIoCResolveException.cs
+++ b/MvvmCross/Exceptions/MvxIoCResolveException.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace MvvmCross.Exceptions
 {
-    // Officially exception should support serialisation, but we don't add it here - mainly because of
-    // serialization limits in PCLs
+    [Serializable]
     public class MvxIoCResolveException : MvxException
     {
         public MvxIoCResolveException()
@@ -30,5 +30,13 @@ namespace MvvmCross.Exceptions
             : base(innerException, messageFormat, formatArguments)
         {
         }
+
+        public MvxIoCResolveException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected MvxIoCResolveException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }        
     }
 }

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -19,6 +19,11 @@ namespace MvvmCross.IoC
 
         object Resolve(Type type);
 
+        bool TryResolve<T>(out T resolved)
+            where T : class;
+
+        bool TryResolve(Type type, out object resolved);
+
         T Create<T>()
             where T : class;
 
@@ -28,11 +33,6 @@ namespace MvvmCross.IoC
             where T : class;
 
         object GetSingleton(Type type);
-
-        bool TryResolve<T>(out T resolved)
-            where T : class;
-
-        bool TryResolve(Type type, out object resolved);
 
         void RegisterType<TFrom, TTo>()
             where TFrom : class
@@ -67,7 +67,9 @@ namespace MvvmCross.IoC
         T IoCConstruct<T>(params object[] arguments)
             where T : class;
 
-        object IoCConstruct(Type type, IDictionary<string, object> arguments = null);
+        object IoCConstruct(Type type);
+
+        object IoCConstruct(Type type, IDictionary<string, object> arguments);
 
         object IoCConstruct(Type type, object arguments);
 

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -58,17 +58,20 @@ namespace MvvmCross.IoC
         T IoCConstruct<T>()
             where T : class;
 
-        object IoCConstruct(Type type);
-
         T IoCConstruct<T>(IDictionary<string, object> arguments)
             where T : class;
 
         T IoCConstruct<T>(object arguments)
             where T : class;
 
-        object IoCConstruct(Type type, IDictionary<string, object> arguments);
+        T IoCConstruct<T>(params object[] arguments)
+            where T : class;
+
+        object IoCConstruct(Type type, IDictionary<string, object> arguments = null);
 
         object IoCConstruct(Type type, object arguments);
+
+        object IoCConstruct(Type type, params object[] arguments);
 
         void CallbackWhenRegistered<T>(Action action);
 

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 namespace MvvmCross.IoC
 {
@@ -58,6 +59,16 @@ namespace MvvmCross.IoC
             where T : class;
 
         object IoCConstruct(Type type);
+
+        T IoCConstruct<T>(IDictionary<string, object> arguments)
+            where T : class;
+
+        T IoCConstruct<T>(object arguments)
+            where T : class;
+
+        object IoCConstruct(Type type, IDictionary<string, object> arguments);
+
+        object IoCConstruct(Type type, object arguments);
 
         void CallbackWhenRegistered<T>(Action action);
 

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -398,7 +398,7 @@ namespace MvvmCross.IoC
             return IoCConstruct(type, selectedConstructor, arguments);
         }
 
-        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments= null)
+        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments = null)
         {
             var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public);
             var firstConstructor = constructors.FirstOrDefault();
@@ -407,7 +407,7 @@ namespace MvvmCross.IoC
                 throw new MvxIoCResolveException("Failed to find constructor for type {0}", type.FullName);
 
             var parameters = GetIoCParameterValues(type, firstConstructor, arguments);
-            return IoCConstruct(type, firstConstructor, arguments.ToArray());
+            return IoCConstruct(type, firstConstructor, parameters.ToArray());
         }
 
         protected virtual object IoCConstruct(Type type, ConstructorInfo constructor, object[] arguments)

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -358,6 +358,11 @@ namespace MvvmCross.IoC
             InternalSetResolver(interfaceType, new ConstructingSingletonResolver(theConstructor));
         }
 
+        public object IoCConstruct(Type type)
+        {
+            return IoCConstruct(type, default(IDictionary<string, object>));
+        }
+
         public T IoCConstruct<T>()
             where T : class
         {
@@ -398,7 +403,7 @@ namespace MvvmCross.IoC
             return IoCConstruct(type, selectedConstructor, arguments);
         }
 
-        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments = null)
+        public virtual object IoCConstruct(Type type, IDictionary<string, object> arguments)
         {
             var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public);
             var firstConstructor = constructors.FirstOrDefault();

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -349,8 +349,7 @@ namespace MvvmCross.IoC
         public void RegisterSingleton<TInterface>(Func<TInterface> theConstructor)
             where TInterface : class
         {
-#warning when the MonoTouch/Droid code fully supports CoVariance (Contra?) then we can change this)
-            RegisterSingleton(typeof(TInterface), () => (object)theConstructor());
+            RegisterSingleton(typeof(TInterface), theConstructor);
         }
 
         public void RegisterSingleton(Type interfaceType, Func<object> theConstructor)

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -41,5 +41,16 @@ namespace MvvmCross.IoC
         {
             ioc.RegisterSingleton(type, constructor);
         }
+
+        public static void RegisterType<TType>(this IMvxIoCProvider ioc)
+            where TType : class
+        {
+            ioc.RegisterType<TType, TType>();
+        }
+
+        public static void RegisterType(this IMvxIoCProvider ioc, Type tType)
+        {
+            ioc.RegisterType(tType, tType);
+        }
     }
 }

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MvvmCross.IoC
+{
+    public static class MvxIoCContainerExtensions
+    {
+        public static void CallbackWhenRegistered<T>(this IMvxIoCProvider ioc, Action<T> action)
+            where T : class
+        {
+            Action simpleAction = () =>
+            {
+                var t = ioc.Resolve<T>();
+                action(t);
+            };
+            ioc.CallbackWhenRegistered<T>(simpleAction);
+        }
+
+        public static void ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            ioc.RegisterSingleton<TInterface>(ioc.IoCConstruct<TType>());
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            ioc.RegisterSingleton<TInterface>(() => ioc.IoCConstruct<TType>());
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface>(this IMvxIoCProvider ioc, Func<TInterface> constructor)
+            where TInterface : class
+        {
+            ioc.RegisterSingleton<TInterface>(constructor);
+        }
+
+        public static void LazyConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, Func<object> constructor)
+        {
+            ioc.RegisterSingleton(type, constructor);
+        }
+    }
+}

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -163,7 +163,7 @@ namespace MvvmCross.IoC
             return _provider.IoCConstruct<T>(arguments);
         }
 
-        public object IoCConstruct(Type type, IDictionary<string, object> arguments)
+        public object IoCConstruct(Type type, IDictionary<string, object> arguments = null)
         {
             return _provider.IoCConstruct(type, arguments);
         }

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -153,6 +153,11 @@ namespace MvvmCross.IoC
             return _provider.IoCConstruct<T>(arguments);
         }
 
+        public T IoCConstruct<T>(params object[] arguments) where T : class
+        {
+            return _provider.IoCConstruct<T>(arguments);
+        }
+
         public T IoCConstruct<T>(object arguments) where T : class
         {
             return _provider.IoCConstruct<T>(arguments);
@@ -164,6 +169,11 @@ namespace MvvmCross.IoC
         }
 
         public object IoCConstruct(Type type, object arguments)
+        {
+            return _provider.IoCConstruct(type, arguments);
+        }
+
+        public object IoCConstruct(Type type, params object[] arguments)
         {
             return _provider.IoCConstruct(type, arguments);
         }

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using MvvmCross.Base;
 
 namespace MvvmCross.IoC
@@ -145,6 +146,26 @@ namespace MvvmCross.IoC
         public virtual object IoCConstruct(Type type)
         {
             return _provider.IoCConstruct(type);
+        }
+
+        public T IoCConstruct<T>(IDictionary<string, object> arguments) where T : class
+        {
+            return _provider.IoCConstruct<T>(arguments);
+        }
+
+        public T IoCConstruct<T>(object arguments) where T : class
+        {
+            return _provider.IoCConstruct<T>(arguments);
+        }
+
+        public object IoCConstruct(Type type, IDictionary<string, object> arguments)
+        {
+            return _provider.IoCConstruct(type, arguments);
+        }
+
+        public object IoCConstruct(Type type, object arguments)
+        {
+            return _provider.IoCConstruct(type, arguments);
         }
 
         public void CallbackWhenRegistered<T>(Action action)

--- a/MvvmCross/IoC/MvxLazySingletonCreator.cs
+++ b/MvvmCross/IoC/MvxLazySingletonCreator.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.IoC
 
                 lock (_lockObject)
                 {
-                    _instance = _instance ?? Mvx.IocConstruct(_type);
+                    _instance = _instance ?? Mvx.IoCConstruct(_type);
                     return _instance;
                 }
             }

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -170,7 +170,7 @@ namespace MvvmCross.IoC
                 if (!pair.ServiceTypes.Any())
                     continue;
 
-                var instance = Mvx.IocConstruct(pair.ImplementationType);
+                var instance = Mvx.IoCConstruct(pair.ImplementationType);
                 foreach (var serviceType in pair.ServiceTypes)
                 {
                     Mvx.RegisterSingleton(serviceType, instance);

--- a/MvvmCross/Mvx.cs
+++ b/MvvmCross/Mvx.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using MvvmCross.Base;
 using MvvmCross.IoC;
 
@@ -63,6 +64,12 @@ namespace MvvmCross
             return ioc.Create<T>();
         }
 
+        public static object Create(Type type)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.Create(type);
+        }
+
         public static T GetSingleton<T>()
             where T : class
         {
@@ -70,59 +77,10 @@ namespace MvvmCross
             return ioc.GetSingleton<T>();
         }
 
-        public static void RegisterSingleton<TInterface>(Func<TInterface> serviceConstructor)
-            where TInterface : class
+        public static object GetSingleton(Type type)
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(serviceConstructor);
-        }
-
-        public static void RegisterSingleton(Type tInterface, Func<object> serviceConstructor)
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(tInterface, serviceConstructor);
-        }
-
-        public static void RegisterSingleton<TInterface>(TInterface service)
-            where TInterface : class
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(service);
-        }
-
-        public static void RegisterSingleton(Type tInterface, object service)
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(tInterface, service);
-        }
-
-        public static void ConstructAndRegisterSingleton<TInterface, TType>()
-            where TInterface : class
-            where TType : TInterface
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton<TInterface>(IocConstruct<TType>());
-        }
-
-        public static void LazyConstructAndRegisterSingleton<TInterface, TType>()
-            where TInterface : class
-            where TType : TInterface
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton<TInterface>(() => IocConstruct<TType>());
-        }
-
-        public static void LazyConstructAndRegisterSingleton<TInterface>(Func<TInterface> constructor)
-            where TInterface : class
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton<TInterface>(constructor);
-        }
-
-        public static void LazyConstructAndRegisterSingleton(Type type, Func<object> constructor)
-        {
-            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            ioc.RegisterSingleton(type, constructor);
+            return ioc.GetSingleton(type);
         }
 
         public static void RegisterType<TInterface, TType>()
@@ -152,29 +110,91 @@ namespace MvvmCross
             ioc.RegisterType(tInterface, tType);
         }
 
-        public static T IocConstruct<T>()
+        public static void RegisterSingleton<TInterface>(Func<TInterface> serviceConstructor)
+            where TInterface : class
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            return (T)ioc.IoCConstruct(typeof(T));
+            ioc.RegisterSingleton(serviceConstructor);
         }
 
-        public static object IocConstruct(Type t)
+        public static void RegisterSingleton(Type tInterface, Func<object> serviceConstructor)
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
-            return ioc.IoCConstruct(t);
+            ioc.RegisterSingleton(tInterface, serviceConstructor);
+        }
+
+        public static void RegisterSingleton<TInterface>(TInterface service)
+            where TInterface : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterSingleton(service);
+        }
+
+        public static void RegisterSingleton(Type tInterface, object service)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterSingleton(tInterface, service);
+        }
+
+        public static T IoCConstruct<T>()
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>();
+        }
+
+        public static T IoCConstruct<T>(IDictionary<string, object> arguments)
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>(arguments);
+        }
+
+        public static T IoCConstruct<T>(object arguments)
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>(arguments);
+        }
+
+        public static T IoCConstruct<T>(params object[] arguments)
+            where T : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct<T>(arguments);
+        }
+
+        public static object IoCConstruct(Type type)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type);
+        }
+
+        public static object IoCConstruct(Type type, IDictionary<string, object> arguments)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type, arguments);
+        }
+
+        public static object IoCConstruct(Type type, object arguments)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type, arguments);
+        }
+
+        public static object IoCConstruct(Type type, params object[] arguments)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.IoCConstruct(type, arguments);
         }
 
         public static void CallbackWhenRegistered<T>(Action<T> action)
             where T : class
         {
-            Action simpleAction = () =>
-                {
-                    var t = Resolve<T>();
-                    action(t);
-                };
-            CallbackWhenRegistered<T>(simpleAction);
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.CallbackWhenRegistered<T>(action);
         }
-        
+
         public static void CallbackWhenRegistered<T>(Action action)
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
@@ -185,6 +205,41 @@ namespace MvvmCross
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
             ioc.CallbackWhenRegistered(type, action);
+        }
+
+        public static void ConstructAndRegisterSingleton<TInterface, TType>()
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.ConstructAndRegisterSingleton<TInterface, TType>();
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface, TType>()
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.LazyConstructAndRegisterSingleton<TInterface, TType>();
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface>(Func<TInterface> constructor)
+            where TInterface : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.LazyConstructAndRegisterSingleton<TInterface>(constructor);
+        }
+
+        public static void LazyConstructAndRegisterSingleton(Type type, Func<object> constructor)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.LazyConstructAndRegisterSingleton(type, constructor);
+        }
+
+        public static IMvxIoCProvider CreateChildContainer()
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            return ioc.CreateChildContainer();
         }
     }
 }

--- a/MvvmCross/Mvx.cs
+++ b/MvvmCross/Mvx.cs
@@ -83,6 +83,13 @@ namespace MvvmCross
             return ioc.GetSingleton(type);
         }
 
+        public static void RegisterType<TType>()
+            where TType : class
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterType<TType>();
+        }
+
         public static void RegisterType<TInterface, TType>()
             where TInterface : class
             where TType : class, TInterface
@@ -96,6 +103,12 @@ namespace MvvmCross
         {
             var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
             ioc.RegisterType(constructor);
+        }
+
+        public static void RegisterType(Type tType)
+        {
+            var ioc = MvxSingleton<IMvxIoCProvider>.Instance;
+            ioc.RegisterType(tType);
         }
 
         public static void RegisterType(Type type, Func<object> constructor)

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -151,7 +151,7 @@ namespace MvvmCross.Navigation
 
             if(viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
             {
-                var facade = (IMvxNavigationFacade)Mvx.IocConstruct(viewModelType);
+                var facade = (IMvxNavigationFacade)Mvx.IoCConstruct(viewModelType);
 
                 try
                 {
@@ -207,7 +207,7 @@ namespace MvvmCross.Navigation
 
             if(viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
             {
-                var facade = (IMvxNavigationFacade)Mvx.IocConstruct(viewModelType);
+                var facade = (IMvxNavigationFacade)Mvx.IoCConstruct(viewModelType);
 
                 try
                 {

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxTimePicker.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxTimePicker.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using Android.Content;
+using Android.OS;
 using Android.Runtime;
 using Android.Util;
 using Android.Widget;
@@ -39,7 +40,11 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         {
             get
             {
-                return new TimeSpan(Hour, Minute, 0);
+                if (Build.VERSION.SdkInt <= BuildVersionCodes.LollipopMr1)
+#pragma warning disable CS0618
+                    return new TimeSpan((int)CurrentHour, (int)CurrentMinute, 0);
+                else
+                    return new TimeSpan(Hour, Minute, 0);
             }
             set
             {
@@ -49,13 +54,28 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                     _initialized = true;
                 }
 
-                if (Hour != value.Hours)
+                if (Build.VERSION.SdkInt <= BuildVersionCodes.LollipopMr1)
                 {
-                    Hour = value.Hours;
+#pragma warning disable CS0618
+                    if ((int)CurrentHour != value.Hours)
+                    {
+                        CurrentHour = (Java.Lang.Integer)value.Hours;
+                    }
+                    if ((int)CurrentMinute != value.Minutes)
+                    {
+                        CurrentMinute = (Java.Lang.Integer)value.Minutes;
+                    }
                 }
-                if (Minute != value.Minutes)
+                else
                 {
-                    Minute = value.Minutes;
+                    if (Hour != value.Hours)
+                    {
+                        Hour = value.Hours;
+                    }
+                    if (Minute != value.Minutes)
+                    {
+                        Minute = value.Minutes;
+                    }
                 }
             }
         }

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -264,9 +264,9 @@ namespace MvvmCross.Platforms.Android.Core
     }
 
     public class MvxAndroidSetup<TApplication> : MvxAndroidSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidApplication.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidApplication.cs
@@ -34,7 +34,7 @@ namespace MvvmCross.Platforms.Android.Views
 
     public abstract class MvxAndroidApplication<TMvxAndroidSetup, TApplication> : MvxAndroidApplication
       where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
-      where TApplication : IMvxApplication, new()
+      where TApplication : class, IMvxApplication, new()
     {
         public MvxAndroidApplication() : base()
         {

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -91,7 +91,7 @@ namespace MvvmCross.Platforms.Android.Views
 
     public abstract class MvxSplashScreenActivity<TMvxAndroidSetup, TApplication> : MvxSplashScreenActivity
             where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
-            where TApplication : IMvxApplication, new()
+            where TApplication : class, IMvxApplication, new()
     {
         protected MvxSplashScreenActivity(int resourceId = NoContent) : base(resourceId)
         {

--- a/MvvmCross/Platforms/Console/Core/MvxConsoleSetup.cs
+++ b/MvvmCross/Platforms/Console/Core/MvxConsoleSetup.cs
@@ -51,9 +51,9 @@ namespace MvvmCross.Platforms.Console.Core
     }
 
     public class MvxConsoleSetup<TApplication> : MvxConsoleSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
@@ -79,7 +79,7 @@ namespace MvvmCross.Platforms.Ios.Core
 
     public abstract class MvxApplicationDelegate<TMvxIosSetup, TApplication> : MvxApplicationDelegate
        where TMvxIosSetup : MvxIosSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
@@ -171,9 +171,9 @@ namespace MvvmCross.Platforms.Ios.Core
     }
 
     public class MvxIosSetup<TApplication> : MvxIosSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -80,7 +80,7 @@ namespace MvvmCross.Platforms.Mac.Core
 
     public class MvxApplicationDelegate<TMvxMacSetup, TApplication> : MvxApplicationDelegate
    where TMvxMacSetup : MvxMacSetup<TApplication>, new()
-   where TApplication : IMvxApplication, new()
+   where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
@@ -177,9 +177,9 @@ namespace MvvmCross.Platforms.Mac.Core
     }
 
     public class MvxMacSetup<TApplication> : MvxMacSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Platforms.Tvos.Core
 
     public abstract class MvxApplicationDelegate<TMvxTvosSetup, TApplication> : MvxApplicationDelegate
        where TMvxTvosSetup : MvxTvosSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
@@ -174,9 +174,9 @@ namespace MvvmCross.Platforms.Tvos.Core
     }
 
     public class MvxTvosSetup<TApplication> : MvxTvosSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
@@ -187,13 +187,13 @@ namespace MvvmCross.Platforms.Uap.Core
     }
 
     public class MvxWindowsSetup<TApplication> : MvxWindowsSetup
-         where TApplication : IMvxApplication, new()
+         where TApplication : class, IMvxApplication, new()
     {
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {
             return new[] { typeof(TApplication).GetTypeInfo().Assembly };
         }
 
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
     }
 }

--- a/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
@@ -152,7 +152,7 @@ namespace MvvmCross.Platforms.Uap.Views
 
     public class MvxApplication<TMvxUapSetup, TApplication> : MvxApplication
        where TMvxUapSetup : MvxWindowsSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -1,15 +1,17 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
+using System.Linq;
 using MvvmCross.Platforms.Uap.Views.Suspension;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace MvvmCross.Platforms.Uap.Views
 {
@@ -68,12 +70,18 @@ namespace MvvmCross.Platforms.Uap.Views
 
         public void ClearBackStack()
         {
-            throw new NotImplementedException();
-            /*
-            // note - we do *not* use CanGoBack here - as that seems to always returns true!
-            while (NavigationService.BackStack.Any())
-                NavigationService.RemoveBackEntry();
-         */
+            var backStack = base.Frame?.BackStack;
+
+            if (backStack != null)
+            {
+                while (backStack.Any())
+                {
+                    backStack.RemoveAt(0);
+                }
+            }
+
+            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
         }
 
         private string _reqData = string.Empty;

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -68,18 +68,20 @@ namespace MvvmCross.Platforms.Uap.Views
             }
         }
 
-        public void ClearBackStack()
+        public virtual void ClearBackStack()
         {
             var backStack = base.Frame?.BackStack;
 
-            if (backStack != null)
+            while (backStack?.Any())
             {
-                while (backStack.Any())
-                {
-                    backStack.RemoveAt(0);
-                }
+                backStack.RemoveAt(0);
             }
 
+            UpdateBackButtonVisibility();
+        }
+        
+        protected virtual void UpdateBackButtonVisibility()
+        {
             SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
         }
 

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -81,7 +81,6 @@ namespace MvvmCross.Platforms.Uap.Views
             }
 
             SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
-
         }
 
         private string _reqData = string.Empty;

--- a/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
+++ b/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
@@ -91,9 +91,9 @@ namespace MvvmCross.Platforms.Wpf.Core
     }
 
     public class MvxWpfSetup<TApplication> : MvxWpfSetup
-        where TApplication : IMvxApplication, new()
+        where TApplication : class, IMvxApplication, new()
     {
-        protected override IMvxApplication CreateApp() => Mvx.IocConstruct<TApplication>();
+        protected override IMvxApplication CreateApp() => Mvx.IoCConstruct<TApplication>();
 
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {

--- a/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
@@ -40,7 +40,7 @@ namespace MvvmCross.Platforms.Wpf.Views
 
     public class MvxApplication<TMvxWpfSetup, TApplication> : MvxApplication
        where TMvxWpfSetup : MvxWpfSetup<TApplication>, new()
-       where TApplication : IMvxApplication, new()
+       where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -66,7 +66,7 @@ namespace MvvmCross.ViewModels
         }
 
         protected void RegisterCustomAppStart<TMvxAppStart>()
-            where TMvxAppStart : IMvxAppStart
+            where TMvxAppStart : class, IMvxAppStart
         {
             Mvx.ConstructAndRegisterSingleton<IMvxAppStart, TMvxAppStart>();
         }

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -36,7 +36,7 @@ namespace MvvmCross.ViewModels
             IMvxViewModel viewModel;
             try
             {
-                viewModel = (IMvxViewModel)Mvx.IocConstruct(viewModelType);
+                viewModel = (IMvxViewModel)Mvx.IoCConstruct(viewModelType);
             }
             catch(Exception exception)
             {
@@ -56,7 +56,7 @@ namespace MvvmCross.ViewModels
             IMvxViewModel<TParameter> viewModel;
             try
             {
-                viewModel = (IMvxViewModel<TParameter>)Mvx.IocConstruct(viewModelType);
+                viewModel = (IMvxViewModel<TParameter>)Mvx.IoCConstruct(viewModelType);
             }
             catch(Exception exception)
             {

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SplashScreen.cs" />
     <Compile Include="Setup.cs" />
+    <Compile Include="Views\Base\BaseSplitDetailView.cs" />
     <Compile Include="Views\CollectionView.cs" />
     <Compile Include="Views\DictionaryBindingView.cs" />
     <Compile Include="Views\RootView.cs" />
@@ -107,6 +108,9 @@
       <SubType>Designer</SubType>
     </AndroidResource>
     <AndroidResource Include="Resources\layout\ItemListSharedElementsTemplate.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include="Resources\layout\SplitDetailNavView.axml">
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>

--- a/Projects/Playground/Playground.Droid/Resources/layout/SplitDetailNavView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/SplitDetailNavView.axml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#880000">
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+      <android.support.v7.widget.Toolbar
+          android:id="@+id/toolbar"
+          android:layout_width="match_parent"
+          android:layout_height="?attr/actionBarSize"
+          android:background="?attr/colorPrimary"
+          local:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+    </android.support.design.widget.AppBarLayout>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="I'm a detail navigation page" />
+    <Button
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:text="Main Menu"
+        local:MvxBind="Click MainMenuCommand" />
+    <Button
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:text="Close"
+        local:MvxBind="Click CloseCommand" />
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/values/styles.xml
+++ b/Projects/Playground/Playground.Droid/Resources/values/styles.xml
@@ -35,5 +35,6 @@
 		parent="AppTheme.Base">
 		<item name="android:statusBarColor">@color/colorPrimaryDark</item>
 		<item name="android:windowNoTitle">true</item>
+    <item name="android:windowBackground">@color/colorAccent</item>
 	</style>
 </resources>

--- a/Projects/Playground/Playground.Droid/Resources/values/styles.xml
+++ b/Projects/Playground/Playground.Droid/Resources/values/styles.xml
@@ -35,6 +35,6 @@
 		parent="AppTheme.Base">
 		<item name="android:statusBarColor">@color/colorPrimaryDark</item>
 		<item name="android:windowNoTitle">true</item>
-    <item name="android:windowBackground">@color/colorAccent</item>
+		<item name="android:windowBackground">@color/colorAccent</item>
 	</style>
 </resources>

--- a/Projects/Playground/Playground.Droid/Views/Base/BaseSplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Views/Base/BaseSplitDetailView.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.Content.Res;
+using Android.OS;
+using Android.Support.V7.Widget;
+using Android.Views;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.ViewModels;
+
+namespace Playground.Droid.Views.Base
+{
+    public abstract class BaseSplitDetailView<TViewModel> : MvxFragment<TViewModel> where TViewModel : class, IMvxViewModel
+    {
+        protected SplitRootView BaseActivity => (SplitRootView)Activity;
+        protected Toolbar _toolbar;
+        protected MvxActionBarDrawerToggle _drawerToggle;
+
+        protected abstract int FragmentLayoutId { get; }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(FragmentLayoutId, null);
+
+            _toolbar = view.FindViewById<Toolbar>(Resource.Id.toolbar);
+            if (_toolbar != null)
+            {
+                BaseActivity.SetSupportActionBar(_toolbar);
+                BaseActivity.SupportActionBar.SetDisplayHomeAsUpEnabled(true);
+
+                _drawerToggle = new MvxActionBarDrawerToggle(
+                    Activity,                               // host Activity
+                    BaseActivity.DrawerLayout,              // DrawerLayout object
+                    _toolbar,                               // nav drawer icon to replace 'Up' caret
+                    Resource.String.drawer_open,            // "open drawer" description
+                    Resource.String.drawer_close            // "close drawer" description
+                );
+                BaseActivity.DrawerLayout.AddDrawerListener(_drawerToggle);
+                _drawerToggle.DrawerIndicatorEnabled = true;
+            }
+
+            return view;
+        }
+
+        public override void OnConfigurationChanged(Configuration newConfig)
+        {
+            base.OnConfigurationChanged(newConfig);
+            if (_toolbar != null)
+                _drawerToggle.OnConfigurationChanged(newConfig);
+        }
+
+        public override void OnActivityCreated(Bundle savedInstanceState)
+        {
+            base.OnActivityCreated(savedInstanceState);
+            if (_toolbar != null)
+                _drawerToggle.SyncState();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Views/SplitDetailNavView.cs
+++ b/Projects/Playground/Playground.Droid/Views/SplitDetailNavView.cs
@@ -2,27 +2,17 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
 using Android.Runtime;
-using Android.Views;
-using MvvmCross.Droid.Support.V4;
-using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
+using Playground.Droid.Views.Base;
 
 namespace Playground.Droid.Views
 {
-    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
+    [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame, AddToBackStack = true)]
     [Register(nameof(SplitDetailNavView))]
-    public class SplitDetailNavView : MvxFragment<SplitDetailNavViewModel>
+    public class SplitDetailNavView : BaseSplitDetailView<SplitDetailNavViewModel>
     {
-        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
-        {
-            base.OnCreateView(inflater, container, savedInstanceState);
-
-            var view = this.BindingInflate(Resource.Layout.SplitDetailView, null);
-
-            return view;
-        }
+        protected override int FragmentLayoutId => Resource.Layout.SplitDetailNavView;
     }
 }

--- a/Projects/Playground/Playground.Droid/Views/SplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Views/SplitDetailView.cs
@@ -2,66 +2,17 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.Content.Res;
-using Android.OS;
 using Android.Runtime;
-using Android.Support.V7.Widget;
-using Android.Views;
-using MvvmCross.Droid.Support.V4;
-using MvvmCross.Droid.Support.V7.AppCompat;
-using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
+using Playground.Droid.Views.Base;
 
 namespace Playground.Droid.Views
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
     [Register(nameof(SplitDetailView))]
-    public class SplitDetailView : MvxFragment<SplitDetailViewModel>
+    public class SplitDetailView : BaseSplitDetailView<SplitDetailViewModel>
     {
-        public SplitRootView BaseActivity => (SplitRootView)Activity;
-
-        private Toolbar _toolbar;
-        private MvxActionBarDrawerToggle _drawerToggle;
-
-        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
-        {
-            base.OnCreateView(inflater, container, savedInstanceState);
-
-            var view = this.BindingInflate(Resource.Layout.SplitDetailView, null);
-
-            _toolbar = view.FindViewById<Toolbar>(Resource.Id.toolbar);
-            if (_toolbar != null)
-            {
-                BaseActivity.SetSupportActionBar(_toolbar);
-                BaseActivity.SupportActionBar.SetDisplayHomeAsUpEnabled(true);
-
-                _drawerToggle = new MvxActionBarDrawerToggle(
-                    Activity,                               // host Activity
-                    BaseActivity.DrawerLayout,  // DrawerLayout object
-                    _toolbar,                               // nav drawer icon to replace 'Up' caret
-                    Resource.String.drawer_open,            // "open drawer" description
-                    Resource.String.drawer_close            // "close drawer" description
-                );
-                BaseActivity.DrawerLayout.AddDrawerListener(_drawerToggle);
-                _drawerToggle.DrawerIndicatorEnabled = true;
-            }
-
-            return view;
-        }
-
-        public override void OnConfigurationChanged(Configuration newConfig)
-        {
-            base.OnConfigurationChanged(newConfig);
-            if (_toolbar != null)
-                _drawerToggle.OnConfigurationChanged(newConfig);
-        }
-
-        public override void OnActivityCreated(Bundle savedInstanceState)
-        {
-            base.OnActivityCreated(savedInstanceState);
-            if (_toolbar != null)
-                _drawerToggle.SyncState();
-        }
+        protected override int FragmentLayoutId => Resource.Layout.SplitDetailView;
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -562,6 +562,21 @@ namespace MvvmCross.UnitTest.Base
             Assert.Equal(enabled, d.Enabled);
         }
 
+        [Fact]
+        public void IocConstruct_WithMultipleTypedArguments_ThrowsFailedToFindCtor()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var subtitle = "The subtitle";
+            var enabled = true;
+
+            Assert.Throws<MvxIoCResolveException>(() => {
+                var d = instance.IoCConstruct<D>(title, subtitle, enabled);
+            });
+        }
+
         // TODO - there are so many tests we could and should do here!
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -90,12 +90,21 @@ namespace MvvmCross.UnitTest.Base
             public string Title { get; }
             public string Subtitle { get; }
             public string Description { get; }
+            public int Amount { get; }
+            public bool Enabled { get; }
 
             public D(string title, string subtitle, string description)
             {
                 Title = title;
                 Subtitle = subtitle;
                 Description = description;
+            }
+
+            public D(string title, int amount, bool enabled)
+            {
+                Title = title;
+                Amount = amount;
+                Enabled = enabled;
             }
         }
 
@@ -534,6 +543,23 @@ namespace MvvmCross.UnitTest.Base
             Assert.Equal(title, d.Title);
             Assert.Equal(subtitle, d.Subtitle);
             Assert.Equal(description, d.Description);
+        }
+
+        [Fact]
+        public void IocConstruct_WithMultipleTypedArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var amount = 5;
+            var enabled = true;
+
+            var d = instance.IoCConstruct<D>(title, amount, enabled);
+
+            Assert.Equal(title, d.Title);
+            Assert.Equal(amount, d.Amount);
+            Assert.Equal(enabled, d.Enabled);
         }
 
         // TODO - there are so many tests we could and should do here!

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -85,6 +85,20 @@ namespace MvvmCross.UnitTest.Base
             }
         }
 
+        public class D
+        {
+            public string Title { get; }
+            public string Subtitle { get; }
+            public string Description { get; }
+
+            public D(string title, string subtitle, string description)
+            {
+                Title = title;
+                Subtitle = subtitle;
+                Description = description;
+            }
+        }
+
         public class COdd : IC
         {
             public static bool FirstTime = true;
@@ -456,6 +470,71 @@ namespace MvvmCross.UnitTest.Base
         }
 
         #endregion
+
+        [Fact]
+        public void IocConstruct_WithDictionaryArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var c = new C2();
+            var arguments = new Dictionary<string, object>
+            {
+                ["c"] = c
+            };
+            instance.IoCConstruct<B>(arguments);
+        }
+
+        [Fact]
+        public void IocConstruct_WithAnonymousTypeArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var c = new C2();
+            instance.IoCConstruct<B>(new { c });
+        }
+
+        [Fact]
+        public void IocConstruct_WithMultipleDictionaryArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var subtitle = "The subtitle";
+            var description = "The description";
+
+            var arguments = new Dictionary<string, object>
+            {
+                ["title"] = title,
+                ["subtitle"] = subtitle,
+                ["description"] = description
+            };
+            var d = instance.IoCConstruct<D>(arguments);
+
+            Assert.Equal(title, d.Title);
+            Assert.Equal(subtitle, d.Subtitle);
+            Assert.Equal(description, d.Description);
+        }
+
+        [Fact]
+        public void IocConstruct_WithMultipleAnonymousArguments_CreatesObject()
+        {
+            MvxSingleton.ClearAllSingletons();
+            var instance = MvxIoCProvider.Initialize();
+
+            var title = "The title";
+            var subtitle = "The subtitle";
+            var description = "The description";
+
+            var arguments = new { title, subtitle, description };
+            var d = instance.IoCConstruct<D>(arguments);
+
+            Assert.Equal(title, d.Title);
+            Assert.Equal(subtitle, d.Subtitle);
+            Assert.Equal(description, d.Description);
+        }
 
         // TODO - there are so many tests we could and should do here!
     }

--- a/build.cake
+++ b/build.cake
@@ -121,6 +121,7 @@ Task("Build")
     var buildItems = new string[] 
     {
         "./MvvmCross/MvvmCross.csproj",
+        "./MvvmCross/MvvmCross.Platforms.Wpf.csproj",
         "./MvvmCross.Android.Support/Fragment/MvvmCross.Droid.Support.Fragment.csproj",
         "./MvvmCross.Android.Support/Design/MvvmCross.Droid.Support.Design.csproj",
         "./MvvmCross.Android.Support/Core.Utils/MvvmCross.Droid.Support.Core.Utils.csproj",

--- a/docs/_documentation/fundamentals/view-presenters.md
+++ b/docs/_documentation/fundamentals/view-presenters.md
@@ -97,11 +97,11 @@ To add your own `MvxPresentationHint` you should follow these steps:
     }
     ```
 
-2. Override the method `CreatePresenter()` in the Setup class and register your custom hint in it. For example, on iOS:
+2. Override the method `CreateViewPresenter()` in the Setup class and register your custom hint in it. For example, on iOS:
     ```c#
-    protected override IMvxIosViewPresenter CreatePresenter()
+    protected override IMvxIosViewPresenter CreateViewPresenter()
     {
-        var presenter = base.CreatePresenter();
+        var presenter = base.CreateViewPresenter();
         presenter.AddPresentationHintHandler<MyCustomHint>(hint => HandleMyCustomHint(hint));
         return presenter;
     }
@@ -121,13 +121,13 @@ To add your own `MvxPresentationHint` you should follow these steps:
     ```
     **Now repeat steps 2 and 3 for each platform (if a platform should just ignore the MvxPresentationHint, it's not necessary to do anything).**
 
-4. Finally, make a call to the ChangePresentation method from a MvxViewModel or a MvxNavigatingObject when necessary:
+4. Finally, make a call to the ChangePresentation method from the IMvxNavigationService when necessary:
     ```c#
-    private void AMethod()
+    private async Task AMethodAsync()
     {
         // your code
 
-        ChangePresentation(new MyCustomHint("example"));
+        bool handled = await mvxNavigationService.ChangePresentation(new MyCustomHint("example"));
 
         // your code
     }

--- a/docs/_documentation/fundamentals/viewmodel-lifecycle.md
+++ b/docs/_documentation/fundamentals/viewmodel-lifecycle.md
@@ -190,7 +190,7 @@ There has been a thread going on on the [Xamarin forums](https://forums.xamarin.
 
 |           | Appearing             | Appeared       | Disappearing         | Disappeared | 
 | iOS       | ViewWillAppear        | ViewDidAppear  | ViewWillDisappear    | ViewDidDisappear | 
-| Android   | OnAttachedToWindow    | OnGlobalLayout | OnPause              | OnDetachedToWindow | 
+| Android   | OnAttachedToWindow    | OnGlobalLayout | OnPause              | OnDetachedFromWindow | 
 | UWP       | Loading               | OnLoaded       | Unloaded             | OnUnloaded |    
 
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes cases of plugin usage in core assembly with no explicit reference on the entry point assembly.
This makes MvxSetup load all referenced assemblies in the entry point referenced assemblies.
Fixes cases where in WPF as an example, we don't need to have a LinkerPleaseIncludeFile and also have no need to create an instance or static reference to a Plugin.

### :arrow_heading_down: What is the current behavior?
If you use a plugin in a WPF project as an example you have to create a strong reference to a Plugin type so that the plugin assembly can be loaded in AppDomain.

### :new: What is the new behavior (if this is a feature change)?
Now you don't need a strong reference, because you probably already have it in your Core project, so MvxSetup will look for plugins in the core project references as well.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Running any plugin in all projects without having a strong reference type to any type in plugin assembly.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X ] All projects build
- [ X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X ] Rebased onto current develop
