### PR TITLE
Added a protected FrameworkElementsDictionary property to MvxWpfViewP…

### DIFF
--- a/MvvmCross/Platforms/Wpf/Presenters/MvxWpfViewPresenter.cs
+++ b/MvvmCross/Platforms/Wpf/Presenters/MvxWpfViewPresenter.cs
@@ -31,10 +31,15 @@ namespace MvvmCross.Platforms.Wpf.Presenters
             }
         }
 
-        private readonly Dictionary<ContentControl, Stack<FrameworkElement>> _frameworkElementsDictionary = new Dictionary<ContentControl, Stack<FrameworkElement>>();
+        private Dictionary<ContentControl, Stack<FrameworkElement>> _frameworkElementsDictionary;
         protected Dictionary<ContentControl, Stack<FrameworkElement>> FrameworkElementsDictionary
         {
-            get { return _frameworkElementsDictionary; }
+            get
+            {
+                if (_frameworkElementsDictionary == null)
+                    _frameworkElementsDictionary = new Dictionary<ContentControl, Stack<FrameworkElement>>();
+                return _frameworkElementsDictionary;
+            }
         }
 
         protected MvxWpfViewPresenter()
@@ -46,7 +51,7 @@ namespace MvvmCross.Platforms.Wpf.Presenters
             if (contentControl is Window window)
                 window.Closed += Window_Closed;
 
-            _frameworkElementsDictionary.Add(contentControl, new Stack<FrameworkElement>());
+            FrameworkElementsDictionary.Add(contentControl, new Stack<FrameworkElement>());
         }
 
         public override void RegisterAttributeTypes()
@@ -143,11 +148,11 @@ namespace MvvmCross.Platforms.Wpf.Presenters
                 };
             }
             window.Closed += Window_Closed;
-            _frameworkElementsDictionary.Add(window, new Stack<FrameworkElement>());
+            FrameworkElementsDictionary.Add(window, new Stack<FrameworkElement>());
 
             if (!(element is Window))
             {
-                _frameworkElementsDictionary[window].Push(element);
+                FrameworkElementsDictionary[window].Push(element);
                 window.Content = element;
             }
 
@@ -163,18 +168,18 @@ namespace MvvmCross.Platforms.Wpf.Presenters
             var window = sender as Window;
             window.Closed -= Window_Closed;
 
-            if (_frameworkElementsDictionary.ContainsKey(window))
-                _frameworkElementsDictionary.Remove(window);
+            if (FrameworkElementsDictionary.ContainsKey(window))
+                FrameworkElementsDictionary.Remove(window);
         }
 
         protected virtual Task<bool> ShowContentView(FrameworkElement element, MvxContentPresentationAttribute attribute, MvxViewModelRequest request)
         {
-            var contentControl = _frameworkElementsDictionary.Keys.FirstOrDefault(w => (w as MvxWindow)?.Identifier == attribute.WindowIdentifier) ?? _frameworkElementsDictionary.Keys.Last();
+            var contentControl = FrameworkElementsDictionary.Keys.FirstOrDefault(w => (w as MvxWindow)?.Identifier == attribute.WindowIdentifier) ?? FrameworkElementsDictionary.Keys.Last();
 
-            if (!attribute.StackNavigation && _frameworkElementsDictionary[contentControl].Any())
-                _frameworkElementsDictionary[contentControl].Pop(); // Close previous view
+            if (!attribute.StackNavigation && FrameworkElementsDictionary[contentControl].Any())
+                FrameworkElementsDictionary[contentControl].Pop(); // Close previous view
 
-            _frameworkElementsDictionary[contentControl].Push(element);
+            FrameworkElementsDictionary[contentControl].Push(element);
             contentControl.Content = element;
             return Task.FromResult(true);
         }
@@ -182,11 +187,11 @@ namespace MvvmCross.Platforms.Wpf.Presenters
         public override async Task<bool> Close(IMvxViewModel toClose)
         {
             // toClose is window
-            if (_frameworkElementsDictionary.Any(i => (i.Key as IMvxWpfView)?.ViewModel == toClose) && await CloseWindow(toClose))
+            if (FrameworkElementsDictionary.Any(i => (i.Key as IMvxWpfView)?.ViewModel == toClose) && await CloseWindow(toClose))
                 return true;
 
             // toClose is content
-            if (_frameworkElementsDictionary.Any(i => i.Value.Any() && (i.Value.Peek() as IMvxWpfView)?.ViewModel == toClose) && await CloseContentView(toClose))
+            if (FrameworkElementsDictionary.Any(i => i.Value.Any() && (i.Value.Peek() as IMvxWpfView)?.ViewModel == toClose) && await CloseContentView(toClose))
                 return true;
 
             MvxLog.Instance.Warn($"Could not close ViewModel type {toClose.GetType().Name}");
@@ -195,11 +200,11 @@ namespace MvvmCross.Platforms.Wpf.Presenters
 
         protected virtual Task<bool> CloseWindow(IMvxViewModel toClose)
         {
-            var item = _frameworkElementsDictionary.FirstOrDefault(i => (i.Key as IMvxWpfView)?.ViewModel == toClose);
+            var item = FrameworkElementsDictionary.FirstOrDefault(i => (i.Key as IMvxWpfView)?.ViewModel == toClose);
             var contentControl = item.Key;
             if (contentControl is Window window)
             {
-                _frameworkElementsDictionary.Remove(window);
+                FrameworkElementsDictionary.Remove(window);
                 window.Close();
                 return Task.FromResult(true);
             }
@@ -209,7 +214,7 @@ namespace MvvmCross.Platforms.Wpf.Presenters
 
         protected virtual Task<bool> CloseContentView(IMvxViewModel toClose)
         {
-            var item = _frameworkElementsDictionary.FirstOrDefault(i => i.Value.Any() && (i.Value.Peek() as IMvxWpfView)?.ViewModel == toClose);
+            var item = FrameworkElementsDictionary.FirstOrDefault(i => i.Value.Any() && (i.Value.Peek() as IMvxWpfView)?.ViewModel == toClose);
             var contentControl = item.Key;
             var elements = item.Value;
 
@@ -225,7 +230,7 @@ namespace MvvmCross.Platforms.Wpf.Presenters
             // Close window if no contents
             if (contentControl is Window window)
             {
-                _frameworkElementsDictionary.Remove(window);
+                FrameworkElementsDictionary.Remove(window);
                 window.Close();
                 return Task.FromResult(true);
             }

--- a/MvvmCross/Platforms/Wpf/Presenters/MvxWpfViewPresenter.cs
+++ b/MvvmCross/Platforms/Wpf/Presenters/MvxWpfViewPresenter.cs
@@ -32,6 +32,10 @@ namespace MvvmCross.Platforms.Wpf.Presenters
         }
 
         private readonly Dictionary<ContentControl, Stack<FrameworkElement>> _frameworkElementsDictionary = new Dictionary<ContentControl, Stack<FrameworkElement>>();
+        protected Dictionary<ContentControl, Stack<FrameworkElement>> FrameworkElementsDictionary
+        {
+            get { return _frameworkElementsDictionary; }
+        }
 
         protected MvxWpfViewPresenter()
         {


### PR DESCRIPTION
…resenter.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds protected property `FrameworkElementsDictionary` to `MvxWpfViewPresenter` so that custom presenters deriving from it can use it. Required for custom `MvxMultiRegionWpfViewPresenter` that supports multiple windows. Also makes it obsolete to hold extra copies of `contentControl` constructor argument value in subclasses.

### :arrow_heading_down: What is the current behavior?
The private property `_frameworkElementsDictionary` isn't available to presenters subclassing `MvxWpfViewPresenter`.

### :new: What is the new behavior (if this is a feature change)?
The new protected property `FrameworkElementsDictionary` is added to `MvxWpfViewPresenter` so that custom presenters deriving from it can use it.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/3121

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop

