### PR TITLE
Handling back pressed for Forms applications

### DIFF
--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
@@ -19,6 +19,7 @@ using MvvmCross.Platforms.Android.Binding.Views;
 using MvvmCross.Platforms.Android.Core;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
+using Xamarin.Forms;
 using Application = Xamarin.Forms.Application;
 
 namespace MvvmCross.Forms.Platforms.Android.Views
@@ -178,17 +179,36 @@ namespace MvvmCross.Forms.Platforms.Android.Views
             ViewModel?.ViewDisappeared();
         }
 
-        public override void OnBackPressed()
+        public override async void OnBackPressed()
         {
-            var page = Xamarin.Forms.Application.Current.MainPage;
-            if (page == null || (page?.Navigation?.NavigationStack?.Count <= 1 && page?.Navigation?.ModalStack?.Count == 0))
+            var presenter = Mvx.Resolve<MvxFormsPagePresenter>();
+            var pages = presenter.CurrentPageTree;
+
+            for (var i = pages.Length - 1; i >= 0; i--)
             {
-                MoveTaskToBack(true);
+                var pg = pages[i];
+                if (pg is NavigationPage navPage)
+                {
+                    if (pg.Navigation.ModalStack.Count > 0)
+                    {
+                        await pg.Navigation.PopModalAsync();
+                        return;
+                    }
+
+                    if (pg.Navigation.NavigationStack.Count > 1)
+                    {
+                        var handled = pg.SendBackButtonPressed();
+                        if (handled) return;
+                    }
+                }
+                else
+                {
+                    var handled = pg.SendBackButtonPressed();
+                    if (handled) return;
+                }
             }
-            else
-            {
-                base.OnBackPressed();
-            }
+
+            MoveTaskToBack(true);
         }
 
         public override View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)

--- a/MvvmCross.Forms/Presenters/IMvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/IMvxFormsPagePresenter.cs
@@ -18,5 +18,9 @@ namespace MvvmCross.Forms.Presenters
         IMvxViewModelLoader ViewModelLoader { get; set; }
 
         Page CreatePage(Type viewType, MvxViewModelRequest request, MvxBasePresentationAttribute attribute);
+
+        Page[] CurrentPageTree { get; }
+
+        NavigationPage TopNavigationPage(Page rootPage = null);
     }
 }

--- a/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
+++ b/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
@@ -34,40 +34,6 @@ namespace Playground.Forms.Droid
             base.OnCreate(bundle);
         }
 
-        //public override async void OnBackPressed()
-        //{
-        //    //base.OnBackPressed();
-
-        //    var presenter = Mvx.Resolve<MvxFormsPagePresenter>();
-        //    var pages = presenter.CurrentPageTree;
-
-        //    for (var i = pages.Length - 1; i >= 0; i--)
-        //    {
-        //        var pg = pages[i];
-        //        if (pg is NavigationPage navPage)
-        //        {
-        //            if(pg.Navigation.ModalStack.Count > 0)
-        //            {
-        //                await pg.Navigation.PopModalAsync();
-        //                return;
-        //            }
-
-        //            if (pg.Navigation.NavigationStack.Count > 1)
-        //            {
-        //                var handled = pg.SendBackButtonPressed();
-        //                if (handled) return;
-        //            }
-        //        }
-        //        else 
-        //        {
-        //            var handled = pg.SendBackButtonPressed();
-        //            if (handled) return;
-        //        }
-        //    }
-                        
-        //    MoveTaskToBack(true);
-        //}
-
         protected override void OnDestroy()
         {
             base.OnDestroy();

--- a/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
+++ b/Projects/Playground/Playground.Forms.Droid/MainActivity.cs
@@ -5,11 +5,14 @@
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using MvvmCross;
 using MvvmCross.Core;
 using MvvmCross.Forms.Platforms.Android.Core;
 using MvvmCross.Forms.Platforms.Android.Views;
+using MvvmCross.Forms.Presenters;
 using Playground.Core.ViewModels;
 using Playground.Forms.UI;
+using Xamarin.Forms;
 
 namespace Playground.Forms.Droid
 {
@@ -20,7 +23,7 @@ namespace Playground.Forms.Droid
         // MainLauncher = true, // No Splash Screen: Uncomment this lines if removing splash screen
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation,
         LaunchMode = LaunchMode.SingleTask)]
-    public class MainActivity : MvxFormsAppCompatActivity <MainViewModel>
+    public class MainActivity : MvxFormsAppCompatActivity<MainViewModel>
     // No Splash Screen: use this base instead
     // MvxFormsAppCompatActivity<Setup, Core.App, FormsApp, MainViewModel>
     {
@@ -29,6 +32,45 @@ namespace Playground.Forms.Droid
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
             base.OnCreate(bundle);
+        }
+
+        //public override async void OnBackPressed()
+        //{
+        //    //base.OnBackPressed();
+
+        //    var presenter = Mvx.Resolve<MvxFormsPagePresenter>();
+        //    var pages = presenter.CurrentPageTree;
+
+        //    for (var i = pages.Length - 1; i >= 0; i--)
+        //    {
+        //        var pg = pages[i];
+        //        if (pg is NavigationPage navPage)
+        //        {
+        //            if(pg.Navigation.ModalStack.Count > 0)
+        //            {
+        //                await pg.Navigation.PopModalAsync();
+        //                return;
+        //            }
+
+        //            if (pg.Navigation.NavigationStack.Count > 1)
+        //            {
+        //                var handled = pg.SendBackButtonPressed();
+        //                if (handled) return;
+        //            }
+        //        }
+        //        else 
+        //        {
+        //            var handled = pg.SendBackButtonPressed();
+        //            if (handled) return;
+        //        }
+        //    }
+                        
+        //    MoveTaskToBack(true);
+        //}
+
+        protected override void OnDestroy()
+        {
+            base.OnDestroy();
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug fix

### :arrow_heading_down: What is the current behavior?
Back button pressed isn't passed down to master details or custom onbackpressed handlers

### :new: What is the new behavior (if this is a feature change)?
All pages in current page hierarchy are given opportunity to handle back pressed

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2817
Deprecates: https://github.com/MvvmCross/MvvmCross/pull/2826

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
