### PR TITLE
[WIP] Make MvxContentView(or any other Mvx Forms View)<>.ViewModel property bindable

### DIFF
--- a/MvvmCross.Forms/Views/MvxContentView.cs
+++ b/MvvmCross.Forms/Views/MvxContentView.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using MvvmCross.Base;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Forms.Views.Base;
 using MvvmCross.ViewModels;
+using Xamarin.Forms;
 
 namespace MvvmCross.Forms.Views
 {
@@ -13,6 +16,7 @@ namespace MvvmCross.Forms.Views
         public MvxContentView()
         {
             this.AdaptForBinding();
+            BindingContextChangedCalled += (sender, args) => ViewModelSetCalled?.Raise(this);
         }
 
         public object DataContext
@@ -58,17 +62,40 @@ namespace MvvmCross.Forms.Views
 
         protected virtual void OnViewModelSet()
         {
+            ViewModelSetCalled.Raise(this);
         }
+
+        public event EventHandler ViewModelSetCalled;
     }
 
     public class MvxContentView<TViewModel>
         : MvxContentView
     , IMvxElement<TViewModel> where TViewModel : class, IMvxViewModel
     {
+        public MvxContentView()
+        {
+            BindingContextChangedCalled += (sender, args) => ViewModel = base.ViewModel as TViewModel;
+        }
+
+        public static readonly BindableProperty ViewModelProperty = BindableProperty.Create(nameof(ViewModel),
+            typeof(TViewModel), typeof(MvxContentView<TViewModel>), null, BindingMode.Default, null, null, null, CoerceValue);
+
         public new TViewModel ViewModel
         {
-            get { return (TViewModel)base.ViewModel; }
-            set { base.ViewModel = value; }
+            get { return (TViewModel)GetValue(ViewModelProperty); }
+            set { SetValue(ViewModelProperty, value); }
         }
+
+        private static TViewModel CoerceValue(BindableObject bindable, object value)
+        {
+            (bindable as MvxContentView<TViewModel>)?.SetBaseViewModel(value as TViewModel);
+            return (bindable as MvxContentView<TViewModel>)?.DataContext as TViewModel;
+        }
+
+        private void SetBaseViewModel(TViewModel newValue)
+        {
+            base.ViewModel = newValue;
+        }
+
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Make MvxContentView(or any other Mvx Forms View)<>.ViewModel a bindable property.
This is just an idea, and not a complete implementation yet, but I wanted to know what you guys thought.

### :arrow_heading_down: What is the current behavior?
MvxContentView<>.ViewModel is not bindable, and accessing a property in it from xaml using `{Binding Source={x:reference mvxViewName}, Path="..."}` requires `Path="BindingContext.DataContext.PropertyName"` and PropertyName does not get suggested in intellisense, as BindingContext.DataContext is not strongly typed.  If you use `Path="ViewModel.PropertyName"`, and ViewModel gets modified for some reason (ie. setting it in the consumer), then the change doesn't get propagated to the view.

### :new: What is the new behavior (if this is a feature change)?
MvxContentView<>.ViewModel is bindable and still functions the same relative to MvxContentView.DataContext

### :boom: Does this PR introduce a breaking change?
 only if you're using `{Binding Source={x:reference mvxViewName}, Path="ViewModel.PropertyName"}` and you expect that setting ViewModel to a new object will not propagate to the view. 

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#2825 
### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
