### PR TITLE
Add ApplyWithClearBindingKey to MvxFluentBindingDescriptionSet

### DIFF
--- a/MvvmCross/Binding/BindingContext/IMvxBaseFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/IMvxBaseFluentBindingDescription.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.Binding.BindingContext
+{
+    public interface IMvxBaseFluentBindingDescription
+    {
+        object ClearBindingKey { get; set; }
+    }
+}

--- a/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
@@ -17,7 +17,7 @@ using MvvmCross.Exceptions;
 namespace MvvmCross.Binding.BindingContext
 {
     public class MvxBaseFluentBindingDescription<TTarget>
-        : MvxApplicableTo<TTarget>
+        : MvxApplicableTo<TTarget>, IMvxBaseFluentBindingDescription
         where TTarget : class
     {
         private readonly TTarget _target;
@@ -162,6 +162,12 @@ namespace MvvmCross.Binding.BindingContext
         }
 
         protected object ClearBindingKey { get; set; }
+
+        object IMvxBaseFluentBindingDescription.ClearBindingKey
+        {
+            get => ClearBindingKey;
+            set => ClearBindingKey = value;
+        }
 
         protected MvxBindingDescription BindingDescription => _bindingDescription;
 

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
@@ -60,5 +60,26 @@ namespace MvvmCross.Binding.BindingContext
                 applicable.Apply();
             base.Apply();
         }
+
+        public void ApplyWithClearBindingKey(object clearBindingKey)
+        {
+            foreach (var applicable in _applicables)
+            {
+                if (applicable is IMvxBaseFluentBindingDescription fluentBindingDescription)
+                {
+                    fluentBindingDescription.ClearBindingKey = clearBindingKey;
+                }
+                else
+                {
+                    MvxBindingLog.Warning("Fluent binding description must implement {0} in order to add {1}",
+                        nameof(IMvxBaseFluentBindingDescription),
+                        nameof(IMvxBaseFluentBindingDescription.ClearBindingKey));
+                }
+
+                applicable.Apply();
+            }
+
+            base.Apply();
+        }
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Bindings/FluentBindingViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Bindings/FluentBindingViewModel.cs
@@ -1,0 +1,35 @@
+﻿using MvvmCross.Commands;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels.Bindings
+{
+    public class FluentBindingViewModel : BaseViewModel
+    {
+        bool _bindingsEnabled = true;
+
+        public FluentBindingViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService)
+            : base(logProvider, navigationService)
+        {
+            ClearBindingsCommand = new MvxCommand(ClearBindings);
+        }
+
+        public IMvxCommand ClearBindingsCommand { get; }
+
+        public MvxInteraction<bool> ClearBindingInteraction { get; } = new MvxInteraction<bool>();
+
+        string _name;
+        public string TextValue
+        {
+            get => _name;
+            set => SetProperty(ref _name, value);
+        }
+
+        void ClearBindings()
+        {
+            _bindingsEnabled = !_bindingsEnabled;
+            ClearBindingInteraction.Raise(_bindingsEnabled);
+        }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/Bindings/FluentBindingViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Bindings/FluentBindingViewModel.cs
@@ -1,4 +1,8 @@
-﻿using MvvmCross.Commands;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
 using MvvmCross.ViewModels;

--- a/Projects/Playground/Playground.Core/ViewModels/Bindings/FluentBindingViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Bindings/FluentBindingViewModel.cs
@@ -23,11 +23,11 @@ namespace Playground.Core.ViewModels.Bindings
 
         public MvxInteraction<bool> ClearBindingInteraction { get; } = new MvxInteraction<bool>();
 
-        string _name;
+        string _textValue;
         public string TextValue
         {
-            get => _name;
-            set => SetProperty(ref _name, value);
+            get => _textValue;
+            set => SetProperty(ref _textValue, value);
         }
 
         void ClearBindings()

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -82,6 +82,9 @@ namespace Playground.Core.ViewModels
             ShowCustomBindingCommand =
                 new MvxAsyncCommand(async () => await NavigationService.Navigate<CustomBindingViewModel>());
 
+            ShowFluentBindingCommand =
+                new MvxAsyncCommand(async () => await NavigationService.Navigate<FluentBindingViewModel>());
+
             _counter = 3;
         }
 
@@ -126,9 +129,11 @@ namespace Playground.Core.ViewModels
             new MvxAsyncCommand(async () => await NavigationService.Navigate<ParentContentViewModel>());
 
         public IMvxAsyncCommand ConvertersCommand =>
-            new MvxAsyncCommand(async ()=> await NavigationService.Navigate<ConvertersViewModel>());
+            new MvxAsyncCommand(async () => await NavigationService.Navigate<ConvertersViewModel>());
 
         public IMvxAsyncCommand ShowSharedElementsCommand { get; }
+
+        public IMvxAsyncCommand ShowFluentBindingCommand { get; }
 
         public string WelcomeText
         {
@@ -206,7 +211,7 @@ namespace Playground.Core.ViewModels
             try
             {
                 var request = new MvxRestRequest("http://github.com/asdsadadad");
-                if(Mvx.IoCProvider.TryResolve(out IMvxRestClient client))
+                if (Mvx.IoCProvider.TryResolve(out IMvxRestClient client))
                 {
                     var task = client.MakeRequestAsync(request);
 

--- a/Projects/Playground/Playground.Droid/Activities/RootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/RootView.cs
@@ -4,6 +4,7 @@
 
 using Android.App;
 using Android.OS;
+using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
@@ -11,7 +12,8 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme")]
+    [Activity(Theme = "@style/AppTheme",
+        WindowSoftInputMode = SoftInput.AdjustPan)]
     public class RootView : MvxAppCompatActivity<RootViewModel>
     {
         protected override void OnCreate(Bundle bundle)

--- a/Projects/Playground/Playground.Droid/Fragments/FluentBindingView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/FluentBindingView.cs
@@ -1,0 +1,71 @@
+﻿using Android.OS;
+using Android.Views;
+using Android.Widget;
+using MvvmCross.Base;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Platforms.Android.Binding;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.ViewModels;
+using Playground.Core.ViewModels;
+using Playground.Core.ViewModels.Bindings;
+
+namespace Playground.Droid.Fragments
+{
+    [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame)]
+    public class FluentBindingView : MvxFragment<FluentBindingViewModel>
+    {
+        EditText _inputText;
+        TextView _outputText;
+        private IMvxInteraction<bool> _clearBindingInteraction;
+        public IMvxInteraction<bool> ClearBindingInteraction
+        {
+            get => _clearBindingInteraction;
+            set
+            {
+                if (_clearBindingInteraction != null)
+                    _clearBindingInteraction.Requested -= OnInteractionRequested;
+
+                _clearBindingInteraction = value;
+                _clearBindingInteraction.Requested += OnInteractionRequested;
+            }
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(Resource.Layout.FluentBindingView, null);
+
+            _inputText = view.FindViewById<EditText>(Resource.Id.inputText);
+            _outputText = view.FindViewById<TextView>(Resource.Id.outputText);
+            var toggleButton = view.FindViewById<Button>(Resource.Id.toggleBtn);
+
+            var bindingSet = this.CreateBindingSet<FluentBindingView, FluentBindingViewModel>();
+            bindingSet.Bind(toggleButton).For(v => v.BindClick()).To(vm => vm.ClearBindingsCommand);
+            bindingSet.Apply();
+
+            BindTextInput();
+
+            return view;
+        }
+
+        void BindTextInput()
+        {
+            var bindingSet = this.CreateBindingSet<FluentBindingView, FluentBindingViewModel>();
+            bindingSet.Bind(_inputText).For(v => v.Text).To(vm => vm.TextValue);
+            bindingSet.Bind(_outputText).For(v => v.Text).To(vm => vm.TextValue);
+            bindingSet.Bind(this).For(v => v.ClearBindingInteraction).To(vm => vm.ClearBindingInteraction);
+            bindingSet.ApplyWithClearBindingKey(nameof(FluentBindingView));
+        }
+
+        private void OnInteractionRequested(object sender, MvxValueEventArgs<bool> eventArgs)
+        {
+            if (eventArgs.Value)
+                BindTextInput();
+            else
+                this.ClearBindings(nameof(FluentBindingView));
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Fragments/FluentBindingView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/FluentBindingView.cs
@@ -1,4 +1,8 @@
-﻿using Android.OS;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.OS;
 using Android.Views;
 using Android.Widget;
 using MvvmCross.Base;

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Bindings\BinaryEditTargetBinding.cs" />
     <Compile Include="Controls\BinaryEdit.cs" />
     <Compile Include="Fragments\BaseSplitDetailView.cs" />
+    <Compile Include="Fragments\FluentBindingView.cs" />
     <Compile Include="Fragments\TabsRootBView.cs" />
     <Compile Include="LinkerPleaseInclude.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
@@ -223,6 +224,11 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable-xxxhdpi\mvvmcross_logo.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\FluentBindingView.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\..\..\XamarinBuild.targets" />

--- a/Projects/Playground/Playground.Droid/Resources/layout/FluentBindingView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/FluentBindingView.axml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+  
+    <TextView
+        android:id="@+id/outputText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+  
+    <EditText
+        android:id="@+id/inputText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <Button
+        android:id="@+id/toggleBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Toggle Bindings"/>
+
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/RootView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/RootView.axml
@@ -80,6 +80,12 @@
                 android:layout_marginTop="10dp"
                 android:text="Show Custom Binding"
                 local:MvxBind="Click ShowCustomBindingCommand" />
+            <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Show Fluent Binding Example"
+                local:MvxBind="Click ShowFluentBindingCommand" />
         </LinearLayout>
     </ScrollView>
     <FrameLayout

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -963,6 +963,35 @@ set.Bind(button).To(vm => vm.readonly)
 
 *Note* : This feature is only available in fluent binding.
 
+### Clear Bindings
+
+If you want to dynamically remove individual bindings after you have applied them to your view you need to add a `ClearBindingKey` to your binding descriptions. The `ClearBindingKey` can be any object type.
+
+***Individual binding***
+
+```c#
+bindingSet.Bind(_inputText)
+    .For(v => v.Text)
+    .To(vm => vm.TextValue)
+    .WithClearBindingKey(nameof(_inputText));
+```
+
+***Binding set*** (applied to all descriptions in the set)
+
+```c#
+bindingSet.Bind(_inputText)
+    .For(v => v.Text)
+    .To(vm => vm.TextValue);
+
+bindingSet.ApplyWithClearBindingKey(nameof(FluentBindingView));
+```
+
+To remove the binding using the `ClearBindingKey` you can make use of `ClearBindings` extension on the `IMvxBindingContextOwner`
+
+ ```c#
+ this.ClearBindings(nameof(FluentBindingView));
+ ```
+
 ### Default view properties
 
 The tables in this section describe the default view properties used in a Fluent binding when the `For` method chain is not provided.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature
### :arrow_heading_down: What is the current behavior?

In order to add clear binding key currently, you have to add one to each individual binding description.
### :new: What is the new behavior (if this is a feature change)?

A developer can now make use of `ApplyWithClearBindingKey` on a `MvxFluentBindingDescriptionSet` which will apply the key to the entire set.
### :boom: Does this PR introduce a breaking change?

No
### :bug: Recommendations for testing

See "Show Fluent Binding Example" option in the Android playground.
### :memo: Links to relevant issues/docs

n/a
### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
