### PR TITLE
Update links in docs

### DIFF
--- a/docs/_documentation/advanced/custom-data-binding.md
+++ b/docs/_documentation/advanced/custom-data-binding.md
@@ -141,4 +141,12 @@ This class is a subclass of [`MvxConvertingTargetBinding`](#mvxconvertingtargetb
 
 To get some inspiration on how to create your own target bindings, you can take a look at the ones that come out of the box with MvvmCross.
 
-You can find them in the [Bindings code](https://github.com/MvvmCross/MvvmCross/tree/develop/MvvmCross/Binding). There are a lot of target bindings you can look at for different kinds of behavior and requirements.
+You can find them here:
+- [Android](https://github.com/MvvmCross/MvvmCross/tree/master/MvvmCross/Platforms/Android/Binding/Target)
+- [macOS](https://github.com/MvvmCross/MvvmCross/tree/master/MvvmCross/Platforms/Mac/Binding/Target)
+- [tvOS](https://github.com/MvvmCross/MvvmCross/tree/master/MvvmCross/Platforms/Tvos/Binding/Target)
+- [UWP](https://github.com/MvvmCross/MvvmCross/tree/master/MvvmCross/Platforms/Uap/Binding/MvxBinding/Target)
+- [WPF](https://github.com/MvvmCross/MvvmCross/tree/master/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target)
+- [iOS](https://github.com/MvvmCross/MvvmCross/tree/master/MvvmCross/Platforms/Ios/Binding/Target)
+
+There are a lot of target bindings you can look at for different kinds of behavior and requirements.

--- a/docs/_documentation/advanced/customizing-using-App-and-Setup.md
+++ b/docs/_documentation/advanced/customizing-using-App-and-Setup.md
@@ -7,14 +7,14 @@ order: 1
 
 In each deployed MvvmCross application there are two key classes which control how your app starts:
 
-* the App class in the core project - which provides the initialization for your core business logic and your viewmodels.
-* the Setup class in the native UI project - this Setup is a bootstrapper for the MvvmCross system and for your app.
+- The App class in the core project - which provides the initialization for your core business logic and your viewmodels.
+- The Setup class in the native UI project - this Setup is a bootstrapper for the MvvmCross system and for your app.
 
 ## App.cs
 
 Typically App.cs provides only initialization of:
 
-* simple rule-based IoC registration - e.g.:
+- Simple rule-based IoC registration - e.g.:
 
 ```c#
 CreatableTypes()
@@ -23,15 +23,14 @@ CreatableTypes()
     .RegisterAsLazySingleton();
 ```
 
-* the ViewModelLocator - how ViewModels are found or created when Views are displayed
-
-* the IMvxAppStart - which ViewModel or ViewModels are shown when the application is first started
+- The IMvxAppStart - which ViewModel or ViewModels are shown when the application is first started
 
 ## Setup.cs
 
 Internally the Setup bootstrapper performs many steps.
 
 You can see most of them in the MvxSetup.cs class source which includes a sequence like this:
+
 ```c#
     // IoC
     InitializeIoC();
@@ -60,6 +59,7 @@ You can see most of them in the MvxSetup.cs class source which includes a sequen
 ```
 
 Most of these steps are virtual - so they allow customization. Also most of these steps are implemented using virtual Create steps - which again should make customization easier:
+
 ```c#
 protected virtual void InitialiseFoo()
 {
@@ -251,18 +251,18 @@ protected override IMvxViewModelLocator CreateDefaultViewModelLocator()
 
 ## Custom Presenters
 
-For 'my first MvvmCross application' most people start with a 'full page' app in which each ShowViewModel causes a new View to be displayed, filling an entire screen at a time.
+For 'my very first MvvmCross application' most people start with a 'full page' app in which each navigation causes a new full-screen View to be displayed.
 
-There are many other possibilities for ViewModel->ViewModel navigation, including:
+There are many other possibilities for ViewModel -> ViewModel navigation, including:
 
-* tabbed displays
-* dialogs and flyouts
-* 'hamburger menus'
-* splitviews, master-detail displays, screen 'regions' and other screen division/fragmentation
+- Tabbed displays
+- Dialogs and flyouts
+- Hamburger menus
+- Splitviews, master-detail displays, screen 'regions' and other screen division/fragmentation
 
-To provide these alternative UI possibilities, MvvmCross allows each app to provide a custom presenter.
+To provide these alternative UI possibilities, MvvmCross provides a default ViewPresenter per platform, but you can always use your own custom presenter.
 
-For more on custom presenters, see several articles and videos linked from: http://slodge.blogspot.co.uk/2013/06/presenter-roundup.html
+For more on ViewPresenters, check out the [official documentation](https://www.mvvmcross.com/documentation/fundamentals/view-presenters).
 
 ## Providing ValueConverters
 
@@ -336,7 +336,7 @@ private void RegisterValueConverters()
 }   
 ```
 
-For more on creating ValueConverters, see the ValueConverter sample in: https://github.com/slodge/MvvmCross-Tutorials/tree/master/ValueConversion
+For more on creating ValueConverters, read the [official documentation](https://www.mvvmcross.com/documentation/fundamentals/value-converters) or read the ValueConverter sample in: https://github.com/MvvmCross/MvvmCross-Samples/tree/master/ValueConversion
 
 ## Providing Custom Views (Android)
 

--- a/docs/_documentation/advanced/mvxnotifytask.md
+++ b/docs/_documentation/advanced/mvxnotifytask.md
@@ -5,7 +5,7 @@ category: Advanced
 order: 5
 ---
 
-MvvmCross provides a super useful helper when it comes to async/await: [MvxNotifyTask](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Core/Core/ViewModels/MvxNotifyTask.cs). 
+MvvmCross provides a super useful helper when it comes to async/await: [MvxNotifyTask](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/ViewModels/MvxNotifyTask.cs). 
 
 You might have missed this, but it is already being used in your application: The Initialize method is fired inside of a MvxNotifyTask, and if your ViewModels derive from `MvxViewModel`, you will find that there is a property called `InitializeTask`. You can use that property to spot any changes to the states of Initialize.
 

--- a/docs/_documentation/contributing/references.md
+++ b/docs/_documentation/contributing/references.md
@@ -4,6 +4,7 @@ title: References
 category: Contributing
 order: 4
 ---
+
 * [MonoCross](http://code.google.com/p/monocross/) was the original starting point for this project, and was used as a reference under MIT
 * [Phone7.Fx](http://phone7.codeplex.com) is redistributed and modified under MS-PL
 * Tiny bits of [MvvmLight](http://mvvmlight.codeplex.com/) are redistributed and modified under MIT
@@ -14,4 +15,5 @@ order: 4
 * [MonoDroid.Dialog](https://github.com/kevinmcmahon/MonoDroid.Dialog) - MIT X11
 * Messenger ideas from [JonathanPeppers/XPlatUtils](https://github.com/jonathanpeppers/XPlatUtils) under Apache License Version 2.0, and from GrumpyDev/TinyMessenger under simple license of "THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY"
 * [Color codes](https://github.com/mono/sysdrawing-coregraphics) under MIT License
+* Some bits of [Mvvm.Async](https://github.com/StephenCleary/Mvvm.Async) are redistributed and modified under MIT License
 

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -59,7 +59,7 @@ In the View:
      - custom C# methods have to be used to get and set the variable values
      - custom Java listeners or Objective-C delegates have to be used to detect when the UI View state changes (e.g. when the user enters text or taps on a button).
 
-For more info on the details on implementing custom bindings, see the [custom bindings blog post by Stuart Lodge](http://slodge.blogspot.co.uk/2013/06/n28-custom-bindings-n1-days-of-mvvmcross.html)
+For more info on the details on implementing custom bindings, see the [official documentation](https://www.mvvmcross.com/documentation/advanced/custom-data-binding)
 
 ### DataBound properties
 
@@ -916,7 +916,7 @@ protected override void InitializeLastChance()
 
     `<TextBlock mvx:Bi.nd="Text Customer.FirstName; Visible=ShowFirstName" />`
 
-- for design-time support, you may also need to pull in additional value converters into the Xaml namespace. For more on this, see http://slodge.blogspot.co.uk/2013/07/n35-multibinding-with-tibet-n1-videos.html
+- for design-time support, you may also need to pull in additional value converters into the Xaml namespace. For more on this, see [slodge's tutorial](http://slodge.blogspot.co.uk/2013/07/n35-multibinding-with-tibet-n1-videos.html)
 
 Once installed, the syntax within these `AttachedProperties` bindings is exactly the same as within all other Swiss and Tibet binding - and this binding functionality can be extended with custom bindings, with FieldBinding, etc - just as in MvvmCross on non-Xaml platforms.
 

--- a/docs/_documentation/fundamentals/inversion-of-control-ioc.md
+++ b/docs/_documentation/fundamentals/inversion-of-control-ioc.md
@@ -415,7 +415,7 @@ I'm not going to go into any more detail on writing plugins here.
 
 If you'd like to see more about writing your own plugin, then:
 
-- see the [Plugins](https://github.com/slodge/MvvmCross/wiki/MvvmCross-plugins) article
+- see the [Getting started](https://www.mvvmcross.com/documentation/plugins/getting-started?scroll=1320) article
 - there's a presentation on this at https://speakerdeck.com/cirrious/plugins-in-mvvmcross
 - there's a sample which creates a `Vibrate` plugin at https://github.com/slodge/MvvmCross-Tutorials/tree/master/GoodVibrations
 

--- a/docs/_documentation/fundamentals/inversion-of-control-ioc.md
+++ b/docs/_documentation/fundamentals/inversion-of-control-ioc.md
@@ -390,7 +390,6 @@ If you want to see how these plugins can be used in your applications, then:
   - N=9 - Messenger http://slodge.blogspot.co.uk/2013/05/n9-getting-message-n1-days-of-mvvmcross.html
   - N=10 - SQLite http://slodge.blogspot.co.uk/2013/05/n10-sqlite-persistent-data-storage-n1.html
   - N=12 -> N=17 - the Collect-A-Bull app http://slodge.blogspot.co.uk/2013/05/n12-collect-bull-full-app-part-1-n1.html
-- see the [Plugins](https://github.com/slodge/MvvmCross/wiki/MvvmCross-plugins) article
 
 #### Plugin Authoring
 
@@ -556,13 +555,6 @@ However, if you feel the MvvmCross detection is wrong - if your app has some beh
             var instance = MvxIoCProvider.Initialize(options);
 
 **Note:** in the event of recursion causing a stack overflow, some mobile runtimes will **not** throw a `StackOverlowException` - but will instead simply exit without warning - this situation can be hard to debug.
-
-### What if... I want advanced IoC features like child containers
-
-The IoC container in MvvmCross is designed to be quite lightweight and is targeted at a level of functionality required in the mobile applications I have built.
-
-If you need more advanced/complex functionality, then you may need to use a different provider or a different approach - some suggestions for this are discussed in: http://stackoverflow.com/questions/16514691/child-containers-in-mvvmcross-ioc
-
 
 ### What if... I want to mix Dynamic and Singleton types
 

--- a/docs/_documentation/fundamentals/linking.md
+++ b/docs/_documentation/fundamentals/linking.md
@@ -90,7 +90,7 @@ This will hint that both the `TouchUpInside` event is used and that we also use 
 
 You will need to add sections to this file as needed.
 
-> You can find some good defaults in our [ContentFiles in our GitHub repository](https://github.com/MvvmCross/MvvmCross/tree/develop/ContentFiles).
+> You can find some good defaults in our [ContentFiles in our GitHub repository](https://github.com/MvvmCross/MvvmCross/tree/master/ContentFiles).
 
 LinkerPleaseInclude files need to be added per platform and need to be compiled. However, these are never invoked, so don't worry if you write code that does not make sense in them. The code is just there to hint the linker.
 

--- a/docs/_documentation/fundamentals/testing.md
+++ b/docs/_documentation/fundamentals/testing.md
@@ -185,8 +185,3 @@ public void Valid_Model_Raises_CanExecute_Test()
 * The [Twitter Search](https://github.com/slodge/MvvmCross-Tutorials/tree/master/Sample%20-%20TwitterSearch) example has a [test project](https://github.com/slodge/MvvmCross-Tutorials/tree/master/Sample%20-%20TwitterSearch/TwitterSearch.Test) which can be used as reference as well
 
 * There is a [N=29 video tutorial](http://slodge.blogspot.co.uk/2013/06/n29-testing-n1-days-of-mvvmcross.html) on testing
-
-* [MvvmCross: Enable Unit-testing](http://blog.fire-development.com/2013/06/29/mvvmcross-enable-unit-testing/). A blog post presenting a slightly different approach, using a custom `MvvmCrossTestSetup` class.
-
-* [MvvmCross: Unit-testing with AutoFixture](http://blog.fire-development.com/2013/06/29/mvvmcross-unit-testing-with-autofixture/). A blog post introducing a way to combine MvvmCross with [AutoFixture](https://github.com/AutoFixture/AutoFixture)
-

--- a/docs/_documentation/fundamentals/value-combiners.md
+++ b/docs/_documentation/fundamentals/value-combiners.md
@@ -7,7 +7,7 @@ order: 9
 
 ### ValueCombiners
 
-Tibet binding (see [wiki/Databinding](https://github.com/slodge/MvvmCross/wiki/Databinding)) introduced a new interface into binding - `IMvxValueCombiner` - this interface allows multiple binding sources to be combined together within a single target expression. This interface is used in, for example, the `MvxFormatValueCombiner` in order to enable binding expressions like:
+Tibet binding (see [wiki/Databinding](https://www.mvvmcross.com/documentation/fundamentals/data-binding)) introduced a new interface into binding - `IMvxValueCombiner` - this interface allows multiple binding sources to be combined together within a single target expression. This interface is used in, for example, the `MvxFormatValueCombiner` in order to enable binding expressions like:
 
          local:MvxBind="Text Format('{0} {1} {2}', Greeting(Gender), FirstName, LastName)"
          

--- a/docs/_documentation/fundamentals/value-converters.md
+++ b/docs/_documentation/fundamentals/value-converters.md
@@ -4,6 +4,7 @@ title: Value converters
 category: Fundamentals
 order: 8
 ---
+
 Value Converters in MvvmCross are used to provide mappings to/from logical values in the view models and presented values in the user interface.
 
 A Value Converter is any class which implements the `IMvxValueConverter` interface
@@ -25,13 +26,13 @@ For value converters which are used with non-editable UI fields (e.g. labels, im
 
 Within MvvmCross, we try to encourage the use of cross-platform value converters wherever possible - but it is also possible and straight-forward to implement platform specific value converters.
      
-Note: this article assumes the reader has an understanding already of MvvmCross data-binding syntax - see [wiki/Databinding](https://github.com/slodge/MvvmCross/wiki/Databinding)
+Note: this article assumes the reader has an understanding already of MvvmCross data-binding syntax - see [wiki/Databinding](https://www.mvvmcross.com/documentation/fundamentals/data-binding)
 
 ### ValueConverter Samples
 
 For several good ValueConverter samples, including Strings, Dates, Colors, Visibility and Two-Way conversion, please see:
 
-- Value Conversion sample - https://github.com/slodge/MvvmCross-Tutorials/tree/master/ValueConversion
+- [Value Conversion sample](https://github.com/MvvmCross/MvvmCross-Samples/tree/master/ValueConversion)
 - N+1 Video - http://slodge.blogspot.ca/2013/04/n4-valueconverters-n1-days-of-mvvmcross.html
 
 ### A first ValueConverter
@@ -128,12 +129,12 @@ The `object parameter` parameter is a general purpose field which you can use in
   
   Both of these would result in the AbbreviateIfLongerThan ValueConverter being called with parameter of `long` 12
 
-Note that the only types that are used when parameters are parsed from text binding descriptions are: `long`, `double`, `bool` or `string` (for more on the binding parsing engine, see [wiki/Databinding](https://github.com/slodge/MvvmCross/wiki/Databinding))
+Note that the only types that are used when parameters are parsed from text binding descriptions are: `long`, `double`, `bool` or `string` (for more on the binding parsing engine, see [wiki/Databinding](https://www.mvvmcross.com/documentation/fundamentals/data-binding))
     
 
 ### Referencing Value Converters in iOS and Droid
 
-Data-Binding syntax including how to specify ValueConverters using Swiss, Fluent and Tibet binding is discussed in [wiki/Databinding](https://github.com/slodge/MvvmCross/wiki/Databinding). This covers all syntax including:
+Data-Binding syntax including how to specify ValueConverters using Swiss, Fluent and Tibet binding is discussed in [wiki/Databinding](https://www.mvvmcross.com/documentation/fundamentals/data-binding). This covers all syntax including:
 
 - Swiss
    
@@ -262,7 +263,7 @@ public class TheNativeTruthValueConverter
 
 ### Using Value Converters in Windows (Tibet binding)
 
-In addition to 'traditional' Xaml bindings, MvvmCross also allows 'Tibet' binding within Windows - for more on this see [wiki/Databinding](https://github.com/slodge/MvvmCross/wiki/Databinding).
+In addition to 'traditional' Xaml bindings, MvvmCross also allows 'Tibet' binding within Windows.
 
 When Tibet binding is used, then Value Converters can be accessed by name - exactly as in Droid and iOS binding - without the above native Xaml wrapping.
 
@@ -518,7 +519,7 @@ In summary - **ValueConverters are good** - use them.
 
 ### ValueConverters and FallbackValues
 
-When specifying a binding, you can also provide a `FallbackValue` - see [wiki/Databinding](https://github.com/slodge/MvvmCross/wiki/Databinding). This `FallbackValue` is used within the View:
+When specifying a binding, you can also provide a `FallbackValue` - see [wiki/Databinding](https://www.mvvmcross.com/documentation/fundamentals/data-binding). This `FallbackValue` is used within the View:
 
 - whenever the binding source path is missing - e.g. if you specify a Path of `Child.Property` and `Child` is currently `null`
 - whenever the value converter throws an exception during the `Convert` conversion
@@ -533,7 +534,7 @@ If you do want to pass a `FallbackValue` through the Value Converter then you ca
 
 ### Tibet: ValueCombiners
 
-Tibet binding (see [wiki/Databinding](https://github.com/slodge/MvvmCross/wiki/Databinding)) introduced a new interface into binding - `IMvxValueCombiner` - this interface allows multiple binding sources to be combined together within a single target expression. This interface is used in, for example, the `MvxFormatValueCombiner` in order to enable binding expressions like:
+Tibet binding introduced a new interface into binding - `IMvxValueCombiner` - this interface allows multiple binding sources to be combined together within a single target expression. This interface is used in, for example, the `MvxFormatValueCombiner` in order to enable binding expressions like:
 
          local:MvxBind="Text Format('{0} {1} {2}', Greeting(Gender), FirstName, LastName)"
          

--- a/docs/_documentation/fundamentals/view-presenters.md
+++ b/docs/_documentation/fundamentals/view-presenters.md
@@ -16,7 +16,7 @@ Going further with the previous idea, it is important to notice that each platfo
 - On MacOS, once again the same app could include a window with a split view.
 - ...
 
-MvvmCross provides default presenters for each platform that support the most used patterns and strategies. However, sometimes you might find yourself needing to display a ViewModel in a particular or rare way that is not covered. This means, you will need to create a custom presenter by subclassing one of the provided by MvvmCross or by implementing the interface [IMvxViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/89eb738f36e600f6e9aa1555e2b4bb6484c553cb/MvvmCross/Core/Core/Views/IMvxViewPresenter.cs).
+MvvmCross provides default presenters for each platform that support the most used patterns and strategies. However, sometimes you might find yourself needing to display a ViewModel in a particular or rare way that is not covered. This means, you will need to create a custom presenter by subclassing one of the provided by MvvmCross or by implementing the interface [IMvxViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Presenters/IMvxViewPresenter.cs).
 
 Let's take a look now at the methods of that interface:
 
@@ -27,19 +27,20 @@ Let's take a look now at the methods of that interface:
 
 ## View Presenters on each platform
 Each platform has its own View Presenter:
-- Android: [MvxAndroidViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Droid/Droid/Views/MvxAndroidViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/presenters/android-view-presenter)
-- Android (support packages): [MvxAppCompatViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross-AndroidSupport/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/presenters/android-view-presenter)
-- iOS: [MvxIosViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/presenters/ios-view-presenter)
-- UWP: [MvxWindowsViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Windows/Uwp/Views/MvxWindowsViewPresenter.cs)
-- WPF: [MvxWpfViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Windows/Wpf/Views/Presenters/MvxWpfViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/presenters/wpf-view-presenter)
-- macOS: [MvxMacViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Mac/Mac/Views/Presenters/MvxMacViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/presenters/mac-view-presenter)
-- tvOS: [MvxTvosViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/tvOS/tvOS/Views/Presenters/MvxTvosViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/presenters/tvos-view-presenter)
+- Android: [MvxAndroidViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/platform/android/android-view-presenter)
+- Android (support packages): [MvxAppCompatViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/platform/android/android-view-presenter)
+- iOS: [MvxIosViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/platform/ios/ios-view-presenter)
+- UWP: [MvxWindowsViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Uap/Presenters/MvxWindowsViewPresenter.cs)
+- WPF: [MvxWpfViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Wpf/Presenters/MvxWpfViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/platform/wpf/wpf-view-presenter)
+- macOS: [MvxMacViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/platform/macos/mac-view-presenter)
+- tvOS: [MvxTvosViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Tvos/Presenters/MvxTvosViewPresenter.cs) - [Documentation](https://www.mvvmcross.com/documentation/platform/tvos/tvos-view-presenter)
+- Tizen: [MvxTizenViewPresenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Tizen/Presenters/MvxTizenViewPresenter.cs)
 
 When you navigate to selected ViewModel, platform specific View Presenter handles displaying View properly.
 
  ![View Presenter schema](../../assets/img/ViewPresenterSchema.png)
 
-MvvmCross ViewPresenters will provide you with a set of attributes on each platform. For example on iOS, [these](https://github.com/MvvmCross/MvvmCross/tree/develop/MvvmCross/iOS/iOS/Views/Presenters/Attributes) are the existing ones: 
+MvvmCross ViewPresenters will provide you with a set of attributes on each platform. For example on iOS, [these](https://github.com/MvvmCross/MvvmCross/tree/master/MvvmCross/Platforms/Ios/Presenters/Attributes) are the existing ones: 
 
 - MvxTabPresentationAttribute – for tabs
 - MvxRootPresentationAttribute – to set a ViewController as root
@@ -77,7 +78,7 @@ In this example the attribute is telling the Presenter that whenever a ViewModel
 ## Requesting presentation changes
 Although for most apps showing / closing ViewModels is enough, there is one more tool that MvvmCross offers, and it is extremely powerful: the ability to request a change to the UI layer.
 
-The best example we can give about this is the `Close` method itself. Once you call Close from a ViewModel or a MvxNavigatingObject, what MvvmCross internally do is to send a `MvxClosePresentationHint` to the ViewPresenter, which then calls `Close(IMvxViewModel toClose)`. You can see how this happen in the [iOS Presenter](https://github.com/MvvmCross/MvvmCross/blob/b4ca1f492b996c9a836f494b7873033336ea83de/MvvmCross/iOS/iOS/Views/Presenters/MvxIosViewPresenter.cs#L67).
+The best example we can give about this is the `Close` method itself. Once you call Close from a ViewModel or a MvxNavigatingObject, what MvvmCross internally do is to send a `MvxClosePresentationHint` to the ViewPresenter, which then calls `Close(IMvxViewModel toClose)`. You can see how this happen in the [Base Presenter](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Presenters/MvxAttributeViewPresenter.cs#L158).
 
 It is important to remark here that these are just unbound requests. Each platform is then responsible for deciding how a presentation hint should be handled - you can also decide to just ignore a hint type -.
 

--- a/docs/_documentation/getting-started/mvvmcross-packages.md
+++ b/docs/_documentation/getting-started/mvvmcross-packages.md
@@ -8,40 +8,25 @@ MvvmCross is a very extensible framework. There is a lot already been made by th
 
 Name | Description | Link
 ---- | ----------- | ----
-`MvvmCross.StarterPack`        | When starting a fresh project you should install this nuget. This will add all files to get you started. Afterwards you need to remove the nuget reference again manually from all your `packages.config` files (not through Nuget as this will delete the source files). | [NuGet](https://www.nuget.org/packages/MvvmCross.StarterPack/)
-`MvvmCross.Forms.StarterPack`  | When starting a fresh Xamarin Forms project and want to use MvvmCross you should install this nuget. This will add all files to get started. In the core project you will find a ToDo file to get the project working. | [NuGet](https://www.nuget.org/packages/MvvmCross.Forms.StarterPack/)
 `MvvmCross`                    | Main nuget. This will add Core and Binding. | [NuGet](https://www.nuget.org/packages/MvvmCross/)
-`MvvmCross.Platform`           | Contains the libraries for all the separate platforms. | [NuGet](https://www.nuget.org/packages/MvvmCross.Platform/)
-`MvvmCross.Core`               | Core libraries for the base of your app. | [NuGet](https://www.nuget.org/packages/MvvmCross.Core/)
 `MvvmCross.Forms`              | Main nuget for Xamarin Forms. | [NuGet](https://www.nuget.org/packages/MvvmCross.Forms/)
 `MvvmCross.Tests`              | Test helpers | [NuGet](https://www.nuget.org/packages/MvvmCross.Tests/)
-`MvvmCross.Console.Platform`   |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Console.Platform/)
 `MvvmCross.CodeAnalysis`       | Code fixes for MvvmCross | [NuGet](https://www.nuget.org/packages/MvvmCross.CodeAnalysis/)
-`MvvmCross.Binding`            | Bindings system for all platforms | [NuGet](https://www.nuget.org/packages/MvvmCross.Binding/)
-`MvvmCross.BindingEx`          |  | [NuGet](https://www.nuget.org/packages/MvvmCross.BindingEx/)
 
 
 ## Android Support
 
 Name | Description | Link
 ---- | ----------- | ----
-`MvvmCross.Droid.Support.V4`              |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.V4/)
 `MvvmCross.Droid.Support.V7.AppCompat`    | AppCompat for MvvmCross | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.V7.AppCompat/)
-`MvvmCross.Droid.Support.V7.Fragging`     | Android support fragments, caching and helpers | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.V7.Fragging/)
 `MvvmCross.Droid.Support.V7.Preference`   |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.V7.Preference/)
 `MvvmCross.Droid.Support.V7.RecyclerView` |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.V7.RecyclerView/)
 `MvvmCross.Droid.Support.V14.Preference`  |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.V14.Preference/)
 `MvvmCross.Droid.Support.V17.Leanback`    |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.V17.Leanback/)
+`MvvmCross.Droid.Support.Fragment`        |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.Fragment/)
 `MvvmCross.Droid.Support.Design`          |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.Design/)
-
-
-## iOS Support
-
-Name | Description | Link
----- | ----------- | ----
-`MvvmCross.iOS.Support`                | Helpers, featured ViewPresenters and Base classes for iOS | [NuGet](https://www.nuget.org/packages/MvvmCross.iOS.Support/)
-`MvvmCross.iOS.Support.JASidePanels`   | Implementation for `JASidePanels` library                 | [NuGet](https://www.nuget.org/packages/MvvmCross.iOS.Support.JASidePanels/)
-`MvvmCross.iOS.Support.XamarinSidebar` | Implementation for `XamarinSidebar` library               | [NuGet](https://www.nuget.org/packages/MvvmCross.iOS.Support.XamarinSidebar/)
+`MvvmCross.Droid.Support.Core.UI`         |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.Core.UI/)
+`MvvmCross.Droid.Support.Core.Utils`      |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Droid.Support.Core.Utils/)
 
 
 ## Plugins
@@ -49,10 +34,8 @@ Name | Description | Link
 Name | Description | Link
 ---- | ----------- | ----
 `MvvmCross.Plugin.All`              |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.All/)
-`MvvmCross.Plugin.Accelerometer`    |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Accelerometer/)
-`MvvmCross.Plugin.Bookmarks`        |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Bookmarks/)
+`MvvmCross.Plugin.Accelerometer`    | Manage the accelerometer from your shared code | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Accelerometer/)
 `MvvmCross.Plugin.Color`            |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Color/)
-`MvvmCross.Plugin.DownloadCache`    |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.DownloadCache/)
 `MvvmCross.Plugin.Email`            |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Email/)
 `MvvmCross.Plugin.FieldBinding`     |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.FieldBinding/)
 `MvvmCross.Plugin.File`             |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.File/)
@@ -61,14 +44,12 @@ Name | Description | Link
 `MvvmCross.Plugin.Location`         |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Location/)
 `MvvmCross.Plugin.Messenger`        |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Messenger/)
 `MvvmCross.Plugin.MethodBinding`    |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.MethodBinding/)
-`MvvmCross.Plugin.Network`          |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.PhoneCall/)
+`MvvmCross.Plugin.Network`          |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Network/)
+`MvvmCross.Plugin.PhoneCall`          |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.PhoneCall/)
 `MvvmCross.Plugin.PictureChooser`   |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.PictureChooser/)
-`MvvmCross.Plugin.ReflectionEx`     |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.ReflectionEx/)
 `MvvmCross.Plugin.ResourceLoader`   |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.ResourceLoader/)
 `MvvmCross.Plugin.Share`            |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Share/)
-`MvvmCross.Plugin.SoundEffects`     |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.SoundEffects/)
-`MvvmCross.Plugin.SQLitePCL`        |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.SQLitePCL/)
-`MvvmCross.Plugin.ThreadUtils`      |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.ThreadUtils/)
 `MvvmCross.Plugin.Visibility`       |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Visibility/)
 `MvvmCross.Plugin.WebBrowser`       |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.WebBrowser/)
+`MvvmCross.Plugin.Sidebar`          |  | [NuGet](https://www.nuget.org/packages/MvvmCross.Plugin.Sidebar/)
 

--- a/docs/_documentation/getting-started/portable-class-library-pcl.md
+++ b/docs/_documentation/getting-started/portable-class-library-pcl.md
@@ -9,7 +9,7 @@ order: 5
 
 With C# Views it is possible to write the MvvM either as a PCL or as a shared project. It is not possible to do that with XAML, you must use a PCL. You might think that this would be a disadvantage because in C# shared projects you can use "#ifdef" statements to conditionally compile code dependent on target platform. Thus you might reason that this would make maintaining and understanding the coding more productive.
 
-However [Xamarin PCL](http://developer.xamarin.com/guides/cross-platform/xamarin-forms/working-with/platform-specifics/) achieves a similar outcome using a class known as the Device. This class although part of the Portable Class Library has methods that return different values depending on the native platform your App is installed on.
+However [Xamarin PCL](https://docs.microsoft.com/es-es/xamarin/xamarin-forms/platform/device) achieves a similar outcome using a class known as the Device. This class although part of the Portable Class Library has methods that return different values depending on the native platform your App is installed on.
 
 The Device static class is available in both C# and XAML coding if you know how to use it.
 

--- a/docs/_documentation/platform/android/android-support-library.md
+++ b/docs/_documentation/platform/android/android-support-library.md
@@ -20,8 +20,9 @@ To get bindings working when using the support libraries (for example if you wan
 ```c#
 namespace MyAwesomeApp.Droid
 {
-public class Setup : MvxAppCompatSetup
-{
-    ...
+    public class Setup : MvxAppCompatSetup
+    {
+        ...
+    }
 }
 ```

--- a/docs/_documentation/platform/android/android-support-library.md
+++ b/docs/_documentation/platform/android/android-support-library.md
@@ -4,19 +4,24 @@ title: Android support library
 category: Platforms
 ---
 
-To get bindings working when using the support libraries (for example if you want to use `MvxAutoCompleteTextView`) you will need to do the following.
+If your app will target the Android platform, you will probably want to make use of the Android Support libraries (because of many reasons).
 
-In Setup.cs override `FillTargetFactories`.
+If you don't really know what Android Support packages are about, we recommend that you read the [official documentation](https://developer.android.com/topic/libraries/support-library/).
+
+When using MvvmCross, all you need to do is to install the MvvmCros support packages. And then you will have access to the "app compat" objects / widgets, like:
+- AppCompatActivity -> MvxAppCompatActivity
+- Fragment -> MvxFragment
+
+We highly recommend you to take a look at some samples, like [StarWarsSample](https://github.com/MvvmCross/MvvmCross-Samples/tree/master/StarWarsSample) or the [Playground.Droid](https://github.com/MvvmCross/MvvmCross/tree/master/Projects/Playground/Playground.Droid) project, which is located in the main repository.
+
+
+To get bindings working when using the support libraries (for example if you want to use `MvxAutoCompleteTextView`) you should ensure your `Setup` class inherits from `MvxAppCompatSetup`:
 
 ```c#
-protected override void FillTargetFactories(
-    IMvxTargetBindingFactoryRegistry registry)
+namespace MyAwesomeApp.Droid
 {
-    MvxAppCompatSetupHelper.FillTargetFactories(registry);
-    base.FillTargetFactories(registry);
+public class Setup : MvxAppCompatSetup
+{
+    ...
 }
 ```
-
-## Samples
-A sample project can be found on github - [MvvmCross-AndroidSupport](https://github.com/MvvmCross/MvvmCross/tree/develop/MvvmCross-AndroidSupport)
-

--- a/docs/_documentation/platform/android/android-view-presenter.md
+++ b/docs/_documentation/platform/android/android-view-presenter.md
@@ -220,4 +220,5 @@ Bundle CreateActivityTransitionOptions(Intent intent, MvxActivityPresentationAtt
 ```
 
 ## Sample please!
-You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/TestProjects/Playground) Android project to see this presenter in action.
+
+You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/blob/master/Projects/Playground/) (Android project) to see this presenter in action.

--- a/docs/_documentation/platform/ios/ios-tables-and-cells.md
+++ b/docs/_documentation/platform/ios/ios-tables-and-cells.md
@@ -8,29 +8,28 @@ category: Platforms
 
 Abstract classes
 
-- [MvxBaseTableViewSource](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs)
+- [MvxBaseTableViewSource](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs)
   - base functionality only 
   - no `ItemsSource` - generally not used directly
-- [MvxTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewSource.cs)
+- [MvxTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewSource.cs)
   - inherits from the basetable and adds `ItemsSource` for data-binding
   - inheriting classes need only to implement `protected abstract UITableViewCell GetOrCreateCellFor(UITableView tableView, NSIndexPath indexPath, object item);`
-- [MvxExpandableTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Platforms/Ios/Views/MvxExpandableTableViewSource.cs)
-  - inherits from [MvxTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewSource.cs)
+- [MvxExpandableTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Views/MvxExpandableTableViewSource.cs)
+  - inherits from [MvxTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewSource.cs)
   - changes `ItemSource` to `IEnumerable<TItemSource> ItemsSource` for data-binding groups
   - inheriting classes need to implement `protected abstract UITableViewCell GetOrCreateCellFor(UITableView tableView, NSIndexPath indexPath, object item);` and register a header cell and table cell
-  - **Note** available in [MvvmCross.iOS.Support](https://www.nuget.org/packages/MvvmCross.iOS.Support/) nuget package
 
 Concrete classes
 
-- [MvxStandardTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Platforms/Ios/Binding/Views/MvxStandardTableViewSource.cs)
+- [MvxStandardTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Binding/Views/MvxStandardTableViewSource.cs)
   - inherits from `MvxTableViewSource`
   - provides the 'standard iPhone cell types' via `UITableViewCellStyle` 
   - within these you can bind `TitleText`, `DetailText`, and (with some teasing) Accessory
-- [MvxSimpleTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs)
+- [MvxSimpleTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs)
   - inherits from `MvxTableViewSource`
   - provides a single cell type for all items in the collection - via `string nibName` in the `ctor`
   - within these cells you can bind what you like - see videos (later)
-- [MvxActionBasedTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross/Platforms/Ios/Binding/Views/MvxActionBasedTableViewSource.cs)
+- [MvxActionBasedTableViewSource.cs](https://github.com/MvvmCross/MvvmCross/blob/master/MvvmCross/Platforms/Ios/Binding/Views/MvxActionBasedTableViewSource.cs)
   - provides some `Func<>`style hooks to allow you to implement `GetOrCreateCellFor` without inheriting a new class from `MvxTableViewSource`
 
 ## Custom table source example
@@ -101,12 +100,11 @@ public class PolymorphicListItemTypesView : MvxTableViewController
 
 For examples of creating custom tables and cells:
 
-- there's a lot of demos of table use in the N+1 series - indexed at [http://mvvmcross.wordpress.com](http://mvvmcross.wordpress.com)
+- there's a lot of demos of table use in [the N+1 series](http://mvvmcross.wordpress.com)
   - N=2 and N=3 are very basic
   - N=6 and N=6.5 covers a book list (a good place to start)
   - N=11 covers collection views
   - N=12 to k=17 make a large app with a list/table from a database
-- the "Working with Collections" sample has quite a lot of Table and List code - [https://github.com/MvvmCross/MvvmCross-Samples/tree/master/WorkingWithCollections](https://github.com/MvvmCross/MvvmCross-Samples/tree/master/WorkingWithCollections)
-- tables are used during the Evolve presentation - [http://xamarin.com/evolve/2013#session-dnoeeoarfj](http://xamarin.com/evolve/2013#session-dnoeeoarfj)
-- there are other samples available - see [https://github.com/MvvmCross/MvvmCross-Samples](https://github.com/MvvmCross/MvvmCross-Samples) (or search on GitHub for mvvmcross - others are also posting samples)
-- Custom Cells Without Using NIB files - [http://benjaminhysell.com/archive/2014/04/mvvmcross-custom-mvxtableviewcell-without-a-nib-file/](http://benjaminhysell.com/archive/2014/04/mvvmcross-custom-mvxtableviewcell-without-a-nib-file/)
+- the [Working with Collections]((https://github.com/MvvmCross/MvvmCross-Samples/tree/master/WorkingWithCollections)) sample has quite a lot of Table and List code
+- there are other samples available - see [MvvmCross-Samples](https://github.com/MvvmCross/MvvmCross-Samples) (or just search on the web for mvvmcross - others are also posting samples)
+- Custom Cells Without Using NIB files - [benjaminhysell blog](http://benjaminhysell.com/archive/2014/04/mvvmcross-custom-mvxtableviewcell-without-a-nib-file/)

--- a/docs/_documentation/platform/ios/ios-view-presenter.md
+++ b/docs/_documentation/platform/ios/ios-view-presenter.md
@@ -122,4 +122,5 @@ _attributeTypesToShowMethodDictionary.Add(
 
 
 ## Sample please!
-You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/TestProjects/Playground) iOS project to see this presenter in action.
+
+You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/Projects/Playground) (iOS project) to see this presenter in action.

--- a/docs/_documentation/platform/macos/mac-view-presenter.md
+++ b/docs/_documentation/platform/macos/mac-view-presenter.md
@@ -117,4 +117,4 @@ AttributeTypesToShowMethodDictionary.Add(
 
 
 ## Sample please!
-You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/TestProjects/Playground) macOS project to see this presenter in action.
+You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/Projects/Playground) (macOS project) to see this presenter in action.

--- a/docs/_documentation/platform/tvos/tvos-view-presenter.md
+++ b/docs/_documentation/platform/tvos/tvos-view-presenter.md
@@ -121,4 +121,5 @@ _attributeTypesToShowMethodDictionary.Add(
 
 
 ## Sample please!
-You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/TestProjects/Playground) tvOS project to see this presenter in action.
+
+You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/Projects/Playground) (tvOS project) to see this presenter in action.

--- a/docs/_documentation/platform/wpf/wpf-view-presenter.md
+++ b/docs/_documentation/platform/wpf/wpf-view-presenter.md
@@ -151,4 +151,4 @@ You can also define new attributes to satisfy your needs. The steps to do so are
 
 
 ## Sample please!
-You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/TestProjects/Playground) WPF project to see this presenter in action.
+You can browse the code of the [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/Projects/Playground) (WPF project) to see this presenter in action.

--- a/docs/_documentation/plugins/getting-started.md
+++ b/docs/_documentation/plugins/getting-started.md
@@ -11,7 +11,7 @@ Each plugin is suposed to provide abstractions of native functionalities such as
 ### A note about MvvmCross 5 and below
 
 If you are using a version of MvvmCross less than Mvx 6.0.0, you will need to add the bootstrap file yourself.
-The bootstrap file is available [here](https://github.com/MvvmCross/MvvmCross/blob/develop/nuspec/BootstrapContent/WebBrowserPluginBootstrap.cs.pp)
+The bootstrap file is available [here](https://github.com/MvvmCross/MvvmCross/blob/5.7.0/nuspec/BootstrapContent/WebBrowserPluginBootstrap.cs.pp)
 
 An example bootstrap class would look like:
 

--- a/docs/_documentation/plugins/ios-sidebar.md
+++ b/docs/_documentation/plugins/ios-sidebar.md
@@ -69,4 +69,4 @@ So when the presenter receives a request to show the master view **and** the app
 
 Subsequent touches on the UI master view which result in a request for view controller that requests to be shown as a detail view will then be shown in this same view (with no navigation occurring) but placed in the detail panel of the same instance of the split view created when the user navigated to the master view.
 
-Confused? See the [demo applications](https://github.com/MvvmCross/MvvmCross/tree/develop/TestProjects/iOS-Support)
+Confused? See the [demo applications](https://github.com/MvvmCross/MvvmCross/tree/master/Projects/IosSupport/XamarinSidebar)

--- a/docs/_documentation/plugins/share.md
+++ b/docs/_documentation/plugins/share.md
@@ -21,5 +21,5 @@ On iOS, currently only sharing by linked Twitter account is supported. There is 
 
 A sample using the Share plugin is:
 
-- Conference - see https://github.com/slodge/MvvmCross-Tutorials/tree/master/Sample%20-%20CirriousConference
+- Conference - see https://github.com/MvvmCross/MvvmCross-Samples/tree/master/OldSamples/CirriousConference
 

--- a/docs/_documentation/samples/samples.md
+++ b/docs/_documentation/samples/samples.md
@@ -14,4 +14,4 @@ Inside the samples repository you will find the [StarWars Sample](https://github
 
 #### Give me the latest and greatest please!
 
-Inside our main repository there is a sample app which contains lots of test scenarios and supports every platform. Check it out: [Playground](https://github.com/MvvmCross/MvvmCross/tree/develop/Projects/Playground).
+Inside our main repository there is a sample app which contains lots of test scenarios and supports every platform. Check it out: [Playground](https://github.com/MvvmCross/MvvmCross/tree/master/Projects/Playground).

--- a/docs/_documentation/tutorials/tipcalc/the-core-project.md
+++ b/docs/_documentation/tutorials/tipcalc/the-core-project.md
@@ -305,7 +305,7 @@ These are the same steps that you need to go through for every new MvvmCross app
 
 The next step is about building a first UI for our MvvmCross application.
 
-[Next!](https://www.mvvmcross.com/documentation/tutorials/tipcalc/the-tip-calc-navigation)
+[Next!](https://www.mvvmcross.com/documentation/tutorials/tipcalc/a-xamarinandroid-ui-project)
 
 
 ## Side note: What is 'Inversion of Control'?


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs

### :arrow_heading_down: What is the current behavior?
Links targeting source code are broken

### :new: What is the new behavior (if this is a feature change)?
Above is fixed. Also improved a few other docs in the process - and fixed a link on the TipCalc tutorial.

Also all links are now targeting `master` instead of develop - this should bring more stability and should make users happier.

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Read the docs :)

### :memo: Links to relevant issues/docs
Closes #2621 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
