### PR TITLE
[WIP] UWP Suspension handling

### DIFF
--- a/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
@@ -94,11 +94,6 @@ namespace MvvmCross.Platforms.Uap.Views
                 Window.Current.Content = rootFrame;
             }
 
-            if (activationArgs.PreviousExecutionState == ApplicationExecutionState.Terminated)
-            {
-                OnResumeFromTerminateState();
-            }
-
             RootFrame = rootFrame;
 
             return rootFrame;
@@ -107,10 +102,6 @@ namespace MvvmCross.Platforms.Uap.Views
         protected virtual Frame CreateFrame()
         {
             return new Frame();
-        }
-
-        protected virtual void OnResumeFromTerminateState()
-        {
         }
 
         protected virtual void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
@@ -133,16 +124,13 @@ namespace MvvmCross.Platforms.Uap.Views
             return Task.CompletedTask;
         }
 
-        private async void OnResuming(object sender, object e)
+        private void OnResuming(object sender, object e)
         {
-            var suspension = Mvx.IoCProvider.GetSingleton<IMvxSuspensionManager>();
-            await Resume(suspension);
-            await suspension.RestoreAsync();
+            Resume(e);
         }
 
-        protected virtual Task Resume(IMvxSuspensionManager suspensionManager)
-        {
-            return Task.CompletedTask;
+        protected virtual void Resume(object e)
+        {           
         }
 
         protected virtual void RegisterSetup()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Goal is to properly implement suspend/restore in UWP.

This will fix #2881 .

### :arrow_heading_down: What is the current behavior?

Suspension is handled correctly, but suspended state is then restored while app is resumed, which is not correct, as when `OnResuming` is called, it means the app is actually fully loaded in memory and therefore there is no reason to restore state (including navigation).

### :new: What is the new behavior (if this is a feature change)?

The old behavior has been removed, but **restore is not yet implemented** (hence WIP :-) ). [UWP documentation](https://docs.microsoft.com/en-us/windows/uwp/launch-resume/app-lifecycle#app-launch) recommends to restore when the previous execution state is `Terminated`, but this cannot be done before `IMvxAppStart` is finished, as `MvvmCross` is not initialized and restoring state from suspension manager would fail.

The only solution I currently see is to let the user implement the restore from `IMvxSuspensionManager` in `MvxAppStart` if they so choose, because if we force it upon the user, the suspended navigation state would replace viewmodel navigated to in `MvxAppStart`. However, I am afraid that doing `async` work there will cause a deadlock the same way as in #3012 . So the goal might rather be to resolve #3012 first. Anyway, this is open for discussion and I welcome any input and ideas :-) .

### :boom: Does this PR introduce a breaking change?

Yes, resuming no longer does navigation stack restore, which should, however, avoid issues like #2881 and ideally should not cause problems.

The `Resume` method no longer takes an `IMvxSuspensionManager` as it should not be used during `Resuming`.

### :bug: Recommendations for testing

-

### :memo: Links to relevant issues/docs

- Default suspension implementation in UWP samples - [here](https://github.com/Microsoft/Windows-universal-samples/blob/master/Samples/BasicSuspension/cs/App.xaml.cs)
- UWP app lifecycle description - [here](https://docs.microsoft.com/en-us/windows/uwp/launch-resume/app-lifecycle)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
