### PR TITLE
Fix crash when switching back to the app after Permission change

### DIFF
--- a/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
+++ b/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
@@ -59,7 +59,7 @@ namespace MvvmCross.Forms.Platforms.Android.Core
                 {
                     var activity = Mvx.IoCProvider.Resolve<IMvxAndroidCurrentTopActivity>()?.Activity ?? ApplicationContext;
                     var asmb = activity.GetType().Assembly;
-                    Xamarin.Forms.Forms.Init(activity, null, ViewAssemblies.FirstOrDefault() ?? asmb);
+                    Xamarin.Forms.Forms.Init(activity, null, GetViewAssemblies()?.FirstOrDefault() ?? asmb);
                 }
                 if (_formsApplication == null)
                 {

--- a/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
+++ b/MvvmCross.Forms/Platforms/Android/Core/MvxFormsAndroidSetup.cs
@@ -59,7 +59,7 @@ namespace MvvmCross.Forms.Platforms.Android.Core
                 {
                     var activity = Mvx.IoCProvider.Resolve<IMvxAndroidCurrentTopActivity>()?.Activity ?? ApplicationContext;
                     var asmb = activity.GetType().Assembly;
-                    Xamarin.Forms.Forms.Init(activity, null, GetViewAssemblies()?.FirstOrDefault() ?? asmb);
+                    Xamarin.Forms.Forms.Init(activity, null, ExecutableAssembly ?? asmb);
                 }
                 if (_formsApplication == null)
                 {

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -38,7 +38,7 @@ namespace MvvmCross.Platforms.Android.Core
             _applicationContext = applicationContext;
         }
 
-        public virtual Assembly ExecutableAssembly => ViewAssemblies.FirstOrDefault() ?? GetType().Assembly;
+        public virtual Assembly ExecutableAssembly => ViewAssemblies?.FirstOrDefault() ?? GetType().Assembly;
 
         public Context ApplicationContext => _applicationContext;
 


### PR DESCRIPTION
when changing permission and going back to the application, ViewAssemblies is null thus causes the app to crash during setup 

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
When Android forms application is running and you change app permissions when going into Android settings, once you switch back to the app, the app crashes as ViewAssemblies is null. s

### :new: What is the new behavior (if this is a feature change)?
I saw that we have a get view assemblies method which we probably should use instead of referenceing ViewAsemblies directly

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Launch App
Go to app Info without closing the app
Enable all permissions available
Go back to app in task switcher
Switch back to permissions
Disable a permission
Switch back to app
App Crashes with error
```
System.Linq.Enumerable.TryGetFirst[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Boolean& found) [0x0000d] in <908c8d3ddc3a406497c942eef2cea13b>:0 
at System.Linq.Enumerable.FirstOrDefault[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x00000] in <908c8d3ddc3a406497c942eef2cea13b>:0 
at MvvmCross.Forms.Platforms.Android.Core.MvxFormsAndroidSetup.get_FormsApplication () [0x00036] in <f9ca34d669a54607bed0e9bd0795a0d4>:0 
at MvvmCross.Forms.Platforms.Android.Core.MvxFormsAndroidSetup.CreateViewPresenter () [0x00006] in <f9ca34d669a54607bed0e9bd0795a0d4>:0 
at MvvmCross.Platforms.Android.Core.MvxAndroidSetup.get_Presenter () [0x00000] in <17df0d0bdae848b7a8a12b58d710f763>:0 
at MvvmCross.Platforms.Android.Core.MvxAndroidSetup.RegisterPresenter () [0x00000] in <17df0d0bdae848b7a8a12b58d710f763>:0 
at MvvmCross.Platforms.Android.Core.MvxAndroidSetup.InitializePlatformServices () [0x0000c] in <17df0d0bdae848b7a8a12b58d710f763>:0 at MvvmCross.Core.MvxSetup.InitializePrimary () [0x00052] in <17df0d0bdae848b7a8a12b58d710f763>:0 
at MvvmCross.Core.MvxSetupSingleton.StartSetupInitialization () [0x0000a] in <17df0d0bdae848b7a8a12b58d710f763>:0 at MvvmCross.Core.MvxSetupSingleton.EnsureInitialized () [0x00017] in <17df0d0bdae848b7a8a12b58d710f763>:0
 at MvvmCross.Forms.Platforms.Android.Views.MvxFormsAppCompatActivity.OnCreate (Android.OS.Bundle bundle) [0x0000c] in <f9ca34d669a54607bed0e9bd0795a0d4>:0
```

### :memo: Links to relevant issues/docs
#2969 
Refer https://stackoverflow.com/questions/33488589/android-marshmallow-dynamic-permission-change-kills-all-application-processe
This also fixes the issue when launching the app from MvxIntentService

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
