### PR TITLE
Fix failing MvxIocPropertyInjectionTest

### DIFF
--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCPropertyInjectionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCPropertyInjectionTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace MvvmCross.UnitTest.Base
 {
-    
+    [Collection("MvxTest")]
     public class MvxIocPropertyInjectionTest
     {
         public interface IA


### PR DESCRIPTION
The [Collection] attribute was missing leading to race against
other tests using the IoC, which is a singleton.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug fix

### :arrow_heading_down: What is the current behavior?
tests fail sometimes due to race condition

### :new: What is the new behavior (if this is a feature change)?
hopefully fixes the test

### :boom: Does this PR introduce a breaking change?
nope

### :bug: Recommendations for testing
run unit test suite a couple of times

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
