### PR TITLE
Propagating exceptions out of setup

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading.Tasks;
 using Android.OS;
 using Android.Runtime;
@@ -77,7 +78,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             base.OnPause();
         }
 
-        public virtual async Task InitializationComplete()
+        public virtual async Task InitializationComplete(Exception initializationException)
         {
             if (!_isResumed)
                 return;

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxSplashScreenAppCompatActivity.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             base.OnPause();
         }
 
-        public virtual async Task InitializationComplete(Exception initializationException)
+        public virtual async Task InitializationComplete()
         {
             if (!_isResumed)
                 return;

--- a/MvvmCross/Core/IMvxSetupMonitor.cs
+++ b/MvvmCross/Core/IMvxSetupMonitor.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace MvvmCross.Core
 {
     public interface IMvxSetupMonitor
     {
-        Task InitializationComplete();
+        Task InitializationComplete(Exception inititializationException);
     }
 }

--- a/MvvmCross/Core/IMvxSetupMonitor.cs
+++ b/MvvmCross/Core/IMvxSetupMonitor.cs
@@ -9,6 +9,6 @@ namespace MvvmCross.Core
 {
     public interface IMvxSetupMonitor
     {
-        Task InitializationComplete(Exception inititializationException);
+        Task InitializationComplete();
     }
 }

--- a/MvvmCross/Core/MvxSetupSingleton.cs
+++ b/MvvmCross/Core/MvxSetupSingleton.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using MvvmCross.Base;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
+using MvvmCross.ViewModels;
 
 namespace MvvmCross.Core
 {
@@ -102,7 +103,11 @@ namespace MvvmCross.Core
                 else
                 {
                     if (IsInitialisedTaskCompletionSource.Task.IsCompleted)
+                    {
+                        if (IsInitialisedTaskCompletionSource.Task.IsFaulted)
+                            throw IsInitialisedTaskCompletionSource.Task.Exception;
                         return;
+                    }
 
                     MvxLog.Instance.Trace("EnsureInitialized has already been called so now waiting for completion");
                 }
@@ -123,7 +128,7 @@ namespace MvvmCross.Core
                     // but don't do it otherwise because it's done elsewhere
                     if (IsInitialisedTaskCompletionSource.Task.IsCompleted)
                     {
-                        _currentMonitor?.InitializationComplete();
+                        _currentMonitor?.InitializationComplete(SetupException);
                     }
 
                     return;
@@ -169,17 +174,32 @@ namespace MvvmCross.Core
             base.Dispose(isDisposing);
         }
 
+        private Exception SetupException { get; set; }
         private void StartSetupInitialization()
         {
             IsInitialisedTaskCompletionSource = new TaskCompletionSource<bool>();
             _setup.InitializePrimary();
             Task.Run(async () =>
             {
-                _setup.InitializeSecondary();
+                try
+                {
+                    _setup.InitializeSecondary();
+                }
+                catch(Exception ex)
+                {
+                    SetupException = ex;
+                }
                 IMvxSetupMonitor monitor;
                 lock (LockObject)
                 {
-                    IsInitialisedTaskCompletionSource.SetResult(true);
+                    if (SetupException == null)
+                    {
+                        IsInitialisedTaskCompletionSource.SetResult(true);
+                    }
+                    else
+                    {
+                        IsInitialisedTaskCompletionSource.SetException(SetupException);
+                    }
                     monitor = _currentMonitor;
                 }
 
@@ -190,7 +210,7 @@ namespace MvvmCross.Core
                     {
                         if (monitor != null)
                         {
-                            await monitor.InitializationComplete();
+                            await monitor.InitializationComplete(SetupException);
                         }
                     });
                 }

--- a/MvvmCross/Core/MvxSetupSingleton.cs
+++ b/MvvmCross/Core/MvxSetupSingleton.cs
@@ -128,7 +128,7 @@ namespace MvvmCross.Core
                     // but don't do it otherwise because it's done elsewhere
                     if (IsInitialisedTaskCompletionSource.Task.IsCompleted)
                     {
-                        _currentMonitor?.InitializationComplete(SetupException);
+                        _currentMonitor?.InitializationComplete();
                     }
 
                     return;
@@ -210,7 +210,7 @@ namespace MvvmCross.Core
                     {
                         if (monitor != null)
                         {
-                            await monitor.InitializationComplete(SetupException);
+                            await monitor.InitializationComplete();
                         }
                     });
                 }

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading.Tasks;
 using Android.OS;
 using Android.Runtime;
@@ -77,7 +78,7 @@ namespace MvvmCross.Platforms.Android.Views
             base.OnPause();
         }
 
-        public virtual async Task InitializationComplete()
+        public virtual async Task InitializationComplete(Exception initializationException)
         {
             if (!_isResumed)
                 return;

--- a/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSplashScreenActivity.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Platforms.Android.Views
             base.OnPause();
         }
 
-        public virtual async Task InitializationComplete(Exception initializationException)
+        public virtual async Task InitializationComplete()
         {
             if (!_isResumed)
                 return;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
If an exception is raised during the second half of initialization of setup class (ie initializeSecondard) it is swallowed and the application never loads the first view of the application

### :new: What is the new behavior (if this is a feature change)?
If an exception is raised during the second half of initialization, initialization completes and the exception is propagated to the host application

### :boom: Does this PR introduce a breaking change?
No (although it does change the IMvxSetupMonitor interface

### :bug: Recommendations for testing
1. Associate more than one view with a view model.
2. Start the app.
3. Previously:The Android splash screen never closes, leaving a white screen displayed.
Now: An exception is bubbled up allowing the error to be detected

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2903

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
