### PR TITLE
IMvxFormsPagePresenter registration & WPF alignment

### DIFF
--- a/MvvmCross.Forms.Wpf/Platforms/Wpf/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms.Wpf/Platforms/Wpf/Core/MvxFormsWindowsSetup.cs
@@ -44,10 +44,18 @@ namespace MvvmCross.Forms.Platforms.Wpf.Core
 
         protected abstract Application CreateFormsApplication();
 
+        protected virtual IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
+        {
+            var formsPagePresenter = new MvxFormsPagePresenter(viewPresenter);
+            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(formsPagePresenter);
+            return formsPagePresenter;
+        }
+
         protected override IMvxWpfViewPresenter CreateViewPresenter(ContentControl contentControl)
         {
             var presenter = new MvxFormsWpfViewPresenter(contentControl, FormsApplication);
             Mvx.IoCProvider.RegisterSingleton<IMvxFormsViewPresenter>(presenter);
+            presenter.FormsPagePresenter = CreateFormsPagePresenter(presenter);
             return presenter;
         }
 

--- a/MvvmCross.Forms.Wpf/Platforms/Wpf/Presenters/MvxFormsWpfViewPresenter.cs
+++ b/MvvmCross.Forms.Wpf/Platforms/Wpf/Presenters/MvxFormsWpfViewPresenter.cs
@@ -41,10 +41,7 @@ namespace MvvmCross.Forms.Platforms.Wpf.Presenters
             get
             {
                 if (_formsPagePresenter == null)
-                {
-                    _formsPagePresenter = new MvxFormsPagePresenter(this);
-                    Mvx.IoCProvider.RegisterSingleton(_formsPagePresenter);
-                }
+                    throw new ArgumentNullException(nameof(FormsPagePresenter), "IMvxFormsPagePresenter cannot be null. Set the value in CreateViewPresenter in the setup.");
                 return _formsPagePresenter;
             }
             set

--- a/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
+++ b/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Forms.Platforms.Android.Core
         protected virtual IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
         {
             var formsPagePresenter = new MvxFormsPagePresenter(viewPresenter);
-            Mvx.IoCProvider.RegisterSingleton(formsPagePresenter);
+            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(formsPagePresenter);
             return formsPagePresenter;
         }
 

--- a/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsIosSetup.cs
+++ b/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsIosSetup.cs
@@ -71,7 +71,7 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
         protected virtual IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
         {
             var formsPagePresenter = new MvxFormsPagePresenter(viewPresenter);
-            Mvx.IoCProvider.RegisterSingleton(formsPagePresenter);
+            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(formsPagePresenter);
             return formsPagePresenter;
         }
 

--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsMacSetup.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsMacSetup.cs
@@ -71,7 +71,7 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
         protected virtual IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
         {
             var formsPagePresenter = new MvxFormsPagePresenter(viewPresenter);
-            Mvx.IoCProvider.RegisterSingleton(formsPagePresenter);
+            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(formsPagePresenter);
             return formsPagePresenter;
         }
 

--- a/MvvmCross.Forms/Platforms/Tizen/Core/MvxFormsTizenSetup.cs
+++ b/MvvmCross.Forms/Platforms/Tizen/Core/MvxFormsTizenSetup.cs
@@ -70,7 +70,7 @@ namespace MvvmCross.Forms.Platforms.Tizen.Core
         protected virtual IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
         {
             var formsPagePresenter = new MvxFormsPagePresenter(viewPresenter);
-            Mvx.IoCProvider.RegisterSingleton(formsPagePresenter);
+            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(formsPagePresenter);
             return formsPagePresenter;
         }
 

--- a/MvvmCross.Forms/Platforms/Uap/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Core/MvxFormsWindowsSetup.cs
@@ -70,7 +70,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Core
         protected virtual IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
         {
             var formsPagePresenter = new MvxFormsPagePresenter(viewPresenter);
-            Mvx.IoCProvider.RegisterSingleton(formsPagePresenter);
+            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(formsPagePresenter);
             return formsPagePresenter;
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #2984 by registering the `IMvxFormsPagePresenter` interface instead of `MvxFormsPagePresenter` type in platform setup classes. In addition, this PR updates `MvxFormsWpfViewPresenter` and `MvxFormsWindowsSetup` for WPF to be aligned with other platforms.

### :arrow_heading_down: What is the current behavior?
On Forms.Android pushing back button crashes the app, because container fails to resolve `IMvxFormsPagePresenter`. After investigation I discovered this was due to the fact that the presenter singleton was registered without type parameter, which registered it as `MvxFormsPagePresenter` instead.

On WPF the page presenter was created inside of `MvxFormsWpfViewPresenter` in contrast to other platforms where it was set inside the platform setup.

### :new: What is the new behavior (if this is a feature change)?
On all platforms the page presenter singleton is registered as interface.

On WPF page presenter initialization was moved to `MvxFormsWindowsSetup`'s `CreateFormsPagePresenter` method and is then assigned to `FormsPagePresenter` property of `IMvxFormsViewPresenter` in `CreateViewPresenter`.

### :boom: Does this PR introduce a breaking change?
Yes, apps that were resolving `MvxFormsViewPresenter` in their code will fail and will need to resolve `IMvxFormsViewPresenter` instead.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
