### PR TITLE
Add IoCProvider property to MvxViewModel

### DIFF
--- a/MvvmCross/ViewModels/IMvxIoCViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxIoCViewModel.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.IoC;
+
+namespace MvvmCross.ViewModels
+{
+    public interface IMvxIoCViewModel : IMvxViewModel
+    {
+        IMvxIoCProvider IoCProvider { get; set; }
+    }
+}

--- a/MvvmCross/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/ViewModels/MvxViewModel.cs
@@ -3,14 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using MvvmCross.IoC;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
 
 namespace MvvmCross.ViewModels
 {
     public abstract class MvxViewModel
-        : MvxNotifyPropertyChanged, IMvxViewModel, IMvxNavigationViewModel, IMvxLogViewModel
+        : MvxNotifyPropertyChanged, IMvxViewModel, IMvxIoCViewModel, IMvxNavigationViewModel, IMvxLogViewModel
     {
+        private IMvxIoCProvider _iocProvider;
         private IMvxLogProvider _logProvider;
         private IMvxLog _log;
         private IMvxNavigationService _navigationService;
@@ -19,15 +21,21 @@ namespace MvvmCross.ViewModels
         {
         }
 
+        public virtual IMvxIoCProvider IoCProvider
+        {
+            get => _iocProvider ?? (_iocProvider = Mvx.IoCProvider);
+            set => _iocProvider = value;
+        }
+		
         public virtual IMvxNavigationService NavigationService
         {
-            get => _navigationService ?? (_navigationService = Mvx.IoCProvider.Resolve<IMvxNavigationService>());
+            get => _navigationService ?? (_navigationService = IoCProvider.Resolve<IMvxNavigationService>());
             set => _navigationService = value;
         }
 
         public virtual IMvxLogProvider LogProvider
         {
-            get => _logProvider ?? (_logProvider = Mvx.IoCProvider.Resolve<IMvxLogProvider>());
+            get => _logProvider ?? (_logProvider = IoCProvider.Resolve<IMvxLogProvider>());
             set => _logProvider = value;
         }
 

--- a/Projects/Playground/Playground.Core/ViewModels/Issues/ParentContentViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Issues/ParentContentViewModel.cs
@@ -40,10 +40,10 @@ namespace Playground.Core.ViewModels
 
         public override void Prepare()
         {
-            var vm = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>().LoadViewModel(MvxViewModelRequest<ChildContentViewModel>.GetDefaultRequest(), null) as ChildContentViewModel;
+            var vm = IoCProvider.Resolve<IMvxViewModelLoader>().LoadViewModel(MvxViewModelRequest<ChildContentViewModel>.GetDefaultRequest(), null) as ChildContentViewModel;
             vm.Test = "Child 1";
             ChildViewModel1 = vm;
-            var bc = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>()
+            var bc = IoCProvider.Resolve<IMvxViewModelLoader>()
                     .LoadViewModel(MvxViewModelRequest<ChildContentViewModel>.GetDefaultRequest(), null) as
                 ChildContentViewModel;
             bc.Test = "Child 2";

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -28,7 +28,7 @@ namespace Playground.Core.ViewModels
             _mvxViewModelLoader = mvxViewModelLoader;
             try
             {
-                var messenger = Mvx.IoCProvider.Resolve<IMvxMessenger>();
+                var messenger = IoCProvider.Resolve<IMvxMessenger>();
                 var str = messenger.ToString();
             }
             catch(Exception e)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Adds `IoCProvider` property to `MvxViewModel`, so it can be accessed like `NavigationService` and `Log`.

### :arrow_heading_down: What is the current behavior?
`IMvxIoCProvider` must be passed in view model constructor and stored or use `Mvx.IoCProvider` to reference `IoCProvider` from view models.

### :new: What is the new behavior (if this is a feature change)?
Allows access to `IoCProvider` from view models through base class property.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Since MvxViewModel.NavigationService is now set by using IoCProvider property, just open a playground project and navigate to another page

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
