### PR TITLE
Fix forms xaml preview on android

### DIFF
--- a/MvvmCross.Forms/Bindings/Bi.n.d.cs
+++ b/MvvmCross.Forms/Bindings/Bi.n.d.cs
@@ -20,13 +20,14 @@ namespace MvvmCross.Forms.Bindings
         }
 
         // ReSharper disable once InconsistentNaming
-        public static readonly BindableProperty ndProperty = BindableProperty.CreateAttached("nd",
-                                                                                             typeof(string),
-                                                                                             typeof(Bi),
-                                                                                             null,
-                                                                                             BindingMode.OneWay,
-                                                                                             null,
-                                                                                             CallBackWhenndIsChanged);
+        public static readonly BindableProperty ndProperty = 
+            BindableProperty.CreateAttached("nd",
+                                            typeof(string),
+                                            typeof(Bi),
+                                            null,
+                                            BindingMode.OneWay,
+                                            null,
+                                            CallBackWhenndIsChanged);
 
         public static string Getnd(BindableObject obj)
         {
@@ -51,8 +52,10 @@ namespace MvvmCross.Forms.Bindings
 
         private static IMvxBindingCreator ResolveBindingCreator()
         {
-            IMvxBindingCreator toReturn;
-            if (!Mvx.IoCProvider.TryResolve<IMvxBindingCreator>(out toReturn))
+            if (MvxDesignTimeChecker.IsDesignTime)
+                return null;
+
+            if (!Mvx.IoCProvider.TryResolve(out IMvxBindingCreator toReturn))
             {
                 throw new MvxException("Unable to resolve the binding creator - have you initialized Xamarin Forms Binding");
             }

--- a/MvvmCross.Forms/Bindings/MvxDesignTimeChecker.cs
+++ b/MvvmCross.Forms/Bindings/MvxDesignTimeChecker.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -24,17 +24,24 @@ namespace MvvmCross.Forms.Bindings
             if (!IsDesignTime)
                 return;
 
-            if (MvxSingleton<IMvxIoCProvider>.Instance == null)
+            try
             {
-                var iocProvider = MvxIoCProvider.Initialize();
-                Mvx.IoCProvider.RegisterSingleton(iocProvider);
-            }
+                if (MvxSingleton<IMvxIoCProvider>.Instance == null)
+                {
+                    var iocProvider = MvxIoCProvider.Initialize();
+                    Mvx.IoCProvider.RegisterSingleton(iocProvider);
+                }
 
-            if (!Mvx.IoCProvider.CanResolve<IMvxBindingParser>())
+                if (!Mvx.IoCProvider.CanResolve<IMvxBindingParser>())
+                {
+                    //We might want to look into returning the platform specific Forms binder
+                    var builder = new MvxBindingBuilder();
+                    builder.DoRegistration();
+                }
+            }
+            catch
             {
-                //We might want to look into returning the platform specific Forms binder
-                var builder = new MvxBindingBuilder();
-                builder.DoRegistration();
+                // ignore
             }
         }
 

--- a/MvvmCross.Forms/Bindings/MvxDesignTimeChecker.cs
+++ b/MvvmCross.Forms/Bindings/MvxDesignTimeChecker.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -21,8 +21,7 @@ namespace MvvmCross.Forms.Bindings
 
             _checked = true;
 
-            // if Application.Current == null Forms is in design mode
-            if (Application.Current != null)
+            if (!IsDesignTime)
                 return;
 
             if (MvxSingleton<IMvxIoCProvider>.Instance == null)
@@ -38,5 +37,7 @@ namespace MvvmCross.Forms.Bindings
                 builder.DoRegistration();
             }
         }
+
+        public static bool IsDesignTime => DesignMode.IsDesignModeEnabled;
     }
 }

--- a/MvvmCross.Forms/Views/MvxElementExtensions.cs
+++ b/MvvmCross.Forms/Views/MvxElementExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using MvvmCross.Exceptions;
+using MvvmCross.Forms.Bindings;
 using MvvmCross.Forms.Views.Base;
 using MvvmCross.Logging;
 using MvvmCross.ViewModels;
@@ -27,24 +28,33 @@ namespace MvvmCross.Forms.Views
             var adapter = new MvxCellAdapter(cell);
         }
 
-        public static void OnBindingContextChanged(this IMvxElement element)
+        private static void LoadViewModelForElement(IMvxElement element)
         {
-            var cache = Mvx.IoCProvider.Resolve<IMvxChildViewModelCache>();
-            var cached = cache.Get(element.FindAssociatedViewModelTypeOrNull());
+            IMvxViewModel cached = null;
+            if (!MvxDesignTimeChecker.IsDesignTime)
+            {
+                var cache = Mvx.IoCProvider.Resolve<IMvxChildViewModelCache>();
+                cached = cache.Get(element.FindAssociatedViewModelTypeOrNull());
+            }
 
             element.OnViewCreate(() => cached ?? element.LoadViewModel());
+        }
+
+        public static void OnBindingContextChanged(this IMvxElement element)
+        {
+            LoadViewModelForElement(element);
         }
 
         public static void OnViewAppearing(this IMvxElement element)
         {
-            var cache = Mvx.IoCProvider.Resolve<IMvxChildViewModelCache>();
-            var cached = cache.Get(element.FindAssociatedViewModelTypeOrNull());
-
-            element.OnViewCreate(() => cached ?? element.LoadViewModel());
+            LoadViewModelForElement(element);
         }
 
         private static IMvxViewModel LoadViewModel(this IMvxElement element)
         {
+            if (MvxDesignTimeChecker.IsDesignTime)
+                return new MvxNullViewModel();
+
             var viewModelType = element.FindAssociatedViewModelTypeOrNull();
             if (viewModelType == typeof(MvxNullViewModel))
                 return new MvxNullViewModel();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When trying to preview XAML layouts in the designer it throws errors

### :new: What is the new behavior (if this is a feature change)?
No errors are thrown and UI is rendered

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Open any of the XAML pages in the playground in the Xamarin.Forms Previewer using the Android platform option inside of it

### :memo: Links to relevant issues/docs
#3091 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
