### PR TITLE
Issue 2884 reproduce

### DIFF
--- a/Projects/Playground/Playground.Droid/App.cs
+++ b/Projects/Playground/Playground.Droid/App.cs
@@ -1,0 +1,13 @@
+﻿using MvvmCross.ViewModels;
+
+namespace Playground.Droid
+{
+    public class App : MvxApplication
+    {
+        public override void Initialize()
+        {
+            // register the appstart object
+            RegisterCustomAppStart<AppStart>();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/AppStart.cs
+++ b/Projects/Playground/Playground.Droid/AppStart.cs
@@ -1,0 +1,22 @@
+﻿using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+using Playground.Droid.ViewModels;
+
+namespace Playground.Droid
+{
+    public class AppStart : MvxAppStart
+    {
+        private readonly IMvxNavigationService _mvxNavigationService;
+
+        public AppStart(IMvxApplication app, IMvxNavigationService mvxNavigationService)
+            : base(app)
+        {
+            _mvxNavigationService = mvxNavigationService;
+        }
+
+        protected override void Startup(object hint = null)
+        {
+            _mvxNavigationService.Navigate<MainViewModel>();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/MvxMultipleViewModelCacheWithLogs.cs
+++ b/Projects/Playground/Playground.Droid/MvxMultipleViewModelCacheWithLogs.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Concurrent;
+using MvvmCross.Platforms.Android.Views;
+using MvvmCross.ViewModels;
+
+namespace Playground.Droid
+{
+    public class MvxMultipleViewModelCacheWithLogs
+        : IMvxMultipleViewModelCache
+    {
+        private readonly Lazy<ConcurrentDictionary<CachedViewModelType, IMvxViewModel>> _lazyCurrentViewModels;
+
+        public MvxMultipleViewModelCacheWithLogs()
+        {
+            _lazyCurrentViewModels =
+                new Lazy<ConcurrentDictionary<CachedViewModelType, IMvxViewModel>>(
+                    () => new ConcurrentDictionary<CachedViewModelType, IMvxViewModel>());
+        }
+
+        private ConcurrentDictionary<CachedViewModelType, IMvxViewModel> CurrentViewModels => _lazyCurrentViewModels.Value;
+
+        public void Cache(IMvxViewModel toCache, string viewModelTag = "singleInstanceCache")
+        {
+            if (toCache == null) return;
+
+            var type = toCache.GetType();
+
+            Console.WriteLine($"MvxMultipleViewModelCacheWithLogs: Add {type} to cache (HashCode = {type.GetHashCode()})");
+
+
+            var cachedViewModelType = new CachedViewModelType(type, viewModelTag);
+            if (!CurrentViewModels.ContainsKey(cachedViewModelType))
+                CurrentViewModels.TryAdd(cachedViewModelType, toCache);
+        }
+
+        public IMvxViewModel GetAndClear(Type viewModelType, string viewModelTag = "singleInstanceCache")
+        {
+            if (viewModelType == null) return null;
+
+            Console.WriteLine($"MvxMultipleViewModelCacheWithLogs: {nameof(GetAndClear)} {viewModelType} from cache");
+
+            IMvxViewModel vm;
+            var cachedViewModelType = new CachedViewModelType(viewModelType, viewModelTag);
+            CurrentViewModels.TryRemove(cachedViewModelType, out vm);
+
+            return vm;
+        }
+
+        public T GetAndClear<T>(string viewModelTag = "singleInstanceCache") where T : IMvxViewModel
+        {
+            return (T)GetAndClear(typeof(T), viewModelTag);
+        }
+
+        private class CachedViewModelType
+        {
+            public Type ViewModelType { get; }
+            public string ViewModelTag { get; }
+
+            public CachedViewModelType(Type viewModelType, string viewModelTag)
+            {
+                ViewModelType = viewModelType;
+                ViewModelTag = viewModelTag ?? string.Empty;
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hashCode = 17;
+                    hashCode = (hashCode * 23) + ViewModelType.GetHashCode();
+                    hashCode = (hashCode * 23) + ViewModelTag.GetHashCode();
+                    return hashCode;
+                }
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(obj, this))
+                    return true;
+
+                var other = obj as CachedViewModelType;
+
+                return other != null &&
+                       other.ViewModelTag.Equals(ViewModelTag) &&
+                       other.ViewModelType == ViewModelType;
+            }
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -54,13 +54,24 @@
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.cs" />
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.SelectedItemEventArgs.cs" />
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.ViewHolder.cs" />
+    <Compile Include="App.cs" />
+    <Compile Include="AppStart.cs" />
+    <Compile Include="MvxMultipleViewModelCacheWithLogs.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SplashScreen.cs" />
     <Compile Include="Setup.cs" />
+    <Compile Include="ViewModels\BaseViewModel.cs" />
+    <Compile Include="ViewModels\FirstViewModel.cs" />
+    <Compile Include="ViewModels\MainViewModel.cs" />
+    <Compile Include="ViewModels\SecondViewModel.cs" />
+    <Compile Include="Views\BaseFragment.cs" />
     <Compile Include="Views\CollectionView.cs" />
     <Compile Include="Views\DictionaryBindingView.cs" />
+    <Compile Include="Views\FirstView.cs" />
+    <Compile Include="Views\MainView.cs" />
     <Compile Include="Views\RootView.cs" />
+    <Compile Include="Views\SecondView.cs" />
     <Compile Include="Views\SharedElements\SharedElementSecondChildView.cs" />
     <Compile Include="Views\SharedElements\SharedElementSecondView.cs" />
     <Compile Include="Views\SharedElements\SharedElementRootChildView.cs" />
@@ -183,11 +194,17 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Plugin.Share">
+      <Version>7.1.1</Version>
+    </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.6.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.Xamarin">
       <Version>0.1.29</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Compat">
+      <Version>27.0.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Design">
       <Version>27.0.2</Version>
@@ -196,7 +213,7 @@
       <Version>27.0.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.4.9</Version>
+      <Version>0.4.11</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -213,6 +230,19 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable-xxxhdpi\mvvmcross_logo.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\SecondView.axml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\FirstView.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\MainView.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Droid/Resources/layout/FirstView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/FirstView.axml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <Button
+                android:id="@+id/btn_second_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="15sp"
+                android:textAllCaps="true"
+                android:background="@color/colorAccent"
+                android:textColor="@android:color/white"
+                android:stateListAnimator="@null"
+                android:text="Open second view"
+                local:MvxBind="Click OpenSecondViewCommand" />
+        </LinearLayout>
+    </RelativeLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/MainView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/MainView.axml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/drawer_layout"
+    android:fitsSystemWindows="true"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/main_frame"
+        android:fitsSystemWindows="true"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <FrameLayout
+            android:id="@+id/content_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true" />
+    </android.support.design.widget.CoordinatorLayout>
+</android.support.v4.widget.DrawerLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/SecondView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/SecondView.axml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:local="http://schemas.android.com/apk/res-auto"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+	<android.support.design.widget.CoordinatorLayout
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:background="@color/colorPrimary">
+		<android.support.v4.widget.NestedScrollView
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:layout_gravity="fill_vertical"
+			android:layout_marginBottom="?attr/actionBarSize"
+			android:isScrollContainer="true"
+			local:layout_behavior="@string/appbar_scrolling_view_behavior">
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:orientation="vertical">
+				<Button
+					android:id="@+id/btn_destroy"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="20dp"
+					android:layout_marginBottom="16dp"
+					android:layout_marginLeft="60dp"
+					android:layout_marginRight="60dp"
+					android:textSize="15sp"
+					android:textAllCaps="true"
+					android:background="@color/colorAccent"
+					android:textColor="@android:color/white"
+					android:stateListAnimator="@null"
+          android:text ="Open browser"
+					local:MvxBind="Click OpenBrowserCommand" />
+			</LinearLayout>
+		</android.support.v4.widget.NestedScrollView>
+	</android.support.design.widget.CoordinatorLayout>
+</RelativeLayout>

--- a/Projects/Playground/Playground.Droid/Setup.cs
+++ b/Projects/Playground/Playground.Droid/Setup.cs
@@ -1,35 +1,55 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
 using System.Collections.Generic;
 using System.Reflection;
+using Android.Support.Design.Widget;
+using Android.Support.V4.View;
+using Android.Support.V4.Widget;
+using Android.Support.V7.Widget;
+using MvvmCross;
+using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Droid.Support.V7.RecyclerView;
-using MvvmCross.Logging;
-using Playground.Core;
-using Serilog;
+using MvvmCross.Platforms.Android.Presenters;
+using MvvmCross.Platforms.Android.Views;
+
 
 namespace Playground.Droid
 {
     public class Setup : MvxAppCompatSetup<App>
     {
-        protected override IEnumerable<Assembly> AndroidViewAssemblies =>
-            new List<Assembly>(base.AndroidViewAssemblies)
-            {
-                typeof(MvxRecyclerView).Assembly
-            };
-
-        public override MvxLogProviderType GetDefaultLogProviderType()
-            => MvxLogProviderType.Serilog;
-
-        protected override IMvxLogProvider CreateLogProvider()
+        protected override IEnumerable<Assembly> AndroidViewAssemblies => new List<Assembly>(base.AndroidViewAssemblies)
         {
-            Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Debug()
-                .WriteTo.AndroidLog()
-                .CreateLogger();
-            return base.CreateLogProvider();
+            typeof(NavigationView).Assembly,
+            typeof(CoordinatorLayout).Assembly,
+            typeof(FloatingActionButton).Assembly,
+            typeof(Toolbar).Assembly,
+            typeof(DrawerLayout).Assembly,
+            typeof(ViewPager).Assembly,
+            typeof(MvxRecyclerView).Assembly,
+        };
+
+        /// <summary>
+        /// Fill the Binding Factory Registry with bindings from the support library.
+        /// </summary>
+        protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+        {
+            MvxAppCompatSetupHelper.FillTargetFactories(registry);
+            base.FillTargetFactories(registry);
+        }
+
+        protected override IMvxAndroidViewPresenter CreateViewPresenter()
+        {
+            return new MvxAppCompatViewPresenter(AndroidViewAssemblies);
+        }
+
+        protected override void InitializeViewModelTypeFinder()
+        {
+            base.InitializeViewModelTypeFinder();
+
+            var mvxMultipleViewModelCacheWithLogs = new MvxMultipleViewModelCacheWithLogs();
+            Mvx.RegisterSingleton<IMvxMultipleViewModelCache>(mvxMultipleViewModelCacheWithLogs);
         }
     }
 }

--- a/Projects/Playground/Playground.Droid/ViewModels/BaseViewModel.cs
+++ b/Projects/Playground/Playground.Droid/ViewModels/BaseViewModel.cs
@@ -1,0 +1,20 @@
+﻿using MvvmCross.ViewModels;
+
+namespace Playground.Droid.ViewModels
+{
+    public abstract class BaseViewModel : MvxViewModel
+    {
+        protected BaseViewModel()
+        {
+        }
+    }
+
+    public abstract class BaseViewModel<TParameter, TResult> : MvxViewModel<TParameter, TResult>
+        where TParameter : class
+        where TResult : class
+    {
+        protected BaseViewModel()
+        {
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/ViewModels/FirstViewModel.cs
+++ b/Projects/Playground/Playground.Droid/ViewModels/FirstViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using StarWarsSample.Droid.ViewModels;
+
+namespace Playground.Droid.ViewModels
+{
+    public class FirstViewModel : BaseViewModel
+    {
+        private readonly IMvxNavigationService _navigationService;
+
+        public FirstViewModel(
+            IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService;
+
+            OpenSecondViewCommand = new MvxAsyncCommand(OpenSecondView);
+        }
+
+        public IMvxCommand OpenSecondViewCommand { get; private set; }
+
+        private async Task OpenSecondView()
+        {
+            await _navigationService.Navigate<SecondViewModel>();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/ViewModels/MainViewModel.cs
+++ b/Projects/Playground/Playground.Droid/ViewModels/MainViewModel.cs
@@ -1,0 +1,19 @@
+﻿using MvvmCross.Commands;
+using MvvmCross.Navigation;
+
+namespace Playground.Droid.ViewModels
+{
+    public class MainViewModel : BaseViewModel
+    {
+        private readonly IMvxNavigationService _navigationService;
+
+        public MainViewModel(IMvxNavigationService navigationService)
+        {
+            _navigationService = navigationService;
+
+            ShowFirstViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<FirstViewModel>());
+        }
+
+        public IMvxAsyncCommand ShowFirstViewModelCommand { get; private set; }
+    }
+}

--- a/Projects/Playground/Playground.Droid/ViewModels/SecondViewModel.cs
+++ b/Projects/Playground/Playground.Droid/ViewModels/SecondViewModel.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using MvvmCross.Commands;
+using Playground.Droid.ViewModels;
+using Plugin.Share;
+using Plugin.Share.Abstractions;
+
+namespace StarWarsSample.Droid.ViewModels
+{
+    public class SecondViewModel : BaseViewModel
+    {
+        public SecondViewModel()
+        {
+            OpenBrowserCommand = new MvxAsyncCommand(OpenBrowser);
+        }
+
+        public override Task Initialize()
+        {
+            return Task.FromResult(0);
+        }
+
+        public IMvxCommand OpenBrowserCommand { get; private set; }
+
+        private async Task OpenBrowser()
+        {
+            await CrossShare.Current.OpenBrowser("https://www.google.com", new BrowserOptions { UseSafariWebViewController = false });
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Views/BaseFragment.cs
+++ b/Projects/Playground/Playground.Droid/Views/BaseFragment.cs
@@ -1,0 +1,31 @@
+﻿using Android.OS;
+using Android.Views;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.ViewModels;
+
+namespace Playground.Droid.Views
+{
+    public abstract class BaseFragment : MvxFragment
+    {
+        protected BaseFragment()
+        {
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            var ignore = base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(FragmentId, null);
+
+            return view;
+        }
+
+        protected abstract int FragmentId { get; }
+    }
+
+    public abstract class BaseFragment<TViewModel> : BaseFragment where TViewModel : class, IMvxViewModel
+    {
+
+    }
+}

--- a/Projects/Playground/Playground.Droid/Views/FirstView.cs
+++ b/Projects/Playground/Playground.Droid/Views/FirstView.cs
@@ -1,0 +1,13 @@
+﻿using Android.Runtime;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Droid.ViewModels;
+
+namespace Playground.Droid.Views
+{
+    [MvxFragmentPresentation(typeof(MainViewModel), Playground.Droid.Resource.Id.content_frame, false)]
+    [Register(nameof(FirstView))]
+    public class FirstView : BaseFragment<FirstViewModel>
+    {
+        protected override int FragmentId => Resource.Layout.FirstView;
+    }
+}

--- a/Projects/Playground/Playground.Droid/Views/MainView.cs
+++ b/Projects/Playground/Playground.Droid/Views/MainView.cs
@@ -1,0 +1,34 @@
+﻿using Android.App;
+using Android.Content.PM;
+using Android.Support.V4.View;
+using Android.Support.V4.Widget;
+using Android.Views;
+using Android.Views.InputMethods;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Droid.ViewModels;
+
+namespace Playground.Droid.Views
+{
+    [MvxActivityPresentation]
+    [Activity(Label = "Star Wars",
+        Theme = "@style/AppTheme",
+        LaunchMode = LaunchMode.SingleTop,
+        Name = "playground.droid.views.MainView"
+        )]
+    public class MainView : MvxAppCompatActivity<MainViewModel>
+    {
+        protected override void OnCreate(Android.OS.Bundle bundle)
+        {
+            base.OnCreate(bundle);
+
+            SetContentView(Playground.Droid.Resource.Layout.MainView);
+
+            if (bundle == null)
+            {
+                ViewModel.ShowFirstViewModelCommand.Execute(null);
+            }
+        }
+    }
+}
+

--- a/Projects/Playground/Playground.Droid/Views/SecondView.cs
+++ b/Projects/Playground/Playground.Droid/Views/SecondView.cs
@@ -1,0 +1,15 @@
+﻿using Android.Runtime;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Droid.ViewModels;
+using StarWarsSample.Droid.ViewModels;
+
+namespace Playground.Droid.Views
+{
+    [MvxFragmentPresentation(typeof(MainViewModel), Playground.Droid.Resource.Id.content_frame, true)]
+    [Register(nameof(SecondView))]
+    public class SecondView : BaseFragment<SecondViewModel>
+    {
+        protected override int FragmentId => Resource.Layout.SecondView;
+
+    }
+}


### PR DESCRIPTION
I add logs to MvxMultipleViewModelCache to see memory leak:
https://github.com/aoershov/MvvmCrossMemoryLeakBrowser/blob/master/MvxMultipleViewModelCacheWithLogs.cs

Steps to reproduce 📜
Press "Open second view"
Press "Open browser"
Browser is shown
Press back
Expected behavior 🤔
No memory leak.

Actual behavior 🐛
From logs I see than FirstViewModel and SecondViewModel added to cache on opening browser,
but never cleaned on back press.
This problem is serious for us because we call Dispose of view model on back press. So we get disposed view model from cache on second opening SecondViewModel.

Configuration 🔧
Version: 6.01

Platform:

 🤖 Android