### PR TITLE
Reducing parameters on viewmodel

### DIFF
--- a/MvvmCross/Logging/IMvxLogProvider.cs
+++ b/MvvmCross/Logging/IMvxLogProvider.cs
@@ -8,6 +8,8 @@ namespace MvvmCross.Logging
 {
     public interface IMvxLogProvider
     {
+        IMvxLog GetLogFor(Type type);
+
         IMvxLog GetLogFor<T>();
 
         IMvxLog GetLogFor(string name);

--- a/MvvmCross/Logging/LogProviders/MvxBaseLogProvider.cs
+++ b/MvvmCross/Logging/LogProviders/MvxBaseLogProvider.cs
@@ -32,8 +32,11 @@ namespace MvvmCross.Logging.LogProviders
                = new Lazy<OpenMdc>(GetOpenMdcMethod);
         }
 
+        public IMvxLog GetLogFor(Type type)
+            => GetLogFor(type.FullName);
+
         public IMvxLog GetLogFor<T>()
-            => GetLogFor(typeof(T).FullName);
+            => GetLogFor(typeof(T));
 
         public IMvxLog GetLogFor(string name)
             => new MvxLog(GetLogger(name));

--- a/MvvmCross/ViewModels/IMvxLogViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxLogViewModel.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+
+using MvvmCross.Logging;
+
+namespace MvvmCross.ViewModels
+{
+    public interface IMvxLogViewModel : IMvxViewModel
+    {
+        IMvxLogProvider LogProvider { get; set; }
+    }
+}

--- a/MvvmCross/ViewModels/IMvxNavigationViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxNavigationViewModel.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Navigation;
+
+namespace MvvmCross.ViewModels
+{
+    public interface IMvxNavigationViewModel : IMvxViewModel
+    {
+        IMvxNavigationService NavigationService { get; set; }
+    }
+}

--- a/MvvmCross/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxViewModel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using MvvmCross.Navigation;
 
 namespace MvvmCross.ViewModels
 {

--- a/MvvmCross/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/ViewModels/MvxViewModel.cs
@@ -3,15 +3,25 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
 
 namespace MvvmCross.ViewModels
 {
     public abstract class MvxViewModel
-        : MvxNotifyPropertyChanged, IMvxViewModel
+        : MvxNotifyPropertyChanged, IMvxViewModel, IMvxNavigationViewModel, IMvxLogViewModel
     {
+        private IMvxLog _log;
+
         protected MvxViewModel()
         {
         }
+
+        public virtual IMvxNavigationService NavigationService { get; set; }
+
+        public virtual IMvxLogProvider LogProvider { get; set; }
+
+        protected virtual IMvxLog Log => _log ?? (_log = LogProvider.GetLogFor(GetType()));
 
         public virtual void ViewCreated()
         {

--- a/Projects/Playground/Playground.Core/ViewModels/Bindings/BindingsViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Bindings/BindingsViewModel.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,13 +10,10 @@ namespace Playground.Core.ViewModels
 {
     public class BindingsViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
         private int _counter = 2;
 
-        public BindingsViewModel(IMvxNavigationService navigationService)
+        public BindingsViewModel()
         {
-            _navigationService = navigationService;
             _counter = 3;
         }
 

--- a/Projects/Playground/Playground.Core/ViewModels/Bindings/CustomBindingViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Bindings/CustomBindingViewModel.cs
@@ -8,8 +8,6 @@ namespace Playground.Core.ViewModels.Bindings
     public class CustomBindingViewModel
         : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
         private IMvxAsyncCommand _closeCommand;
 
         private int _counter = 2;
@@ -17,11 +15,6 @@ namespace Playground.Core.ViewModels.Bindings
         private DateTime _date = DateTime.Now;
 
         private string _hello = "Hello MvvmCross";
-
-        public CustomBindingViewModel(IMvxNavigationService navigationService)
-        {
-            _navigationService = navigationService;
-        }
 
         public string Hello
         {
@@ -31,7 +24,7 @@ namespace Playground.Core.ViewModels.Bindings
 
         public IMvxAsyncCommand CloseCommand => _closeCommand ??
                                                 (_closeCommand = new MvxAsyncCommand(async () =>
-                                                    await _navigationService.Close(this)));
+                                                    await NavigationService.Close(this)));
 
         public int Counter
         {

--- a/Projects/Playground/Playground.Core/ViewModels/Bindings/DictionaryBindingViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Bindings/DictionaryBindingViewModel.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using MvvmCross.Commands;
-using MvvmCross.Navigation;
-using MvvmCross.ViewModels;
 
 namespace Playground.Core.ViewModels
 {
@@ -19,19 +17,13 @@ namespace Playground.Core.ViewModels
 
         IMvxAsyncCommand _closeCommand;
         public IMvxAsyncCommand CloseCommand =>
-            _closeCommand ?? (_closeCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this)));
+            _closeCommand ?? (_closeCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this)));
 
 
         IMvxCommand _incrementCommand;
-        private IMvxNavigationService _navigationService;
 
         public IMvxCommand IncrementCommand =>
             _incrementCommand ?? (_incrementCommand = new MvxCommand(Increment));
-
-        public DictionaryBindingViewModel(IMvxNavigationService navigationService)
-        {
-            _navigationService = navigationService;
-        }
 
         private void Increment()
         {

--- a/Projects/Playground/Playground.Core/ViewModels/MainViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/MainViewModel.cs
@@ -12,39 +12,35 @@ namespace Playground.Core.ViewModels
 {
     public class MainViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
         private string _bindableText = "I'm bound!";
 
         private int _counter = 2;
 
-        public MainViewModel(IMvxNavigationService navigationService)
+        public MainViewModel()
         {
-            _navigationService = navigationService;
+            ShowChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ChildViewModel>());
 
-            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
-
-            ShowModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalViewModel>());
+            ShowModalCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ModalViewModel>());
 
             ShowModalNavCommand =
-                new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<ModalNavViewModel>());
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
 
-            ShowSplitCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitRootViewModel>());
+            ShowSplitCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitRootViewModel>());
 
             ShowOverrideAttributeCommand = new MvxAsyncCommand(async () =>
-                await _navigationService.Navigate<OverrideAttributeViewModel>());
+                await NavigationService.Navigate<OverrideAttributeViewModel>());
 
-            ShowSheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SheetViewModel>());
+            ShowSheetCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SheetViewModel>());
 
-            ShowWindowCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<WindowViewModel>());
+            ShowWindowCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<WindowViewModel>());
 
             ShowMixedNavigationCommand =
-                new MvxAsyncCommand(async () => await _navigationService.Navigate<MixedNavFirstViewModel>());
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<MixedNavFirstViewModel>());
 
             ShowCustomBindingCommand =
-                new MvxAsyncCommand(async () => await _navigationService.Navigate<CustomBindingViewModel>());
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<CustomBindingViewModel>());
 
             _counter = 3;
         }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/ChildViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/ChildViewModel.cs
@@ -12,19 +12,15 @@ namespace Playground.Core.ViewModels
 {
     public class ChildViewModel : MvxViewModel<SampleModel>
     {
-        private readonly IMvxNavigationService _navigationService;
-
         private SampleModel _parameter;
 
-        public ChildViewModel(IMvxNavigationService navigationService)
+        public ChildViewModel()
         {
-            _navigationService = navigationService;
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            ShowSecondChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SecondChildViewModel>());
 
-            ShowSecondChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SecondChildViewModel>());
-
-            ShowRootCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
+            ShowRootCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<RootViewModel>());
         }
 
         public override void Prepare()

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavFirstViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavFirstViewModel.cs
@@ -11,13 +11,6 @@ namespace Playground.Core.ViewModels
 {
     public class MixedNavFirstViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-        
-        public MixedNavFirstViewModel(IMvxNavigationService navigationService)
-        {
-            _navigationService = navigationService;
-        }
-
         public IMvxAsyncCommand LoginCommand => new MvxAsyncCommand(GotoMasterDetailPage, CanLogin);
 
         private bool CanLogin()
@@ -27,8 +20,8 @@ namespace Playground.Core.ViewModels
 
         private async Task GotoMasterDetailPage()
         {
-            await _navigationService.Navigate<MixedNavMasterDetailViewModel>();
-            await _navigationService.Navigate<MixedNavMasterRootContentViewModel>();
+            await NavigationService.Navigate<MixedNavMasterDetailViewModel>();
+            await NavigationService.Navigate<MixedNavMasterRootContentViewModel>();
         }
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavMasterDetailViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavMasterDetailViewModel.cs
@@ -12,7 +12,6 @@ namespace Playground.Core.ViewModels
 {
     public class MixedNavMasterDetailViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
         private MenuItem _menuItem;
         private IMvxAsyncCommand<MenuItem> _onSelectedChangedCommand;
 
@@ -24,9 +23,8 @@ namespace Playground.Core.ViewModels
             public Type ViewModelType { get; set; }
         }
 
-        public MixedNavMasterDetailViewModel(IMvxNavigationService navigationService)
+        public MixedNavMasterDetailViewModel()
         {
-            _navigationService = navigationService;
             Menu = new[] {
                 new MenuItem { Title = "Root", Description = "The root page", ViewModelType = typeof(MixedNavMasterRootContentViewModel) },
                 new MenuItem { Title = "Tabs", Description = "Tabbed detail page", ViewModelType = typeof(MixedNavTabsViewModel)},
@@ -52,7 +50,7 @@ namespace Playground.Core.ViewModels
                         return;
 
                     var vmType = item.ViewModelType;
-                    await _navigationService.Navigate(vmType);
+                    await NavigationService.Navigate(vmType);
                 }));
             }
         }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavMasterRootContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavMasterRootContentViewModel.cs
@@ -11,14 +11,10 @@ namespace Playground.Core.ViewModels
 {
     public class MixedNavMasterRootContentViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public MixedNavMasterRootContentViewModel(IMvxNavigationService navigationService)
+        public MixedNavMasterRootContentViewModel()
         {
-            _navigationService = navigationService;
-
-            ShowModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
-            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel, SampleModel>(new SampleModel { Message = "Hey", Value = 1.23m }));
+            ShowModalCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ModalNavViewModel>());
+            ShowChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ChildViewModel, SampleModel>(new SampleModel { Message = "Hey", Value = 1.23m }));
         }
 
         public IMvxAsyncCommand ShowModalCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavResultDetailViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavResultDetailViewModel.cs
@@ -8,12 +8,9 @@ namespace Playground.Core.ViewModels
 {
     public class MixedNavResultDetailViewModel : MvxViewModel, IMvxViewModelResult<DetailResultResult>
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public MixedNavResultDetailViewModel(IMvxNavigationService navigationService)
+        public MixedNavResultDetailViewModel()
         {
-            _navigationService = navigationService;
-            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this, DetailResultResult.Build()));
+            CloseViewModelCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this, DetailResultResult.Build()));
         }
 
 

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavTabsViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MixedNavTabsViewModel.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,14 +12,6 @@ namespace Playground.Core.ViewModels
 {
     public class MixedNavTabsViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public MixedNavTabsViewModel(IMvxNavigationService navigationService)
-        {
-            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
-        }
-
-
         public override async void ViewAppearing()
         {
             await ShowInitialViewModels();
@@ -29,11 +21,11 @@ namespace Playground.Core.ViewModels
         private async Task ShowInitialViewModels()
         {
             var tasks = new List<Task>();
-            tasks.Add(_navigationService.Navigate<MixedNavTab1ViewModel>());
-            tasks.Add(_navigationService.Navigate<MixedNavTab2ViewModel>());
-            //tasks.Add(_navigationService.Navigate<Tab1ViewModel, string>("test"));
-            //tasks.Add(_navigationService.Navigate<Tab2ViewModel>());
-            //tasks.Add(_navigationService.Navigate<Tab3ViewModel>());
+            tasks.Add(NavigationService.Navigate<MixedNavTab1ViewModel>());
+            tasks.Add(NavigationService.Navigate<MixedNavTab2ViewModel>());
+            //tasks.Add(NavigationService.Navigate<Tab1ViewModel, string>("test"));
+            //tasks.Add(NavigationService.Navigate<Tab2ViewModel>());
+            //tasks.Add(NavigationService.Navigate<Tab3ViewModel>());
             await Task.WhenAll(tasks);
         }
     }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/ModalNavViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/ModalNavViewModel.cs
@@ -10,17 +10,13 @@ namespace Playground.Core.ViewModels
 {
     public class ModalNavViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public ModalNavViewModel(IMvxNavigationService navigationService)
+        public ModalNavViewModel()
         {
-            _navigationService = navigationService;
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            ShowChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ChildViewModel>());
 
-            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
-
-            ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NestedModalViewModel>());
+            ShowNestedModalCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<NestedModalViewModel>());
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/ModalViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/ModalViewModel.cs
@@ -10,17 +10,13 @@ namespace Playground.Core.ViewModels
 {
     public class ModalViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public ModalViewModel(IMvxNavigationService navigationService)
+        public ModalViewModel()
         {
-            _navigationService = navigationService;
+            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
-
-            ShowNestedModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NestedModalViewModel>());
+            ShowNestedModalCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<NestedModalViewModel>());
         }
 
         public override System.Threading.Tasks.Task Initialize()

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/NestedChildViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/NestedChildViewModel.cs
@@ -11,16 +11,12 @@ namespace Playground.Core.ViewModels
 {
     public class NestedChildViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public NestedChildViewModel(IMvxNavigationService navigationService)
+        public NestedChildViewModel()
         {
-            _navigationService = navigationService;
-
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
-            PopToChildCommand = new MvxCommand(() => _navigationService.ChangePresentation(new MvxPopPresentationHint(typeof(ChildViewModel))));
-            PopToRootCommand = new MvxCommand(() => _navigationService.ChangePresentation(new MvxPopToRootPresentationHint()));
-            RemoveCommand = new MvxCommand(() => _navigationService.ChangePresentation(new MvxRemovePresentationHint(typeof(SecondChildViewModel))));
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
+            PopToChildCommand = new MvxCommand(() => NavigationService.ChangePresentation(new MvxPopPresentationHint(typeof(ChildViewModel))));
+            PopToRootCommand = new MvxCommand(() => NavigationService.ChangePresentation(new MvxPopToRootPresentationHint()));
+            RemoveCommand = new MvxCommand(() => NavigationService.ChangePresentation(new MvxRemovePresentationHint(typeof(SecondChildViewModel))));
         }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/NestedModalViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/NestedModalViewModel.cs
@@ -10,15 +10,11 @@ namespace Playground.Core.ViewModels
 {
     public class NestedModalViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public NestedModalViewModel(IMvxNavigationService navigationService)
+        public NestedModalViewModel()
         {
-            _navigationService = navigationService;
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
-
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
         }
 
         public IMvxAsyncCommand ShowTabsCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/OverrideAttributeViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/OverrideAttributeViewModel.cs
@@ -10,17 +10,13 @@ namespace Playground.Core.ViewModels
 {
     public class OverrideAttributeViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public OverrideAttributeViewModel(IMvxNavigationService navigationService)
+        public OverrideAttributeViewModel()
         {
-            _navigationService = navigationService;
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
-
-            ShowSecondChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SecondChildViewModel>());
+            ShowSecondChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SecondChildViewModel>());
         }
 
         public IMvxAsyncCommand ShowTabsCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SecondChildViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SecondChildViewModel.cs
@@ -10,15 +10,11 @@ namespace Playground.Core.ViewModels
 {
     public class SecondChildViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public SecondChildViewModel(IMvxNavigationService navigationService)
+        public SecondChildViewModel()
         {
-            _navigationService = navigationService;
+            ShowNestedChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<NestedChildViewModel>());
 
-            ShowNestedChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NestedChildViewModel>());
-
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
         }
 
         public IMvxAsyncCommand ShowNestedChildCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SheetViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SheetViewModel.cs
@@ -11,12 +11,8 @@ namespace Playground.Core.ViewModels
 {
     public class SheetViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public SheetViewModel(IMvxNavigationService navigationService)
+        public SheetViewModel()
         {
-            _navigationService = navigationService;
-
             CloseCommand = new MvxAsyncCommand(CloseSheet);
         }
 
@@ -24,7 +20,7 @@ namespace Playground.Core.ViewModels
 
         private async Task CloseSheet()
         {
-            await _navigationService.Close(this);
+            await NavigationService.Close(this);
         }
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailNavViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailNavViewModel.cs
@@ -10,14 +10,10 @@ namespace Playground.Core.ViewModels
 {
     public class SplitDetailNavViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public SplitDetailNavViewModel(IMvxNavigationService navigationService)
+        public SplitDetailNavViewModel()
         {
-            _navigationService = navigationService;
-
-            MainMenuCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<MixedNavFirstViewModel>());
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            MainMenuCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<MixedNavFirstViewModel>());
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
         }
 
         public IMvxAsyncCommand MainMenuCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailViewModel.cs
@@ -10,13 +10,9 @@ namespace Playground.Core.ViewModels
 {
     public class SplitDetailViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public SplitDetailViewModel(IMvxNavigationService navigationService)
+        public SplitDetailViewModel()
         {
-            _navigationService = navigationService;
-
-            ShowChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitDetailNavViewModel>());
+            ShowChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitDetailNavViewModel>());
         }
 
         public IMvxAsyncCommand ShowChildCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitMasterViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitMasterViewModel.cs
@@ -10,17 +10,13 @@ namespace Playground.Core.ViewModels
 {
     public class SplitMasterViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public SplitMasterViewModel(IMvxNavigationService navigationService)
+        public SplitMasterViewModel()
         {
-            _navigationService = navigationService;
+            OpenDetailCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitDetailViewModel>());
 
-            OpenDetailCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitDetailViewModel>());
+            OpenDetailNavCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitDetailNavViewModel>());
 
-            OpenDetailNavCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitDetailNavViewModel>());
-
-            ShowRootViewModel = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
+            ShowRootViewModel = new MvxAsyncCommand(async () => await NavigationService.Navigate<RootViewModel>());
         }
 
         public string PaneText => "Text for the Master Pane";

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitRootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitRootViewModel.cs
@@ -11,12 +11,8 @@ namespace Playground.Core.ViewModels
 {
     public class SplitRootViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public SplitRootViewModel(IMvxNavigationService navigationService)
+        public SplitRootViewModel()
         {
-            _navigationService = navigationService;
-
             ShowInitialMenuCommand = new MvxAsyncCommand(ShowInitialViewModel);
             ShowDetailCommand = new MvxAsyncCommand(ShowDetailViewModel);
         }
@@ -35,12 +31,12 @@ namespace Playground.Core.ViewModels
 
         private async Task ShowInitialViewModel()
         {
-            await _navigationService.Navigate<SplitMasterViewModel>();
+            await NavigationService.Navigate<SplitMasterViewModel>();
         }
 
         private async Task ShowDetailViewModel()
         {
-            await _navigationService.Navigate<SplitDetailViewModel>();
+            await NavigationService.Navigate<SplitDetailViewModel>();
         }
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
@@ -11,19 +11,15 @@ namespace Playground.Core.ViewModels
 {
     public class Tab1ViewModel : MvxViewModel<string>
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public Tab1ViewModel(IMvxNavigationService navigationService)
+        public Tab1ViewModel()
         {
-            _navigationService = navigationService;
+            OpenChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ChildViewModel>());
 
-            OpenChildCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ChildViewModel>());
+            OpenModalCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ModalViewModel>());
 
-            OpenModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalViewModel>());
+            OpenNavModalCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ModalNavViewModel>());
 
-            OpenNavModalCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
-
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
         }
 
         public override async Task Initialize()

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab2ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab2ViewModel.cs
@@ -10,15 +10,11 @@ namespace Playground.Core.ViewModels
 {
     public class Tab2ViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public Tab2ViewModel(IMvxNavigationService navigationService)
+        public Tab2ViewModel()
         {
-            _navigationService = navigationService;
+            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<RootViewModel>());
 
-            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
-
-            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseViewModelCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
         }
 
         public IMvxAsyncCommand ShowRootViewModelCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab3ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab3ViewModel.cs
@@ -11,17 +11,13 @@ namespace Playground.Core.ViewModels
 {
     public class Tab3ViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public Tab3ViewModel(IMvxNavigationService navigationService)
+        public Tab3ViewModel()
         {
-            _navigationService = navigationService;
+            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<RootViewModel>());
 
-            ShowRootViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<RootViewModel>());
+            CloseViewModelCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
-            CloseViewModelCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
-
-            ShowPageOneCommand = new MvxCommand(() => _navigationService.ChangePresentation(new MvxPagePresentationHint(typeof(Tab1ViewModel))));
+            ShowPageOneCommand = new MvxCommand(() => NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(Tab1ViewModel))));
         }
 
         public IMvxAsyncCommand ShowRootViewModelCommand { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/TabsRootBViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/TabsRootBViewModel.cs
@@ -14,13 +14,8 @@ namespace Playground.Core.ViewModels
 {
     public class TabsRootBViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-        private readonly IMvxLog _log;
-
-        public TabsRootBViewModel(IMvxNavigationService navigationService, IMvxLogProvider logProvider)
+        public TabsRootBViewModel()
         {
-            _log = logProvider.GetLogFor(nameof(TabsRootBViewModel));
-            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
             ShowInitialViewModelsCommand = new MvxAsyncCommand(ShowInitialViewModels);
         }
 
@@ -29,8 +24,8 @@ namespace Playground.Core.ViewModels
         private async Task ShowInitialViewModels()
         {
             var tasks = new List<Task>();
-            tasks.Add(_navigationService.Navigate<Tab1ViewModel, string>("test"));
-            tasks.Add(_navigationService.Navigate<Tab2ViewModel>());
+            tasks.Add(NavigationService.Navigate<Tab1ViewModel, string>("test"));
+            tasks.Add(NavigationService.Navigate<Tab2ViewModel>());
             await Task.WhenAll(tasks);
         }
 
@@ -43,7 +38,7 @@ namespace Playground.Core.ViewModels
             {
                 if (_itemIndex == value) return;
                 _itemIndex = value;
-                _log.Trace("Tab item changed to {0}", _itemIndex.ToString());
+                Log.Trace("Tab item changed to {0}", _itemIndex.ToString());
                 RaisePropertyChanged(() => ItemIndex);
             }
         }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/TabsRootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/TabsRootViewModel.cs
@@ -14,16 +14,10 @@ namespace Playground.Core.ViewModels
 {
     public class TabsRootViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-        private readonly IMvxLog _log;
-
-        public TabsRootViewModel(IMvxNavigationService navigationService, IMvxLogProvider logProvider)
+        public TabsRootViewModel()
         {
-            _log = logProvider.GetLogFor(nameof(TabsRootViewModel));
-            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
-
             ShowInitialViewModelsCommand = new MvxAsyncCommand(ShowInitialViewModels);
-            ShowTabsRootBCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootBViewModel>());
+            ShowTabsRootBCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootBViewModel>());
         }
 
         public IMvxAsyncCommand ShowInitialViewModelsCommand { get; private set; }
@@ -33,9 +27,9 @@ namespace Playground.Core.ViewModels
         private async Task ShowInitialViewModels()
         {
             var tasks = new List<Task>();
-            tasks.Add(_navigationService.Navigate<Tab1ViewModel, string>("test"));
-            tasks.Add(_navigationService.Navigate<Tab2ViewModel>());
-            tasks.Add(_navigationService.Navigate<Tab3ViewModel>());
+            tasks.Add(NavigationService.Navigate<Tab1ViewModel, string>("test"));
+            tasks.Add(NavigationService.Navigate<Tab2ViewModel>());
+            tasks.Add(NavigationService.Navigate<Tab3ViewModel>());
             await Task.WhenAll(tasks);
         }
 
@@ -48,7 +42,7 @@ namespace Playground.Core.ViewModels
             {
                 if (_itemIndex == value) return;
                 _itemIndex = value;
-                _log.Trace("Tab item changed to {0}", _itemIndex.ToString());
+                Log.Trace("Tab item changed to {0}", _itemIndex.ToString());
                 RaisePropertyChanged(() => ItemIndex);
             }
         }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/WindowChildViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/WindowChildViewModel.cs
@@ -10,16 +10,12 @@ namespace Playground.Core.ViewModels
 {
     public class WindowChildViewModel : MvxViewModel<WindowChildParam>
     {
-        private readonly IMvxNavigationService _navigationService;
-
         private WindowChildParam _param;
 
         public int ParentNo => _param.ParentNo;
         public string Text => $"I'm No.{_param.ChildNo}. My parent is No.{_param.ParentNo}";
 
-        public IMvxAsyncCommand CloseCommand => new MvxAsyncCommand(async () => await _navigationService.Close(this));
-
-        public WindowChildViewModel(IMvxNavigationService navigationService) => _navigationService = navigationService;
+        public IMvxAsyncCommand CloseCommand => new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
         public override void Prepare(WindowChildParam param) => _param = param;
     }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/WindowViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/WindowViewModel.cs
@@ -18,8 +18,6 @@ namespace Playground.Core.ViewModels
 
     public class WindowViewModel : MvxViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
         private static int _count;
 
         public string Title => $"No.{Count} Window View";
@@ -82,23 +80,21 @@ namespace Playground.Core.ViewModels
 
         public int Count { get; set; }
 
-        public WindowViewModel(IMvxNavigationService navigationService)
+        public WindowViewModel()
         {
-            _navigationService = navigationService;
-
             _count++;
             Count = _count;
 
             ShowWindowChildCommand = new MvxAsyncCommand<int>(async no =>
             {
-                await _navigationService.Navigate<WindowChildViewModel, WindowChildParam>(new WindowChildParam
+                await NavigationService.Navigate<WindowChildViewModel, WindowChildParam>(new WindowChildParam
                 {
                     ParentNo = Count,
                     ChildNo = no
                 });
             });
 
-            CloseCommand = new MvxAsyncCommand(async () => await _navigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
 
             ToggleSettingCommand = new MvxAsyncCommand(async () => 
             {

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -16,20 +16,16 @@ namespace Playground.Core.ViewModels
     public class RootViewModel : MvxViewModel
     {
         private readonly IMvxViewModelLoader _mvxViewModelLoader;
-        private readonly IMvxNavigationService _navigationService;
 
         private int _counter = 2;
 
-        public RootViewModel(IMvxNavigationService navigationService, IMvxLogProvider logProvider,
-            IMvxViewModelLoader mvxViewModelLoader)
+        public RootViewModel(IMvxViewModelLoader mvxViewModelLoader)
         {
-            _navigationService = navigationService;
             _mvxViewModelLoader = mvxViewModelLoader;
 
-            logProvider.GetLogFor<RootViewModel>().Warn(() => "Testing log");
 
             ShowChildCommand = new MvxAsyncCommand(async () =>
-                await _navigationService.Navigate<ChildViewModel, SampleModel>(new SampleModel
+                await NavigationService.Navigate<ChildViewModel, SampleModel>(new SampleModel
                 {
                     Message = "Hey",
                     Value = 1.23m
@@ -38,35 +34,35 @@ namespace Playground.Core.ViewModels
             ShowModalCommand = new MvxAsyncCommand(Navigate);
 
             ShowModalNavCommand =
-                new MvxAsyncCommand(async () => await _navigationService.Navigate<ModalNavViewModel>());
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<ModalNavViewModel>());
 
-            ShowTabsCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
 
-            ShowSplitCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SplitRootViewModel>());
+            ShowSplitCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitRootViewModel>());
 
-            ShowNativeCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<NativeViewModel>());
+            ShowNativeCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<NativeViewModel>());
 
             ShowOverrideAttributeCommand = new MvxAsyncCommand(async () =>
-                await _navigationService.Navigate<OverrideAttributeViewModel>());
+                await NavigationService.Navigate<OverrideAttributeViewModel>());
 
-            ShowSheetCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<SheetViewModel>());
+            ShowSheetCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SheetViewModel>());
 
-            ShowWindowCommand = new MvxAsyncCommand(async () => await _navigationService.Navigate<WindowViewModel>());
+            ShowWindowCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<WindowViewModel>());
 
             ShowMixedNavigationCommand =
-                new MvxAsyncCommand(async () => await _navigationService.Navigate<MixedNavFirstViewModel>());
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<MixedNavFirstViewModel>());
 
             ShowDictionaryBindingCommand = new MvxAsyncCommand(async () =>
-                await _navigationService.Navigate<DictionaryBindingViewModel>());
+                await NavigationService.Navigate<DictionaryBindingViewModel>());
 
             ShowCollectionViewCommand =
-                new MvxAsyncCommand(async () => await _navigationService.Navigate<CollectionViewModel>());
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<CollectionViewModel>());
 
             ShowSharedElementsCommand = new MvxAsyncCommand(async () =>
-                await _navigationService.Navigate<SharedElementRootChildViewModel>());
+                await NavigationService.Navigate<SharedElementRootChildViewModel>());
 
             ShowCustomBindingCommand =
-                new MvxAsyncCommand(async () => await _navigationService.Navigate<CustomBindingViewModel>());
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<CustomBindingViewModel>());
 
             _counter = 3;
         }
@@ -100,21 +96,23 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowCollectionViewCommand { get; }
 
         public IMvxAsyncCommand ShowListViewCommand =>
-            new MvxAsyncCommand(async () => await _navigationService.Navigate<ListViewModel>());
+            new MvxAsyncCommand(async () => await NavigationService.Navigate<ListViewModel>());
 
         public IMvxAsyncCommand ShowBindingsViewCommand =>
-            new MvxAsyncCommand(async () => await _navigationService.Navigate<BindingsViewModel>());
+            new MvxAsyncCommand(async () => await NavigationService.Navigate<BindingsViewModel>());
 
         public IMvxAsyncCommand ShowCodeBehindViewCommand =>
-            new MvxAsyncCommand(async () => await _navigationService.Navigate<CodeBehindViewModel>());
+            new MvxAsyncCommand(async () => await NavigationService.Navigate<CodeBehindViewModel>());
 
         public IMvxAsyncCommand ShowContentViewCommand =>
-            new MvxAsyncCommand(async () => await _navigationService.Navigate<ParentContentViewModel>());
+            new MvxAsyncCommand(async () => await NavigationService.Navigate<ParentContentViewModel>());
 
         public IMvxAsyncCommand ShowSharedElementsCommand { get; }
 
         public override async Task Initialize()
         {
+            Log.Warn(() => "Testing log");
+
             await base.Initialize();
 
             _mvxViewModelLoader.LoadViewModel(MvxViewModelRequest.GetDefaultRequest(typeof(ChildViewModel)),
@@ -157,7 +155,7 @@ namespace Playground.Core.ViewModels
         {
             try
             {
-                await _navigationService.Navigate<ModalViewModel>();
+                await NavigationService.Navigate<ModalViewModel>();
             }
             catch (Exception)
             {

--- a/Projects/Playground/Playground.Core/ViewModels/SharedElements/SharedElementRootChildViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/SharedElements/SharedElementRootChildViewModel.cs
@@ -10,13 +10,6 @@ namespace Playground.Core.ViewModels
 {
     public class SharedElementRootChildViewModel : BaseViewModel
     {
-        private readonly IMvxNavigationService _navigationService;
-
-        public SharedElementRootChildViewModel(IMvxNavigationService navigationService)
-        {
-            _navigationService = navigationService;
-        }
-
         public override Task Initialize()
         {
             Items = new MvxObservableCollection<ListItemViewModel>
@@ -51,11 +44,11 @@ namespace Playground.Core.ViewModels
 
             if (item.Id % 2 == 0)
             {
-                _navigationService.Navigate<SharedElementSecondViewModel>();
+                NavigationService.Navigate<SharedElementSecondViewModel>();
             }
             else
             {
-                _navigationService.Navigate<SharedElementSecondChildViewModel>();
+                NavigationService.Navigate<SharedElementSecondChildViewModel>();
             }
         }
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently for a VM to access navigation or logging they need to add parameters to constructor

### :new: What is the new behavior (if this is a feature change)?
MvxViewModel has access to navigationservice and log

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current 6.1.0
