### PR TITLE
Fixing WPF XF build - version mismatch on XF reference

### DIFF
--- a/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
+++ b/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
@@ -20,7 +20,7 @@ This package contains the 'MvvmCross.Forms.Platforms.Wpf' libraries for MvvmCros
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.530893" />
     <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="3.0.0.530893" />
   </ItemGroup>
   


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Appveyour build failing

### :new: What is the new behavior (if this is a feature change)?
Appveyour build success

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Watch the build

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X ] All projects build
- [ X ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ X ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
