### PR TITLE
Fix TipCalc Core navigation link

### DIFF
--- a/docs/_documentation/tutorials/tipcalc/the-core-project.md
+++ b/docs/_documentation/tutorials/tipcalc/the-core-project.md
@@ -305,7 +305,7 @@ These are the same steps that you need to go through for every new MvvmCross app
 
 The next step is about building a first UI for our MvvmCross application.
 
-[Next!](https://www.mvvmcross.com/documentation/tutorials/tipcalc/the-tip-calc-navigation)
+[Next!](https://www.mvvmcross.com/documentation/tutorials/tipcalc/a-xamarinandroid-ui-project) 
 
 
 ## Side note: What is 'Inversion of Control'?


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
Navigation for TipCalc tutorial is incorrect. This is critical because a lot of people follow that tutorial when getting started.

### :new: What is the new behavior (if this is a feature change)?
Link is fixed.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
Fixes #2920 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
