### PR TITLE
Adds Android.Support.V7.Preferences.Preference.PreferenceClick target binding

### DIFF
--- a/MvvmCross.Android.Support/V7.Preference/MvxPreferencePropertyBinding.cs
+++ b/MvvmCross.Android.Support/V7.Preference/MvxPreferencePropertyBinding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,5 +10,6 @@ namespace MvvmCross.Droid.Support.V7.Preference
         public const string EditTextPreference_Text = "Text";
         public const string ListPreference_Value = "Value";
         public const string TwoStatePreference_Checked = "Checked";
+        public const string Preference_Click = "PreferenceClick";
     }
 }

--- a/MvvmCross.Android.Support/V7.Preference/MvxPreferenceSetupHelper.cs
+++ b/MvvmCross.Android.Support/V7.Preference/MvxPreferenceSetupHelper.cs
@@ -27,6 +27,10 @@ namespace MvvmCross.Droid.Support.V7.Preference
             registry.RegisterCustomBindingFactory<TwoStatePreference>(
                 MvxPreferencePropertyBinding.TwoStatePreference_Checked,
                 preference => new MvxTwoStatePreferenceCheckedTargetBinding(preference));
+
+            registry.RegisterCustomBindingFactory<Android.Support.V7.Preferences.Preference>(
+                MvxPreferencePropertyBinding.Preference_Click,
+                preference => new MvxPreferenceClickTargetBinding(preference));
         }
     }
 }

--- a/MvvmCross.Android.Support/V7.Preference/README.md
+++ b/MvvmCross.Android.Support/V7.Preference/README.md
@@ -12,7 +12,7 @@ protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry reg
 }
 ```
 
-Then one can bind to classes like `EditTextPreference` etc.
+Then one can bind to classes like `EditTextPreference`, `Preference`, etc.
 
 As an example given a `preferences.xml` like the following:
 ```xml
@@ -21,10 +21,13 @@ As an example given a `preferences.xml` like the following:
   <EditTextPreference android:title="Server Address"
                       android:key="pref_server"
                       android:summary="URL of the Server"/>
+  <Preference android:title="Reset Settings"
+              android:key="pref_reset"
+              android:summary="Restores all settings to default"/>
 </PreferenceScreen>
 ```
 
-One can bind to the ViewModel's `ServerAddress` property:
+One can bind to the ViewModel's `ServerAddress` property or `ResetSettings` command:
 ```csharp
 public class SettingsViewFragment : MvxPreferenceFragmentCompat<SettingsViewModel>
 {   
@@ -35,11 +38,15 @@ public class SettingsViewFragment : MvxPreferenceFragmentCompat<SettingsViewMode
         var view = base.OnCreateView(inflater, container, savedInstanceState);
 
         var serverPreference = (EditTextPreference)this.FindPreference("pref_server");
+        var resetSettingsPreference = this.FindPreference("pref_reset");
 
         var bindingSet = this.CreateBindingSet<SettingsViewFragment, SettingsViewModel>();
         bindingSet.Bind(serverPreference)
             .For(v => v.Text)
             .To(vm => vm.ServerAddress);
+        bindingSet.Bind(resetSettingsPreference)
+            .For("PreferenceClick")
+            .To(vm => vm.ResetSettings);
         bindingSet.Apply();
 
         return view;

--- a/MvvmCross.Android.Support/V7.Preference/Target/MvxPreferenceClickTargetBinding.cs
+++ b/MvvmCross.Android.Support/V7.Preference/Target/MvxPreferenceClickTargetBinding.cs
@@ -55,12 +55,7 @@ namespace MvvmCross.Droid.Support.V7.Preference.Target
             if (view == null)
                 return;
 
-            var shouldBeEnabled = false;
-            if (_command != null)
-            {
-                shouldBeEnabled = _command.CanExecute(null);
-            }
-            view.Enabled = shouldBeEnabled;
+            view.Enabled = _command?.CanExecute(null) ?? false;
         }
 
         private void OnCanExecuteChanged(object sender, EventArgs e)

--- a/MvvmCross.Android.Support/V7.Preference/Target/MvxPreferenceClickTargetBinding.cs
+++ b/MvvmCross.Android.Support/V7.Preference/Target/MvxPreferenceClickTargetBinding.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Windows.Input;
+using MvvmCross.Binding;
+using MvvmCross.Platforms.Android.Binding.Target;
+using MvvmCross.Platforms.Android.WeakSubscription;
+
+namespace MvvmCross.Droid.Support.V7.Preference.Target
+{
+    public class MvxPreferenceClickTargetBinding : MvxAndroidTargetBinding
+    {
+        private ICommand _command;
+        private IDisposable _clickSubscription;
+        private IDisposable _canExecuteSubscription;
+        private readonly EventHandler<EventArgs> _canExecuteEventHandler;
+
+        protected Android.Support.V7.Preferences.Preference Preference => (Android.Support.V7.Preferences.Preference)Target;
+
+        public MvxPreferenceClickTargetBinding(Android.Support.V7.Preferences.Preference view)
+            : base(view)
+        {
+            _canExecuteEventHandler = OnCanExecuteChanged;
+
+            _clickSubscription = Preference.WeakSubscribe<Android.Support.V7.Preferences.Preference, Android.Support.V7.Preferences.Preference.PreferenceClickEventArgs>(
+                nameof(Preference.PreferenceClick),
+                ViewOnPreferenceClick);
+        }
+
+        private void ViewOnPreferenceClick(object sender, Android.Support.V7.Preferences.Preference.PreferenceClickEventArgs args)
+        {
+            if (_command == null)
+                return;
+
+            if (!_command.CanExecute(null))
+                return;
+
+            _command.Execute(null);
+        }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            _canExecuteSubscription?.Dispose();
+            _canExecuteSubscription = null;
+
+            _command = value as ICommand;
+            if (_command != null)
+            {
+                _canExecuteSubscription = MvvmCross.WeakSubscription.MvxWeakSubscriptionExtensions.WeakSubscribe(_command, _canExecuteEventHandler);
+            }
+            RefreshEnabledState();
+        }
+
+        private void RefreshEnabledState()
+        {
+            var view = Preference;
+            if (view == null)
+                return;
+
+            var shouldBeEnabled = false;
+            if (_command != null)
+            {
+                shouldBeEnabled = _command.CanExecute(null);
+            }
+            view.Enabled = shouldBeEnabled;
+        }
+
+        private void OnCanExecuteChanged(object sender, EventArgs e)
+        {
+            RefreshEnabledState();
+        }
+
+        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
+
+        public override Type TargetType => typeof(ICommand);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                _clickSubscription?.Dispose();
+                _clickSubscription = null;
+
+                _canExecuteSubscription?.Dispose();
+                _canExecuteSubscription = null;
+            }
+            base.Dispose(isDisposing);
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
There is no support to bind `Android.Support.V7.Preferences.Preference.PreferenceClick` event to an `ICommand`.

### :new: What is the new behavior (if this is a feature change)?
Adds support to bind `Android.Support.V7.Preferences.Preference.PreferenceClick` event to an `ICommand`.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
See MvvmCross.Android.Support/V7.Preference/README.MD for usage.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
