### PR TITLE
Playground.Droid: Remove incorrect button on SplitDetailNavView

### DIFF
--- a/Projects/Playground/Playground.Droid/Resources/layout/SplitDetailNavView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/SplitDetailNavView.axml
@@ -24,11 +24,6 @@
     <Button
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:text="Main Menu"
-        local:MvxBind="Click MainMenuCommand" />
-    <Button
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
         android:text="Close"
         local:MvxBind="Click CloseCommand" />
 </LinearLayout>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Sample fix

### :arrow_heading_down: What is the current behavior?
Playground.Droid has a button for a screen which isn't implemented on that platform.

### :new: What is the new behavior (if this is a feature change)?
Button is removed.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run the sample, follow the steps of the issue.

### :memo: Links to relevant issues/docs
Closes #2931

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
