### PR TITLE
Check for IMvxWindow instead of MvxWindow on WPF

### DIFF
--- a/MvvmCross/Platforms/Wpf/Presenters/MvxWpfViewPresenter.cs
+++ b/MvvmCross/Platforms/Wpf/Presenters/MvxWpfViewPresenter.cs
@@ -120,15 +120,15 @@ namespace MvvmCross.Platforms.Wpf.Presenters
         protected virtual Task<bool> ShowWindow(FrameworkElement element, MvxWindowPresentationAttribute attribute, MvxViewModelRequest request)
         {
             Window window;
-            if (element is MvxWindow)
+            if (element is IMvxWindow mvxWindow)
             {
                 window = (Window)element;
-                ((MvxWindow)window).Identifier = attribute.Identifier ?? element.GetType().Name;
+                mvxWindow.Identifier = attribute.Identifier ?? element.GetType().Name;
             }
-            else if (element is Window)
+            else if (element is Window normalWindow)
             {
                 // Accept normal Window class
-                window = (Window)element;
+                window = normalWindow;
             }
             else
             {


### PR DESCRIPTION
This allows anyone to implement the IMvxWindow interface, which allows them to use other Window types. This should fix #3080

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
Presenter only accepts derivatives of MvxWindow

### :new: What is the new behavior (if this is a feature change)?
You can implement your own IMvxWindow and use default presenter

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
fixes #3080

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
