### PR TITLE
FragmentJavaName centralized

### DIFF
--- a/MvvmCross.Android.Support/Fragment/MvxCachingFragmentPagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxCachingFragmentPagerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,6 +13,7 @@ using Android.Views;
 using Java.Lang;
 using MvvmCross.Logging;
 using Object = Java.Lang.Object;
+using MvvmCross.Platforms.Android.Views;
 
 namespace MvvmCross.Droid.Support.V4
 {
@@ -108,7 +109,7 @@ namespace MvvmCross.Droid.Support.V4
             //if fragment tag is null let's set it to something meaning full;
             if (string.IsNullOrEmpty(fragmentTag))
             {
-                fragmentTag = FragmentJavaName(fragment.GetType());
+                fragmentTag = fragment.GetType().FragmentJavaName();
             }
 
 #if DEBUG
@@ -124,11 +125,6 @@ namespace MvvmCross.Droid.Support.V4
             _curTransaction.Add(container.Id, fragment, fragmentTag);
 
             return fragment;
-        }
-
-        protected string FragmentJavaName(Type fragmentType)
-        {
-            return Class.FromType(fragmentType).Name;
         }
 
         public override bool IsViewFromObject(View view, Object objectValue)

--- a/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
@@ -44,7 +44,7 @@ namespace MvvmCross.Droid.Support.V4
         public override Fragment GetItem(int position, Fragment.SavedState fragmentSavedState = null)
         {
             var fragInfo = FragmentsInfo.ElementAt(position);
-            var fragment = Fragment.Instantiate(_context, FragmentJavaName(fragInfo.FragmentType));
+            var fragment = Fragment.Instantiate(_context, fragInfo.FragmentType.FragmentJavaName());
 
             var mvxFragment = fragment as IMvxFragmentView;
             if (mvxFragment == null)

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
@@ -10,6 +10,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.App;
 using Java.Lang;
+using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 using String = Java.Lang.String;
@@ -44,7 +45,8 @@ namespace MvvmCross.Droid.Support.V4
 
             if (fragInfo.CachedFragment == null)
             {
-                fragInfo.CachedFragment = Fragment.Instantiate(_context, FragmentJavaName(fragInfo.FragmentType));
+                fragInfo.CachedFragment = 
+                    Fragment.Instantiate(_context, fragInfo.FragmentType.FragmentJavaName());
 
                 var fragmentAsView = (IMvxView) fragInfo.CachedFragment;
 
@@ -53,11 +55,6 @@ namespace MvvmCross.Droid.Support.V4
             }
 
             return fragInfo.CachedFragment;
-        }
-
-        protected static string FragmentJavaName(Type fragmentType)
-        {
-            return Class.FromType(fragmentType).Name;
         }
 
         public override ICharSequence GetPageTitleFormatted(int position)

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,6 +10,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.App;
 using Java.Lang;
+using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 using String = Java.Lang.String;
@@ -44,7 +45,8 @@ namespace MvvmCross.Droid.Support.V4
 
             if (fragInfo.CachedFragment == null)
             {
-                fragInfo.CachedFragment = Fragment.Instantiate(_context, FragmentJavaName(fragInfo.FragmentType));
+                fragInfo.CachedFragment = 
+                    Fragment.Instantiate(_context, fragInfo.FragmentType.FragmentJavaName());
 
                 var fragmentAsView = (IMvxView)fragInfo.CachedFragment;
 
@@ -53,11 +55,6 @@ namespace MvvmCross.Droid.Support.V4
             }
 
             return fragInfo.CachedFragment;
-        }
-
-        protected static string FragmentJavaName(Type fragmentType)
-        {
-            return Class.FromType(fragmentType).Name;
         }
 
         public override ICharSequence GetPageTitleFormatted(int position)

--- a/MvvmCross.Android.Support/Fragment/MvxTabsFragmentActivity.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxTabsFragmentActivity.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,9 +11,9 @@ using Android.Runtime;
 using Android.Support.V4.App;
 using Android.Views;
 using Android.Widget;
-using Java.Lang;
 using MvvmCross.Base;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 using Object = Java.Lang.Object;
 
@@ -176,9 +176,10 @@ namespace MvvmCross.Droid.Support.V4
                 {
                     if (newTab.CachedFragment == null)
                     {
-                        newTab.CachedFragment = Fragment.Instantiate(this,
-                                                                     FragmentJavaName(newTab.FragmentType),
-                                                                     newTab.Bundle);
+                        newTab.CachedFragment =
+                            Fragment.Instantiate(
+                                this, newTab.FragmentType.FragmentJavaName(), newTab.Bundle);
+
                         FixupDataContext(newTab);
                         ft.Add(_tabContentId, newTab.CachedFragment, newTab.Tag);
                     }
@@ -203,11 +204,6 @@ namespace MvvmCross.Droid.Support.V4
 
             if (consumer.DataContext != newTab.ViewModel)
                 consumer.DataContext = newTab.ViewModel;
-        }
-
-        protected virtual string FragmentJavaName(Type fragmentType)
-        {
-            return Class.FromType(fragmentType).Name;
         }
 
         public virtual void OnTabFragmentChanging(string tag, FragmentTransaction transaction)

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -267,7 +267,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             MvxFragmentPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            var fragmentName = FragmentJavaName(attribute.ViewType);
+            var fragmentName = attribute.ViewType.FragmentJavaName();
 
             IMvxFragmentView fragment = null;
             if (attribute.IsCacheableFragment)
@@ -369,7 +369,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
            MvxDialogFragmentPresentationAttribute attribute,
            MvxViewModelRequest request)
         {
-            var fragmentName = FragmentJavaName(attribute.ViewType);
+            var fragmentName = attribute.ViewType.FragmentJavaName();
             IMvxFragmentView mvxFragmentView = CreateFragment(attribute, fragmentName);
             var dialog = mvxFragmentView as DialogFragment;
             if (dialog == null)
@@ -515,7 +515,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         #region Close implementations
         protected override Task<bool> CloseFragmentDialog(IMvxViewModel viewModel, MvxDialogFragmentPresentationAttribute attribute)
         {
-            string tag = FragmentJavaName(attribute.ViewType);
+            string tag = attribute.ViewType.FragmentJavaName();
             var toClose = CurrentFragmentManager.FindFragmentByTag(tag);
             if (toClose != null && toClose is DialogFragment dialog)
             {
@@ -601,7 +601,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             FragmentManager fragmentManager,
             MvxFragmentPresentationAttribute fragmentAttribute)
         {
-            var fragmentName = FragmentJavaName(fragmentAttribute.ViewType);
+            var fragmentName = fragmentAttribute.ViewType.FragmentJavaName();
 
             if (fragmentManager.BackStackEntryCount > 0)
             {
@@ -652,7 +652,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected virtual new Fragment GetFragmentByViewType(Type type)
         {
-            var fragmentName = FragmentJavaName(type);
+            var fragmentName = type.FragmentJavaName();
             var fragment = CurrentFragmentManager?.FindFragmentByTag(fragmentName);
 
             if (fragment != null)

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -12,7 +12,6 @@ using Android.Content;
 using Android.OS;
 using Android.Util;
 using Android.Views;
-using Java.Lang;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
 using MvvmCross.Platforms.Android.Core;
@@ -360,7 +359,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             MvxFragmentPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            var fragmentName = FragmentJavaName(attribute.ViewType);
+            var fragmentName = attribute.ViewType.FragmentJavaName();
 
             IMvxFragmentView fragment = null;
             if (attribute.IsCacheableFragment)
@@ -463,7 +462,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             MvxDialogFragmentPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
-            var fragmentName = FragmentJavaName(attribute.ViewType);
+            var fragmentName = attribute.ViewType.FragmentJavaName();
             IMvxFragmentView mvxFragmentView = CreateFragment(attribute, fragmentName);
             var dialog = (DialogFragment)mvxFragmentView;
 
@@ -525,7 +524,7 @@ namespace MvvmCross.Platforms.Android.Presenters
 
         protected virtual Task<bool> CloseFragmentDialog(IMvxViewModel viewModel, MvxDialogFragmentPresentationAttribute attribute)
         {
-            string tag = FragmentJavaName(attribute.ViewType);
+            string tag = attribute.ViewType.FragmentJavaName();
             var toClose = CurrentFragmentManager.FindFragmentByTag(tag);
             if (toClose != null && toClose is DialogFragment dialog)
             {
@@ -575,7 +574,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             FragmentManager fragmentManager,
             MvxFragmentPresentationAttribute fragmentAttribute)
         {
-            var fragmentName = FragmentJavaName(fragmentAttribute.ViewType);
+            var fragmentName = fragmentAttribute.ViewType.FragmentJavaName();
 
             if (fragmentManager.BackStackEntryCount > 0)
             {
@@ -609,11 +608,6 @@ namespace MvvmCross.Platforms.Android.Presenters
         }
         #endregion
 
-        protected virtual string FragmentJavaName(Type fragmentType)
-        {
-            return Class.FromType(fragmentType).Name;
-        }
-
         protected virtual IMvxFragmentView CreateFragment(MvxBasePresentationAttribute attribute,
             string fragmentName)
         {
@@ -630,7 +624,7 @@ namespace MvvmCross.Platforms.Android.Presenters
 
         protected virtual Fragment GetFragmentByViewType(Type type)
         {
-            var fragmentName = FragmentJavaName(type);
+            var fragmentName = type.FragmentJavaName();
             var fragment = CurrentFragmentManager?.FindFragmentByTag(fragmentName);
 
             if (fragment != null)

--- a/MvvmCross/Platforms/Android/Views/MvxFragmentExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxFragmentExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -86,6 +86,11 @@ namespace MvvmCross.Platforms.Android.Views
             {
                 throw exception.MvxWrap("Problem running viewModel lifecycle of type {0}", viewModel.GetType().Name);
             }
+        }
+
+        public static string FragmentJavaName(this Type fragmentType)
+        {
+            return Java.Lang.Class.FromType(fragmentType).Name;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bugfix

### :arrow_heading_down: What is the current behavior?
Implementations spread all over

### :new: What is the new behavior (if this is a feature change)?
One extension method used every place needed

### :boom: Does this PR introduce a breaking change?
Kind of. We had `FragmentJavaName` virtuals in classes that used them before. However, I highly doubt anyone ever overrides this.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
