### PR TITLE
Correct behviour for ViewModel Lifecycle for UWP

### DIFF
--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -39,7 +39,7 @@ namespace MvvmCross.Platforms.Uap.Views
 
         private void MvxWindowsPage_Unloaded(object sender, RoutedEventArgs e)
         {
-            ViewModel?.ViewDisappeared();
+            ViewModel?.ViewDestroy();
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
@@ -104,6 +104,7 @@ namespace MvvmCross.Platforms.Uap.Views
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
+            ViewModel?.ViewDisappeared();
             base.OnNavigatedFrom(e);
             var bundle = this.CreateSaveStateBundle();
             SaveStateBundle(e, bundle);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This fixes Issue https://github.com/MvvmCross/MvvmCross/issues/2860 
It should correctly call ViewModel#ViewDestroy

### :arrow_heading_down: What is the current behavior?
ViewModel#ViewDestroy does not get called

### :new: What is the new behavior (if this is a feature change)?
ViewModel#ViewDestroy does get called

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Set breakpoints in the Playground ViewModels and navigate through the sample.

### :memo: Links to relevant issues/docs
Issue: https://github.com/MvvmCross/MvvmCross/issues/2860 

https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.page.onnavigatedfrom#Windows_UI_Xaml_Controls_Page_OnNavigatedFrom_Windows_UI_Xaml_Navigation_NavigationEventArgs_

https://msdn.microsoft.com/en-us/library/system.windows.frameworkelement.unloaded(v=vs.110).aspx

The docs for Page.OnNavigatedFrom are a bit misleading. They say it gets called immediately after the page gets unloaded, but they don't mean the unloaded event. The Unloaded event is the last "lifecycle" event of a Page.


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
