### PR TITLE
[WIP] Fix stack overflow in MvxFormsPagePresenter.BuildPageTree

### DIFF
--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -751,7 +751,11 @@ namespace MvvmCross.Forms.Presenters
             {
                 // Check for modals
                 var topMostModal = navigationPage?.Navigation?.ModalStack?.LastOrDefault();
-                if (topMostModal != null && topMostModal != navigationPage)
+				var modalNotRootPage = topMostModal != null && topMostModal != navigationPage;
+				var modalNotContainingRootPage = topMostModal is MasterDetailPage md &&
+				                                 md.Master != navigationPage &&
+				                                 md.Detail != navigationPage;
+                if (modalNotRootPage && modalNotContainingRootPage)
                 {
                     var currentModalNav = BuildPageTree(topMostModal);
                     if (currentModalNav != null) return (List<Page> list) => currentModalNav(pageListBuilder(list));


### PR DESCRIPTION

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Stack overflow

### :new: What is the new behavior (if this is a feature change)?
Assume the following setup:

A `NavigationPage` presenting a modal `MasterDetailPage` (via `MvxModalPresentationAttribute`), which in turn has a `Detail` set to a NavigationPage. The second NP contains the MDP in its `ModalStack`, for whatever reason.

Now the current implementation recurses through the navigation stack, finds a `MasterDetailPage`, recurses through the `Detail` stack, finds a `NavigationPage`, checks the modal stack, finds a `MasterDetailPage`, recurses through the `Detail` stack... and oops, stack overflow. So I added another check to see if the modal is a MDP and is already containing the current `rootPage` in which case we just continue recursing happily.

As this is just adding 3 lines and removing 2, I thought to make a PR like this, if you need anything more please tell me, I am new to contributing to MvvmCross...

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Occurred on Android when showing a MasterDetailPage modally as described above, then press the hardware back key

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
