### PR TITLE
Add inverted boolean Fluent extension

### DIFF
--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -167,7 +167,7 @@ namespace MvvmCross.Binding.BindingContext
 
         public MvxFluentBindingDescription<TTarget, TSource> WithInvertedBoolean()
         {
-            SourceStepDescription.Converter = new MvxInvertedBooleanConverter();
+            SourceStepDescription.Converter = new MvxInvertedBooleanValueConverter();
             return this;
         }
     }
@@ -308,7 +308,7 @@ namespace MvvmCross.Binding.BindingContext
 
         public MvxFluentBindingDescription<TTarget> WithInvertedBoolean()
         {
-            SourceStepDescription.Converter = new MvxInvertedBooleanConverter();
+            SourceStepDescription.Converter = new MvxInvertedBooleanValueConverter();
             return this;
         }
     }

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -164,6 +164,12 @@ namespace MvvmCross.Binding.BindingContext
             ClearBindingKey = clearBindingKey;
             return this;
         }
+
+        public MvxFluentBindingDescription<TTarget, TSource> WithInvertedBoolean()
+        {
+            SourceStepDescription.Converter = new MvxInvertedBooleanConverter();
+            return this;
+        }
     }
 
     public class MvxFluentBindingDescription<TTarget>
@@ -297,6 +303,12 @@ namespace MvvmCross.Binding.BindingContext
         public MvxFluentBindingDescription<TTarget> WithClearBindingKey(object clearBindingKey)
         {
             ClearBindingKey = clearBindingKey;
+            return this;
+        }
+
+        public MvxFluentBindingDescription<TTarget> WithInvertedBoolean()
+        {
+            SourceStepDescription.Converter = new MvxInvertedBooleanConverter();
             return this;
         }
     }

--- a/MvvmCross/Binding/MvxCoreBindingBuilder.cs
+++ b/MvvmCross/Binding/MvxCoreBindingBuilder.cs
@@ -116,6 +116,7 @@ namespace MvvmCross.Binding
         {
             registry.AddOrOverwrite("CommandParameter", new MvxCommandParameterValueConverter());
             registry.AddOrOverwrite("Language", new MvxLanguageConverter());
+            registry.AddOrOverwrite("InvertedBoolean", new MvxInvertedBooleanValueConverter());
         }
 
         protected virtual void RegisterValueCombinerProvider()
@@ -155,7 +156,7 @@ namespace MvvmCross.Binding
             registry.AddOrOverwrite("And", new MvxAndValueCombiner());
             registry.AddOrOverwrite("Or", new MvxOrValueCombiner());
             registry.AddOrOverwrite("XOr", new MvxXorValueCombiner());
-			registry.AddOrOverwrite("Inverted", new MvxInvertedValueCombiner());
+            registry.AddOrOverwrite("Inverted", new MvxInvertedValueCombiner());
 
             // Note: MvxValueConverterValueCombiner is not registered - it is unconventional
             //registry.AddOrOverwrite("ValueConverter", new MvxValueConverterValueCombiner());

--- a/MvvmCross/Binding/ValueConverters/MvxInvertedBooleanConverter.cs
+++ b/MvvmCross/Binding/ValueConverters/MvxInvertedBooleanConverter.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using MvvmCross.Converters;
+
+namespace MvvmCross.Binding.ValueConverters
+{
+    public class MvxInvertedBooleanConverter : MvxValueConverter<bool, bool>
+    {
+        protected override bool Convert(bool value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return !value;
+        }
+
+        protected override bool ConvertBack(bool value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return !value;
+        }
+    }
+}

--- a/MvvmCross/Binding/ValueConverters/MvxInvertedBooleanValueConverter.cs
+++ b/MvvmCross/Binding/ValueConverters/MvxInvertedBooleanValueConverter.cs
@@ -8,7 +8,7 @@ using MvvmCross.Converters;
 
 namespace MvvmCross.Binding.ValueConverters
 {
-    public class MvxInvertedBooleanConverter : MvxValueConverter<bool, bool>
+    public class MvxInvertedBooleanValueConverter : MvxValueConverter<bool, bool>
     {
         protected override bool Convert(bool value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -965,14 +965,10 @@ set.Bind(button).To(vm => vm.readonly)
 
 ### Inverting boolean value
 
-If you want to easily invert a View Model boolean value you can make use of the `WithInvertedBoolean` Fluent binding extension or `MvxInvertedBooleanConverter` for XML bindings.
+If you want to easily invert a View Model boolean value you can make use of the `WithInvertedBoolean` Fluent binding.
 
 ```c#
 set.Bind(button).For(v => v.Hidden).To(vm => vm.CanShow).WithInvertedBoolean();
-```
-
-```Text
-local:MvxBind="Enabled InvertedBoolean(CanDisable);"
 ```
 
 ### Default view properties

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -963,6 +963,18 @@ set.Bind(button).To(vm => vm.readonly)
 
 *Note* : This feature is only available in fluent binding.
 
+### Inverting boolean value
+
+If you want to easily invert a View Model boolean value you can make use of the `WithInvertedBoolean` Fluent binding extension or `MvxInvertedBooleanConverter` for XML bindings.
+
+```c#
+set.Bind(button).For(v => v.Hidden).To(vm => vm.CanShow).WithInvertedBoolean();
+```
+
+```Text
+local:MvxBind="Enabled InvertedBoolean(CanDisable);"
+```
+
 ### Default view properties
 
 The tables in this section describe the default view properties used in a Fluent binding when the `For` method chain is not provided.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature
### :arrow_heading_down: What is the current behavior?

A combiner exists for XML based binding but nothing equivalent exists for Fluent binding.
### :new: What is the new behavior (if this is a feature change)?

Binding to bool property can now make use of either a Fluent extension method `WithInvertedBoolean()` or a converter `MvxInvertedBooleanValueConverter` to invert the value of the bool. 
### :boom: Does this PR introduce a breaking change?

no
### :bug: Recommendations for testing

See update to docs for testing example.
### :memo: Links to relevant issues/docs

n/a
### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
