### PR TITLE
Add InOnMainThread

### DIFF
--- a/MvvmCross/Base/IMvxMainThreadAsyncDispatcher.cs
+++ b/MvvmCross/Base/IMvxMainThreadAsyncDispatcher.cs
@@ -14,5 +14,6 @@ namespace MvvmCross.Base
     {
         Task ExecuteOnMainThreadAsync(Action action, bool maskExceptions = true);
         Task ExecuteOnMainThreadAsync(Func<Task> action, bool maskExceptions = true);
+        bool IsOnMainThread { get; }
     }
 }

--- a/MvvmCross/Base/IMvxMainThreadDispatcher.cs
+++ b/MvvmCross/Base/IMvxMainThreadDispatcher.cs
@@ -11,5 +11,6 @@ namespace MvvmCross.Base
     {
         [Obsolete("Use IMvxMainThreadAsyncDispatcher.ExecuteOnMainThreadAsync instead")]
         bool RequestMainThreadAction(Action action, bool maskExceptions = true);
+        bool IsOnMainThread { get; }
     }
 }

--- a/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
+++ b/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
@@ -39,5 +39,7 @@ namespace MvvmCross.Base
             // a new thread to wait
             await Task.Run(async () => await completion.Task);
         }
+
+        public abstract override bool IsOnMainThread { get; }
     }
 }

--- a/MvvmCross/Base/MvxMainThreadDispatcher.cs
+++ b/MvvmCross/Base/MvxMainThreadDispatcher.cs
@@ -37,5 +37,7 @@ namespace MvvmCross.Base
         }
 
         public abstract bool RequestMainThreadAction(Action action, bool maskExceptions = true);
+
+        public abstract bool IsOnMainThread { get; }
     }
 }

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidMainThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidMainThreadDispatcher.cs
@@ -12,9 +12,11 @@ namespace MvvmCross.Platforms.Android.Views
 {
     public class MvxAndroidMainThreadDispatcher : MvxMainThreadAsyncDispatcher
     {
+        public override bool IsOnMainThread => Application.SynchronizationContext == SynchronizationContext.Current;
+
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
-            if (Application.SynchronizationContext == SynchronizationContext.Current)
+            if (IsOnMainThread)
                 action();
             else
             {

--- a/MvvmCross/Platforms/Console/Views/MvxConsoleViewDispatcher.cs
+++ b/MvvmCross/Platforms/Console/Views/MvxConsoleViewDispatcher.cs
@@ -14,6 +14,8 @@ namespace MvvmCross.Platforms.Console.Views
         : MvxMainThreadAsyncDispatcher
         , IMvxViewDispatcher
     {
+        public override bool IsOnMainThread => throw new NotImplementedException();
+
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
             action();

--- a/MvvmCross/Platforms/Ios/Views/MvxIosUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxIosUIThreadDispatcher.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Platforms.Ios.Views
 
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
-            if (_uiSynchronizationContext == SynchronizationContext.Current)
+            if (IsOnMainThread)
                 action();
             else
                 UIApplication.SharedApplication.BeginInvokeOnMainThread(() =>
@@ -33,5 +33,7 @@ namespace MvvmCross.Platforms.Ios.Views
                 });
             return true;
         }
+
+        public override bool IsOnMainThread => _uiSynchronizationContext == SynchronizationContext.Current;
     }
 }

--- a/MvvmCross/Platforms/Mac/Views/MvxMacUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Mac/Views/MvxMacUIThreadDispatcher.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platforms.Mac.Views
         public override bool RequestMainThreadAction(Action action,
             bool maskExceptions = true)
         {
-            if (_uiSynchronizationContext == SynchronizationContext.Current)
+            if (IsOnMainThread)
                 action();
             else
                 NSApplication.SharedApplication.BeginInvokeOnMainThread(() =>
@@ -35,5 +35,7 @@ namespace MvvmCross.Platforms.Mac.Views
                 });
             return true;
         }
+
+        public override bool IsOnMainThread => _uiSynchronizationContext == SynchronizationContext.Current;
     }
 }

--- a/MvvmCross/Platforms/Tizen/Views/MvxTizenMainThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Tizen/Views/MvxTizenMainThreadDispatcher.cs
@@ -8,9 +8,12 @@ namespace MvvmCross.Platforms.Tizen.Views
 {
     public class MvxTizenMainThreadDispatcher : MvxMainThreadAsyncDispatcher
     {
+        public override bool IsOnMainThread => true;
+
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
             //TODO: implement
+            action();
             return true;
         }
     }

--- a/MvvmCross/Platforms/Tvos/Views/MvxTvosUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxTvosUIThreadDispatcher.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Platforms.Tvos.Views
 
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
-            if (_uiSynchronizationContext == SynchronizationContext.Current)
+            if (IsOnMainThread)
                 action();
             else
                 UIApplication.SharedApplication.BeginInvokeOnMainThread(() =>
@@ -33,5 +33,7 @@ namespace MvvmCross.Platforms.Tvos.Views
             });
             return true;
         }
+
+        public override bool IsOnMainThread => _uiSynchronizationContext == SynchronizationContext.Current;
     }
 }

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsMainThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsMainThreadDispatcher.cs
@@ -17,9 +17,11 @@ namespace MvvmCross.Platforms.Uap.Views
             _uiDispatcher = uiDispatcher;
         }
 
+        public override bool IsOnMainThread => _uiDispatcher.HasThreadAccess;
+
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
-            if (_uiDispatcher.HasThreadAccess)
+            if (IsOnMainThread)
             {
                 action();
                 return true;

--- a/MvvmCross/Platforms/Wpf/Views/MvxWpfUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWpfUIThreadDispatcher.cs
@@ -18,9 +18,11 @@ namespace MvvmCross.Platforms.Wpf.Views
             _dispatcher = dispatcher;
         }
 
+        public override bool IsOnMainThread => _dispatcher.CheckAccess();
+
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
-            if (_dispatcher.CheckAccess())
+            if (IsOnMainThread)
             {
                 action();
             }

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/CallbackMockMainThreadDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/CallbackMockMainThreadDispatcher.cs
@@ -17,6 +17,8 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
             _callback = callback;
         }
 
+        public override bool IsOnMainThread => true;
+
         public override bool RequestMainThreadAction(Action action,
                                                     bool maskExceptions = true)
         {

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/CountingMockMainThreadDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/CountingMockMainThreadDispatcher.cs
@@ -12,6 +12,8 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
     {
         public int Count { get; set; }
 
+        public override bool IsOnMainThread => true;
+
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
             Count++;

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/InlineMockMainThreadDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/InlineMockMainThreadDispatcher.cs
@@ -10,6 +10,8 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
     public class InlineMockMainThreadDispatcher
         : MvxMainThreadAsyncDispatcher
     {
+        public override bool IsOnMainThread => true;
+
         public override bool RequestMainThreadAction(Action action, 
             bool maskExceptions = true)
         {

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
@@ -20,6 +20,8 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
         public readonly List<MvxViewModelRequest> Requests = new List<MvxViewModelRequest>();
         public readonly List<MvxPresentationHint> Hints = new List<MvxPresentationHint>();
 
+        public bool IsOnMainThread => true;
+
         public virtual bool RequestMainThreadAction(Action action,
                                                     bool maskExceptions = true)
         {

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxObservableCollectionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxObservableCollectionTest.cs
@@ -25,6 +25,8 @@ namespace MvvmCross.UnitTest.ViewModels
 
         public class DummyDispatcher : MvxSingleton<IMvxMainThreadDispatcher>, IMvxMainThreadDispatcher
         {
+            public bool IsOnMainThread => true;
+
             public bool RequestMainThreadAction(Action action, bool maskExceptions = true)
             {
                 action?.Invoke();


### PR DESCRIPTION
Introduced a property for being able to identify whether the current context is that of the UI thread or not.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
A new feature.

### :arrow_heading_down: What is the current behavior?
The current behaviour is that it is not possible by easy means for other developers to easily find out whether the current synchronization context is that of the UI thread. This has to be done platform specifically as well.

### :new: What is the new behavior (if this is a feature change)?
A new property indicating whether the current synchronization context is that of the UI thread or not.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Unit testing.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
