### PR TITLE
Make activities dictionary protected to ease extension

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
@@ -83,7 +83,7 @@ namespace MvvmCross.Platforms.Android.Views
         /// <summary>
         /// Used to store additional info along with an activity.
         /// </summary>
-        private class ActivityInfo
+        protected class ActivityInfo
         {
             public bool IsCurrent { get; set; }
             public Activity Activity { get; set; }

--- a/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
@@ -10,7 +10,8 @@ namespace MvvmCross.Platforms.Android.Views
 {
     public class MvxApplicationCallbacksCurrentTopActivity : Java.Lang.Object, Application.IActivityLifecycleCallbacks, IMvxAndroidCurrentTopActivity
     {
-        protected ConcurrentDictionary<string, ActivityInfo> _Activities { get; private set; } = new ConcurrentDictionary<string, ActivityInfo>();
+        protected ConcurrentDictionary<string, ActivityInfo> Activities { get; private set; } = new ConcurrentDictionary<string, ActivityInfo>();
+        
         public Activity Activity => GetCurrentActivity();
 
         public void OnActivityCreated(Activity activity, Bundle savedInstanceState)
@@ -21,7 +22,7 @@ namespace MvvmCross.Platforms.Android.Views
         public void OnActivityDestroyed(Activity activity)
         {
             var activityName = GetActivityName(activity);
-            _Activities.TryRemove(activityName, out ActivityInfo removed);
+            Activities.TryRemove(activityName, out ActivityInfo removed);
         }
 
         public void OnActivityPaused(Activity activity)
@@ -48,11 +49,11 @@ namespace MvvmCross.Platforms.Android.Views
             UpdateActivityListItem(activity, false);
         }
 
-        private void UpdateActivityListItem(Activity activity, bool isCurrent)
+        protected virtual void UpdateActivityListItem(Activity activity, bool isCurrent)
         {
             var toAdd = new ActivityInfo { Activity = activity, IsCurrent = isCurrent };
             var activityName = GetActivityName(activity);
-            _Activities.AddOrUpdate(activityName, toAdd, (key, existing) =>
+            Activities.AddOrUpdate(activityName, toAdd, (key, existing) =>
             {
                 existing.Activity = activity;
                 existing.IsCurrent = isCurrent;
@@ -60,11 +61,11 @@ namespace MvvmCross.Platforms.Android.Views
             });
         }
 
-        private Activity GetCurrentActivity()
+        protected virtual Activity GetCurrentActivity()
         {
-            if (_Activities.Count > 0)
+            if (Activities.Count > 0)
             {
-                var e = _Activities.GetEnumerator();
+                var e = Activities.GetEnumerator();
                 while (e.MoveNext())
                 {
                     var current = e.Current;
@@ -78,7 +79,7 @@ namespace MvvmCross.Platforms.Android.Views
             return null;
         }
 
-        protected string GetActivityName(Activity activity) => $"{activity.Class.SimpleName}_{activity.Handle.ToString()}";
+        protected virtual string GetActivityName(Activity activity) => $"{activity.Class.SimpleName}_{activity.Handle.ToString()}";
 
         /// <summary>
         /// Used to store additional info along with an activity.

--- a/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
@@ -10,7 +10,7 @@ namespace MvvmCross.Platforms.Android.Views
 {
     public class MvxApplicationCallbacksCurrentTopActivity : Java.Lang.Object, Application.IActivityLifecycleCallbacks, IMvxAndroidCurrentTopActivity
     {
-        protected ConcurrentDictionary<string, ActivityInfo> _Activities { private set; } = new ConcurrentDictionary<string, ActivityInfo>();
+        protected ConcurrentDictionary<string, ActivityInfo> _Activities { get; private set; } = new ConcurrentDictionary<string, ActivityInfo>();
         public Activity Activity => GetCurrentActivity();
 
         public void OnActivityCreated(Activity activity, Bundle savedInstanceState)

--- a/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
@@ -10,7 +10,7 @@ namespace MvvmCross.Platforms.Android.Views
 {
     public class MvxApplicationCallbacksCurrentTopActivity : Java.Lang.Object, Application.IActivityLifecycleCallbacks, IMvxAndroidCurrentTopActivity
     {
-        private ConcurrentDictionary<string, ActivityInfo> _Activities = new ConcurrentDictionary<string, ActivityInfo>();
+        protected ConcurrentDictionary<string, ActivityInfo> _Activities { private set; } = new ConcurrentDictionary<string, ActivityInfo>();
         public Activity Activity => GetCurrentActivity();
 
         public void OnActivityCreated(Activity activity, Bundle savedInstanceState)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It changes the visibility of backing dictionary on MvxApplicationCallbacksCurrentTopActivity.cs to protected to make changes and tweaks easier.

### :arrow_heading_down: What is the current behavior?
The dictionary is private.

### :new: What is the new behavior (if this is a feature change)?
The dictionary read access becomes protected, making extension easier.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
This changes nothing otherwise. It doesn't affect the current usage or behaviour.
Everything should be as it was before.

### :memo: Links to relevant issues/docs
Source issue: #3048 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop