### PR TITLE
Binding to Child View's BindingContextProperty

### DIFF
--- a/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
+++ b/MvvmCross.Forms/Bindings/MvxBaseBindExtension.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using MvvmCross.Binding;
 using Xamarin.Forms;
@@ -16,26 +18,69 @@ namespace MvvmCross.Forms.Bindings
         public string Converter { get; set; }
         public string ConverterParameter { get; set; }
         public string FallbackValue { get; set; }
-
-        public IProvideValueTarget Target { get; private set; }
-        public object BindableObj { get; private set; }
-        public object BindableProp { get; private set; }
         public string PropertyName { get; private set; } = string.Empty;
 
-        public abstract object ProvideValue(IServiceProvider serviceProvider);
+        protected object BindableObjectRaw;
+        protected object BindablePropertyRaw;
+
+        protected BindableObject Bindable;
+        protected BindableProperty BindableProp;
+        protected IEnumerable<BindableObject> BindableTree;
+        public Page SourcePage { protected get; set; }
 
         object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
         {
-            Target = (IProvideValueTarget)serviceProvider.GetService(typeof(IProvideValueTarget));
-            BindableObj = Target.TargetObject;
-            BindableProp = Target.TargetProperty;
-
-            if (Target.TargetProperty is BindableProperty bp)
-                PropertyName = bp.PropertyName;
-            else if (Target.TargetProperty is PropertyInfo pi)
-                PropertyName = pi.Name;
+            if (serviceProvider == null) throw new ArgumentNullException(nameof(serviceProvider));
+            var valueTargetProvider = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+            var rootObjectProvider = serviceProvider.GetService(typeof(IRootObjectProvider)) as IRootObjectProvider;
+            Initialize(valueTargetProvider, rootObjectProvider);
 
             return ProvideValue(serviceProvider);
+        }
+
+        public abstract object ProvideValue(IServiceProvider serviceProvider);
+
+        private void Initialize(IProvideValueTarget valueTargetProvider, IRootObjectProvider rootObjectProvider)
+        {
+            // if XamlCompilation is active, IRootObjectProvider is not available, but SimpleValueTargetProvider is available
+            // if XamlCompilation is inactive, IRootObjectProvider is available, but SimpleValueTargetProvider is not available
+            object rootObject;
+
+            var propertyInfo = valueTargetProvider.GetType().GetTypeInfo().DeclaredProperties.FirstOrDefault(dp => dp.Name.Contains("ParentObjects"));
+            if (propertyInfo == null) throw new ArgumentNullException("ParentObjects");
+            var parentObjects = (propertyInfo.GetValue(valueTargetProvider) as IEnumerable<object>).ToList();
+            BindableTree = parentObjects.Cast<BindableObject>();
+
+            if (rootObjectProvider == null && valueTargetProvider == null)
+                throw new ArgumentException("serviceProvider does not provide an IRootObjectProvider or SimpleValueTargetProvider");
+            if (rootObjectProvider == null)
+            {
+                var parentObject = parentObjects.FirstOrDefault(pO => pO.GetType().GetTypeInfo().IsSubclassOf(typeof(Page)));
+
+                BindableObjectRaw = parentObjects.FirstOrDefault();
+                Bindable = BindableObjectRaw as BindableObject;
+                rootObject = parentObject ?? throw new ArgumentNullException("parentObject");
+            }
+            else
+            {
+                rootObject = rootObjectProvider.RootObject;
+                BindableObjectRaw = valueTargetProvider.TargetObject;
+                Bindable = BindableObjectRaw as BindableObject;
+            }
+
+            BindablePropertyRaw = valueTargetProvider.TargetProperty;
+            if (BindablePropertyRaw is BindableProperty bp)
+            {
+                BindableProp = bp;
+                PropertyName = bp.PropertyName;
+            }
+            else if (BindablePropertyRaw is PropertyInfo pi)
+                PropertyName = pi.Name;
+            else if(BindablePropertyRaw != null)
+                PropertyName = BindablePropertyRaw.ToString();
+
+            if (rootObject is Page providedPage)
+                SourcePage = SourcePage ?? providedPage;
         }
     }
 }

--- a/MvvmCross.Forms/Bindings/MvxBindExtension.cs
+++ b/MvvmCross.Forms/Bindings/MvxBindExtension.cs
@@ -14,14 +14,12 @@ namespace MvvmCross.Forms.Bindings
     public class MvxBindExtension : MvxBaseBindExtension
     {
         public string Path { get; set; } = ".";
-
         public string StringFormat { get; set; }
-
         public string CommandParameter { get; set; }
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
-            if (BindableObj is BindableObject obj && !string.IsNullOrEmpty(PropertyName))
+            if (!string.IsNullOrEmpty(PropertyName))
             {
                 StringBuilder bindingBuilder = new StringBuilder($"{PropertyName} {Path}, Mode={Mode}");
 
@@ -45,9 +43,9 @@ namespace MvvmCross.Forms.Bindings
                     bindingBuilder.Append($", CommandParameter={CommandParameter}");
                 }
 
-                obj.SetValue(Bi.ndProperty, bindingBuilder.ToString());
+                Bindable.SetValue(Bi.ndProperty, bindingBuilder.ToString());
             }
-            else if (BindableObj is IMarkupExtension ext)
+            else if (BindableObjectRaw is IMarkupExtension ext)
             {
                 return ext.ProvideValue(serviceProvider);
             }

--- a/MvvmCross.Forms/Bindings/MvxLangExtension.cs
+++ b/MvvmCross.Forms/Bindings/MvxLangExtension.cs
@@ -15,18 +15,14 @@ namespace MvvmCross.Forms.Bindings
     public class MvxLangExtension : MvxBaseBindExtension
     {
         public string Source { get; set; }
-
         public string NameSpaceKey { get; set; } = "";
-
         public string TypeKey { get; set; } = "";
-
         public object[] Arguments { get; set; }
-
         public string Key { get; set; }
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
-            if (BindableObj is BindableObject obj && !string.IsNullOrEmpty(PropertyName))
+            if (!string.IsNullOrEmpty(PropertyName))
             {
                 StringBuilder bindingBuilder = new StringBuilder($"{PropertyName} {Source}");
 
@@ -50,16 +46,16 @@ namespace MvvmCross.Forms.Bindings
                     bindingBuilder.Append($", FallbackValue={FallbackValue}");
                 }
 
-                obj.SetValue(La.ngProperty, bindingBuilder.ToString());
+                Bindable.SetValue(La.ngProperty, bindingBuilder.ToString());
             }
-            else if(Mvx.CanResolve<IMvxTextProvider>())
+            else if(!string.IsNullOrEmpty(Source) && Mvx.CanResolve<IMvxTextProvider>())
             {
                 if(Arguments == null)
                     return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source);
                 else
                     return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source, Arguments);
             }
-            else if(BindableObj is IMarkupExtension ext)
+            else if(BindableObjectRaw is IMarkupExtension ext)
             {
                 return ext.ProvideValue(serviceProvider);
             }

--- a/MvvmCross.Forms/Views/MvxBoxView.cs
+++ b/MvvmCross.Forms/Views/MvxBoxView.cs
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxBoxView.cs
+++ b/MvvmCross.Forms/Views/MvxBoxView.cs
@@ -18,7 +18,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -29,7 +29,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxCarouselPage.cs
+++ b/MvvmCross.Forms/Views/MvxCarouselPage.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxCarouselPage.cs
+++ b/MvvmCross.Forms/Views/MvxCarouselPage.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxContentPage.cs
+++ b/MvvmCross.Forms/Views/MvxContentPage.cs
@@ -42,7 +42,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxContentPage.cs
+++ b/MvvmCross.Forms/Views/MvxContentPage.cs
@@ -25,7 +25,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -36,7 +36,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxContentView.cs
+++ b/MvvmCross.Forms/Views/MvxContentView.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxContentView.cs
+++ b/MvvmCross.Forms/Views/MvxContentView.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxEntryCell.cs
+++ b/MvvmCross.Forms/Views/MvxEntryCell.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxEntryCell.cs
+++ b/MvvmCross.Forms/Views/MvxEntryCell.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxImageCell.cs
+++ b/MvvmCross.Forms/Views/MvxImageCell.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxImageCell.cs
+++ b/MvvmCross.Forms/Views/MvxImageCell.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxMasterDetailPage.cs
+++ b/MvvmCross.Forms/Views/MvxMasterDetailPage.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxMasterDetailPage.cs
+++ b/MvvmCross.Forms/Views/MvxMasterDetailPage.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxNavigationPage.cs
+++ b/MvvmCross.Forms/Views/MvxNavigationPage.cs
@@ -29,7 +29,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -40,7 +40,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxNavigationPage.cs
+++ b/MvvmCross.Forms/Views/MvxNavigationPage.cs
@@ -46,7 +46,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxPage.cs
+++ b/MvvmCross.Forms/Views/MvxPage.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxPage.cs
+++ b/MvvmCross.Forms/Views/MvxPage.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxSwitchCell.cs
+++ b/MvvmCross.Forms/Views/MvxSwitchCell.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxSwitchCell.cs
+++ b/MvvmCross.Forms/Views/MvxSwitchCell.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxTabbedPage.cs
+++ b/MvvmCross.Forms/Views/MvxTabbedPage.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxTabbedPage.cs
+++ b/MvvmCross.Forms/Views/MvxTabbedPage.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxTextCell.cs
+++ b/MvvmCross.Forms/Views/MvxTextCell.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxTextCell.cs
+++ b/MvvmCross.Forms/Views/MvxTextCell.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/MvvmCross.Forms/Views/MvxViewCell.cs
+++ b/MvvmCross.Forms/Views/MvxViewCell.cs
@@ -41,7 +41,7 @@ namespace MvvmCross.Forms.Views
             set
             {
                 _bindingContext = value;
-                base.BindingContext = _bindingContext.DataContext ?? _bindingContext;
+                base.BindingContext = _bindingContext.DataContext;
             }
         }
 

--- a/MvvmCross.Forms/Views/MvxViewCell.cs
+++ b/MvvmCross.Forms/Views/MvxViewCell.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Forms.Views
             }
             set
             {
-                if (value != null && !ReferenceEquals(DataContext, value))
+                if (value != null && !(_bindingContext != null && ReferenceEquals(DataContext, value)))
                     BindingContext = new MvxBindingContext(value);
             }
         }
@@ -35,7 +35,7 @@ namespace MvvmCross.Forms.Views
             get
             {
                 if (_bindingContext == null)
-                    BindingContext = new MvxBindingContext();
+                    BindingContext = new MvxBindingContext(base.BindingContext);
                 return _bindingContext;
             }
             set

--- a/Projects/Playground/Playground.Core/ViewModels/Issues/ChildContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Issues/ChildContentViewModel.cs
@@ -5,6 +5,11 @@ namespace Playground.Core.ViewModels
 {
     public class ChildContentViewModel : MvxViewModel
     {
+        public ChildContentViewModel()
+        {
+
+        }
+
         private string _test;
 
         public string Test
@@ -15,7 +20,7 @@ namespace Playground.Core.ViewModels
 
         public override async Task Initialize()
         {
-            Test = "Bound Text";
+            //Test = "Bound Text";
             await Task.Yield();
         }
     }

--- a/Projects/Playground/Playground.Core/ViewModels/Issues/ChildContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Issues/ChildContentViewModel.cs
@@ -7,7 +7,6 @@ namespace Playground.Core.ViewModels
     {
         public ChildContentViewModel()
         {
-
         }
 
         private string _test;

--- a/Projects/Playground/Playground.Core/ViewModels/Issues/ParentContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Issues/ParentContentViewModel.cs
@@ -41,10 +41,12 @@ namespace Playground.Core.ViewModels
         public override void Prepare()
         {
             var vm = Mvx.Resolve<IMvxViewModelLoader>().LoadViewModel(MvxViewModelRequest<ChildContentViewModel>.GetDefaultRequest(), null) as ChildContentViewModel;
+            vm.Test = "Child 1";
             ChildViewModel1 = vm;
             var bc = Mvx.Resolve<IMvxViewModelLoader>()
                     .LoadViewModel(MvxViewModelRequest<ChildContentViewModel>.GetDefaultRequest(), null) as
                 ChildContentViewModel;
+            bc.Test = "Child 2";
             ChildBindingContext2 = bc;
         }
     }

--- a/Projects/Playground/Playground.Core/ViewModels/Issues/ParentContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Issues/ParentContentViewModel.cs
@@ -6,13 +6,22 @@ namespace Playground.Core.ViewModels
 {
     public class ParentContentViewModel : MvxViewModel
     {
-        private ChildContentViewModel _childViewModel;
+        private ChildContentViewModel _childViewModel1;
         public ChildContentViewModel ChildViewModel1
         {
-            get => _childViewModel;
+            get => _childViewModel1;
             set
             {
-                SetProperty(ref _childViewModel, value);
+                SetProperty(ref _childViewModel1, value);
+            }
+        }
+        private ChildContentViewModel _childBindingContext2;
+        public ChildContentViewModel ChildBindingContext2
+        {
+            get => _childBindingContext2;
+            set
+            {
+                SetProperty(ref _childBindingContext2, value);
             }
         }
         private bool _childViewModelEnabled;
@@ -24,13 +33,19 @@ namespace Playground.Core.ViewModels
                 SetProperty(ref _childViewModelEnabled, value);
             }
         }
-        public IMvxCommand ChangeButtonCmd => new MvxCommand(() => ChildViewModel1.Test = (ChildViewModel1.Test == "Bound Text 1" ? "Bound Text 2" : "Bound Text 1"));
-        public IMvxCommand ToggleChildEnabledCmd => new MvxCommand(() => ChildViewModelEnabled = !ChildViewModelEnabled);
+        public IMvxCommand ChangeButtonCmd1 => new MvxCommand(() => ChildViewModel1.Test = (ChildViewModel1.Test == "Bound Text 1" ? "Bound Text 2" : "Bound Text 1"));
+        public IMvxCommand ToggleChild1EnabledCmd => new MvxCommand(() => ChildViewModelEnabled = !ChildViewModelEnabled);
+
+        public IMvxCommand ChangeButtonCmd2 => new MvxCommand(() => ChildBindingContext2.Test = (ChildBindingContext2.Test == "Bound Text 1" ? "Bound Text 2" : "Bound Text 1"));
 
         public override void Prepare()
         {
             var vm = Mvx.Resolve<IMvxViewModelLoader>().LoadViewModel(MvxViewModelRequest<ChildContentViewModel>.GetDefaultRequest(), null) as ChildContentViewModel;
             ChildViewModel1 = vm;
+            var bc = Mvx.Resolve<IMvxViewModelLoader>()
+                    .LoadViewModel(MvxViewModelRequest<ChildContentViewModel>.GetDefaultRequest(), null) as
+                ChildContentViewModel;
+            ChildBindingContext2 = bc;
         }
     }
 }

--- a/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml
@@ -8,9 +8,11 @@
              x:Name="ParentPage">
     <ContentPage.Content>
         <StackLayout>
-            <views:ChildContentView ViewModel="{Binding ChildViewModel1}" IsEnabled="{Binding ViewModel.ChildViewModelEnabled, Source={x:Reference ParentPage}}"/>
-            <Button Text="Change Child Text" Command="{Binding ChangeButtonCmd}" />
-            <Button Text="Toggle Child Enabled" Command="{Binding ToggleChildEnabledCmd}" />
+            <views:ChildContentView ViewModel="{Binding Source={x:Reference ParentPage}, Path=ViewModel.ChildViewModel1}" IsEnabled="{Binding ViewModel.ChildViewModelEnabled, Source={x:Reference ParentPage}}"/>
+            <Button Text="Change Child1 Text" Command="{Binding ChangeButtonCmd1}" />
+            <Button Text="Toggle Child Enabled" Command="{Binding ToggleChild1EnabledCmd}" />
+            <views:ChildContentView BindingContext="{Binding Source={x:Reference ParentPage}, Path=ViewModel.ChildBindingContext2}"/>
+            <Button Text="Change Child2 Text" Command="{Binding ChangeButtonCmd2}" />
         </StackLayout>
     </ContentPage.Content>
 </views1:MvxContentPage>

--- a/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/ParentContentPage.xaml
@@ -7,12 +7,18 @@
              x:Class="Playground.Forms.UI.Pages.ParentContentPage" x:TypeArguments="viewModels:ParentContentViewModel"
              x:Name="ParentPage">
     <ContentPage.Content>
-        <StackLayout>
-            <views:ChildContentView ViewModel="{Binding Source={x:Reference ParentPage}, Path=ViewModel.ChildViewModel1}" IsEnabled="{Binding ViewModel.ChildViewModelEnabled, Source={x:Reference ParentPage}}"/>
+        <StackLayout x:Name="RootLayout">
+            <views:ChildContentView ViewModel="{Binding ChildViewModel1}" IsEnabled="{Binding BindingContext.ChildViewModelEnabled, Source={x:Reference RootLayout}}"/>
+            <Button Text="Change Child1 Text" Command="{Binding ChangeButtonCmd1}" />
+            <Button Text="Toggle Child Enabled" Command="{Binding ToggleChild1EnabledCmd}" />
+            <views:ChildContentView BindingContext="{Binding ChildBindingContext2}"/>
+            <Button Text="Change Child2 Text" Command="{Binding ChangeButtonCmd2}" />
+
+            <!--<views:ChildContentView ViewModel="{Binding Source={x:Reference ParentPage}, Path=ViewModel.ChildViewModel1}" IsEnabled="{Binding ViewModel.ChildViewModelEnabled, Source={x:Reference ParentPage}}"/>
             <Button Text="Change Child1 Text" Command="{Binding ChangeButtonCmd1}" />
             <Button Text="Toggle Child Enabled" Command="{Binding ToggleChild1EnabledCmd}" />
             <views:ChildContentView BindingContext="{Binding Source={x:Reference ParentPage}, Path=ViewModel.ChildBindingContext2}"/>
-            <Button Text="Change Child2 Text" Command="{Binding ChangeButtonCmd2}" />
+            <Button Text="Change Child2 Text" Command="{Binding ChangeButtonCmd2}" />-->
         </StackLayout>
     </ContentPage.Content>
 </views1:MvxContentPage>

--- a/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
+++ b/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\ResourceLoader\MvvmCross.Plugin.ResourceLoader.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross\MvvmCross.csproj" />
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj" />
+    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
   </ItemGroup>
 
   <Import Project="..\..\..\XamarinForms.targets" />

--- a/Projects/Playground/Playground.Forms.UI/Views/ChildContentView.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Views/ChildContentView.xaml
@@ -3,12 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:views="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
              xmlns:viewModels="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
+             x:Name="ContentRoot"
              x:Class="Playground.Forms.UI.Views.ChildContentView" x:TypeArguments="viewModels:ChildContentViewModel">
-  <ContentView.Content>
-      <StackLayout>
-          <Label Text="Static Text" />
-          <Label Text="{Binding Test}" />
-          <Button Text="ChildViewEnabledOrDisabled" />
+    <ContentView.Content>
+        <StackLayout>
+            <Label Text="Static Text" />
+            <Label Text="{Binding Test}" />
+            <Button Text="ChildViewEnabledOrDisabled" 
+                    IsEnabled="{Binding Source={x:Reference ContentRoot}, Path=IsEnabled}" />
         </StackLayout>
-  </ContentView.Content>
+    </ContentView.Content>
 </views:MvxContentView>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds a demo to the playground for binding a child view's BindingContextProperty to a parent view model's member.

### :arrow_heading_down: What is the current behavior?
Xaml binding a child view's BindingContextProperty no longer properly synchronizes between parent view model and child view.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
Playground.Forms.Droid ->Show Content View -> Tap "Change Child2 Text"

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
