### PR TITLE
#2904 Fix activity handle on current top activity.

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Platforms.Android.Views
             return null;
         }
 
-        protected string GetActivityName(Activity activity) => activity.Class.SimpleName;
+        protected string GetActivityName(Activity activity) => $"{activity.Class.SimpleName}_{activity.Handle.ToString()}";
 
         /// <summary>
         /// Used to store additional info along with an activity.


### PR DESCRIPTION
Can't close second viewmodel with same type with navigation service.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Inside RootViewModel at Playground Android sample add:

a button "Open Same VM" with action : await _navigationService.Navigate<RootViewModel>();
a button "Close this VM" with action : await _navigationService.Close(this);

click on button "Open Same VM", then click on button "Close this VM".


### :arrow_heading_down: What is the current behavior?
The second rootWiewModel can't close with navigationService.
Console log : close for viewmodel - rootframe has no current page.

### :new: What is the new behavior (if this is a feature change)?
The second rootWiewModel close successfully with navigationService.

### :boom: Does this PR introduce a breaking change?
No breaking change.

### :bug: Recommendations for testing
Android Cycle life

### :memo: Links to relevant issues/docs
#2904

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
