### PR TITLE
MvxSimpleTableViewSource for include ViewCell designir in storyboard.

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -21,6 +21,12 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             : base(handle)
         {
             MvxLog.Instance.Warn("MvxSimpleTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+        }
+
+        public MvxSimpleTableViewSource(UITableView tableView, string cellIdentifier)
+            : base(tableView)
+        {
+            _cellIdentifier = new NSString(cellIdentifier);
         }
 
         public MvxSimpleTableViewSource(UITableView tableView, string nibName, string cellIdentifier = null,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
New possibility in existing feature.

### :arrow_heading_down: What is the current behavior?
The problem is that if you define a ViewCell embedded in your TableView within a storyboard does not need to register the ViewCell.

### :new: What is the new behavior (if this is a feature change)?
On a storyboard we define a TableView with its ViewCell. We define an identifier name, in the storyboard editor. We pass that name to the builder of the MvxSimpleTableViewSource

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
