### PR TITLE
Update missing Fluent binding extensions method and doc entries

### DIFF
--- a/MvvmCross.Android.Support/V7.Preference/MvxPreferencePropertyBindingExtensions.cs
+++ b/MvvmCross.Android.Support/V7.Preference/MvxPreferencePropertyBindingExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,5 +19,8 @@ namespace MvvmCross.Droid.Support.V7.Preference
 
         public static string BindChecked(this TwoStatePreference twoStatePreference)
             => MvxPreferencePropertyBinding.TwoStatePreference_Checked;
+
+        public static string BindClick(this Android.Support.V7.Preferences.Preference preference)
+            => MvxPreferencePropertyBinding.Preference_Click;
     }
 }

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using MvvmCross.Base;
 using MvvmCross.Converters;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
@@ -176,8 +175,7 @@ namespace MvvmCross.Platforms.Ios.Binding
 
             registry.RegisterCustomBindingFactory<UISwitch>(
                 MvxIosPropertyBinding.UISwitch_On,
-                uiSwitch => new MvxUISwitchOnTargetBinding(uiSwitch)
-            );
+                uiSwitch => new MvxUISwitchOnTargetBinding(uiSwitch));
 
             registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxUISearchBarTextTargetBinding),

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBindingExtensions.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBindingExtensions.cs
@@ -121,5 +121,8 @@ namespace MvvmCross.Platforms.Ios.Binding
 
         public static string BindTextFocus(this UIView uiView)
             => MvxIosPropertyBinding.UITextField_TextFocus;
+
+        public static string BindClicked(this UIBarButtonItem uiBarButtonItem)
+            => MvxIosPropertyBinding.UIBarButtonItem_Clicked;
     }
 }

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -1120,12 +1120,13 @@ MvvmCross.Droid.Support.V7.AppCompat.Widget.MvxAppCompatRadioGroup | SelectedIte
 
 **Android - `using MvvmCross.Droid.Support.V7.Preference`**
 
-Base Control | String | Extension method
+Base Control | String | Extension method | Mvx version introduced
 ---- | --------- | ---------
 Android.Support.V7.Preferences.Preference | Value | BindValue()
 Android.Support.V7.Preferences.ListPreference | Value | BindValue()
 Android.Support.V7.Preferences.EditTextPreference | Text | BindText()
 Android.Support.V7.Preferences.TwoStatePreference | Checked | BindChecked()
+Android.Support.V7.Preferences.Preference | PreferenceClick | BindClick() | 6.2.0
 
 **iOS**
 
@@ -1176,6 +1177,7 @@ UIKit.UIView | TextFocus | BindTextFocus()
 UIKit.UIView | Visibility | BindVisibility()
 UIKit.UIView | TwoFingerTap | BindTwoFingerTap()
 UIKit.UIView | LayerBorderWidth | BindLayerBorderWidth()
+UIKit.UIBarButtonItem | Clicked | BindClicked()
 
 **Mac**
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix
### :arrow_heading_down: What is the current behavior?

Missing extensions methods for fluent binding, `Preference` for `PreferenceClick` and `UIBarButtonItem` for `Clicked`. 
Missing entries in docs.

### :new: What is the new behavior (if this is a feature change)?

Add extension methods and updated docs
### :boom: Does this PR introduce a breaking change?

no
### :bug: Recommendations for testing

n/a
### :memo: Links to relevant issues/docs

n/a
### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
