### PR TITLE
Update WPF version too, to avoid NuGet restore complaining about downgrade

### DIFF
--- a/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
+++ b/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
@@ -21,8 +21,8 @@ This package contains the 'MvvmCross.Forms.Platforms.Wpf' libraries for MvvmCros
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="3.0.0.446417" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="3.0.0.482510" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bugfix

### :arrow_heading_down: What is the current behavior?
NuGet fails restoring packages because of version mismatch and it says we are downgrading versions

### :new: What is the new behavior (if this is a feature change)?
It doesn't

### :boom: Does this PR introduce a breaking change?
Nein

### :bug: Recommendations for testing
Restore NuGet packages

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
