### PR TITLE
Fix issues when pressing back button on splash screen

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxActivityViewExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxActivityViewExtensions.cs
@@ -74,9 +74,8 @@ namespace MvvmCross.Platforms.Android.Views
             view.OnViewDestroy();
 
             var currentActivity = Mvx.IoCProvider.Resolve<IMvxAndroidCurrentTopActivity>()?.Activity;
-            if (currentActivity == null && view is Activity destroyedActivity && destroyedActivity.IsFinishing)
+            if (currentActivity == null && view is Activity destroyedActivity && destroyedActivity.IsFinishing && Mvx.IoCProvider.TryResolve<IMvxAppStart>(out var appStart))
             {
-                var appStart = Mvx.IoCProvider.Resolve<IMvxAppStart>();
                 appStart?.ResetStart();
             }
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
If you repeatedly press the Android back or home buttons while the splash screen is displaying you can end up with an unhandled exception saying IMvxAppStart couldn't be resolved.

### :new: What is the new behavior (if this is a feature change)?
Changes `Mvx.IocProvider.Resolve<IMvxAppStart>` to `Mvx.IocProvider.TryResolve<IMvxAppStart>` to avoid the exception.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
You need to have #3084 in place before you can fully test this!

Start Playground.Droid and repeatedly press the Android back or home buttons before the splash screen is fully loaded.

### :memo: Links to relevant issues/docs
Fixes #3017 
Fixes #2810 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
