### PR TITLE
Fixing plugin discovery

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -286,7 +286,7 @@ namespace MvvmCross.Core
         public virtual IEnumerable<Assembly> GetPluginAssemblies()
         {
             var mvvmCrossAssemblyName = typeof(MvxPluginAttribute).Assembly.GetName().Name;
-            var allAssemblies = LoadAllReferencedAssemblies(Assembly.GetExecutingAssembly());
+            var allAssemblies = LoadAllReferencedAssemblies(Assembly.GetEntryAssembly());
             var pluginAssemblies =
                 allAssemblies
                     .AsParallel()


### PR DESCRIPTION
Fixes an issue where the plugin framework tries to find plugins by looking at the referenced assemblies of the MvvmCross project, rather than the application assembly itself.

Fixes #2937

### :sparkles: Bug fix

### :arrow_heading_down: Plugins are not found because the code looks into the wrong assembly's references.

### :new: Plugins are found.

### :boom: No breaking changes.

### :bug: Try any of the playground projects and add the Messenger. I tested it on iOS, and the plugin would not be registered.

### :memo: See issue #2937

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
