### PR TITLE
Add support for async startup

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
@@ -76,12 +77,19 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             base.OnPause();
         }
 
-        public virtual void InitializationComplete()
+        public virtual async Task InitializationComplete()
         {
             if (!_isResumed)
                 return;
 
-            RunAppStart(_bundle);
+            await RunAppStartAsync(_bundle);
+        }
+
+        protected virtual async Task RunAppStartAsync(Bundle bundle)
+        {
+            var startup = Mvx.Resolve<IMvxAppStart>();
+            if (!startup.IsStarted)
+                await startup.StartAsync(GetAppStartHint(bundle));
         }
 
         protected virtual void RegisterSetup()

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -87,7 +87,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected virtual async Task RunAppStartAsync(Bundle bundle)
         {
-            var startup = Mvx.Resolve<IMvxAppStart>();
+            var startup = Mvx.IoCProvider.Resolve<IMvxAppStart>();
             if (!startup.IsStarted)
                 await startup.StartAsync(GetAppStartHint(bundle));
         }

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsSplashScreenActivity.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using MvvmCross.Core;
+using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Forms.Platforms.Android.Core;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
@@ -10,7 +11,7 @@ using Xamarin.Forms;
 
 namespace MvvmCross.Forms.Platforms.Android.Views
 {
-    public abstract class MvxFormsSplashScreenActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenActivity
+    public abstract class MvxFormsSplashScreenActivity<TMvxAndroidSetup, TApplication, TFormsApplication> : MvxSplashScreenAppCompatActivity
             where TMvxAndroidSetup : MvxFormsAndroidSetup<TApplication, TFormsApplication>, new()
             where TApplication : class, IMvxApplication, new()
             where TFormsApplication : Application, new()

--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -291,6 +291,7 @@ namespace MvvmCross.Forms.Presenters
                 MvxFormsLog.Instance.Trace(FormsApplication.Hierarchy());
             }
 #endif
+            }
         }
 
         protected virtual bool RemoveByViewModel(INavigation navigation, Type viewModelToRemove)
@@ -367,6 +368,7 @@ namespace MvvmCross.Forms.Presenters
                 MvxFormsLog.Instance.Trace(FormsApplication.Hierarchy());
             }
 #endif
+            }
         }
 
         public virtual async Task<bool> ShowCarouselPage(
@@ -402,7 +404,7 @@ namespace MvvmCross.Forms.Presenters
         public virtual Task<bool> CloseCarouselPage(IMvxViewModel viewModel, MvxCarouselPagePresentationAttribute attribute)
         {
             if (attribute.Position == CarouselPosition.Root)
-                return ClosePage(FormsApplication.MainPage, null, attribute);
+                return await ClosePage(FormsApplication.MainPage, null, attribute);
             else
             {
                 var carouselHost = GetPageOfType<MvxCarouselPage>();
@@ -463,7 +465,7 @@ namespace MvvmCross.Forms.Presenters
 
         public virtual Task<bool> CloseContentPage(IMvxViewModel viewModel, MvxContentPagePresentationAttribute attribute)
         {
-            return ClosePage(FormsApplication.MainPage, null, attribute);
+            return await ClosePage(FormsApplication.MainPage, null, attribute);
         }
 
         public virtual async Task<bool> ShowMasterDetailPage(
@@ -526,11 +528,11 @@ namespace MvvmCross.Forms.Presenters
             switch (attribute.Position)
             {
                 case MasterDetailPosition.Root:
-                    return ClosePage(FormsApplication.MainPage, null, attribute);
+                    return await ClosePage(FormsApplication.MainPage, null, attribute);
                 case MasterDetailPosition.Master:
-                    return ClosePage(masterDetailHost.Master, null, attribute);
+                    return await ClosePage(masterDetailHost.Master, null, attribute);
                 case MasterDetailPosition.Detail:
-                    return ClosePage(masterDetailHost.Detail, null, attribute);
+                    return await ClosePage(masterDetailHost.Detail, null, attribute);
             }
             return Task.FromResult(true);
         }
@@ -636,7 +638,7 @@ namespace MvvmCross.Forms.Presenters
         public virtual Task<bool> CloseTabbedPage(IMvxViewModel viewModel, MvxTabbedPagePresentationAttribute attribute)
         {
             if (attribute.Position == TabbedPosition.Root)
-                return ClosePage(FormsApplication.MainPage, null, attribute);
+                return await ClosePage(FormsApplication.MainPage, null, attribute);
             else
             {
                 var tabHost = GetPageOfType<MvxTabbedPage>();

--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -291,7 +291,6 @@ namespace MvvmCross.Forms.Presenters
                 MvxFormsLog.Instance.Trace(FormsApplication.Hierarchy());
             }
 #endif
-            }
         }
 
         protected virtual bool RemoveByViewModel(INavigation navigation, Type viewModelToRemove)
@@ -368,7 +367,6 @@ namespace MvvmCross.Forms.Presenters
                 MvxFormsLog.Instance.Trace(FormsApplication.Hierarchy());
             }
 #endif
-            }
         }
 
         public virtual async Task<bool> ShowCarouselPage(
@@ -404,7 +402,7 @@ namespace MvvmCross.Forms.Presenters
         public virtual Task<bool> CloseCarouselPage(IMvxViewModel viewModel, MvxCarouselPagePresentationAttribute attribute)
         {
             if (attribute.Position == CarouselPosition.Root)
-                return await ClosePage(FormsApplication.MainPage, null, attribute);
+                return ClosePage(FormsApplication.MainPage, null, attribute);
             else
             {
                 var carouselHost = GetPageOfType<MvxCarouselPage>();
@@ -465,7 +463,7 @@ namespace MvvmCross.Forms.Presenters
 
         public virtual Task<bool> CloseContentPage(IMvxViewModel viewModel, MvxContentPagePresentationAttribute attribute)
         {
-            return await ClosePage(FormsApplication.MainPage, null, attribute);
+            return ClosePage(FormsApplication.MainPage, null, attribute);
         }
 
         public virtual async Task<bool> ShowMasterDetailPage(
@@ -528,11 +526,11 @@ namespace MvvmCross.Forms.Presenters
             switch (attribute.Position)
             {
                 case MasterDetailPosition.Root:
-                    return await ClosePage(FormsApplication.MainPage, null, attribute);
+                    return ClosePage(FormsApplication.MainPage, null, attribute);
                 case MasterDetailPosition.Master:
-                    return await ClosePage(masterDetailHost.Master, null, attribute);
+                    return ClosePage(masterDetailHost.Master, null, attribute);
                 case MasterDetailPosition.Detail:
-                    return await ClosePage(masterDetailHost.Detail, null, attribute);
+                    return ClosePage(masterDetailHost.Detail, null, attribute);
             }
             return Task.FromResult(true);
         }
@@ -638,7 +636,7 @@ namespace MvvmCross.Forms.Presenters
         public virtual Task<bool> CloseTabbedPage(IMvxViewModel viewModel, MvxTabbedPagePresentationAttribute attribute)
         {
             if (attribute.Position == TabbedPosition.Root)
-                return await ClosePage(FormsApplication.MainPage, null, attribute);
+                return ClosePage(FormsApplication.MainPage, null, attribute);
             else
             {
                 var tabHost = GetPageOfType<MvxTabbedPage>();

--- a/MvvmCross/Core/IMvxSetupMonitor.cs
+++ b/MvvmCross/Core/IMvxSetupMonitor.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+
 namespace MvvmCross.Core
 {
     public interface IMvxSetupMonitor
     {
-        void InitializationComplete();
+        Task InitializationComplete();
     }
 }

--- a/MvvmCross/Core/MvxSetupSingleton.cs
+++ b/MvvmCross/Core/MvxSetupSingleton.cs
@@ -185,7 +185,7 @@ namespace MvvmCross.Core
 
                 if (monitor != null)
                 {
-                    var dispatcher = Mvx.GetSingleton<IMvxMainThreadAsyncDispatcher>();
+                    var dispatcher = Mvx.IoCProvider.GetSingleton<IMvxMainThreadAsyncDispatcher>();
                     await dispatcher.ExecuteOnMainThreadAsync(async () =>
                     {
                         if (monitor != null)

--- a/MvvmCross/Core/MvxSetupSingleton.cs
+++ b/MvvmCross/Core/MvxSetupSingleton.cs
@@ -115,20 +115,20 @@ namespace MvvmCross.Core
             lock (LockObject)
             {
                 _currentMonitor = setupMonitor;
-                
+
                 // if the tcs is not null, it means the initialization is running
                 if (IsInitialisedTaskCompletionSource != null)
                 {
                     // If the task is already completed at this point, let the monitor know it has finished. 
                     // but don't do it otherwise because it's done elsewhere
-                    if(IsInitialisedTaskCompletionSource.Task.IsCompleted)
+                    if (IsInitialisedTaskCompletionSource.Task.IsCompleted)
                     {
                         _currentMonitor?.InitializationComplete();
                     }
 
                     return;
                 }
-                
+
                 StartSetupInitialization();
             }
         }
@@ -173,18 +173,24 @@ namespace MvvmCross.Core
         {
             IsInitialisedTaskCompletionSource = new TaskCompletionSource<bool>();
             _setup.InitializePrimary();
-            Task.Run(() =>
+            Task.Run(async () =>
             {
                 _setup.InitializeSecondary();
+                IMvxSetupMonitor monitor;
                 lock (LockObject)
                 {
                     IsInitialisedTaskCompletionSource.SetResult(true);
-                    var dispatcher = Mvx.IoCProvider.GetSingleton<IMvxMainThreadDispatcher>();
-                    dispatcher.RequestMainThreadAction(() =>
+                    monitor = _currentMonitor;
+                }
+
+                if (monitor != null)
+                {
+                    var dispatcher = Mvx.GetSingleton<IMvxMainThreadAsyncDispatcher>();
+                    await dispatcher.ExecuteOnMainThreadAsync(async () =>
                     {
-                        if (_currentMonitor != null)
+                        if (monitor != null)
                         {
-                            _currentMonitor?.InitializationComplete();
+                            await monitor.InitializationComplete();
                         }
                     });
                 }

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
@@ -76,12 +77,19 @@ namespace MvvmCross.Platforms.Android.Views
             base.OnPause();
         }
 
-        public virtual void InitializationComplete()
+        public virtual async Task InitializationComplete()
         {
             if (!_isResumed)
                 return;
 
-            RunAppStart(_bundle);
+            await RunAppStartAsync(_bundle);
+        }
+
+        protected virtual async Task RunAppStartAsync(Bundle bundle)
+        {
+            var startup = Mvx.Resolve<IMvxAppStart>();
+            if (!startup.IsStarted)
+                await startup.StartAsync(GetAppStartHint(bundle));
         }
 
         protected virtual void RegisterSetup()

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -87,7 +87,7 @@ namespace MvvmCross.Platforms.Android.Views
 
         protected virtual async Task RunAppStartAsync(Bundle bundle)
         {
-            var startup = Mvx.Resolve<IMvxAppStart>();
+            var startup = Mvx.IoCProvider.Resolve<IMvxAppStart>();
             if (!startup.IsStarted)
                 await startup.StartAsync(GetAppStartHint(bundle));
         }

--- a/MvvmCross/ViewModels/IMvxAppStart.cs
+++ b/MvvmCross/ViewModels/IMvxAppStart.cs
@@ -2,11 +2,15 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+
 namespace MvvmCross.ViewModels
 {
     public interface IMvxAppStart
     {
         void Start(object hint = null);
+
+        Task StartAsync(object hint = null);
 
         bool IsStarted { get; }
 

--- a/MvvmCross/ViewModels/IMvxApplication.cs
+++ b/MvvmCross/ViewModels/IMvxApplication.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross.Plugin;
 
 namespace MvvmCross.ViewModels
@@ -12,7 +13,7 @@ namespace MvvmCross.ViewModels
 
         void Initialize();
 
-        void Startup();
+        Task Startup();
 
         void Reset();
     }

--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -29,25 +29,25 @@ namespace MvvmCross.ViewModels
             if (Interlocked.CompareExchange(ref startHasCommenced, 1, 0) == 1)
                 return;
 
-            Startup(hint).GetAwaiter().GetResult();
+            StartAsync(hint).GetAwaiter().GetResult();
         }
 
         public async Task StartAsync(object hint = null)
         {
-            var applicationHint = ApplicationStartup(hint);
+            var applicationHint = await ApplicationStartup(hint);
             if (applicationHint != null)
             {
                 MvxLog.Instance.Trace("Hint ignored in default MvxAppStart");
             }
 
-            NavigateToFirstViewModel(applicationHint);
+            await NavigateToFirstViewModel(applicationHint);
         }
 
-        protected abstract void NavigateToFirstViewModel(object hint = null);
+        protected abstract Task NavigateToFirstViewModel(object hint = null);
 
-        protected virtual object ApplicationStartup(object hint = null)
+        protected virtual async Task<object> ApplicationStartup(object hint = null)
         {
-            Application.Startup();
+            await Application.Startup();
             return hint;
         }
 
@@ -72,11 +72,11 @@ namespace MvvmCross.ViewModels
         {
         }
 
-        protected override void NavigateToFirstViewModel(object hint = null)
+        protected override async Task NavigateToFirstViewModel(object hint = null)
         {
             try
             {
-                NavigationService.Navigate<TViewModel>().GetAwaiter().GetResult();
+                await NavigationService.Navigate<TViewModel>();
             }
             catch (System.Exception exception)
             {
@@ -91,16 +91,16 @@ namespace MvvmCross.ViewModels
         {
         }
 
-        protected override object ApplicationStartup(object hint = null)
+        protected override async Task<object> ApplicationStartup(object hint = null)
         {
-            var applicationHint = base.ApplicationStartup(hint);
+            var applicationHint = await base.ApplicationStartup(hint);
             if (applicationHint is TParameter parameter && Application is IMvxApplication<TParameter> typedApplication)
                 return typedApplication.Startup(parameter);
             else
                 return applicationHint;
         }
 
-        protected override void NavigateToFirstViewModel(object hint = null)
+        protected override async Task NavigateToFirstViewModel(object hint = null)
         {
             try
             {
@@ -109,7 +109,7 @@ namespace MvvmCross.ViewModels
                 else
                 {
                     MvxLog.Instance.Trace($"Hint is not matching type of {nameof(TParameter)}. Doing navigation without typed parameter instead.");
-                    base.NavigateToFirstViewModel(hint);
+                    await base.NavigateToFirstViewModel(hint);
                 }
             }
             catch (System.Exception exception)

--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
+using System.Threading.Tasks;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
@@ -28,10 +29,10 @@ namespace MvvmCross.ViewModels
             if (Interlocked.CompareExchange(ref startHasCommenced, 1, 0) == 1)
                 return;
 
-            Startup(hint);
+            Startup(hint).GetAwaiter().GetResult();
         }
 
-        protected virtual void Startup(object hint = null)
+        public async Task StartAsync(object hint = null)
         {
             var applicationHint = ApplicationStartup(hint);
             if (applicationHint != null)

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using MvvmCross.IoC;
 using MvvmCross.Logging;
 using MvvmCross.Plugin;
@@ -45,9 +46,10 @@ namespace MvvmCross.ViewModels
         /// <summary>
         /// Any initialization steps that need to be done on the UI thread
         /// </summary>
-        public virtual void Startup()
+        public virtual Task Startup()
         {
             MvxLog.Instance.Trace("AppStart: Application Startup - On UI thread");
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/Projects/Playground/Playground.Core/App.cs
+++ b/Projects/Playground/Playground.Core/App.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using MvvmCross;
 using MvvmCross.IoC;
 using MvvmCross.Localization;
@@ -32,9 +33,9 @@ namespace Playground.Core
         /// <summary>
         /// Do any UI bound startup actions here
         /// </summary>
-        public override void Startup()
+        public override Task Startup()
         {
-            base.Startup();
+            return base.Startup();
         }
 
         /// <summary>

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -139,6 +139,9 @@ namespace Playground.Core.ViewModels
 
             await base.Initialize();
 
+            // Uncomment this to demonstrate use of StartAsync for async first navigation
+            // await Task.Delay(5000);
+
             _mvxViewModelLoader.LoadViewModel(MvxViewModelRequest.GetDefaultRequest(typeof(ChildViewModel)),
                 new SampleModel
                 {

--- a/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
+++ b/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
@@ -23,9 +23,9 @@ namespace Playground.Forms.Droid
         // MainLauncher = true, // No Splash Screen: Uncomment this lines if removing splash screen
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation,
         LaunchMode = LaunchMode.SingleTask)]
-    public class MainActivity : MvxFormsAppCompatActivity<MainViewModel>
+    public class MainActivity : MvxFormsAppCompatActivity
     // No Splash Screen: use this base instead
-    // MvxFormsAppCompatActivity<Setup, Core.App, FormsApp, MainViewModel>
+    // MvxFormsAppCompatActivity<Setup, Core.App, FormsApp>
     {
         protected override void OnCreate(Bundle bundle)
         {

--- a/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
+++ b/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
@@ -21,6 +21,11 @@ namespace Playground.Forms.Droid
         , ScreenOrientation = ScreenOrientation.Portrait)]
     public class SplashScreen : MvxFormsSplashScreenActivity<Setup, Core.App, FormsApp>
     {
+        public SplashScreen()
+            : base(Resource.Layout.SplashScreen)
+        {
+        }
+
         protected override Task RunAppStartAsync(Bundle bundle)
         {
             StartActivity(typeof(MainActivity));

--- a/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
+++ b/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using MvvmCross.Core;
 using MvvmCross.Forms.Platforms.Android.Views;
-using MvvmCross.Platforms.Android.Views;
 using Playground.Forms.UI;
 
 namespace Playground.Forms.Droid
@@ -22,10 +21,10 @@ namespace Playground.Forms.Droid
         , ScreenOrientation = ScreenOrientation.Portrait)]
     public class SplashScreen : MvxFormsSplashScreenActivity<Setup, Core.App, FormsApp>
     {
-        protected override void RunAppStart(Bundle bundle)
+        protected override Task RunAppStartAsync(Bundle bundle)
         {
             StartActivity(typeof(MainActivity));
-            base.RunAppStart(bundle);
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently the built in MvxAppStart only supports a synchronous startup. In cases where a splash screen is used, it should be possible to use an async startup which would allow the Initialize method to do long running actions. Currently this is achieved by overriding the default MvxAppStart.

### :new: What is the new behavior (if this is a feature change)?
Added support for StartAsync into IMvxAppStart
Altered SplashScreen (Android only) to make use of StartAsync
TODO: Add equivalent splash screen view to other platforms to show how this could work

### :boom: Does this PR introduce a breaking change?
Yes - some interfaces now return Task where previously was void

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Deprecates: https://github.com/MvvmCross/MvvmCross/pull/2830

### :thinking: Checklist before submitting
Follow up PR to: https://github.com/MvvmCross/MvvmCross/pull/2784
In response to Issue: https://github.com/MvvmCross/MvvmCross/issues/2829
Dependent on: https://github.com/MvvmCross/MvvmCross/pull/2868

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
Note: This needs to be rebased onto v6.1 after PR 2784 has been merged
