### PR TITLE
Implementing INotifyPropertyChanging

### DIFF
--- a/MvvmCross/Base/MvxMainThreadDispatchingObject.cs
+++ b/MvvmCross/Base/MvxMainThreadDispatchingObject.cs
@@ -3,16 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace MvvmCross.Base
 {
     public abstract class MvxMainThreadDispatchingObject
     {
         protected IMvxMainThreadDispatcher Dispatcher => MvxMainThreadDispatcher.Instance;
+        protected IMvxMainThreadAsyncDispatcher AsyncDispatcher => MvxMainThreadDispatcher.Instance as IMvxMainThreadAsyncDispatcher;
 
         protected void InvokeOnMainThread(Action action)
         {
             Dispatcher?.RequestMainThreadAction(action);
+        }
+
+        protected Task InvokeOnMainThreadAsync(Action action)
+        {
+            return AsyncDispatcher?.ExecuteOnMainThreadAsync(action);
         }
     }
 }

--- a/MvvmCross/Core/IMvxSettings.cs
+++ b/MvvmCross/Core/IMvxSettings.cs
@@ -7,5 +7,9 @@ namespace MvvmCross.Core
     public interface IMvxSettings
     {
         bool AlwaysRaiseInpcOnUserInterfaceThread { get; set; }
+
+        bool ShouldRaisePropertyChanging { get; set; }
+
+        bool ShouldLogInpc { get; set; }
     }
 }

--- a/MvvmCross/Core/MvxSettings.cs
+++ b/MvvmCross/Core/MvxSettings.cs
@@ -8,9 +8,15 @@ namespace MvvmCross.Core
     {
         public bool AlwaysRaiseInpcOnUserInterfaceThread { get; set; }
 
+        public bool ShouldRaisePropertyChanging { get; set; }
+
+        public bool ShouldLogInpc { get; set; }
+
         public MvxSettings()
         {
             AlwaysRaiseInpcOnUserInterfaceThread = true;
+            ShouldRaisePropertyChanging = true;
+            ShouldLogInpc = false;
         }
     }
 }

--- a/MvvmCross/ViewModels/IMvxInpcInterceptor.cs
+++ b/MvvmCross/ViewModels/IMvxInpcInterceptor.cs
@@ -9,5 +9,6 @@ namespace MvvmCross.ViewModels
     public interface IMvxInpcInterceptor
     {
         MvxInpcInterceptionResult Intercept(IMvxNotifyPropertyChanged sender, PropertyChangedEventArgs args);
+        MvxInpcInterceptionResult Intercept(IMvxNotifyPropertyChanged sender, PropertyChangingEventArgs args);
     }
 }

--- a/MvvmCross/ViewModels/IMvxNotifyPropertyChanged.cs
+++ b/MvvmCross/ViewModels/IMvxNotifyPropertyChanged.cs
@@ -5,20 +5,31 @@
 using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace MvvmCross.ViewModels
 {
-    public interface IMvxNotifyPropertyChanged : INotifyPropertyChanged
+    public interface IMvxNotifyPropertyChanged : INotifyPropertyChanged, INotifyPropertyChanging
     {
         // this ShouldAlwaysRaiseInpcOnUserInterfaceThread is not a Property so as to avoid Inpc pollution
         bool ShouldAlwaysRaiseInpcOnUserInterfaceThread();
 
         void ShouldAlwaysRaiseInpcOnUserInterfaceThread(bool value);
 
-        void RaisePropertyChanged<T>(Expression<Func<T>> property);
+        bool ShouldRaisePropertyChanging();
 
-        void RaisePropertyChanged(string whichProperty);
+        void ShouldRaisePropertyChanging(bool value);
 
-        void RaisePropertyChanged(PropertyChangedEventArgs changedArgs);
+        bool RaisePropertyChanging<T>(T newValue, Expression<Func<T>> property);
+
+        bool RaisePropertyChanging<T>(T newValue, string whichProperty);
+
+        bool RaisePropertyChanging<T>(MvxPropertyChangingEventArgs<T> changingArgs);
+
+        Task RaisePropertyChanged<T>(Expression<Func<T>> property);
+
+        Task RaisePropertyChanged(string whichProperty);
+
+        Task RaisePropertyChanged(PropertyChangedEventArgs changedArgs);
     }
 }

--- a/MvvmCross/ViewModels/MvxInpcInterceptionResult.cs
+++ b/MvvmCross/ViewModels/MvxInpcInterceptionResult.cs
@@ -8,6 +8,8 @@ namespace MvvmCross.ViewModels
     {
         NotIntercepted,
         RaisePropertyChanged,
-        DoNotRaisePropertyChanged
+        DoNotRaisePropertyChanged,
+        RaisePropertyChanging,
+        DoNotRaisePropertyChanging
     }
 }

--- a/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
@@ -186,15 +186,4 @@ namespace MvvmCross.ViewModels
             return MvxInpcInterceptionResult.NotIntercepted;
         }
     }
-
-    public class MvxPropertyChangingEventArgs<T> : PropertyChangingEventArgs
-    {
-        public MvxPropertyChangingEventArgs(string propertyName, T newValue) : base(propertyName)
-        {
-            NewValue = newValue;
-        }
-
-        public bool Cancel { get; set; }
-        public T NewValue { get; set; }
-    }
 }

--- a/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using MvvmCross.Annotations;
 using MvvmCross.Base;
+using MvvmCross.Logging;
 
 namespace MvvmCross.ViewModels
 {
@@ -18,8 +20,11 @@ namespace MvvmCross.ViewModels
     {
         private static readonly PropertyChangedEventArgs AllPropertiesChanged = new PropertyChangedEventArgs(string.Empty);
         public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler PropertyChanging;
 
         private bool _shouldAlwaysRaiseInpcOnUserInterfaceThread;
+        private bool _shouldRaisePropertyChanging;
+        private bool _shouldLogInpc;
 
         public bool ShouldAlwaysRaiseInpcOnUserInterfaceThread()
         {
@@ -31,37 +36,94 @@ namespace MvvmCross.ViewModels
             _shouldAlwaysRaiseInpcOnUserInterfaceThread = value;
         }
 
+        public bool ShouldRaisePropertyChanging()
+        {
+            return _shouldRaisePropertyChanging;
+        }
+
+        public void ShouldRaisePropertyChanging(bool value)
+        {
+            _shouldRaisePropertyChanging = value;
+        }
+        public bool ShouldLogInpc()
+        {
+            return _shouldLogInpc;
+        }
+
+        public void ShouldLogInpc(bool value)
+        {
+            _shouldLogInpc = value;
+        }
+
         protected MvxNotifyPropertyChanged()
         {
             var alwaysOnUIThread = MvxSingletonCache.Instance == null || MvxSingletonCache.Instance.Settings.AlwaysRaiseInpcOnUserInterfaceThread;
             ShouldAlwaysRaiseInpcOnUserInterfaceThread(alwaysOnUIThread);
+            var raisePropertyChanging = MvxSingletonCache.Instance == null || MvxSingletonCache.Instance.Settings.ShouldRaisePropertyChanging;
+            ShouldRaisePropertyChanging(raisePropertyChanging);
+            var shouldLogInpc = MvxSingletonCache.Instance == null || MvxSingletonCache.Instance.Settings.ShouldLogInpc;
+            ShouldLogInpc(shouldLogInpc);
         }
 
-        [NotifyPropertyChangedInvocator]
-        public void RaisePropertyChanged<T>(Expression<Func<T>> property)
+        public bool RaisePropertyChanging<T>(T newValue, Expression<Func<T>> property)
         {
             var name = this.GetPropertyNameFromExpression(property);
-            RaisePropertyChanged(name);
+            return RaisePropertyChanging(newValue, name);
+        }
+
+        public bool RaisePropertyChanging<T>(T newValue, [CallerMemberName] string whichProperty = "")
+        {
+            var changedArgs = new MvxPropertyChangingEventArgs<T>(whichProperty, newValue);
+            return RaisePropertyChanging(changedArgs);
+        }
+
+        public virtual bool RaisePropertyChanging<T>(MvxPropertyChangingEventArgs<T> changingArgs)
+        {
+            // check for interception before broadcasting change
+            if (InterceptRaisePropertyChanging(changingArgs)
+                == MvxInpcInterceptionResult.DoNotRaisePropertyChanging)
+                return !changingArgs.Cancel;
+
+            if (ShouldLogInpc())
+                MvxLog.Instance.Trace($"Property '{changingArgs.PropertyName}' changing value to {changingArgs.NewValue.ToString()}");
+
+            PropertyChanging?.Invoke(this, changingArgs);
+
+            return !changingArgs.Cancel;
         }
 
         [NotifyPropertyChangedInvocator]
-        public void RaisePropertyChanged([CallerMemberName] string whichProperty = "")
+        public Task RaisePropertyChanged<T>(Expression<Func<T>> property)
+        {
+            var name = this.GetPropertyNameFromExpression(property);
+            return RaisePropertyChanged(name);
+        }
+
+        [NotifyPropertyChangedInvocator]
+        public virtual Task RaisePropertyChanged([CallerMemberName] string whichProperty = "")
         {
             var changedArgs = new PropertyChangedEventArgs(whichProperty);
-            RaisePropertyChanged(changedArgs);
+            return RaisePropertyChanged(changedArgs);
         }
 
-        public virtual void RaiseAllPropertiesChanged()
+        public virtual Task RaiseAllPropertiesChanged()
         {
-            RaisePropertyChanged(AllPropertiesChanged);
+            return RaisePropertyChanged(AllPropertiesChanged);
         }
 
-        public virtual void RaisePropertyChanged(PropertyChangedEventArgs changedArgs)
+        public virtual async Task RaisePropertyChanged(PropertyChangedEventArgs changedArgs)
         {
             // check for interception before broadcasting change
             if (InterceptRaisePropertyChanged(changedArgs)
                 == MvxInpcInterceptionResult.DoNotRaisePropertyChanged)
                 return;
+
+            void raiseChange()
+            {
+                if (ShouldLogInpc())
+                    MvxLog.Instance.Trace($"Property '{changedArgs.PropertyName}' value changed");
+                PropertyChanged?.Invoke(this, changedArgs);
+            }
 
             if (ShouldAlwaysRaiseInpcOnUserInterfaceThread())
             {
@@ -69,11 +131,11 @@ namespace MvvmCross.ViewModels
                 if (PropertyChanged == null)
                     return;
 
-                InvokeOnMainThread(() => PropertyChanged?.Invoke(this, changedArgs));
+                await InvokeOnMainThreadAsync(raiseChange);
             }
             else
             {
-                PropertyChanged?.Invoke(this, changedArgs);
+                raiseChange();
             }
         }
 
@@ -85,11 +147,17 @@ namespace MvvmCross.ViewModels
                 return false;
             }
 
+            if (ShouldRaisePropertyChanging())
+            {
+                var shouldSetValue = RaisePropertyChanging(value, propertyName);
+                if (!shouldSetValue)
+                    return false;
+            }
+
             storage = value;
             RaisePropertyChanged(propertyName);
             return true;
         }
-
         protected virtual MvxInpcInterceptionResult InterceptRaisePropertyChanged(PropertyChangedEventArgs changedArgs)
         {
             if (MvxSingletonCache.Instance != null)
@@ -103,5 +171,30 @@ namespace MvvmCross.ViewModels
 
             return MvxInpcInterceptionResult.NotIntercepted;
         }
+
+        protected virtual MvxInpcInterceptionResult InterceptRaisePropertyChanging(PropertyChangingEventArgs changingArgs)
+        {
+            if (MvxSingletonCache.Instance != null)
+            {
+                var interceptor = MvxSingletonCache.Instance.InpcInterceptor;
+                if (interceptor != null)
+                {
+                    return interceptor.Intercept(this, changingArgs);
+                }
+            }
+
+            return MvxInpcInterceptionResult.NotIntercepted;
+        }
+    }
+
+    public class MvxPropertyChangingEventArgs<T> : PropertyChangingEventArgs
+    {
+        public MvxPropertyChangingEventArgs(string propertyName, T newValue) : base(propertyName)
+        {
+            NewValue = newValue;
+        }
+
+        public bool Cancel { get; set; }
+        public T NewValue { get; set; }
     }
 }

--- a/MvvmCross/ViewModels/MvxNotifyPropertyChangedExtensions.cs
+++ b/MvvmCross/ViewModels/MvxNotifyPropertyChangedExtensions.cs
@@ -7,14 +7,52 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace MvvmCross.ViewModels
 {
     public static class MvxNotifyPropertyChangedExtensions
     {
+        private static bool RaiseIfChanging<TSource, TReturn>(
+            TSource source, TReturn backingField, TReturn newValue,
+            Func<bool> raiseAction)
+            where TSource : IMvxNotifyPropertyChanged
+        {
+            if (EqualityComparer<TReturn>.Default.Equals(backingField, newValue) == false)
+            {
+                return raiseAction();
+            }
+
+            return false;
+        }
+
+        public static bool RaiseIfChanging<TSource, TReturn>(this TSource source,
+            TReturn backingField,
+            TReturn newValue, Expression<Func<TReturn>> propertySelector)
+            where TSource : IMvxNotifyPropertyChanged
+        {
+            return RaiseIfChanging(source, backingField, newValue, () => source.RaisePropertyChanging(newValue, propertySelector));
+        }
+
+        public static bool RaiseIfChanging<TSource, TReturn>(this TSource source,
+            TReturn backingField,
+            TReturn newValue, [CallerMemberName] string propertyName = "")
+            where TSource : IMvxNotifyPropertyChanged
+        {
+            return RaiseIfChanging(source, backingField, newValue, () => source.RaisePropertyChanging(newValue, propertyName));
+        }
+
+        public static bool RaiseIfChanging<TSource, TReturn>(this TSource source,
+            TReturn backingField,
+            TReturn newValue, MvxPropertyChangingEventArgs<TReturn> args)
+            where TSource : IMvxNotifyPropertyChanged
+        {
+            return RaiseIfChanging(source, backingField, newValue, () => source.RaisePropertyChanging(args));
+        }
+
         private static TReturn RaiseAndSetIfChanged<TSource, TReturn, TActionParameter>(
             TSource source, ref TReturn backingField, TReturn newValue,
-            Action<TActionParameter> raiseAction,
+            Func<TActionParameter, Task> raiseAction,
             TActionParameter raiseActionParameter)
             where TSource : IMvxNotifyPropertyChanged
         {

--- a/MvvmCross/ViewModels/MvxPropertyChangingEventArgs.cs
+++ b/MvvmCross/ViewModels/MvxPropertyChangingEventArgs.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace MvvmCross.ViewModels
+{
+    public class MvxPropertyChangingEventArgs<T> : PropertyChangingEventArgs
+    {
+        public MvxPropertyChangingEventArgs(string propertyName, T newValue) : base(propertyName)
+        {
+            NewValue = newValue;
+        }
+
+        public bool Cancel { get; set; }
+        public T NewValue { get; set; }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/MainViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/MainViewModel.cs
@@ -72,11 +72,7 @@ namespace Playground.Core.ViewModels
             get => _bindableText;
             set
             {
-                if (BindableText != value)
-                {
-                    _bindableText = value;
-                    RaisePropertyChanged();
-                }
+                SetProperty(ref _bindableText, value);
             }
         }
 

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -21,6 +21,8 @@ namespace Playground.Core.ViewModels
 
         private int _counter = 2;
 
+        private string _welcomeText = "Default welcome";
+
         public RootViewModel(IMvxViewModelLoader mvxViewModelLoader)
         {
             _mvxViewModelLoader = mvxViewModelLoader;
@@ -120,6 +122,17 @@ namespace Playground.Core.ViewModels
 
         public IMvxAsyncCommand ShowSharedElementsCommand { get; }
 
+        public string WelcomeText
+        {
+            get => _welcomeText;
+            set
+            {
+                ShouldLogInpc(true);
+                SetProperty(ref _welcomeText, value);
+                ShouldLogInpc(false);
+            }
+        }
+
         public override async Task Initialize()
         {
             Log.Warn(() => "Testing log");
@@ -143,6 +156,8 @@ namespace Playground.Core.ViewModels
                 async () =>
                 {
                     await Task.Delay(300);
+
+                    WelcomeText = "Welcome to MvvmCross!";
 
                     throw new Exception("Boom!");
                 }, exception => { });

--- a/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
@@ -10,6 +10,7 @@
         <ScrollView>
             <StackLayout Margin="10">
                 <Image Source="MvvmCross" HorizontalOptions="Center" />
+                <Label Text="{Binding WelcomeText}"/>
                 <Label Text="Forms views" TextColor="{StaticResource Red}" />
                 <Button Text="Show Child" mvx:Bi.nd="Command ShowChildCommand"/>
                 <Button Text="Show Modal" mvx:Bi.nd="Command ShowModalCommand"/>

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/CountingMockMainThreadDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/CountingMockMainThreadDispatcher.cs
@@ -16,6 +16,7 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
 
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
+            action();
             Count++;
             return true;
         }

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using MvvmCross.Base;
 using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
@@ -25,11 +26,79 @@ namespace MvvmCross.UnitTest.ViewModels
 
         public class TestInpc : MvxNotifyPropertyChanged
         {
-            public string Foo { get; set; }
+            private string _foo;
+
+            public string Foo { get => _foo; set => SetProperty(ref _foo, value); }
         }
 
         [Fact]
-        public void Test_RaisePropertyChangedForExpression()
+        public void Test_RaisePropertyChangingForExpression()
+        {
+            _fixture.ClearAll();
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
+
+            var notified = new List<string>();
+            var t = new TestInpc();
+            var newValue = string.Empty;
+            t.PropertyChanging += (sender, args) =>
+            {
+                notified.Add(args.PropertyName);
+                newValue = (args as MvxPropertyChangingEventArgs<string>)?.NewValue;
+            };
+            t.RaisePropertyChanging("Foobar", () => t.Foo);
+
+            Assert.True(notified.Count == 1);
+            Assert.True(notified[0] == "Foo");
+            Assert.Equal("Foobar", newValue);
+        }
+
+        [Fact]
+        public void Test_RaisePropertyChangingForName()
+        {
+            _fixture.ClearAll();
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
+
+            var notified = new List<string>();
+            var t = new TestInpc();
+            var newValue = string.Empty;
+            t.PropertyChanging += (sender, args) =>
+            {
+                notified.Add(args.PropertyName);
+                newValue = (args as MvxPropertyChangingEventArgs<string>)?.NewValue;
+            };
+            t.RaisePropertyChanging("Foobar", "Foo");
+
+            Assert.True(notified.Count == 1);
+            Assert.True(notified[0] == "Foo");
+            Assert.Equal("Foobar", newValue);
+        }
+
+        [Fact]
+        public void Test_RaisePropertyChangingDirect()
+        {
+            _fixture.ClearAll();
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
+
+            var notified = new List<string>();
+            var t = new TestInpc();
+            var newValue = string.Empty;
+            t.PropertyChanging += (sender, args) =>
+            {
+                notified.Add(args.PropertyName);
+                newValue = (args as MvxPropertyChangingEventArgs<string>)?.NewValue;
+            };
+            t.RaisePropertyChanging(new MvxPropertyChangingEventArgs<string>("Foo", "Foobar"));
+
+            Assert.True(notified.Count == 1);
+            Assert.True(notified[0] == "Foo");
+            Assert.Equal("Foobar", newValue);
+        }
+
+        [Fact]
+        public async Task Test_RaisePropertyChangedForExpression()
         {
             _fixture.ClearAll();
             var dispatcher = new InlineMockMainThreadDispatcher();
@@ -38,14 +107,14 @@ namespace MvvmCross.UnitTest.ViewModels
             var notified = new List<string>();
             var t = new TestInpc();
             t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
-            t.RaisePropertyChanged(() => t.Foo);
+            await t.RaisePropertyChanged(() => t.Foo);
 
             Assert.True(notified.Count == 1);
             Assert.True(notified[0] == "Foo");
         }
 
         [Fact]
-        public void Test_RaisePropertyChangedForName()
+        public async Task Test_RaisePropertyChangedForName()
         {
             _fixture.ClearAll();
             var dispatcher = new InlineMockMainThreadDispatcher();
@@ -54,14 +123,14 @@ namespace MvvmCross.UnitTest.ViewModels
             var notified = new List<string>();
             var t = new TestInpc();
             t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
-            t.RaisePropertyChanged("Foo");
+            await t.RaisePropertyChanged("Foo");
 
             Assert.True(notified.Count == 1);
             Assert.True(notified[0] == "Foo");
         }
 
         [Fact]
-        public void Test_RaisePropertyChangedDirect()
+        public async Task Test_RaisePropertyChangedDirect()
         {
             _fixture.ClearAll();
             var dispatcher = new InlineMockMainThreadDispatcher();
@@ -70,14 +139,66 @@ namespace MvvmCross.UnitTest.ViewModels
             var notified = new List<string>();
             var t = new TestInpc();
             t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
-            t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
+            await t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
 
             Assert.True(notified.Count == 1);
             Assert.True(notified[0] == "Foo");
         }
 
         [Fact]
-        public void Test_TurnOffUIThread()
+        public void Test_SetPropertyChangeValue()
+        {
+            _fixture.ClearAll();
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
+
+            var notified = new List<string>();
+            var t = new TestInpc();
+            t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
+            t.Foo = "Foobar";
+
+            Assert.True(notified.Count == 1);
+            Assert.True(notified[0] == "Foo");
+            Assert.Equal("Foobar", t.Foo);
+        }
+
+        [Fact]
+        public void Test_SetPropertyNoValueChange()
+        {
+            _fixture.ClearAll();
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
+
+            var notified = new List<string>();
+            var t = new TestInpc();
+            t.Foo = "Foobar";
+            t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
+            t.Foo = "Foobar";
+
+            Assert.True(notified.Count == 0);
+            Assert.Equal("Foobar", t.Foo);
+        }
+
+        [Fact]
+        public void Test_SetPropertyChangeValueCancelled()
+        {
+            _fixture.ClearAll();
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
+
+            var notified = new List<string>();
+            var t = new TestInpc();
+            t.Foo = "Default value";
+            t.PropertyChanging += (sender, args) => (args as MvxPropertyChangingEventArgs<string>).Cancel = true;
+            t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
+            t.Foo = "Foobar";
+
+            Assert.True(notified.Count == 0);
+            Assert.Equal("Default value", t.Foo);
+        }
+
+        [Fact]
+        public async Task Test_TurnOffUIThread()
         {
             _fixture.ClearAll();
             var dispatcher = new CountingMockMainThreadDispatcher();
@@ -87,32 +208,38 @@ namespace MvvmCross.UnitTest.ViewModels
             var t = new TestInpc();
             t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
             t.ShouldAlwaysRaiseInpcOnUserInterfaceThread(false);
-            t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
+            await t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
 
             Assert.True(dispatcher.Count == 0);
             Assert.True(notified.Count == 1);
             Assert.True(notified[0] == "Foo");
 
             t.ShouldAlwaysRaiseInpcOnUserInterfaceThread(true);
-            t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
+            await t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
 
             Assert.Equal(1, dispatcher.Count);
-            Assert.True(notified.Count == 1);
+            Assert.True(notified.Count == 2);
             Assert.True(notified[0] == "Foo");
         }
 
         public class Interceptor : IMvxInpcInterceptor
         {
             public Func<IMvxNotifyPropertyChanged, PropertyChangedEventArgs, MvxInpcInterceptionResult> Handler;
+            public Func<IMvxNotifyPropertyChanged, PropertyChangingEventArgs, MvxInpcInterceptionResult> ChangingHandler;
 
             public MvxInpcInterceptionResult Intercept(IMvxNotifyPropertyChanged sender, PropertyChangedEventArgs args)
             {
                 return Handler(sender, args);
             }
+
+            public MvxInpcInterceptionResult Intercept(IMvxNotifyPropertyChanged sender, PropertyChangingEventArgs args)
+            {
+                return ChangingHandler(sender, args);
+            }
         }
 
         [Fact]
-        public void Test_Interceptor()
+        public async Task Test_Interceptor()
         {
             _fixture.ClearAll();
 
@@ -125,18 +252,21 @@ namespace MvvmCross.UnitTest.ViewModels
             var notified = new List<string>();
             var t = new TestInpc();
             t.PropertyChanged += (sender, args) => notified.Add(args.PropertyName);
+            interceptor.ChangingHandler = (s, e) => MvxInpcInterceptionResult.RaisePropertyChanging;
             interceptor.Handler = (s, e) => MvxInpcInterceptionResult.RaisePropertyChanged;
-            t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
+            await t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
 
             Assert.True(dispatcher.Count == 1);
 
             interceptor.Handler = (s, e) => MvxInpcInterceptionResult.DoNotRaisePropertyChanged;
-            t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
+            interceptor.ChangingHandler = (s, e) => MvxInpcInterceptionResult.RaisePropertyChanging;
+            await t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
 
             Assert.True(dispatcher.Count == 1);
 
             interceptor.Handler = (s, e) => MvxInpcInterceptionResult.RaisePropertyChanged;
-            t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
+            interceptor.ChangingHandler = (s, e) => MvxInpcInterceptionResult.RaisePropertyChanging;
+            await t.RaisePropertyChanged(new PropertyChangedEventArgs("Foo"));
 
             Assert.True(dispatcher.Count == 2);
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
No event being raised when a property about to change

### :new: What is the new behavior (if this is a feature change)?
PropertyChanging event is raised (by default) when a property is changing

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run the Playground Forms samples


### :memo: Links to relevant issues/docs
fixes https://github.com/MvvmCross/MvvmCross/issues/1489

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current 6.2 branch
