### PR TITLE
Fix Playground.Forms showing a black screen after splash

### DIFF
--- a/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
+++ b/Projects/Playground/Playground.Forms.Droid/SplashScreen.cs
@@ -29,7 +29,7 @@ namespace Playground.Forms.Droid
         protected override Task RunAppStartAsync(Bundle bundle)
         {
             StartActivity(typeof(MainActivity));
-            return Task.CompletedTask;
+            return base.RunAppStartAsync(bundle);
         }
     }
 }


### PR DESCRIPTION
AppStart Start isn't called.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Black screen on Android after Splash Screen

### :new: What is the new behavior (if this is a feature change)?
App actually runs

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Launch Playground.Forms.Droid

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
