### PR TITLE
Adding cancel support through navigation

### DIFF
--- a/MvvmCross/Navigation/EventArguments/ChangePresentationEventArgs.cs
+++ b/MvvmCross/Navigation/EventArguments/ChangePresentationEventArgs.cs
@@ -3,17 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Navigation.EventArguments
 {
-    public class ChangePresentationEventArgs : EventArgs
+    public class ChangePresentationEventArgs : MvxCancelEventArgs
     {
-        public ChangePresentationEventArgs()
+        public ChangePresentationEventArgs(CancellationToken cancellationToken = default) : base(cancellationToken)
         {
         }
 
-        public ChangePresentationEventArgs(MvxPresentationHint hint)
+        public ChangePresentationEventArgs(MvxPresentationHint hint, CancellationToken cancellationToken = default) : this(cancellationToken)
         {
             Hint = hint;
         }

--- a/MvvmCross/Navigation/EventArguments/IMvxNavigateEventArgs.cs
+++ b/MvvmCross/Navigation/EventArguments/IMvxNavigateEventArgs.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.ViewModels;
+
+namespace MvvmCross.Navigation.EventArguments
+{
+    public interface IMvxNavigateEventArgs
+    {
+        bool Cancel { get; set; }
+        NavigationMode Mode { get; set; }
+        IMvxViewModel ViewModel { get; set; }
+    }
+}

--- a/MvvmCross/Navigation/EventArguments/MvxCancelEventArgs.cs
+++ b/MvvmCross/Navigation/EventArguments/MvxCancelEventArgs.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Threading;
+
+namespace MvvmCross.Navigation.EventArguments
+{
+    public class MvxCancelEventArgs : CancelEventArgs
+    {
+        public MvxCancelEventArgs(CancellationToken cancellationToken = default)
+        {
+            CancellationToken = cancellationToken;
+            if (CancellationToken != default)
+                CancellationToken.Register(Canceled);
+        }
+        protected CancellationToken CancellationToken { get; }
+
+        protected virtual void Canceled()
+        {
+            Cancel = true;
+        }
+    }
+}

--- a/MvvmCross/Navigation/EventArguments/NavigateEventArgs.cs
+++ b/MvvmCross/Navigation/EventArguments/NavigateEventArgs.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.Navigation.EventArguments
             Mode = mode;
         }
 
-        public MvxNavigateEventArgs(NavigationMode mode, IMvxViewModel viewModel, CancellationToken cancellationToken = default) : this(mode, cancellationToken)
+        public MvxNavigateEventArgs(IMvxViewModel viewModel, NavigationMode mode, CancellationToken cancellationToken = default) : this(mode, cancellationToken)
         {
             ViewModel = viewModel;
         }

--- a/MvvmCross/Navigation/EventArguments/NavigateEventArgs.cs
+++ b/MvvmCross/Navigation/EventArguments/NavigateEventArgs.cs
@@ -2,25 +2,32 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.ComponentModel;
 using System.Threading;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Navigation.EventArguments
 {
-    public class NavigateEventArgs : EventArgs
+    public enum NavigationMode
     {
-        public NavigateEventArgs()
+        None,
+        Show,
+        Close
+    }
+
+    public class MvxNavigateEventArgs : MvxCancelEventArgs, IMvxNavigateEventArgs
+    {
+        public MvxNavigateEventArgs(NavigationMode mode, CancellationToken cancellationToken = default) : base(cancellationToken)
         {
+            Mode = mode;
         }
 
-        public NavigateEventArgs(IMvxViewModel viewModel, CancellationToken cancellationToken = default(CancellationToken))
+        public MvxNavigateEventArgs(NavigationMode mode, IMvxViewModel viewModel, CancellationToken cancellationToken = default) : this(mode, cancellationToken)
         {
             ViewModel = viewModel;
-            CancellationToken = cancellationToken;
         }
 
+        public NavigationMode Mode { get; set; }
         public IMvxViewModel ViewModel { get; set; }
-        public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/MvvmCross/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Navigation/IMvxNavigationService.cs
@@ -10,10 +10,10 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Navigation
 {
-    public delegate void BeforeNavigateEventHandler(object sender, NavigateEventArgs e);
-    public delegate void AfterNavigateEventHandler(object sender, NavigateEventArgs e);
-    public delegate void BeforeCloseEventHandler(object sender, NavigateEventArgs e);
-    public delegate void AfterCloseEventHandler(object sender, NavigateEventArgs e);
+    public delegate void BeforeNavigateEventHandler(object sender, IMvxNavigateEventArgs e);
+    public delegate void AfterNavigateEventHandler(object sender, IMvxNavigateEventArgs e);
+    public delegate void BeforeCloseEventHandler(object sender, IMvxNavigateEventArgs e);
+    public delegate void AfterCloseEventHandler(object sender, IMvxNavigateEventArgs e);
     public delegate void BeforeChangePresentationEventHandler(object sender, ChangePresentationEventArgs e);
     public delegate void AfterChangePresentationEventHandler(object sender, ChangePresentationEventArgs e);
 
@@ -34,8 +34,8 @@ namespace MvvmCross.Navigation
         /// </summary>
         /// <param name="viewModel"></param>
         /// <param name="presentationBundle"></param>
-        /// <returns></returns>
-        Task Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Navigates to an instance of a ViewModel and passes TParameter
@@ -44,8 +44,8 @@ namespace MvvmCross.Navigation
         /// <param name="viewModel"></param>
         /// <param name="param"></param>
         /// <param name="presentationBundle"></param>
-        /// <returns></returns>
-        Task Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Navigates to an instance of a ViewModel and returns TResult
@@ -74,8 +74,8 @@ namespace MvvmCross.Navigation
         /// </summary>
         /// <param name="viewModelType"></param>
         /// <param name="presentationBundle"></param>
-        /// <returns></returns>
-        Task Navigate(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Navigates to a ViewModel Type and passes TParameter
@@ -84,8 +84,8 @@ namespace MvvmCross.Navigation
         /// <param name="viewModelType"></param>
         /// <param name="param"></param>
         /// <param name="presentationBundle"></param>
-        /// <returns></returns>
-        Task Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Navigates to a ViewModel Type passes and returns TResult
@@ -114,8 +114,8 @@ namespace MvvmCross.Navigation
         /// </summary>
         /// <param name="path">URI to route</param>
         /// <param name="presentationBundle"></param>
-        /// <returns></returns>
-        Task Navigate(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -124,8 +124,8 @@ namespace MvvmCross.Navigation
         /// <param name="path"></param>
         /// <param name="param"></param>
         /// <param name="presentationBundle"></param>
-        /// <returns></returns>
-        Task Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -149,10 +149,10 @@ namespace MvvmCross.Navigation
         /// <returns></returns>
         Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
 
-        Task Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        Task<bool> Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModel;
 
-        Task Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModel<TParameter>;
 
         Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -35,7 +35,8 @@ namespace MvvmCross.Navigation
         private IMvxViewsContainer _viewsContainer;
         protected IMvxViewsContainer ViewsContainer
         {
-            get {
+            get
+            {
                 if (_viewsContainer == null)
                     _viewsContainer = Mvx.IoCProvider.Resolve<IMvxViewsContainer>();
                 return _viewsContainer;
@@ -64,7 +65,7 @@ namespace MvvmCross.Navigation
         public static void LoadRoutes(IEnumerable<Assembly> assemblies)
         {
             Routes.Clear();
-            foreach(var routeAttr in
+            foreach (var routeAttr in
                 assemblies.SelectMany(a => a.GetCustomAttributes<MvxNavigationAttribute>()))
             {
                 Routes.Add(new Regex(routeAttr.UriRegex,
@@ -79,7 +80,7 @@ namespace MvvmCross.Navigation
             {
                 var matches = Routes.Where(t => t.Key.IsMatch(url)).ToList();
 
-                switch(matches.Count)
+                switch (matches.Count)
                 {
                     case 0:
                         entry = default(KeyValuePair<Regex, Type>);
@@ -92,7 +93,7 @@ namespace MvvmCross.Navigation
 
                 var directMatch = matches.Where(t => t.Key.Match(url).Groups.Count == 1).ToList();
 
-                if(directMatch.Count == 1)
+                if (directMatch.Count == 1)
                 {
                     entry = directMatch[0];
                     return true;
@@ -105,7 +106,7 @@ namespace MvvmCross.Navigation
                 entry = default(KeyValuePair<Regex, Type>);
                 return false;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Log.Error("MvxNavigationService", "Unable to determine routability: {0}", ex);
                 entry = default(KeyValuePair<Regex, Type>);
@@ -117,7 +118,7 @@ namespace MvvmCross.Navigation
         {
             var paramDict = new Dictionary<string, string>();
 
-            for(var i = 1 /* 0 == Match itself */; i < match.Groups.Count; i++)
+            for (var i = 1 /* 0 == Match itself */; i < match.Groups.Count; i++)
             {
                 var group = match.Groups[i];
                 var name = regex.GroupNameFromNumber(i);
@@ -131,7 +132,7 @@ namespace MvvmCross.Navigation
         {
             KeyValuePair<Regex, Type> entry;
 
-            if(!TryGetRoute(path, out entry))
+            if (!TryGetRoute(path, out entry))
             {
                 throw new MvxException($"Navigation route request could not be obtained for path: {path}");
             }
@@ -149,28 +150,28 @@ namespace MvvmCross.Navigation
                 ParameterValues = parameterValues?.SafeGetData()
             };
 
-            if(viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
+            if (viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
             {
                 var facade = (IMvxNavigationFacade)Mvx.IoCProvider.IoCConstruct(viewModelType);
 
                 try
                 {
                     var facadeRequest = await facade.BuildViewModelRequest(path, paramDict).ConfigureAwait(false);
-                    if(facadeRequest == null)
+                    if (facadeRequest == null)
                     {
                         throw new MvxException($"{nameof(MvxNavigationService)}: Facade did not return a valid {nameof(MvxViewModelRequest)}.");
                     }
 
                     request.ViewModelType = facadeRequest.ViewModelType;
 
-                    if(facadeRequest.ParameterValues != null)
+                    if (facadeRequest.ParameterValues != null)
                     {
                         request.ParameterValues = facadeRequest.ParameterValues;
                     }
 
                     request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, null);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     throw ex.MvxWrap($"{nameof(MvxNavigationService)}: Exception thrown while processing URL: {path} with RoutingFacade: {viewModelType}");
                 }
@@ -187,7 +188,7 @@ namespace MvvmCross.Navigation
         {
             KeyValuePair<Regex, Type> entry;
 
-            if(!TryGetRoute(path, out entry))
+            if (!TryGetRoute(path, out entry))
             {
                 throw new MvxException($"Navigation route request could not be obtained for path: {path}");
             }
@@ -205,28 +206,28 @@ namespace MvvmCross.Navigation
                 ParameterValues = parameterValues?.SafeGetData()
             };
 
-            if(viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
+            if (viewModelType.GetInterfaces().Contains(typeof(IMvxNavigationFacade)))
             {
                 var facade = (IMvxNavigationFacade)Mvx.IoCProvider.IoCConstruct(viewModelType);
 
                 try
                 {
                     var facadeRequest = await facade.BuildViewModelRequest(path, paramDict).ConfigureAwait(false);
-                    if(facadeRequest == null)
+                    if (facadeRequest == null)
                     {
                         throw new MvxException($"{nameof(MvxNavigationService)}: Facade did not return a valid {nameof(MvxViewModelRequest)}.");
                     }
 
                     request.ViewModelType = facadeRequest.ViewModelType;
 
-                    if(facadeRequest.ParameterValues != null)
+                    if (facadeRequest.ParameterValues != null)
                     {
                         request.ParameterValues = facadeRequest.ParameterValues;
                     }
 
                     request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, param, null);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     ex.MvxWrap($"{nameof(MvxNavigationService)}: Exception thrown while processing URL: {path} with RoutingFacade: {viewModelType}");
                 }
@@ -241,7 +242,7 @@ namespace MvvmCross.Navigation
 
         public virtual Task<bool> CanNavigate(string path)
         {
-            return Task.FromResult(TryGetRoute(path, out KeyValuePair<Regex, Type> entry));
+            return Task.FromResult(TryGetRoute(path, out var entry));
         }
 
         public virtual Task<bool> CanNavigate<TViewModel>() where TViewModel : IMvxViewModel
@@ -254,23 +255,94 @@ namespace MvvmCross.Navigation
             return Task.FromResult(ViewsContainer.GetViewType(viewModelType) != null);
         }
 
-        protected virtual async Task Navigate(MvxViewModelRequest request, IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task<bool> Navigate(MvxViewModelRequest request, IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            bool hasNavigated = false;
+            var hasNavigated = false;
+
+            var args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
+            OnBeforeNavigate(this, args);
+
+            if (args.Cancel)
+                return false;
+
+            hasNavigated = await ViewDispatcher.ShowViewModel(request);
+            if (!hasNavigated)
+                return false;
+
+            if (viewModel.InitializeTask?.Task != null)
+                await viewModel.InitializeTask.Task.ConfigureAwait(false);
+
+            OnAfterNavigate(this, args);
+            return true;
+        }
+
+        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var hasNavigated = false;
+            var tcs = new TaskCompletionSource<object>();
+
             if (cancellationToken != default(CancellationToken))
             {
                 cancellationToken.Register(async () =>
                 {
-                    if(hasNavigated)
-                        await Close(viewModel);
+                    if (hasNavigated && !tcs.Task.IsCompleted)
+                        await Close(viewModel, default(TResult));
                 });
             }
 
-            var args = new NavigateEventArgs(viewModel, cancellationToken);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
             OnBeforeNavigate(this, args);
 
+            viewModel.CloseCompletionSource = tcs;
+            _tcsResults.Add(viewModel, tcs);
+
             if (cancellationToken.IsCancellationRequested)
-                return;
+                return default(TResult);
+
+            hasNavigated = await ViewDispatcher.ShowViewModel(request);
+            if (!hasNavigated)
+                return default(TResult);
+
+            // TODO: Should Initialize task be done on UI or non-UI thread? Now that ShowViewModel is async, we could ConfigureAwait it to return on non-UI thread
+            if (viewModel.InitializeTask?.Task != null)
+                await viewModel.InitializeTask.Task.ConfigureAwait(false);
+
+            OnAfterNavigate(this, args);
+
+            try
+            {
+                return (TResult)await tcs.Task;
+            }
+            catch (Exception)
+            {
+                return default(TResult);
+            }
+        }
+
+        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken), IMvxNavigateEventArgs args = null)
+        {
+            var hasNavigated = false;
+            if (cancellationToken != default(CancellationToken))
+            {
+                cancellationToken.Register(async () =>
+                {
+                    if (hasNavigated)
+                        await Close(viewModel, default(TResult));
+                });
+            }
+
+            if (args == null)
+            {
+                args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
+            }
+            OnBeforeNavigate(this, args);
+
+            var tcs = new TaskCompletionSource<object>();
+            viewModel.CloseCompletionSource = tcs;
+            _tcsResults.Add(viewModel, tcs);
+
+            if (cancellationToken.IsCancellationRequested)
+                return default(TResult);
 
             hasNavigated = await ViewDispatcher.ShowViewModel(request);
 
@@ -278,97 +350,27 @@ namespace MvvmCross.Navigation
                 await viewModel.InitializeTask.Task.ConfigureAwait(false);
 
             OnAfterNavigate(this, args);
-        }
-
-        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            bool hasNavigated = false;
-            if (cancellationToken != default(CancellationToken))
-            {
-                cancellationToken.Register(async () =>
-                {
-                    if (hasNavigated)
-                        await Close(viewModel, default(TResult));
-                });
-            }
-
-            var args = new NavigateEventArgs(viewModel, cancellationToken);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<object>();
-            viewModel.CloseCompletionSource = tcs;
-            _tcsResults.Add(viewModel, tcs);
-
-            if (cancellationToken.IsCancellationRequested)
-                return default(TResult);
-
-            hasNavigated = await ViewDispatcher.ShowViewModel(request);
-
-            // TODO: Should Initialize task be done on UI or non-UI thread? Now that ShowViewModel is async, we could ConfigureAwait it to return on non-UI thread
-            if(viewModel.InitializeTask?.Task != null)
-                await viewModel.InitializeTask.Task.ConfigureAwait(false);
-
-            OnAfterNavigate(this, args);
 
             try
             {
                 return (TResult)await tcs.Task;
             }
-            catch(Exception)
+            catch (Exception)
             {
                 return default(TResult);
             }
         }
 
-        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            bool hasNavigated = false;
-            if (cancellationToken != default(CancellationToken))
-            {
-                cancellationToken.Register(async () =>
-                {
-                    if (hasNavigated)
-                        await Close(viewModel, default(TResult));
-                });
-            }
-
-            var args = new NavigateEventArgs(viewModel, cancellationToken);
-            OnBeforeNavigate(this, args);
-
-            var tcs = new TaskCompletionSource<object>();
-            viewModel.CloseCompletionSource = tcs;
-            _tcsResults.Add(viewModel, tcs);
-
-            if (cancellationToken.IsCancellationRequested)
-                return default(TResult);
-
-            hasNavigated = await ViewDispatcher.ShowViewModel(request);
-
-            if(viewModel.InitializeTask?.Task != null)
-                await viewModel.InitializeTask.Task.ConfigureAwait(false);
-
-            OnAfterNavigate(this, args);
-
-            try
-            {
-                return (TResult)await tcs.Task;
-            }
-            catch(Exception)
-            {
-                return default(TResult);
-            }
-        }
-
-        public virtual async Task Navigate(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
-            await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = await NavigationRouteRequest(path, param, presentationBundle).ConfigureAwait(false);
-            await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -383,24 +385,24 @@ namespace MvvmCross.Navigation
             return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, null);
-            await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, param, null);
-            await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -415,20 +417,22 @@ namespace MvvmCross.Navigation
 
         public virtual async Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            var args = new MvxNavigateEventArgs(NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
                 PresentationValues = presentationBundle?.SafeGetData()
             };
             request.ViewModelInstance = (IMvxViewModel<TParameter, TResult>)ViewModelLoader.LoadViewModel(request, param, null);
-            return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
+            args.ViewModel = request.ViewModelInstance;
+            return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken, args).ConfigureAwait(false);
         }
 
-        public virtual Task Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel
+        public virtual Task<bool> Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel
         {
             return Navigate(typeof(TViewModel), presentationBundle, cancellationToken);
         }
 
-        public virtual Task Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter>
+        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter>
         {
             return Navigate(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
@@ -443,18 +447,18 @@ namespace MvvmCross.Navigation
             return Navigate<TParameter, TResult>(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
 
-        public virtual async Task Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate(IMvxViewModel viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
-            await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
-            await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -466,16 +470,20 @@ namespace MvvmCross.Navigation
 
         public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            var args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
-            return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken).ConfigureAwait(false);
+            return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken, args).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> ChangePresentation(MvxPresentationHint hint, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> ChangePresentation(MvxPresentationHint hint, CancellationToken cancellationToken = default)
         {
             MvxLog.Instance.Trace("Requesting presentation change");
-            var args = new ChangePresentationEventArgs(hint);
+            var args = new ChangePresentationEventArgs(hint, cancellationToken);
             OnBeforeChangePresentation(this, args);
+
+            if (args.Cancel)
+                return false;
 
             var result = await ViewDispatcher.ChangePresentation(hint);
 
@@ -487,10 +495,10 @@ namespace MvvmCross.Navigation
 
         public virtual async Task<bool> Close(IMvxViewModel viewModel, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var args = new NavigateEventArgs(viewModel, cancellationToken);
+            var args = new MvxNavigateEventArgs(NavigationMode.Close, viewModel, cancellationToken);
             OnBeforeClose(this, args);
 
-            if (cancellationToken.IsCancellationRequested)
+            if (args.Cancel)
                 return false;
 
             var close = await ViewDispatcher.ChangePresentation(new MvxClosePresentationHint(viewModel));
@@ -501,7 +509,7 @@ namespace MvvmCross.Navigation
 
         public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken))
         {
-            _tcsResults.TryGetValue(viewModel, out TaskCompletionSource<object> _tcs);
+            _tcsResults.TryGetValue(viewModel, out var _tcs);
 
             //Disable cancelation of the Task when closing ViewModel through the service
             viewModel.CloseCompletionSource = null;
@@ -509,7 +517,7 @@ namespace MvvmCross.Navigation
             try
             {
                 var closeResult = await Close(viewModel, cancellationToken);
-                if(closeResult)
+                if (closeResult)
                 {
                     _tcs?.TrySetResult(result);
                     _tcsResults.Remove(viewModel);
@@ -518,29 +526,29 @@ namespace MvvmCross.Navigation
                     viewModel.CloseCompletionSource = _tcs;
                 return closeResult;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _tcs?.TrySetException(ex);
                 return false;
             }
         }
 
-        protected virtual void OnBeforeNavigate(object sender, NavigateEventArgs e)
+        protected virtual void OnBeforeNavigate(object sender, IMvxNavigateEventArgs e)
         {
             BeforeNavigate?.Invoke(sender, e);
         }
 
-        protected virtual void OnAfterNavigate(object sender, NavigateEventArgs e)
+        protected virtual void OnAfterNavigate(object sender, IMvxNavigateEventArgs e)
         {
             AfterNavigate?.Invoke(sender, e);
         }
 
-        protected virtual void OnBeforeClose(object sender, NavigateEventArgs e)
+        protected virtual void OnBeforeClose(object sender, IMvxNavigateEventArgs e)
         {
             BeforeClose?.Invoke(sender, e);
         }
 
-        protected virtual void OnAfterClose(object sender, NavigateEventArgs e)
+        protected virtual void OnAfterClose(object sender, IMvxNavigateEventArgs e)
         {
             AfterClose?.Invoke(sender, e);
         }

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -259,7 +259,7 @@ namespace MvvmCross.Navigation
         {
             var hasNavigated = false;
 
-            var args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
+            var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
             OnBeforeNavigate(this, args);
 
             if (args.Cancel)
@@ -290,7 +290,7 @@ namespace MvvmCross.Navigation
                 });
             }
 
-            var args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
+            var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
             OnBeforeNavigate(this, args);
 
             viewModel.CloseCompletionSource = tcs;
@@ -333,7 +333,7 @@ namespace MvvmCross.Navigation
 
             if (args == null)
             {
-                args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
+                args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
             }
             OnBeforeNavigate(this, args);
 
@@ -470,7 +470,7 @@ namespace MvvmCross.Navigation
 
         public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var args = new MvxNavigateEventArgs(NavigationMode.Show, viewModel, cancellationToken);
+            var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
             return await Navigate<TParameter, TResult>(request, viewModel, param, presentationBundle, cancellationToken, args).ConfigureAwait(false);
@@ -495,7 +495,7 @@ namespace MvvmCross.Navigation
 
         public virtual async Task<bool> Close(IMvxViewModel viewModel, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var args = new MvxNavigateEventArgs(NavigationMode.Close, viewModel, cancellationToken);
+            var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Close, cancellationToken);
             OnBeforeClose(this, args);
 
             if (args.Cancel)

--- a/MvvmCross/ViewModels/IMvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLoader.cs
@@ -1,17 +1,19 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+
+using MvvmCross.Navigation.EventArguments;
 
 namespace MvvmCross.ViewModels
 {
     public interface IMvxViewModelLoader
     {
-        IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState);
+        IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState);
+        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState);
+        IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState);
+        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
     }
 }

--- a/MvvmCross/ViewModels/IMvxViewModelLocator.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLocator.cs
@@ -1,19 +1,20 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using MvvmCross.Navigation.EventArguments;
 
 namespace MvvmCross.ViewModels
 {
     public interface IMvxViewModelLocator
     {
-        IMvxViewModel Load(Type viewModelType, IMvxBundle parameterValues, IMvxBundle savedState);
+        IMvxViewModel Load(Type viewModelType, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel<TParameter> Load<TParameter>(Type viewModelType, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState);
+        IMvxViewModel<TParameter> Load<TParameter>(Type viewModelType, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel Reload(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState);
+        IMvxViewModel Reload(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel<TParameter> Reload<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState);
+        IMvxViewModel<TParameter> Reload<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
     }
 }

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -60,7 +60,7 @@ namespace MvvmCross.ViewModels
                 throw exception.MvxWrap("Problem creating viewModel of type {0}", viewModelType.Name);
             }
 
-            RunViewModelLifecycle(viewModel, parameterValues, savedState);
+            RunViewModelLifecycle(viewModel, parameterValues, savedState, navigationArgs);
 
             return viewModel;
         }
@@ -80,7 +80,7 @@ namespace MvvmCross.ViewModels
                 throw exception.MvxWrap("Problem creating viewModel of type {0}", viewModelType.Name);
             }
 
-            RunViewModelLifecycle(viewModel, param, parameterValues, savedState);
+            RunViewModelLifecycle(viewModel, param, parameterValues, savedState, navigationArgs);
 
             return viewModel;
         }
@@ -95,7 +95,7 @@ namespace MvvmCross.ViewModels
             viewModel.CallBundleMethods("ReloadState", savedState);
         }
 
-        protected void RunViewModelLifecycle(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState)
+        protected void RunViewModelLifecycle(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
             try
             {

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -6,6 +6,7 @@ using System;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
+using MvvmCross.Navigation.EventArguments;
 
 namespace MvvmCross.ViewModels
 {
@@ -28,9 +29,9 @@ namespace MvvmCross.ViewModels
 
         public virtual IMvxViewModel Reload(IMvxViewModel viewModel,
                                             IMvxBundle parameterValues,
-                                            IMvxBundle savedState)
+                                            IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
-            RunViewModelLifecycle(viewModel, parameterValues, savedState);
+            RunViewModelLifecycle(viewModel, parameterValues, savedState, navigationArgs);
 
             return viewModel;
         }
@@ -38,23 +39,23 @@ namespace MvvmCross.ViewModels
         public virtual IMvxViewModel<TParameter> Reload<TParameter>(IMvxViewModel<TParameter> viewModel,
                                                                     TParameter param,
                                                                     IMvxBundle parameterValues,
-                                                                    IMvxBundle savedState)
+                                                                    IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
-            RunViewModelLifecycle(viewModel, param, parameterValues, savedState);
+            RunViewModelLifecycle(viewModel, param, parameterValues, savedState, navigationArgs);
 
             return viewModel;
         }
 
         public virtual IMvxViewModel Load(Type viewModelType,
                                           IMvxBundle parameterValues,
-                                          IMvxBundle savedState)
+                                          IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
             IMvxViewModel viewModel;
             try
             {
                 viewModel = (IMvxViewModel)Mvx.IoCProvider.IoCConstruct(viewModelType);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap("Problem creating viewModel of type {0}", viewModelType.Name);
             }
@@ -67,14 +68,14 @@ namespace MvvmCross.ViewModels
         public virtual IMvxViewModel<TParameter> Load<TParameter>(Type viewModelType,
                                                                   TParameter param,
                                                                   IMvxBundle parameterValues,
-                                                                  IMvxBundle savedState)
+                                                                  IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
             IMvxViewModel<TParameter> viewModel;
             try
             {
                 viewModel = (IMvxViewModel<TParameter>)Mvx.IoCProvider.IoCConstruct(viewModelType);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap("Problem creating viewModel of type {0}", viewModelType.Name);
             }
@@ -99,39 +100,58 @@ namespace MvvmCross.ViewModels
             try
             {
                 CallCustomInitMethods(viewModel, parameterValues);
-                if(savedState != null)
+                if (navigationArgs.Cancel)
+                    return;
+                if (savedState != null)
                 {
                     CallReloadStateMethods(viewModel, savedState);
+                    if (navigationArgs.Cancel)
+                        return;
                 }
                 viewModel.Start();
+                if (navigationArgs.Cancel)
+                    return;
 
                 viewModel.Prepare();
+                if (navigationArgs.Cancel)
+                    return;
 
                 viewModel.InitializeTask = MvxNotifyTask.Create(() => viewModel.Initialize());
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap("Problem running viewModel lifecycle of type {0}", viewModel.GetType().Name);
             }
         }
 
-        protected void RunViewModelLifecycle<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState)
+        protected void RunViewModelLifecycle<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
             try
             {
                 CallCustomInitMethods(viewModel, parameterValues);
-                if(savedState != null)
+                if (navigationArgs.Cancel)
+                    return;
+                if (savedState != null)
                 {
                     CallReloadStateMethods(viewModel, savedState);
+                    if (navigationArgs.Cancel)
+                        return;
                 }
                 viewModel.Start();
+                if (navigationArgs.Cancel)
+                    return;
 
                 viewModel.Prepare();
+                if (navigationArgs.Cancel)
+                    return;
+
                 viewModel.Prepare(param);
+                if (navigationArgs.Cancel)
+                    return;
 
                 viewModel.InitializeTask = MvxNotifyTask.Create(() => viewModel.Initialize());
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap("Problem running viewModel lifecycle of type {0}", viewModel.GetType().Name);
             }

--- a/MvvmCross/ViewModels/MvxNavigationViewModel.cs
+++ b/MvvmCross/ViewModels/MvxNavigationViewModel.cs
@@ -11,7 +11,6 @@ namespace MvvmCross.ViewModels
     public abstract class MvxNavigationViewModel
         : MvxViewModel
     {
-        private IMvxLogProvider _logProvider;
         private IMvxLog _log;
 
         protected MvxNavigationViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base()

--- a/MvvmCross/ViewModels/MvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/MvxViewModelLoader.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using MvvmCross.Exceptions;
+using MvvmCross.Navigation.EventArguments;
 
 namespace MvvmCross.ViewModels
 {
@@ -18,16 +19,16 @@ namespace MvvmCross.ViewModels
         }
 
         // Reload should be used to re-run cached ViewModels lifecycle if required.
-        public IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState)
+        public IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
             var viewModelLocator = FindViewModelLocator(request);
 
             var parameterValues = new MvxBundle(request.ParameterValues);
             try
             {
-                viewModel = viewModelLocator.Reload(viewModel, parameterValues, savedState);
+                viewModel = viewModelLocator.Reload(viewModel, parameterValues, savedState, navigationArgs);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap(
                     "Failed to reload a previously created created ViewModel for type {0} from locator {1} - check InnerException for more information",
@@ -37,16 +38,16 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState)
+        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
             var viewModelLocator = FindViewModelLocator(request);
 
             var parameterValues = new MvxBundle(request.ParameterValues);
             try
             {
-                viewModel = viewModelLocator.Reload(viewModel, param, parameterValues, savedState);
+                viewModel = viewModelLocator.Reload(viewModel, param, parameterValues, savedState, navigationArgs);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap(
                     "Failed to reload a previously created created ViewModel for type {0} from locator {1} - check InnerException for more information",
@@ -56,9 +57,9 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState)
+        public IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
-            if(request.ViewModelType == typeof(MvxNullViewModel))
+            if (request.ViewModelType == typeof(MvxNullViewModel))
             {
                 return new MvxNullViewModel();
             }
@@ -69,9 +70,9 @@ namespace MvvmCross.ViewModels
             var parameterValues = new MvxBundle(request.ParameterValues);
             try
             {
-                viewModel = viewModelLocator.Load(request.ViewModelType, parameterValues, savedState);
+                viewModel = viewModelLocator.Load(request.ViewModelType, parameterValues, savedState, navigationArgs);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap(
                     "Failed to construct and initialize ViewModel for type {0} from locator {1} - check InnerException for more information",
@@ -80,9 +81,9 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState)
+        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
         {
-            if(request.ViewModelType == typeof(MvxNullViewModel))
+            if (request.ViewModelType == typeof(MvxNullViewModel))
             {
                 return new MvxNullViewModel();
             }
@@ -93,9 +94,9 @@ namespace MvvmCross.ViewModels
             var parameterValues = new MvxBundle(request.ParameterValues);
             try
             {
-                viewModel = viewModelLocator.Load(request.ViewModelType, param, parameterValues, savedState);
+                viewModel = viewModelLocator.Load(request.ViewModelType, param, parameterValues, savedState, navigationArgs);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw exception.MvxWrap(
                     "Failed to construct and initialize ViewModel for type {0} from locator {1} - check InnerException for more information",
@@ -108,7 +109,7 @@ namespace MvvmCross.ViewModels
         {
             var viewModelLocator = LocatorCollection.FindViewModelLocator(request);
 
-            if(viewModelLocator == null)
+            if (viewModelLocator == null)
             {
                 throw new MvxException($"Sorry - somehow there's no viewmodel locator registered for {request.ViewModelType}");
             }

--- a/UnitTests/MvvmCross.UnitTest/Navigation/NavigationServiceTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Navigation/NavigationServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Moq;
 using MvvmCross.Core;
 using MvvmCross.Navigation;
+using MvvmCross.Navigation.EventArguments;
 using MvvmCross.Presenters.Hints;
 using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
@@ -37,7 +38,7 @@ namespace MvvmCross.UnitTest.Navigation
         {
             MockLoader = new Mock<IMvxViewModelLoader>();
             MockLoader.Setup(
-                l => l.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleTestViewModel)), It.IsAny<IMvxBundle>()))
+                l => l.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleTestViewModel)), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                       .Returns(() =>
                        {
                            var vm = new SimpleTestViewModel();
@@ -46,7 +47,7 @@ namespace MvvmCross.UnitTest.Navigation
                            return vm;
                        });
             MockLoader.Setup(
-                l => l.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleResultTestViewModel)), It.IsAny<IMvxBundle>()))
+                l => l.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleResultTestViewModel)), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                       .Returns(() =>
                        {
                            var vm = new SimpleResultTestViewModel();
@@ -55,7 +56,7 @@ namespace MvvmCross.UnitTest.Navigation
                            return vm;
                        });
             MockLoader.Setup(
-                l => l.LoadViewModel<string>(It.IsAny<MvxViewModelRequest>(), It.IsAny<string>(), It.IsAny<IMvxBundle>()))
+                l => l.LoadViewModel<string>(It.IsAny<MvxViewModelRequest>(), It.IsAny<string>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                       .Returns(() =>
                       {
                           var vm = new SimpleParameterTestViewModel();
@@ -65,7 +66,7 @@ namespace MvvmCross.UnitTest.Navigation
                           return vm;
                       });
             MockLoader.Setup(
-                l => l.ReloadViewModel(It.IsAny<IMvxViewModel>(), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>()))
+                l => l.ReloadViewModel(It.IsAny<IMvxViewModel>(), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                       .Returns(() =>
                       {
                           var vm = new SimpleTestViewModel();
@@ -74,7 +75,7 @@ namespace MvvmCross.UnitTest.Navigation
                           return vm;
                       });
             MockLoader.Setup(
-                l => l.ReloadViewModel<string>(It.IsAny<IMvxViewModel<string>>(), It.IsAny<string>(), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>()))
+                l => l.ReloadViewModel<string>(It.IsAny<IMvxViewModel<string>>(), It.IsAny<string>(), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                       .Returns(() =>
                       {
                           var vm = new SimpleParameterTestViewModel();
@@ -100,7 +101,7 @@ namespace MvvmCross.UnitTest.Navigation
 
             await navigationService.Navigate<SimpleTestViewModel>();
 
-            MockLoader.Verify(loader => loader.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleTestViewModel)), It.IsAny<IMvxBundle>()),
+            MockLoader.Verify(loader => loader.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleTestViewModel)), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -133,7 +134,7 @@ namespace MvvmCross.UnitTest.Navigation
 
             await navigationService.Navigate(mockVm.Object);
 
-            MockLoader.Verify(loader => loader.ReloadViewModel(It.Is<SimpleTestViewModel>(val => mockVm.Object == val), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>()),
+            MockLoader.Verify(loader => loader.ReloadViewModel(It.Is<SimpleTestViewModel>(val => mockVm.Object == val), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -151,7 +152,7 @@ namespace MvvmCross.UnitTest.Navigation
             var parameter = "hello";
             await navigationService.Navigate<SimpleParameterTestViewModel, string>(parameter);
 
-            MockLoader.Verify(loader => loader.LoadViewModel<string>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<string>(val => val == parameter), It.IsAny<IMvxBundle>()),
+            MockLoader.Verify(loader => loader.LoadViewModel<string>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<string>(val => val == parameter), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -171,7 +172,7 @@ namespace MvvmCross.UnitTest.Navigation
             var parameter = "hello";
             await navigationService.Navigate<string>(mockVm.Object, parameter);
 
-            MockLoader.Verify(loader => loader.ReloadViewModel<string>(It.Is<SimpleParameterTestViewModel>(val => mockVm.Object == val), It.Is<string>(val => val == parameter), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>()),
+            MockLoader.Verify(loader => loader.ReloadViewModel<string>(It.Is<SimpleParameterTestViewModel>(val => mockVm.Object == val), It.Is<string>(val => val == parameter), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -188,7 +189,7 @@ namespace MvvmCross.UnitTest.Navigation
 
             await navigationService.Navigate(typeof(SimpleTestViewModel));
 
-            MockLoader.Verify(loader => loader.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleTestViewModel)), It.IsAny<IMvxBundle>()),
+            MockLoader.Verify(loader => loader.LoadViewModel(It.Is<MvxViewModelRequest>(val => val.ViewModelType == typeof(SimpleTestViewModel)), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -218,7 +219,7 @@ namespace MvvmCross.UnitTest.Navigation
             var parameter = "hello";
             await navigationService.Navigate<string>(typeof(SimpleParameterTestViewModel), parameter);
 
-            MockLoader.Verify(loader => loader.LoadViewModel<string>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<string>(val => val == parameter), It.IsAny<IMvxBundle>()),
+            MockLoader.Verify(loader => loader.LoadViewModel<string>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<string>(val => val == parameter), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -235,7 +236,7 @@ namespace MvvmCross.UnitTest.Navigation
 
             var result = await navigationService.Navigate<SimpleResultTestViewModel, bool>();
 
-            MockLoader.Verify(loader => loader.LoadViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleResultTestViewModel)), It.IsAny<IMvxBundle>()),
+            MockLoader.Verify(loader => loader.LoadViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleResultTestViewModel)), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(

--- a/UnitTests/MvvmCross.UnitTest/Navigation/RoutingServiceTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Navigation/RoutingServiceTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using MvvmCross.Core;
 using MvvmCross.Exceptions;
 using MvvmCross.Navigation;
+using MvvmCross.Navigation.EventArguments;
 using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
@@ -48,9 +49,9 @@ namespace MvvmCross.UnitTest.Navigation
         {
             var mockLocator = new Mock<IMvxViewModelLocator>();
             mockLocator.Setup(
-                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>())).Returns(() => new SimpleTestViewModel());
+                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>())).Returns(() => new SimpleTestViewModel());
             mockLocator.Setup(
-                m => m.Reload(It.IsAny<IMvxViewModel>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>())).Returns(() => new SimpleTestViewModel());
+                m => m.Reload(It.IsAny<IMvxViewModel>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>())).Returns(() => new SimpleTestViewModel());
 
             var mockCollection = new Mock<IMvxViewModelLocatorCollection>();
             mockCollection.Setup(m => m.FindViewModelLocator(It.IsAny<MvxViewModelRequest>()))

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxDefaultViewModelLocatorTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxDefaultViewModelLocatorTest.cs
@@ -6,6 +6,7 @@ using System;
 using MvvmCross.Core;
 using MvvmCross.Exceptions;
 using MvvmCross.Navigation;
+using MvvmCross.Navigation.EventArguments;
 using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
@@ -49,8 +50,9 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
             var toTest = new MvxDefaultViewModelLocator(navigationService);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
 
-            IMvxViewModel viewModel = toTest.Load(typeof(Test1ViewModel), bundle, null);
+            IMvxViewModel viewModel = toTest.Load(typeof(Test1ViewModel), bundle, null, args);
 
             Assert.NotNull(viewModel);
             var typedViewModel = (Test1ViewModel)viewModel;
@@ -108,7 +110,8 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
             var toTest = new MvxDefaultViewModelLocator(navigationService);
-            IMvxViewModel viewModel = toTest.Load(typeof(Test1ViewModel), initBundle, reloadBundle);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
+            IMvxViewModel viewModel = toTest.Load(typeof(Test1ViewModel), initBundle, reloadBundle, args);
 
             Assert.NotNull(viewModel);
             var typedViewModel = (Test1ViewModel)viewModel;
@@ -135,9 +138,10 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
             var toTest = new MvxDefaultViewModelLocator(navigationService);
-
-            Assert.Throws<MvxException>(() => {
-                IMvxViewModel viewModel = toTest.Load(typeof(Test4ViewModel), bundle, null);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
+            Assert.Throws<MvxException>(() =>
+            {
+                IMvxViewModel viewModel = toTest.Load(typeof(Test4ViewModel), bundle, null, args);
             });
         }
 
@@ -152,9 +156,11 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
             var toTest = new MvxDefaultViewModelLocator(navigationService);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
 
-            Assert.Throws<MvxException>(() => {
-                IMvxViewModel viewModel = toTest.Load(typeof(Test4ViewModel), bundle, null);
+            Assert.Throws<MvxException>(() =>
+            {
+                IMvxViewModel viewModel = toTest.Load(typeof(Test4ViewModel), bundle, null, args);
             });
         }
 
@@ -170,9 +176,10 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
             var toTest = new MvxDefaultViewModelLocator(navigationService);
-
-            Assert.Throws<MvxException>(() => {
-                IMvxViewModel viewModel = toTest.Load(typeof(Test4ViewModel), bundle, null);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
+            Assert.Throws<MvxException>(() =>
+            {
+                IMvxViewModel viewModel = toTest.Load(typeof(Test4ViewModel), bundle, null, args);
             });
         }
     }

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxViewModelLoaderTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxViewModelLoaderTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Moq;
 using MvvmCross.Exceptions;
+using MvvmCross.Navigation.EventArguments;
 using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
@@ -32,7 +33,8 @@ namespace MvvmCross.UnitTest.ViewModels
             var request = new MvxViewModelRequest<MvxNullViewModel>(null, null);
             var state = new MvxBundle();
             var loader = new MvxViewModelLoader(null);
-            var viewModel = loader.LoadViewModel(request, state);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
+            var viewModel = loader.LoadViewModel(request, state, args);
 
             Assert.IsType<MvxNullViewModel>(viewModel);
         }
@@ -46,7 +48,7 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var mockLocator = new Mock<IMvxViewModelLocator>();
             mockLocator.Setup(
-                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>()))
+                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                        .Returns(() => outViewModel);
 
             var mockCollection = new Mock<IMvxViewModelLocatorCollection>();
@@ -57,7 +59,8 @@ namespace MvvmCross.UnitTest.ViewModels
             var request = new MvxViewModelRequest<Test2ViewModel>(new MvxBundle(parameters), null);
             var state = new MvxBundle();
             var loader = new MvxViewModelLoader(mockCollection.Object);
-            var viewModel = loader.LoadViewModel(request, state);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
+            var viewModel = loader.LoadViewModel(request, state, args);
 
             Assert.Equal(outViewModel, viewModel);
         }
@@ -69,7 +72,7 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var mockLocator = new Mock<IMvxViewModelLocator>();
             mockLocator.Setup(
-                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>()))
+                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                        .Throws<MvxException>();
 
             var mockCollection = new Mock<IMvxViewModelLocatorCollection>();
@@ -80,8 +83,10 @@ namespace MvvmCross.UnitTest.ViewModels
             var request = new MvxViewModelRequest<Test2ViewModel>(new MvxBundle(parameters), null);
             var state = new MvxBundle();
             var loader = new MvxViewModelLoader(mockCollection.Object);
-            Assert.Throws<MvxException>(() => {
-                var viewModel = loader.LoadViewModel(request, state);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
+            Assert.Throws<MvxException>(() =>
+            {
+                var viewModel = loader.LoadViewModel(request, state, args);
             });
         }
 
@@ -98,9 +103,10 @@ namespace MvvmCross.UnitTest.ViewModels
             var request = new MvxViewModelRequest<Test2ViewModel>(new MvxBundle(parameters), null);
             var state = new MvxBundle();
             var loader = new MvxViewModelLoader(mockCollection.Object);
-
-            Assert.Throws<MvxException>(() => {
-                var viewModel = loader.LoadViewModel(request, state);
+            var args = new MvxNavigateEventArgs(NavigationMode.Show);
+            Assert.Throws<MvxException>(() =>
+            {
+                var viewModel = loader.LoadViewModel(request, state, args);
             });
         }
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Cancellation of navigation is only supported via Cancellation token (ie can't cancel within navigation lifecycle)

### :new: What is the new behavior (if this is a feature change)?
Navigation can still be cancelled via cancellation token (ie by code that triggers navigation)
Navigation can also be cancelled throughout the navigation lifecycle

### :boom: Does this PR introduce a breaking change?
Yes - added support for MvxNavigationEventArgs

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
