### PR TITLE
Default MvxAppCompatSpinner DropDownItemTemplate doesn't display strings or use ToString on models

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/Widget/MvxAppCompatSpinner.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/Widget/MvxAppCompatSpinner.cs
@@ -25,8 +25,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Widget
             : this(context, attrs,
                 new MvxAdapter(context)
                 {
-                    ItemTemplateId = Android.Resource.Layout.SimpleSpinnerItem,
-                    DropDownItemTemplateId = Resource.Layout.support_simple_spinner_dropdown_item
+                    ItemTemplateId = global::Android.Resource.Layout.SimpleSpinnerItem,
+                    DropDownItemTemplateId = global::Android.Resource.Layout.SimpleSpinnerDropDownItem
                 })
         {
         }

--- a/Projects/Playground/Playground.Droid/Resources/layout/CollectionView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/CollectionView.axml
@@ -3,7 +3,8 @@
     xmlns:local="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
     <MvvmCross.Droid.Support.V7.RecyclerView.MvxRecyclerView
         android:id="@+id/code_recycler_view"
         android:layout_width="match_parent"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MvxAppCompatSpinner is using a default DropDownItemTemplate `support_simple_spinner_dropdown_item` from the Support library, which MvxAdapter doesn't know about so it can't translate to MvxSimpleListItemView. This causes the default MvxAppCompatSpinner items displayed in the drop down to be empty. This appears to only happen when using AppCompat libraries. The default MvxSpinner without using AppCompat libraries seems to be OK.

### :new: What is the new behavior (if this is a feature change)?
MvxAppCompatSpinner is using `global::Android.Resource.Layout.SimpleSpinnerDropDownItem` so MvxAdapter can display the string or display model.ToString().

### :boom: Does this PR introduce a breaking change?
There are some minor UI differences between `Resource.Layout.support_simple_spinner_dropdown_item` and `global::Android.Resource.Layout.SimpleSpinnerDropDownItem`

### :bug: Recommendations for testing
Add a MvxSpinner to CollectionView.axml in the Playground.Droid project.

### :memo: Links to relevant issues/docs
I can't create issues right now so I don't have one to link 🤷‍♂️ 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
