### PR TITLE
mvx:Lang and mvx:Bind crashes in Setter Value

### DIFF
--- a/MvvmCross.Forms/Bindings/MvxBindExtension.cs
+++ b/MvvmCross.Forms/Bindings/MvxBindExtension.cs
@@ -43,7 +43,15 @@ namespace MvvmCross.Forms.Bindings
                     bindingBuilder.Append($", CommandParameter={CommandParameter}");
                 }
 
-                Bindable.SetValue(Bi.ndProperty, bindingBuilder.ToString());
+                if (Bindable != null)
+                {
+                    Bindable.SetValue(Bi.ndProperty, bindingBuilder.ToString());
+                }
+                else
+                {
+                    MvxFormsLog.Instance.Trace("Can only use MvxBind on a bindable view");
+                }
+                
             }
             else if (BindableObjectRaw is IMarkupExtension ext)
             {

--- a/MvvmCross.Forms/Bindings/MvxBindExtension.cs
+++ b/MvvmCross.Forms/Bindings/MvxBindExtension.cs
@@ -51,7 +51,6 @@ namespace MvvmCross.Forms.Bindings
                 {
                     MvxFormsLog.Instance.Trace("Can only use MvxBind on a bindable view");
                 }
-                
             }
             else if (BindableObjectRaw is IMarkupExtension ext)
             {

--- a/MvvmCross.Forms/Bindings/MvxLangExtension.cs
+++ b/MvvmCross.Forms/Bindings/MvxLangExtension.cs
@@ -46,16 +46,20 @@ namespace MvvmCross.Forms.Bindings
                     bindingBuilder.Append($", FallbackValue={FallbackValue}");
                 }
 
-                Bindable.SetValue(La.ngProperty, bindingBuilder.ToString());
-            }
-            else if(!string.IsNullOrEmpty(Source) && Mvx.IoCProvider.CanResolve<IMvxTextProvider>())
-            {
-                if(Arguments == null)
-                    return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source);
+                if (Bindable != null)
+                {
+                    Bindable.SetValue(La.ngProperty, bindingBuilder.ToString());
+                }
                 else
-                    return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source, Arguments);
+                {
+                    MvxFormsLog.Instance.Trace("Can only use MvxLang on a bindable type");
+                }
             }
-            else if(BindableObjectRaw is IMarkupExtension ext)
+            else if (!string.IsNullOrEmpty(Source) && Mvx.IoCProvider.CanResolve<IMvxTextProvider>())
+            {
+                return GetStringFromLanguageBinder();
+            }
+            else if (BindableObjectRaw is IMarkupExtension ext)
             {
                 return ext.ProvideValue(serviceProvider);
             }
@@ -65,6 +69,14 @@ namespace MvvmCross.Forms.Bindings
             }
 
             return null;
+        }
+
+        private string GetStringFromLanguageBinder()
+        {
+            if (Arguments == null)
+                return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source);
+            else
+                return new MvxLanguageBinder(NameSpaceKey, TypeKey).GetText(Source, Arguments);
         }
     }
 }

--- a/Projects/Playground/Playground.Core/Resources/Text.json
+++ b/Projects/Playground/Playground.Core/Resources/Text.json
@@ -1,5 +1,7 @@
 ﻿{
     "ThisIsLocalized": "Localized text",
     "ThisIsLocalizedToo": "I'm using MvxLang markup!",
-    "ThisIsLocalizedThroughMvxBind": "MvxBind markup with converter!"
+    "ThisIsLocalizedThroughMvxBind": "MvxBind markup with converter!",
+    "HideLabel": "I am hidden!",
+    "ShowLabel": "I am not hidden!"
 }

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,6 +7,7 @@ using System.Net;
 using System.Threading.Tasks;
 using MvvmCross;
 using MvvmCross.Commands;
+using MvvmCross.Localization;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
 using MvvmCross.Plugin.Messenger;
@@ -25,6 +26,11 @@ namespace Playground.Core.ViewModels
         private int _counter = 2;
 
         private string _welcomeText = "Default welcome";
+
+        public IMvxLanguageBinder TextSource
+        {
+            get { return new MvxLanguageBinder("Playground.Core", "Text"); }
+        }
 
         public RootViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService, IMvxViewModelLoader mvxViewModelLoader) : base(logProvider, navigationService)
         {
@@ -86,6 +92,9 @@ namespace Playground.Core.ViewModels
                 new MvxAsyncCommand(async () => await NavigationService.Navigate<FluentBindingViewModel>());
 
             _counter = 3;
+
+            TriggerVisibilityCommand =
+                new MvxCommand(() => IsVisible = !IsVisible);
         }
 
         public MvxNotifyTask MyTask { get; set; }
@@ -134,6 +143,15 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowSharedElementsCommand { get; }
 
         public IMvxAsyncCommand ShowFluentBindingCommand { get; }
+
+        public IMvxCommand TriggerVisibilityCommand { get; }
+
+        private bool _isVisible;
+        public bool IsVisible
+        {
+            get => _isVisible;
+            set => SetProperty(ref _isVisible, value);
+        }
 
         public string WelcomeText
         {

--- a/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/RootPage.xaml
@@ -28,6 +28,16 @@
                 <Button Text="Show Bindings view" mvx:Bi.nd="Command ShowBindingsViewCommand"/>
                 <Button Text="Show CodeBehind view" mvx:Bi.nd="Command ShowCodeBehindViewCommand"/>
                 <Button Text="Show Converters view" mvx:Bi.nd="Command ConvertersCommand" />
+
+                <Label Text="{mvx:MvxLang ShowLabel}" TextColor="{StaticResource PrimaryColor}">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label" Binding="{Binding IsVisible}" Value="True">
+                            <Setter Property="Text" Value="{mvx:MvxLang HideLabel}" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
+
+                <Button Text="Trigger Visibility" mvx:Bi.nd="Command TriggerVisibilityCommand" />
             </StackLayout>
         </ScrollView>
 	</ContentPage.Content>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
App crashes when using DataTrigger with Setter using mvx:Lang or mvx:Bind markup.

### :new: What is the new behavior (if this is a feature change)?
It doesn't crash, and warns in the log that trying to bind a object which isnt a BindableObject

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Forms samples

### :memo: Links to relevant issues/docs
Fixes crash in #3072 

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
