### PR TITLE
[WIP] Adding SignClient, updating unit test runner + security fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,6 @@ artifacts/
 
 #linting
 .sonarqube/
+
+# dotnet tools
+.store/

--- a/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
+++ b/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/MvvmCross.UnitTest/Plugin/MvxPluginManagerTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Plugin/MvxPluginManagerTests.cs
@@ -28,6 +28,7 @@ namespace MvvmCross.UnitTest.Plugin
             protected IMvxPluginConfiguration ConfigurationSource(Type arg) => null;
         }
 
+        [Collection("MvxTest")]
         public class TheEnsurePluginLoadedMethod : MvxPluginManagerTest
         {
             [Fact]
@@ -74,6 +75,7 @@ namespace MvvmCross.UnitTest.Plugin
             }
         }
 
+        [Collection("MvxTest")]
         public class TheIsPluginLoadedMethod : MvxPluginManagerTest
         {
             [Fact]
@@ -95,6 +97,7 @@ namespace MvvmCross.UnitTest.Plugin
             }
         }
 
+        [Collection("MvxTest")]
         public class TheTryEnsurePluginLoadedMethod : MvxPluginManagerTest
         {
             [Fact]
@@ -142,6 +145,7 @@ namespace MvvmCross.UnitTest.Plugin
             }
         }
 
+        [Collection("MvxTest")]
         public class TheLoadedPluginsProperty : MvxPluginManagerTest
         {
             [Fact]

--- a/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
+++ b/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Color.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Color.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.JsonLocalization.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.JsonLocalization.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
+++ b/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Messenger.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Messenger.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/Plugins.Network.UnitTest/MvvmCross.Plugins.Network.UnitTest.csproj
+++ b/UnitTests/Plugins.Network.UnitTest/MvvmCross.Plugins.Network.UnitTest.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Network.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Network.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
+++ b/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.ResourceLoader.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.ResourceLoader.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.ResxLocalization.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.ResxLocalization.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
+++ b/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Visibility.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Visibility.UnitTest</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@
   environment:
     NUGET_SOURCE: https://www.nuget.org/api/v2/package
     NUGET_APIKEY:
-      secure: odCUzBq+YWTrwvRhhuQZP1uldezh8PJRn79miIgZnZrDbruYkP9aoJAlTcat5AGh
+      secure: comaeGesY3d2OjzhTCIVxwQsjW31fqrWVgMBu0+WHs8JlqnVdujThv6ncTGgZmVQ
     SIGNING_USER:
       secure: by3V38s+rierF9BmeYoxcpNY5Z8CoxTi0FpTU357vN+qmeH9IHKpxYZK8MDIUG9W
     SIGNING_SECRET:
@@ -33,7 +33,7 @@
   environment:
     NUGET_SOURCE: https://www.myget.org/F/mvvmcross/api/v2/package
     NUGET_APIKEY:
-      secure: m3uewWCh6Y5jqTZIfwMDfs8GWdbwTZjfiEl13AWY7T3u3bPspGA/lgwe8jdxjBm9
+      secure: NM0W8q3QK30yBNVmTEPvc1QD7tcCqjueGGHM/3ZxpAwYC6+BGtkTZ4TJdYgdZXyR
     SIGNING_USER:
       secure: by3V38s+rierF9BmeYoxcpNY5Z8CoxTi0FpTU357vN+qmeH9IHKpxYZK8MDIUG9W
     SIGNING_SECRET:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,10 @@
     NUGET_SOURCE: https://www.nuget.org/api/v2/package
     NUGET_APIKEY:
       secure: odCUzBq+YWTrwvRhhuQZP1uldezh8PJRn79miIgZnZrDbruYkP9aoJAlTcat5AGh
+    SIGNING_USER:
+      secure: by3V38s+rierF9BmeYoxcpNY5Z8CoxTi0FpTU357vN+qmeH9IHKpxYZK8MDIUG9W
+    SIGNING_SECRET:
+      secure: l9ST2SDzpFtdq9H4sFHwWtWqwzYRffyHmYyUNI1VHlU=
   build_script:
   - ps: .\build.ps1
   test: off
@@ -30,6 +34,10 @@
     NUGET_SOURCE: https://www.myget.org/F/mvvmcross/api/v2/package
     NUGET_APIKEY:
       secure: m3uewWCh6Y5jqTZIfwMDfs8GWdbwTZjfiEl13AWY7T3u3bPspGA/lgwe8jdxjBm9
+    SIGNING_USER:
+      secure: by3V38s+rierF9BmeYoxcpNY5Z8CoxTi0FpTU357vN+qmeH9IHKpxYZK8MDIUG9W
+    SIGNING_SECRET:
+      secure: l9ST2SDzpFtdq9H4sFHwWtWqwzYRffyHmYyUNI1VHlU=
   build_script:
   - ps: .\build.ps1
   test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@
   image: Visual Studio 2017
   before_build:
   - cmd: dotnet --info
+  - cmd: dotnet tool install --tool-path . SignClient
   environment:
     NUGET_SOURCE: https://www.nuget.org/api/v2/package
     NUGET_APIKEY:
@@ -28,6 +29,7 @@
   image: Visual Studio 2017
   before_build:
   - cmd: dotnet --info
+  - cmd: dotnet tool install --tool-path . SignClient
   environment:
     NUGET_SOURCE: https://www.myget.org/F/mvvmcross/api/v2/package
     NUGET_APIKEY:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,6 @@
   test: off
   cache:
   - '%USERPROFILE%\.nuget\packages -> **\project.json'  # project.json cache
-  on_failure:
-  - ps: Get-ChildItem *.binlog -recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 -
   branches:
       only:
@@ -43,5 +41,3 @@
   test: off
   cache:
   - '%USERPROFILE%\.nuget\packages -> **\project.json'  # project.json cache
-  on_failure:
-  - ps: Get-ChildItem *.binlog -recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,7 @@
 #tool nuget:?package=GitVersion.CommandLine
 #tool nuget:?package=vswhere
-#addin nuget:?package=Cake.Figlet
-#addin nuget:?package=Cake.Incubator&version=1.7.1
-#addin nuget:?package=Cake.Git&version=0.16.1
+#addin nuget:?package=Cake.Figlet&version=1.1.0
+#addin nuget:?package=Cake.Git&version=0.17.0
 #addin nuget:?package=Polly
 
 using Polly;

--- a/build.cake
+++ b/build.cake
@@ -242,13 +242,11 @@ Task("UploadAppVeyorArtifact")
     .WithCriteria(() => isRunningOnAppVeyor)
     .Does(() => 
 {
-
     Information("Artifacts Dir: {0}", outputDir.FullPath);
 
     var uploadSettings = new AppVeyorUploadArtifactsSettings();
 
-    var artifacts = GetFiles(solutionName + "*/**/bin/" + configuration + "/**/*.nupkg")
-        + GetFiles(outputDir.FullPath + "/**/*");
+    var artifacts = GetFiles(outputDir.FullPath + "/**/*");
 
     foreach(var file in artifacts) {
         Information("Uploading {0}", file.FullPath);

--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,6 @@
 #addin nuget:?package=Cake.Figlet&version=1.1.0
 #addin nuget:?package=Cake.Git&version=0.17.0
 #addin nuget:?package=Polly
-#tool nuget:?package=SignClient&version=0.9.1&include=/tools/netcoreapp2.0/SignClient.dll
 
 using Polly;
 

--- a/build.cake
+++ b/build.cake
@@ -126,15 +126,21 @@ Task("UnitTest")
 
     var testPaths = GetFiles("./UnitTests/*.UnitTest/*.UnitTest.csproj");
     var testsFailed = false;
+
+    var settings = new DotNetCoreTestSettings
+    {
+        Configuration = "Release",
+        NoBuild = true
+    };
+
     foreach(var project in testPaths)
     {
         var projectName = project.GetFilenameWithoutExtension();
-        var testXml = new FilePath(outputDir + "/Tests/" + projectName + ".xml").MakeAbsolute(Context.Environment);
+        var testXml = MakeAbsolute(new FilePath(outputDir + "/Tests/" + projectName + ".xml"));
+        settings.Logger = $"xunit;LogFilePath={testXml.FullPath}";
         try 
         {
-            DotNetCoreTool(project,
-                "xunit",  "-fxversion 2.1.0 --no-build -parallel none -configuration " + 
-                configuration + " -xml \"" + testXml.FullPath + "\"");
+            DotNetCoreTest(project.ToString(), settings);
         }
         catch
         {

--- a/build.cake
+++ b/build.cake
@@ -116,12 +116,6 @@ Task("Build")
         .WithProperty("NoPackageAnalysis", "True")
         .WithTarget("Build");
 
-    settings.BinaryLogger = new MSBuildBinaryLogSettings 
-    {
-        Enabled = true,
-        FileName = "mvvmcross.binlog"
-    };
-	
     MSBuild(sln, settings);
 });
 

--- a/build.cake
+++ b/build.cake
@@ -132,7 +132,7 @@ Task("UnitTest")
         try 
         {
             DotNetCoreTool(project,
-                "xunit",  "-fxversion 2.0.0 --no-build -parallel none -configuration " + 
+                "xunit",  "-fxversion 2.1.0 --no-build -parallel none -configuration " + 
                 configuration + " -xml \"" + testXml.FullPath + "\"");
         }
         catch

--- a/build.cake
+++ b/build.cake
@@ -12,6 +12,7 @@ var repoName = "mvvmcross/mvvmcross";
 var sln = new FilePath("./" + solutionName + ".sln");
 var outputDir = new DirectoryPath("./artifacts");
 var nuspecDir = new DirectoryPath("./nuspec");
+var nugetPackagesDir = new DirectoryPath("./nuget/packages");
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 var verbosityArg = Argument("verbosity", "Minimal");
@@ -56,6 +57,7 @@ Task("Clean").Does(() =>
     CleanDirectories("./**/bin");
     CleanDirectories("./**/obj");
     CleanDirectories(outputDir.FullPath);
+    CleanDirectories(nugetPackagesDir.FullPath);
 
     EnsureDirectoryExists(outputDir);
 });
@@ -85,6 +87,8 @@ Task("Restore")
     .Does(() => 
 {
     var settings = GetDefaultBuildSettings()
+        .WithProperty("RestoreNoCache", "True")
+        .WithProperty("RestorePackagesPath", MakeAbsolute(nugetPackagesDir).FullPath.ToString())
         .WithTarget("Restore");
     MSBuild(sln, settings);
 });

--- a/signclient.json
+++ b/signclient.json
@@ -1,0 +1,13 @@
+{
+    "SignClient": {
+      "AzureAd": {
+        "AADInstance": "https://login.microsoftonline.com/",
+        "ClientId": "c248d68a-ba6f-4aa9-8a68-71fe872063f8",
+        "TenantId": "16076fdc-fcc1-4a15-b1ca-32c9a255900e"
+      },
+      "Service": {
+        "Url": "https://codesign.dotnetfoundation.org/",
+        "ResourceId": "https://SignService/3c30251f-36f3-490b-a955-520addb85001"
+      }
+    }
+  }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.24.0" />
+    <package id="Cake" version="0.28.0" />
 </packages>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds Sign Client so we can sign our NuGet packages with the signing cert we get from dotnet fdn.

Right now the step is disabled as creds are returning 401. Have e-mailed @onovotny 

Also removed binlogs from being generated. We can enable them when we need more details when builds fail.

Also switched to `dotnet test` instead of `dotnet xunit` as per @onovotny's request below.

### :arrow_heading_down: What is the current behavior?
No signing

### :new: What is the new behavior (if this is a feature change)?
Signing of NuGet packages

### :boom: Does this PR introduce a breaking change?
No

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
