### PR TITLE
Playground.Core.ViewModels.BindingsViewModel: Fix incorrect namespace…

### DIFF
--- a/Projects/Playground/Playground.Core/ViewModels/BindingsViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/BindingsViewModel.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -36,7 +36,7 @@ namespace Playground.Core.ViewModels
 
         public IMvxLanguageBinder TextSource
         {
-            get { return new MvxLanguageBinder("MvxBindingsExample", "Text"); }
+            get { return new MvxLanguageBinder("Playground.Core", "Text"); }
         }
 
         private string _bindableText = "I'm bound!";


### PR DESCRIPTION
… in MvxLanguageBinder that caused labels in sample to not show localized text.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix #2176

### :arrow_heading_down: What is the current behavior?
Localized text does not show in labels

### :new: What is the new behavior (if this is a feature change)?
Localized text correctly appears

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Xamarin.Forms playground, click Bindings View, see that labels following "Lang Binding" appear.

### :memo: Links to relevant issues/docs
#2176

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
