### PR TITLE
Support for MvxPagePresentationHint in MvxIosViewPresenter (#2518).

### DIFF
--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
+using MvvmCross.Presenters.Hints;
 using MvvmCross.ViewModels;
 
 namespace Playground.Core.ViewModels
@@ -21,6 +22,8 @@ namespace Playground.Core.ViewModels
             OpenNavModalCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<ModalNavViewModel>());
 
             CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
+
+            OpenTab2Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(Tab2ViewModel))));
         }
 
         public override async Task Initialize()
@@ -44,6 +47,8 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand OpenModalCommand { get; private set; }
 
         public IMvxAsyncCommand OpenNavModalCommand { get; private set; }
+
+        public IMvxAsyncCommand OpenTab2Command { get; private set; }
 
         public IMvxAsyncCommand CloseCommand { get; private set; }
     }

--- a/Projects/Playground/Playground.iOS/Main.storyboard
+++ b/Projects/Playground/Playground.iOS/Main.storyboard
@@ -328,6 +328,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11854">
+                                <rect key="frame" x="168.5" y="288" width="77" height="30"/>
+                                <state key="normal" title="Show tab 2">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -341,12 +347,15 @@
                             <constraint firstItem="155" firstAttribute="centerX" secondItem="125" secondAttribute="centerX" constant="1" id="405"/>
                             <constraint firstItem="157" firstAttribute="centerX" secondItem="125" secondAttribute="centerX" id="406"/>
                             <constraint firstItem="157" firstAttribute="top" secondItem="155" secondAttribute="bottom" constant="33" id="407"/>
+                            <constraint id="11855" firstItem="11854" firstAttribute="centerX" secondItem="125" secondAttribute="centerX"/>
+                            <constraint id="11856" firstItem="11854" firstAttribute="top" secondItem="157" secondAttribute="bottom" constant="33"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="btnChild" destination="157" id="name-outlet-157"/>
                         <outlet property="btnModal" destination="155" id="name-outlet-155"/>
                         <outlet property="btnNavModal" destination="156" id="name-outlet-156"/>
+                        <outlet property="btnTab2" destination="11854" id="name-outlet-11854"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="126" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -738,9 +747,4 @@
             <point key="canvasLocation" x="3304" y="1373"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="home.png" width="25" height="25"/>
-        <image name="ic_tabbar_menu.png" width="25" height="25"/>
-        <image name="settings.png" width="24" height="24"/>
-    </resources>
 </document>

--- a/Projects/Playground/Playground.iOS/Views/Tab1View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Tab1View.cs
@@ -23,6 +23,7 @@ namespace Playground.iOS.Views
             set.Bind(btnModal).To(vm => vm.OpenModalCommand);
             set.Bind(btnNavModal).To(vm => vm.OpenNavModalCommand);
             set.Bind(btnChild).To(vm => vm.OpenChildCommand);
+            set.Bind(btnTab2).To(vm => vm.OpenTab2Command);
 
             set.Apply();
         }

--- a/Projects/Playground/Playground.iOS/Views/Tab1View.designer.cs
+++ b/Projects/Playground/Playground.iOS/Views/Tab1View.designer.cs
@@ -1,6 +1,6 @@
-// WARNING
+﻿// WARNING
 //
-// This file has been generated automatically by Xamarin Studio from the outlets and
+// This file has been generated automatically by Visual Studio from the outlets and
 // actions declared in your storyboard file.
 // Manual changes to this file will not be maintained.
 //
@@ -26,6 +26,10 @@ namespace Playground.iOS.Views
         [GeneratedCode ("iOS Designer", "1.0")]
         UIKit.UIButton btnNavModal { get; set; }
 
+        [Outlet]
+        [GeneratedCode ("iOS Designer", "1.0")]
+        UIKit.UIButton btnTab2 { get; set; }
+
         void ReleaseDesignerOutlets ()
         {
             if (btnChild != null) {
@@ -41,6 +45,11 @@ namespace Playground.iOS.Views
             if (btnNavModal != null) {
                 btnNavModal.Dispose ();
                 btnNavModal = null;
+            }
+
+            if (btnTab2 != null) {
+                btnTab2.Dispose ();
+                btnTab2 = null;
             }
         }
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR implements support for the `MvxPagePresentationHint` in the `MvxIosViewPresenter` for switching tabs programmatically.

### :arrow_heading_down: What is the current behavior?
The hint is not supported in the iOS presenter.

### :new: What is the new behavior (if this is a feature change)?
The presentation hint is supported on iOS (which aligns it with the `MvxFormsPagePresenter`).

### :boom: Does this PR introduce a breaking change?
No, it does not as far as I can see.

### :bug: Recommendations for testing
The `Playground.iOS` project has been updated. There is now a button labeled "Show tab 2" on the tab navigation page.

![videoresized](https://user-images.githubusercontent.com/1481801/44229629-ed1cf900-a198-11e8-8642-dfd2f5c1f09b.gif)

### :memo: Links to relevant issues/docs
Issue #2518 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
