### PR TITLE
Move VisibleUIViewController to MvxTabBarViewController

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxTabBarViewController.cs
@@ -16,6 +16,30 @@ namespace MvvmCross.Platforms.Ios.Views
     {
         private int _tabsCount = 0;
 
+        public virtual UIViewController VisibleUIViewController
+        {
+            get
+            {
+                var topViewController = (SelectedViewController as UINavigationController)?.TopViewController ?? SelectedViewController;
+
+                if (topViewController != null && topViewController.PresentedViewController != null)
+                {
+                    if (topViewController.PresentedViewController is UINavigationController presentedNavigationController)
+                    {
+                        return presentedNavigationController.TopViewController;
+                    }
+                    else
+                    {
+                        return topViewController.PresentedViewController;
+                    }
+                }
+                else
+                {
+                    return topViewController;
+                }
+            }
+        }
+
         public MvxTabBarViewController() : base()
         {
             // WORKAROUND: UIKit makes a first ViewDidLoad call, because a TabViewController expects it's view (tabs) to be drawn 
@@ -194,30 +218,6 @@ namespace MvvmCross.Platforms.Ios.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
-        }
-
-        public virtual UIViewController VisibleUIViewController
-        {
-            get
-            {
-                var topViewController = (SelectedViewController as UINavigationController)?.TopViewController ?? SelectedViewController;
-
-                if (topViewController != null && topViewController.PresentedViewController != null)
-                {
-                    if (topViewController.PresentedViewController is UINavigationController presentedNavigationController)
-                    {
-                        return presentedNavigationController.TopViewController;
-                    }
-                    else
-                    {
-                        return topViewController.PresentedViewController;
-                    }
-                }
-                else
-                {
-                    return topViewController;
-                }
-            }
         }
 
         public MvxTabBarViewController() : base()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Refactor.

Move the VisibleUIViewController property to MvxTabBarViewController class. Is more generic.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
