### PR TITLE
Fix views namespaces

### DIFF
--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -230,7 +230,7 @@ namespace MvvmCross.Platforms.Android.Core
 
         protected virtual IDictionary<string, string> ViewNamespaceAbbreviations => new Dictionary<string, string>
         {
-            { "Mvx", "MvvmCross.Binding.Droid.Views" }
+            { "Mvx", "MvvmCross.Platforms.Android.Views" }
         };
 
         protected virtual IEnumerable<string> ViewNamespaces => new List<string>
@@ -238,7 +238,7 @@ namespace MvvmCross.Platforms.Android.Core
             "Android.Views",
             "Android.Widget",
             "Android.Webkit",
-            "MvvmCross.Binding.Droid.Views",
+            "MvvmCross.Platforms.Android.Views",
         };
 
         protected virtual IEnumerable<Assembly> AndroidViewAssemblies => new List<Assembly>()


### PR DESCRIPTION
This was forgotten during the moving around of classes when upgrading to NET Standard

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Can't use Mvx abbreviation and MvvmCross expects views to be in wrong namespace

### :new: What is the new behavior (if this is a feature change)?
Abbreviation should work again

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #3102 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
