### PR TITLE
Update viewmodel-lifecycle.md

### DIFF
--- a/docs/_documentation/fundamentals/viewmodel-lifecycle.md
+++ b/docs/_documentation/fundamentals/viewmodel-lifecycle.md
@@ -43,7 +43,7 @@ public class MyViewModel : MvxViewModel
 If you need to send some parameters to a ViewModel, you will want to use this method. MvxViewModel can have two Prepare methods:
 
 - Parameterless `Prepare`: Called in every scenario.
-- `Prepare(TParameter parameter)`: Called when you are navigating to a ViewModel with initial parameters. You shouldn't perform any logics on this method more than saving the parameters.
+- `Prepare(TParameter parameter)`: Called when you are navigating to a ViewModel with initial parameters and after the parameterless version of it. You shouldn't perform any logics on this method more than saving the parameters.
 
 This is how a typical ViewModel with initial parameters look like:
 


### PR DESCRIPTION
Set which of the Prepare methods is called first when navigating to a ViewModel with a Parameter

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
Lacks saying with Prepare method is executed first when navigating to a ViewModel

### :new: What is the new behavior (if this is a feature change)?
It states which Prepare method is executed first when navigating to a ViewModel

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
