### PR TITLE
MvxNativeValueConverter and MvxFormsValueConverter for MvvmCross.Forms

### DIFF
--- a/MvvmCross.Forms/Converters/MvxFormsValueConverter.cs
+++ b/MvvmCross.Forms/Converters/MvxFormsValueConverter.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Converters;
+using Xamarin.Forms;
+
+namespace MvvmCross.Forms.Converters
+{
+    public class MvxFormsValueConverter : MvxValueConverter, IValueConverter
+    {
+    }
+
+    public class MvxFormsValueConverter<TFrom> : MvxValueConverter<TFrom>, IValueConverter
+    {
+    }
+
+    public class MvxFormsValueConverter<TFrom, TTo> : MvxValueConverter<TFrom, TTo>, IValueConverter
+    {
+    }
+}

--- a/MvvmCross.Forms/Converters/MvxNativeValueConverter.cs
+++ b/MvvmCross.Forms/Converters/MvxNativeValueConverter.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using MvvmCross.Converters;
+using MvvmCross.Logging;
+using Xamarin.Forms;
+
+namespace MvvmCross.Forms.Converters
+{
+    public class MvxNativeValueConverter
+        : IValueConverter
+    {
+        protected IMvxValueConverter Wrapped { get; }
+
+        public MvxNativeValueConverter(IMvxValueConverter wrapped)
+        {
+            Wrapped = wrapped;
+        }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var toReturn = Wrapped.Convert(value, targetType, parameter, culture);
+            return MapIfSpecialValue(toReturn);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var toReturn = Wrapped.ConvertBack(value, targetType, parameter, culture);
+            return MapIfSpecialValue(toReturn);
+        }
+
+        private static object MapIfSpecialValue(object toReturn)
+        {
+            MvxLog.Instance.Trace("DoNothing and UnsetValue is not available in Xamarin.Forms - returning empty object instead");
+            if (toReturn == MvxBindingConstant.DoNothing || toReturn == MvxBindingConstant.UnsetValue)
+            {
+                return new object();
+            }
+            return toReturn;
+        }
+    }
+
+    public class MvxNativeValueConverter<T>
+        : MvxNativeValueConverter
+        where T : IMvxValueConverter, new()
+    {
+        protected new T Wrapped => (T)base.Wrapped;
+
+        public MvxNativeValueConverter()
+            : base(new T())
+        {
+        }
+    }
+}

--- a/Projects/Playground/Playground.Core/Converters/StringToLowerValueConverter.cs
+++ b/Projects/Playground/Playground.Core/Converters/StringToLowerValueConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using MvvmCross.Converters;
+
+namespace Playground.Core.Converters
+{
+    public class StringToLowerValueConverter : MvxValueConverter<string, string>
+    {
+        protected override string Convert(string value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value.ToLower();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -12,6 +12,7 @@ using MvvmCross.Plugin.Messenger;
 using MvvmCross.ViewModels;
 using Playground.Core.Models;
 using Playground.Core.ViewModels.Bindings;
+using Playground.Core.ViewModels.Samples;
 
 namespace Playground.Core.ViewModels
 {
@@ -121,6 +122,9 @@ namespace Playground.Core.ViewModels
 
         public IMvxAsyncCommand ShowContentViewCommand =>
             new MvxAsyncCommand(async () => await NavigationService.Navigate<ParentContentViewModel>());
+
+        public IMvxAsyncCommand ConvertersCommand =>
+            new MvxAsyncCommand(async ()=> await NavigationService.Navigate<ConvertersViewModel>());
 
         public IMvxAsyncCommand ShowSharedElementsCommand { get; }
 

--- a/Projects/Playground/Playground.Core/ViewModels/Samples/ConvertersViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Samples/ConvertersViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels.Samples
+{
+    public class ConvertersViewModel : MvxViewModel
+    {
+        public string UppercaseConverterTest => "this text was lowercase";
+
+        public string LowercaseConverterTest => "THIS TEXT WAS UPPERCASE";
+    }
+}

--- a/Projects/Playground/Playground.Forms.UI/Converters/NativeConverters.cs
+++ b/Projects/Playground/Playground.Forms.UI/Converters/NativeConverters.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MvvmCross.Forms.Converters;
+using Playground.Core.Converters;
+
+namespace Playground.Forms.UI.Converters
+{
+    public class NativeStringToLowerValueConverter : MvxNativeValueConverter<StringToLowerValueConverter> { }
+}

--- a/Projects/Playground/Playground.Forms.UI/Converters/StringToUpperValueConverter.cs
+++ b/Projects/Playground/Playground.Forms.UI/Converters/StringToUpperValueConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using MvvmCross.Forms.Converters;
+
+namespace Playground.Forms.UI.Converters
+{
+    public class StringToUpperValueConverter : MvxFormsValueConverter<string, string>
+    {
+        protected override string Convert(string value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value.ToUpper();
+        }
+    }
+}

--- a/Projects/Playground/Playground.Forms.UI/Pages/ConvertersPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/ConvertersPage.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:MvxContentPage x:TypeArguments="samples:ConvertersViewModel" xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
+             xmlns:samples="clr-namespace:Playground.Core.ViewModels.Samples;assembly=Playground.Core"
+             xmlns:converters="clr-namespace:Playground.Forms.UI.Converters;assembly=Playground.Forms.UI"
+             x:Class="Playground.Forms.UI.Pages.ConvertersPage">
+    <ContentPage.Resources>
+        <converters:NativeStringToLowerValueConverter x:Key="StringToLowerValueConverter" />
+        <converters:StringToUpperValueConverter x:Key="StringToUpperValueConverter" />
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="{Binding UppercaseConverterTest, Converter={StaticResource StringToUpperValueConverter}}"
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+            <Label Text="{Binding LowercaseConverterTest, Converter={StaticResource StringToLowerValueConverter}}"
+                   VerticalOptions="CenterAndExpand" 
+                   HorizontalOptions="CenterAndExpand" />
+        </StackLayout>
+    </ContentPage.Content>
+</views:MvxContentPage>

--- a/Projects/Playground/Playground.Forms.UI/Pages/ConvertersPage.xaml.cs
+++ b/Projects/Playground/Playground.Forms.UI/Pages/ConvertersPage.xaml.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MvvmCross.Forms.Views;
+using Playground.Core.ViewModels.Samples;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Playground.Forms.UI.Pages
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class ConvertersPage : MvxContentPage<ConvertersViewModel>
+	{
+		public ConvertersPage ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
@@ -27,6 +27,7 @@
                 <Button Text="Show ListView" mvx:Bi.nd="Command ShowListViewCommand"/>
                 <Button Text="Show Bindings view" mvx:Bi.nd="Command ShowBindingsViewCommand"/>
                 <Button Text="Show CodeBehind view" mvx:Bi.nd="Command ShowCodeBehindViewCommand"/>
+                <Button Text="Show Converters view" mvx:Bi.nd="Command ConvertersCommand" />
             </StackLayout>
         </ScrollView>
 	</ContentPage.Content>

--- a/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
+++ b/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
@@ -14,6 +14,12 @@
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj" />
     <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Update="Pages\ConvertersPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 
   <Import Project="..\..\..\XamarinForms.targets" />
 </Project>

--- a/docs/_documentation/fundamentals/value-converters.md
+++ b/docs/_documentation/fundamentals/value-converters.md
@@ -219,9 +219,9 @@ protected override FillValueConverters (IMvxValueConverterRegistry registry)
 
 Note: unless your application is very large, this is most likely only a micro-optimization and will most likely not significantly change your app's startup time.
  
-### Using Value Converters in Windows (conventional Xaml binding)
+### Using Value Converters in Windows and Xamarin.Forms (conventional Xaml binding) (conventional Xaml binding)
 
-The `IMvxValueConverter` interface is closely based on the `IValueConverter` interface used in Windows WPF and Silverlight Xaml binding. This interface is also similar (but slightly different) to the `IValueConverter` interface used in Windows WinRT Xaml binding. 
+The `IMvxValueConverter` interface is closely based on the `IValueConverter` interface used in Windows WPF and Silverlight Xaml binding. This interface is also similar (but slightly different) to the `IValueConverter` interface used in Windows WinRT Xaml binding and `IValueConverter` interface used in Xamarin.Forms Xaml binding. 
 
 Because these Xaml `IValueConverter` interfaces are not 100% identical to each other, nor to the `IMvxValueConverter` version, shared Mvx ValueConverters cannot be used directly in Windows Xaml binding - they must instead be wrapped for use in Xaml.
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)


Feature (see #2847)

_This is a new PR instead of #3011 , which auto-closed when I had to revert a bad commit. Sorry about the confusion and complication._


### :arrow_heading_down: What is the current behavior?

Currently it is not easy to reuse existing `MvxValueConverters` in MvvmCross.Forms projects, as there is no helper class analogous to UWP's `MvxNativeValueConverter` that would act as an adapter between MvvmCross' `IMvxValueConverter` and Xamarin.Forms' `IValueConverter`.

### :new: What is the new behavior (if this is a feature change)?

**`MvxNativeValueConverter`** is an adapter that allows developers reuse existing MvvmCross value converters in their MvvmCross.Forms projects.

**`MvxFormsValueConverter`** is just a convenience class that specifies the `IValueConverter`. This can act as the base class for MvvmCross.Forms-only value converters.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
x

### :memo: Links to relevant issues/docs
x

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
