### PR TITLE
Call to ViewCreated and ViewDestroy in UWP and WPF

### DIFF
--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -29,6 +29,7 @@ namespace MvvmCross.Platforms.Uap.Views
 
         private void MvxWindowsPage_Loading(FrameworkElement sender, object args)
         {
+            ViewModel?.ViewCreated();
             ViewModel?.ViewAppearing();
         }
 
@@ -45,6 +46,7 @@ namespace MvvmCross.Platforms.Uap.Views
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             ViewModel?.ViewDisappearing();
+            ViewModel?.ViewDestroy();
             base.OnNavigatingFrom(e);
         }
 

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -41,12 +41,12 @@ namespace MvvmCross.Platforms.Uap.Views
         private void MvxWindowsPage_Unloaded(object sender, RoutedEventArgs e)
         {
             ViewModel?.ViewDisappeared();
+            ViewModel?.ViewDestroy();
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             ViewModel?.ViewDisappearing();
-            ViewModel?.ViewDestroy();
             base.OnNavigatingFrom(e);
         }
 

--- a/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
@@ -43,10 +43,12 @@ namespace MvvmCross.Platforms.Wpf.Views
         {
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
+            ViewModel?.ViewDestroy();
         }
 
         private void MvxWindow_Loaded(object sender, RoutedEventArgs e)
         {
+            ViewModel?.ViewCreated();
             ViewModel?.ViewAppearing();
             ViewModel?.ViewAppeared();
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
In UWP and WPF the methods ViewCreated and ViewDestroy of MvxViewModel are not executed. 

### :arrow_heading_down: What is the current behavior?
Call to ViewCreate and ViewDestroy in UWP and WPF.

### :new: What is the new behavior (if this is a feature change)?
There is homogeneity between platforms.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
