### PR TITLE
Demonstrates #2903.

### DIFF
--- a/Projects/Playground/Playground.Droid/Activities/ThisActivityFreezesTheSplashScreen.cs
+++ b/Projects/Playground/Playground.Droid/Activities/ThisActivityFreezesTheSplashScreen.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.App;
+using Android.OS;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Core.ViewModels;
+
+namespace Playground.Droid.Activities
+{
+    [MvxActivityPresentation]
+    [Activity(Theme = "@style/AppTheme")]
+    public class ThisActivityFreezesTheSplashScreen : MvxAppCompatActivity<RootViewModel>
+    {
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+
+            SetContentView(Resource.Layout.RootView);
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activities\CustomBindingView.cs" />
+    <Compile Include="Activities\ThisActivityFreezesTheSplashScreen.cs" />
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.cs" />
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.SelectedItemEventArgs.cs" />
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.ViewHolder.cs" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Demonstrates bug #2903. Requested by @nickrandolph 

### :arrow_heading_down: What is the current behavior?
Exceptions thrown during startup are being swallowed and not appearing in the output window, MvxLog, etc. I have to turn on all exceptions in "Exception Settings" while debugging to see what's going on. MvvmCross versions before 6 would bubble these kind of exceptions to the calling app.

### :new: What is the new behavior (if this is a feature change)?
I've simply added a second view for `RootViewModel` which is one of many ways to cause an exception to happen during setup.

### :boom: Does this PR introduce a breaking change?
Yes, it breaks Playground.Droid.

### :bug: Recommendations for testing
Start Playground.Droid. The splash screen will remain indefinitely.

### :memo: Links to relevant issues/docs
#2903 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
