### PR TITLE
Catch exceptions in ProcessMvxIntentResult and log

### DIFF
--- a/MvvmCross.Plugins/PictureChooser/Platforms/Android/MvxPictureChooserTask.cs
+++ b/MvvmCross.Plugins/PictureChooser/Platforms/Android/MvxPictureChooserTask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -104,26 +104,36 @@ namespace MvvmCross.Plugin.PictureChooser.Platforms.Android
 
         protected override void ProcessMvxIntentResult(MvxIntentResultEventArgs result)
         {
-            MvxPluginLog.Instance.Trace("ProcessMvxIntentResult started...");
-
-            Uri uri;
-
-            switch ((MvxIntentRequestCode)result.RequestCode)
+            try
             {
-                case MvxIntentRequestCode.PickFromFile:
-                    uri = result.Data?.Data;
-                    break;
-                case MvxIntentRequestCode.PickFromCamera:
-                    uri = _cachedUriLocation;
-                    break;
-                default:
-                    // ignore this result - it's not for us
-                    MvxPluginLog.Instance.Trace("Unexpected request received from MvxIntentResult - request was {0}",
-                                   result.RequestCode);
-                    return;
-            }
+                MvxPluginLog.Instance.Trace("ProcessMvxIntentResult started...");
 
-            ProcessPictureUri(result, uri);
+                Uri uri;
+
+                switch ((MvxIntentRequestCode)result.RequestCode)
+                {
+                    case MvxIntentRequestCode.PickFromFile:
+                        uri = result.Data?.Data;
+                        break;
+                    case MvxIntentRequestCode.PickFromCamera:
+                        uri = _cachedUriLocation;
+                        break;
+                    default:
+                        // ignore this result - it's not for us
+                        MvxPluginLog.Instance.Trace("Unexpected request received from MvxIntentResult - request was {0}",
+                                       result.RequestCode);
+                        return;
+                }
+
+                ProcessPictureUri(result, uri);
+            }
+            catch (Exception e)
+            {
+                // TODO: We currently have no way of bubbling this up. Throwing here
+                // can crash the app :(
+
+                MvxPluginLog.Instance.ErrorException("Failed to process Intent from PictureChooser", e);
+            }
         }
 
         private void ProcessPictureUri(MvxIntentResultEventArgs result, Uri uri)


### PR DESCRIPTION
Currently we have no way of surfacing a exception thrown
in ProcessMvxIntentResult, since this is called as part of
Activity.OnActivityResult. Throwing in ProcessMvxIntentResult
will lead to an application crash.
For now we just catch the exception and log it.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
App crashes if exception is thrown in ProcessMvxIntentResult

### :new: What is the new behavior (if this is a feature change)?
No crash

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Partially fixes #2134

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
