### PR TITLE
Fixes #3028.

### DIFF
--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -25,15 +25,15 @@ namespace MvvmCross.ViewModels
 
         public void Start(object hint = null)
         {
-            // Check whether Start has commenced, and return if it has
-            if (Interlocked.CompareExchange(ref startHasCommenced, 1, 0) == 1)
-                return;
-
             StartAsync(hint).GetAwaiter().GetResult();
         }
 
         public async Task StartAsync(object hint = null)
         {
+            // Check whether Start has commenced, and return if it has
+            if (Interlocked.CompareExchange(ref startHasCommenced, 1, 0) == 1)
+                return;
+
             var applicationHint = await ApplicationStartup(hint);
             if (applicationHint != null)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The first ViewModel is navigated to twice on Android.

### :new: What is the new behavior (if this is a feature change)?
The first ViewModel is navigated to once on Android.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Start Playground.Droid. Press the back button once to finish the `RootViewModel` activity. The `RootViewModel` activity is no longer displayed twice in a row.

### :memo: Links to relevant issues/docs
[Issue 3028](https://github.com/MvvmCross/MvvmCross/issues/3028)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
