### PR TITLE
Fix memory leaks on IMvxMultipleViewModelCache

### DIFF
--- a/MvvmCross.Android.Support/Fragment/MvxFragmentExtensions.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentExtensions.cs
@@ -50,7 +50,7 @@ namespace MvvmCross.Droid.Support.V4
             var viewModelType = fragmentView.FindAssociatedViewModelType(fragment.Activity.GetType());
             var view = fragmentView as IMvxView;
 
-            var cached = cache.GetAndClear(fragmentView.ViewModel.GetType(), fragmentView.UniqueImmutableCacheTag);
+            var cached = cache.GetAndClear(viewModelType, fragmentView.UniqueImmutableCacheTag);
 
             view.OnViewCreate(() => cached ?? fragmentView.LoadViewModel(bundle, fragment.Activity.GetType(), request));
         }

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentExtensions.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentExtensions.cs
@@ -148,7 +148,7 @@ namespace MvvmCross.Droid.Support.V4
 
         public static void LoadViewModelFrom(this IMvxFragmentView view, MvxViewModelRequest request, IMvxBundle savedState = null)
         {
-            var loader = Mvx.Resolve<IMvxViewModelLoader>();
+            var loader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
             var viewModel = loader.LoadViewModel(request, savedState);
             if (viewModel == null) {
                 MvxAndroidLog.Instance.Warn("ViewModel not loaded for {0}", request.ViewModelType.FullName);

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentExtensions.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentExtensions.cs
@@ -28,8 +28,13 @@ namespace MvvmCross.Droid.Support.V4
 
         public static void OnCreate(this IMvxFragmentView fragmentView, IMvxBundle bundle, MvxViewModelRequest request = null)
         {
+            var cache = Mvx.IoCProvider.Resolve<IMvxMultipleViewModelCache>();
+
             if (fragmentView.ViewModel != null)
             {
+                // check if ViewModel instance was cached. If so, clear it and ignore previous instance
+                cache.GetAndClear(fragmentView.ViewModel.GetType(), fragmentView.UniqueImmutableCacheTag);
+
                 //TODO call MvxViewModelLoader.Reload when it's added in MvvmCross, tracked by #1165
                 //until then, we're going to re-run the viewmodel lifecycle here.
                 Platforms.Android.Views.MvxFragmentExtensions.RunViewModelLifecycle(fragmentView.ViewModel, bundle, request);
@@ -45,8 +50,7 @@ namespace MvvmCross.Droid.Support.V4
             var viewModelType = fragmentView.FindAssociatedViewModelType(fragment.Activity.GetType());
             var view = fragmentView as IMvxView;
 
-            var cache = Mvx.IoCProvider.Resolve<IMvxMultipleViewModelCache>();
-            var cached = cache.GetAndClear(viewModelType, fragmentView.UniqueImmutableCacheTag);
+            var cached = cache.GetAndClear(fragmentView.ViewModel.GetType(), fragmentView.UniqueImmutableCacheTag);
 
             view.OnViewCreate(() => cached ?? fragmentView.LoadViewModel(bundle, fragment.Activity.GetType(), request));
         }
@@ -144,7 +148,7 @@ namespace MvvmCross.Droid.Support.V4
 
         public static void LoadViewModelFrom(this IMvxFragmentView view, MvxViewModelRequest request, IMvxBundle savedState = null)
         {
-            var loader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
+            var loader = Mvx.Resolve<IMvxViewModelLoader>();
             var viewModel = loader.LoadViewModel(request, savedState);
             if (viewModel == null) {
                 MvxAndroidLog.Instance.Warn("ViewModel not loaded for {0}", request.ViewModelType.FullName);

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
@@ -149,7 +149,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
 
         public static void LoadViewModelFrom(this Android.Views.IMvxFragmentView view, MvxViewModelRequest request, IMvxBundle savedState = null)
         {
-            var loader = Mvx.Resolve<IMvxViewModelLoader>();
+            var loader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
             var viewModel = loader.LoadViewModel(request, savedState);
             if (viewModel == null)
             {

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
@@ -48,7 +48,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             var viewModelType = fragmentView.FindAssociatedViewModelType(fragment.Activity.GetType());
             var view = fragmentView as IMvxView;
 
-            var cached = cache.GetAndClear(fragmentView.ViewModel.GetType(), fragmentView.UniqueImmutableCacheTag);
+            var cached = cache.GetAndClear(viewModelType, fragmentView.UniqueImmutableCacheTag);
 
             view.OnViewCreate(() => cached ?? fragmentView.LoadViewModel(bundle, fragment.Activity.GetType(), request));
         }

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
@@ -26,8 +26,13 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
 
         public static void OnCreate(this IMvxFragmentView fragmentView, IMvxBundle bundle, MvxViewModelRequest request = null)
         {
+            var cache = Mvx.IoCProvider.Resolve<IMvxMultipleViewModelCache>();
+
             if (fragmentView.ViewModel != null)
             {
+                // check if ViewModel instance was cached. If so, clear it and ignore previous instance
+                cache.GetAndClear(fragmentView.ViewModel.GetType(), fragmentView.UniqueImmutableCacheTag);
+
                 //TODO call MvxViewModelLoader.Reload when it's added in MvvmCross, tracked by #1165
                 //until then, we're going to re-run the viewmodel lifecycle here.
                 Android.Views.MvxFragmentExtensions.RunViewModelLifecycle(fragmentView.ViewModel, bundle, request);
@@ -43,8 +48,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             var viewModelType = fragmentView.FindAssociatedViewModelType(fragment.Activity.GetType());
             var view = fragmentView as IMvxView;
 
-            var cache = Mvx.IoCProvider.Resolve<IMvxMultipleViewModelCache>();
-            var cached = cache.GetAndClear(viewModelType, fragmentView.UniqueImmutableCacheTag);
+            var cached = cache.GetAndClear(fragmentView.ViewModel.GetType(), fragmentView.UniqueImmutableCacheTag);
 
             view.OnViewCreate(() => cached ?? fragmentView.LoadViewModel(bundle, fragment.Activity.GetType(), request));
         }
@@ -145,7 +149,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
 
         public static void LoadViewModelFrom(this Android.Views.IMvxFragmentView view, MvxViewModelRequest request, IMvxBundle savedState = null)
         {
-            var loader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
+            var loader = Mvx.Resolve<IMvxViewModelLoader>();
             var viewModel = loader.LoadViewModel(request, savedState);
             if (viewModel == null)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The method which was previously responsible for creating ViewModel instances (when `ShowViewModel ` was the default) used to clear old ViewModel instances from `IMvxMultipleViewModelCache`.

Since MvxNavigationService was introduced, that code isn't run anymore (unless the app is coming back from tombstoning) so ViewModel instances are not being removed from the cache. Which leads to memory leaks of all kinds.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Download the branch from the PR #2888, run the app and you'll see that ViewModel instances are never removed.
Then apply the changes from this PR and check again.

### :memo: Links to relevant issues/docs
Fixes #2884

Also makes #2888 obsolete.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
