### PR TITLE
Fix for unable to resolve plugins in Playground samples

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -286,7 +286,7 @@ namespace MvvmCross.Core
         public virtual IEnumerable<Assembly> GetPluginAssemblies()
         {
             var mvvmCrossAssemblyName = typeof(MvxPluginAttribute).Assembly.GetName().Name;
-            var allAssemblies = LoadAllReferencedAssemblies(Assembly.GetExecutingAssembly());
+            var allAssemblies = LoadAllReferencedAssemblies(Assembly.GetEntryAssembly());
             var pluginAssemblies =
                 allAssemblies
                     .AsParallel()

--- a/Projects/Playground/Playground.Core/Playground.Core.csproj
+++ b/Projects/Playground/Playground.Core/Playground.Core.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\JsonLocalization\MvvmCross.Plugin.JsonLocalization.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\Json\MvvmCross.Plugin.Json.csproj" />
+    <ProjectReference Include="..\..\..\MvvmCross.Plugins\Messenger\MvvmCross.Plugin.Messenger.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\ResourceLoader\MvvmCross.Plugin.ResourceLoader.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross\MvvmCross.csproj" />
   </ItemGroup>

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -4,9 +4,11 @@
 
 using System;
 using System.Threading.Tasks;
+using MvvmCross;
 using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
+using MvvmCross.Plugin.Messenger;
 using MvvmCross.ViewModels;
 using Playground.Core.Models;
 using Playground.Core.ViewModels.Bindings;
@@ -22,6 +24,15 @@ namespace Playground.Core.ViewModels
         public RootViewModel(IMvxViewModelLoader mvxViewModelLoader)
         {
             _mvxViewModelLoader = mvxViewModelLoader;
+            try
+            {
+                var messenger = Mvx.Resolve<IMvxMessenger>();
+                var str = messenger.ToString();
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
 
 
             ShowChildCommand = new MvxAsyncCommand(async () =>

--- a/Projects/Playground/Playground.Droid/LinkerPleaseInclude.cs
+++ b/Projects/Playground/Playground.Droid/LinkerPleaseInclude.cs
@@ -8,7 +8,7 @@ using MvvmCross.Binding.BindingContext;
 using MvvmCross.Navigation;
 using MvvmCross.ViewModels;
 
-namespace Playground.Forms.Droid
+namespace Playground.Droid
 {
     // This class is never actually executed, but when Xamarin linking is enabled it does how to ensure types and properties
     // are preserved in the deployed app

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Bindings\BinaryEditTargetBinding.cs" />
     <Compile Include="Controls\BinaryEdit.cs" />
     <Compile Include="Fragments\BaseSplitDetailView.cs" />
+    <Compile Include="LinkerPleaseInclude.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SplashScreen.cs" />

--- a/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -57,6 +57,7 @@
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LinkerPleaseInclude.cs" />
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
+++ b/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\..\..\MvvmCross.Forms\MvvmCross.Forms.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\JsonLocalization\MvvmCross.Plugin.JsonLocalization.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\Json\MvvmCross.Plugin.Json.csproj" />
+    <ProjectReference Include="..\..\..\MvvmCross.Plugins\Messenger\MvvmCross.Plugin.Messenger.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\ResourceLoader\MvvmCross.Plugin.ResourceLoader.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross\MvvmCross.csproj" />
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj" />

--- a/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -159,6 +159,10 @@
       <Project>{9a82f120-fbe8-4205-94a3-575630dbcbb9}</Project>
       <Name>MvvmCross.Plugin.Json</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross.Plugins\Messenger\MvvmCross.Plugin.Messenger.csproj">
+      <Project>{2d99f487-5a83-49a3-811a-6c4a7fffabea}</Project>
+      <Name>MvvmCross.Plugin.Messenger</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\ResourceLoader\MvvmCross.Plugin.ResourceLoader.csproj">
       <Project>{4d47736f-d8dc-42f1-8f75-8fc3eff28894}</Project>
       <Name>MvvmCross.Plugin.ResourceLoader</Name>

--- a/Projects/Playground/Playground.Uwp/LinkerPleaseInclude.cs
+++ b/Projects/Playground/Playground.Uwp/LinkerPleaseInclude.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Windows.Input;
+using MvvmCross;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace Playground.Uwp
+{
+    // This class is never actually executed, but when Xamarin linking is enabled it does how to ensure types and properties
+    // are preserved in the deployed app
+    [Preserve(AllMembers = true)]
+    public class LinkerPleaseInclude
+    {
+        public void Include(MvvmCross.Plugin.Json.Plugin plugin)
+        {
+            plugin.Load();
+        }
+
+        public void Include(MvvmCross.Plugin.Messenger.Plugin plugin)
+        {
+            plugin.Load();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -94,6 +94,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="LinkerPleaseInclude.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Views\ChildView.xaml.cs">
       <DependentUpon>ChildView.xaml</DependentUpon>
@@ -181,6 +182,10 @@
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\Json\MvvmCross.Plugin.Json.csproj">
       <Project>{9a82f120-fbe8-4205-94a3-575630dbcbb9}</Project>
       <Name>MvvmCross.Plugin.Json</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\MvvmCross.Plugins\Messenger\MvvmCross.Plugin.Messenger.csproj">
+      <Project>{2d99f487-5a83-49a3-811a-6c4a7fffabea}</Project>
+      <Name>MvvmCross.Plugin.Messenger</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\ResourceLoader\MvvmCross.Plugin.ResourceLoader.csproj">
       <Project>{4d47736f-d8dc-42f1-8f75-8fc3eff28894}</Project>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
In some of the playground samples plugins aren't being resolved

### :new: What is the new behavior (if this is a feature change)?
Plugins are resolved

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run all playground samples and make sure the Json plugin is resolved

### :memo: Links to relevant issues/docs
This is to reproduce issue #2937 


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop



