### PR TITLE
Android support for the MvxPagePresentationHint.

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -163,21 +163,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
                 if (attribute is MvxViewPagerFragmentPresentationAttribute pagerFragmentAttribute)
                 {
-                    ViewPager viewPager = null;
-
-                    // check for a ViewPager inside a Fragment
-                    if (pagerFragmentAttribute.FragmentHostViewType != null)
-                    {
-                        var fragment = GetFragmentByViewType(pagerFragmentAttribute.FragmentHostViewType);
-                        viewPager = fragment.View.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
-                    }
-                    
-                    // check for a ViewPager inside an Activity
-                    if (viewPager == null && pagerFragmentAttribute.ActivityHostViewModelType != null)
-                    {
-                        viewPager = CurrentActivity.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
-                    }
-
+                    var viewPager = FindViewPagerInFragmentPresentation(pagerFragmentAttribute);
                     if (viewPager?.Adapter is MvxCachingFragmentStatePagerAdapter adapter)
                     {
                         if (adapter.FragmentsInfo.Any(f => f.Tag == pagerFragmentAttribute.Title))
@@ -195,6 +181,26 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             }
 
             return base.ChangePresentation(hint);
+        }
+
+        private ViewPager FindViewPagerInFragmentPresentation(MvxViewPagerFragmentPresentationAttribute pagerFragmentAttribute)
+        {
+            ViewPager viewPager = null;
+
+            // check for a ViewPager inside a Fragment
+            if (pagerFragmentAttribute.FragmentHostViewType != null)
+            {
+                var fragment = GetFragmentByViewType(pagerFragmentAttribute.FragmentHostViewType);
+                viewPager = fragment.View.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
+            }
+
+            // check for a ViewPager inside an Activity
+            if (viewPager == null && pagerFragmentAttribute.ActivityHostViewModelType != null)
+            {
+                viewPager = CurrentActivity.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
+            }
+
+            return viewPager;
         }
 
         #region Show implementations

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -20,6 +20,7 @@ using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.Presenters;
 using MvvmCross.Presenters.Attributes;
+using MvvmCross.Presenters.Hints;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Droid.Support.V7.AppCompat
@@ -151,6 +152,46 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             }
 
             return base.CreatePresentationAttribute(viewModelType, viewType);
+        }
+
+        public override Task<bool> ChangePresentation(MvxPresentationHint hint)
+        {
+            if (hint is MvxPagePresentationHint pagePresentationHint)
+            {
+                var request = new MvxViewModelRequest(pagePresentationHint.ViewModel);
+                var attribute = GetPresentationAttribute(request);
+
+                if (attribute is MvxViewPagerFragmentPresentationAttribute pagerFragmentAttribute)
+                {
+                    ViewPager viewPager = null;
+
+                    // check for a ViewPager inside a Fragment
+                    if (pagerFragmentAttribute.FragmentHostViewType != null)
+                    {
+                        var fragment = GetFragmentByViewType(pagerFragmentAttribute.FragmentHostViewType);
+                        viewPager = fragment.View.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
+                    }
+
+                    // check for a ViewPager inside an Activity
+                    if (pagerFragmentAttribute.ActivityHostViewModelType != null)
+                    {
+                        viewPager = CurrentActivity.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
+                    }
+
+                    if (viewPager?.Adapter is MvxCachingFragmentStatePagerAdapter adapter)
+                    {
+                        if (adapter.FragmentsInfo.Any(f => f.Tag == pagerFragmentAttribute.Title))
+                        {
+                            var index = adapter.FragmentsInfo.FindIndex(f => f.Tag == pagerFragmentAttribute.Title);
+                            viewPager.SetCurrentItem(index > -1 ? index : 0, true);
+
+                            return Task.FromResult(true);
+                        }
+                    }
+                }
+            }
+
+            return base.ChangePresentation(hint);
         }
 
         #region Show implementations
@@ -403,20 +444,12 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             if (viewPager.Adapter is MvxCachingFragmentStatePagerAdapter adapter)
             {
-                if (adapter.FragmentsInfo.Any(f => f.Tag == attribute.Title))
-                {
-                    var index = adapter.FragmentsInfo.FindIndex(f => f.Tag == attribute.Title);
-                    viewPager.SetCurrentItem(index > -1 ? index : 0, true);
-                }
+                if (request is MvxViewModelInstanceRequest instanceRequest)
+                    adapter.FragmentsInfo.Add(new MvxViewPagerFragmentInfo(attribute.Title, attribute.ViewType, instanceRequest.ViewModelInstance));
                 else
-                {
-                    if (request is MvxViewModelInstanceRequest instanceRequest)
-                        adapter.FragmentsInfo.Add(new MvxViewPagerFragmentInfo(attribute.Title, attribute.ViewType, instanceRequest.ViewModelInstance));
-                    else
-                        adapter.FragmentsInfo.Add(new MvxViewPagerFragmentInfo(attribute.Title, attribute.ViewType, attribute.ViewModelType));
+                    adapter.FragmentsInfo.Add(new MvxViewPagerFragmentInfo(attribute.Title, attribute.ViewType, attribute.ViewModelType));
 
-                    adapter.NotifyDataSetChanged();
-                }
+                adapter.NotifyDataSetChanged();
             }
             else
             {

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -166,16 +166,17 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                     var viewPager = FindViewPagerInFragmentPresentation(pagerFragmentAttribute);
                     if (viewPager?.Adapter is MvxCachingFragmentStatePagerAdapter adapter)
                     {
-                        if (adapter.FragmentsInfo.Any(f => f.Tag == pagerFragmentAttribute.Title))
+                        var index = adapter.FragmentsInfo.FindIndex(f => f.Tag == pagerFragmentAttribute.Title);
+                        if (index < 0)
                         {
-                            var index = adapter.FragmentsInfo.FindIndex(f => f.Tag == pagerFragmentAttribute.Title);
-                            if (index < 0)
-                                index = 0;
+                            MvxAndroidLog.Instance.Trace("Did not find ViewPager index for {0}, skipping presentation change...",
+                                pagerFragmentAttribute.Title);
 
-                            viewPager.SetCurrentItem(index, true);
-
-                            return Task.FromResult(true);
+                            return Task.FromResult(false);
                         }
+
+                        viewPager.SetCurrentItem(index, true);
+                        return Task.FromResult(true);
                     }
                 }
             }

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -183,7 +183,10 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                         if (adapter.FragmentsInfo.Any(f => f.Tag == pagerFragmentAttribute.Title))
                         {
                             var index = adapter.FragmentsInfo.FindIndex(f => f.Tag == pagerFragmentAttribute.Title);
-                            viewPager.SetCurrentItem(index > -1 ? index : 0, true);
+                            if (index < 0)
+                                index = 0;
+
+                            viewPager.SetCurrentItem(index, true);
 
                             return Task.FromResult(true);
                         }

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -171,9 +171,9 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                         var fragment = GetFragmentByViewType(pagerFragmentAttribute.FragmentHostViewType);
                         viewPager = fragment.View.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
                     }
-
+                    
                     // check for a ViewPager inside an Activity
-                    if (pagerFragmentAttribute.ActivityHostViewModelType != null)
+                    if (viewPager == null && pagerFragmentAttribute.ActivityHostViewModelType != null)
                     {
                         viewPager = CurrentActivity.FindViewById<ViewPager>(pagerFragmentAttribute.ViewPagerResourceId);
                     }

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -21,7 +21,6 @@ using MvvmCross.Platforms.Android.Views;
 using MvvmCross.Platforms.Android.Views.Fragments;
 using MvvmCross.Presenters;
 using MvvmCross.Presenters.Attributes;
-using MvvmCross.Presenters.Hints;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 
@@ -204,21 +203,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             }
             return null;
         }
-
-        public override Task<bool> ChangePresentation(MvxPresentationHint hint)
-        {
-            if (hint is MvxPagePresentationHint pagePresentationHint)
-            {
-                var request = new MvxViewModelRequest(pagePresentationHint.ViewModel);
-                var attribute = GetPresentationAttribute(request);
-                GetPresentationAttributeAction(request, out attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
-
-                return Task.FromResult(true);
-            }
-
-            return base.ChangePresentation(hint);
-        }
-
+        
         protected Type GetCurrentActivityViewModelType()
         {
             Type currentActivityType = CurrentActivity?.GetType();

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -21,6 +21,7 @@ using MvvmCross.Platforms.Android.Views;
 using MvvmCross.Platforms.Android.Views.Fragments;
 using MvvmCross.Presenters;
 using MvvmCross.Presenters.Attributes;
+using MvvmCross.Presenters.Hints;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 
@@ -203,6 +204,21 @@ namespace MvvmCross.Platforms.Android.Presenters
             }
             return null;
         }
+
+        public override Task<bool> ChangePresentation(MvxPresentationHint hint)
+        {
+            if (hint is MvxPagePresentationHint pagePresentationHint)
+            {
+                var request = new MvxViewModelRequest(pagePresentationHint.ViewModel);
+                var attribute = GetPresentationAttribute(request);
+                GetPresentationAttributeAction(request, out attribute).ShowAction.Invoke(attribute.ViewType, attribute, request);
+
+                return Task.FromResult(true);
+            }
+
+            return base.ChangePresentation(hint);
+        }
+
 
         protected Type GetCurrentActivityViewModelType()
         {

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -219,7 +219,6 @@ namespace MvvmCross.Platforms.Android.Presenters
             return base.ChangePresentation(hint);
         }
 
-
         protected Type GetCurrentActivityViewModelType()
         {
             Type currentActivityType = CurrentActivity?.GetType();

--- a/MvvmCross/Presenters/Hints/MvxPagePresentationHint.cs
+++ b/MvvmCross/Presenters/Hints/MvxPagePresentationHint.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,6 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Presenters.Hints
 {
-    //Only available on Xamarin.Forms
     public class MvxPagePresentationHint
         : MvxPresentationHint
     {

--- a/Projects/Playground/Playground.Droid/Resources/layout/Tab1View.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/Tab1View.axml
@@ -11,6 +11,12 @@
         android:layout_marginTop="10dp"
         android:text="Show Child"
         local:MvxBind="Click OpenChildCommand;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show Tab 2"
+        local:MvxBind="Click OpenTab2Command;" />
     <FrameLayout
         android:id="@+id/content_frame"
         android:layout_width="match_parent"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Support for changing tabs using the `MvxPagePresentationHint` on Android.

### :arrow_heading_down: What is the current behavior?

Changing tabs is not possible (neither through `ChangePresentation` or the `Navigate` method on the `MvxNavigationService`).

### :new: What is the new behavior (if this is a feature change)?

Tabs can be activated using the `MvxPagePresentationHint`.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

The `Playground.Droid` project has been aligned with the iOS project. There is now a "Show tab 2" button on the tab page:

![recording](https://user-images.githubusercontent.com/1481801/44931892-83d5e200-ad63-11e8-81e4-a087a52acbef.gif)

### :memo: Links to relevant issues/docs

https://github.com/MvvmCross/MvvmCross/issues/2518

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
