### PR TITLE
Added recursive method to search for referenced assemblies and load t…

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -286,16 +286,32 @@ namespace MvvmCross.Core
         public virtual IEnumerable<Assembly> GetPluginAssemblies()
         {
             var mvvmCrossAssemblyName = typeof(MvxPluginAttribute).Assembly.GetName().Name;
-
+            var allAssemblies = LoadAllReferencedAssemblies(Assembly.GetExecutingAssembly());
             var pluginAssemblies =
-                AppDomain.CurrentDomain
-                    .GetAssemblies()
+                allAssemblies
                     .AsParallel()
                     .Where(asmb=> AssemblyReferencesMvvmCross(asmb, mvvmCrossAssemblyName));
 
             return pluginAssemblies;
+        }
 
+        protected virtual IEnumerable<Assembly> LoadAllReferencedAssemblies(Assembly assembly)
+        {
+            var loadedAssemblies = new HashSet<Assembly>();
+            LoadReferencedAssemblies(assembly, loadedAssemblies);
+            return loadedAssemblies;
+        }
 
+        private void LoadReferencedAssemblies(Assembly assembly, ISet<Assembly> loadedAssemblies)
+        {
+            foreach (var referencedAssembly in assembly.GetReferencedAssemblies())
+            {
+                var loadedAssembly = Assembly.Load(referencedAssembly);
+                if (loadedAssemblies.Add(loadedAssembly))
+                {
+                    LoadReferencedAssemblies(loadedAssembly, loadedAssemblies);
+                }
+            }
         }
 
         private bool AssemblyReferencesMvvmCross(Assembly assembly, string mvvmCrossAssemblyName)


### PR DESCRIPTION
Recreated based on 6.1.0

Plugin loading on references of core assemblies 

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes cases of plugin usage in core assembly with no explicit reference on the entry point assembly.
This makes MvxSetup load all referenced assemblies in the entry point referenced assemblies.
Fixes cases where in WPF as an example, we don't need to have a LinkerPleaseIncludeFile and also have no need to create an instance or static reference to a Plugin.

### :arrow_heading_down: What is the current behavior?
If you use a plugin in a WPF project as an example you have to create a strong reference to a Plugin type so that the plugin assembly can be loaded in AppDomain.

### :new: What is the new behavior (if this is a feature change)?
Now you don't need a strong reference, because you probably already have it in your Core project, so MvxSetup will look for plugins in the core project references as well.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Running any plugin in all projects without having a strong reference type to any type in plugin assembly.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
