### PR TITLE
Add ability to use tags from attributes

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -22,7 +22,7 @@
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' and '$(IsTestProject)' != 'true'">true</GeneratePackageOnBuild>
     
     <Platform>AnyCPU</Platform>
-    <DebugType>embedded</DebugType>
+    <DebugType>portable</DebugType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     

--- a/MvvmCross.Android.Support/Fragment/MvxViewPagerFragmentInfo.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxViewPagerFragmentInfo.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Android.Support.V4.App;
+using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Droid.Support.V4
@@ -19,7 +20,7 @@ namespace MvvmCross.Droid.Support.V4
                             object parameterValuesObject = null)
         {
             Title = title;
-            Tag = tag ?? title;
+            Tag = tag ?? fragmentType.FragmentJavaName();
             FragmentType = fragmentType;
             ViewModelType = viewModelType;
             ParameterValuesObject = parameterValuesObject;

--- a/MvvmCross.Android.Support/Fragment/MvxViewPagerFragmentInfo.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxViewPagerFragmentInfo.cs
@@ -4,35 +4,24 @@
 
 using System;
 using Android.Support.V4.App;
-using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Droid.Support.V4
 {
     public class MvxViewPagerFragmentInfo
     {
-        public MvxViewPagerFragmentInfo(string title, Type fragmentType, Type viewModelType, object parameterValuesObject = null)
-            : this(title, null, fragmentType, viewModelType, parameterValuesObject)
-        {
-        }
-
         public MvxViewPagerFragmentInfo(string title, string tag, Type fragmentType, Type viewModelType,
-                            object parameterValuesObject = null)
+            object parameterValuesObject = null)
         {
             Title = title;
-            Tag = tag ?? fragmentType.FragmentJavaName();
+            Tag = tag;
             FragmentType = fragmentType;
             ViewModelType = viewModelType;
             ParameterValuesObject = parameterValuesObject;
         }
 
-        public MvxViewPagerFragmentInfo(string title, Type fragmentType, IMvxViewModel viewModel, object parameterValuesObject = null)
-            : this(title, null, fragmentType, viewModel.GetType(), parameterValuesObject)
-        {
-            ViewModel = viewModel;
-        }
-
-        public MvxViewPagerFragmentInfo(string title, string tag, Type fragmentType, IMvxViewModel viewModel, object parameterValuesObject = null)
+        public MvxViewPagerFragmentInfo(string title, string tag, Type fragmentType, 
+            IMvxViewModel viewModel, object parameterValuesObject = null)
             : this(title, tag, fragmentType, viewModel.GetType(), parameterValuesObject)
         {
             ViewModel = viewModel;

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -269,11 +269,12 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             MvxViewModelRequest request)
         {
             var fragmentName = attribute.ViewType.FragmentJavaName();
+            var tag = attribute.Tag ?? fragmentName;
 
             IMvxFragmentView fragment = null;
             if (attribute.IsCacheableFragment)
             {
-                fragment = (IMvxFragmentView)fragmentManager.FindFragmentByTag(fragmentName);
+                fragment = (IMvxFragmentView)fragmentManager.FindFragmentByTag(tag);
             }
             fragment = fragment ?? CreateFragment(attribute, fragmentName);
 
@@ -312,7 +313,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             OnFragmentChanging(ft, fragmentView, attribute, request);
 
-            ft.Replace(attribute.FragmentContentId, (Fragment)fragment, fragmentName);
+            ft.Replace(attribute.FragmentContentId, (Fragment)fragment, tag);
             ft.CommitAllowingStateLoss();
 
             OnFragmentChanged(ft, fragmentView, attribute, request);
@@ -371,6 +372,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
            MvxViewModelRequest request)
         {
             var fragmentName = attribute.ViewType.FragmentJavaName();
+            var tag = attribute.Tag ?? fragmentName;
+
             IMvxFragmentView mvxFragmentView = CreateFragment(attribute, fragmentName);
             var dialog = mvxFragmentView as DialogFragment;
             if (dialog == null)
@@ -400,7 +403,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             OnFragmentChanging(ft, dialog, attribute, request);
 
-            dialog.Show(ft, fragmentName);
+            dialog.Show(ft, tag);
 
             OnFragmentChanged(ft, dialog, attribute, request);
             return Task.FromResult(true);
@@ -426,7 +429,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                     throw new MvxException("Fragment not found", attribute.FragmentHostViewType.Name);
 
                 if(fragment.View == null)
-                    throw new MvxException("Fragment.View is null. Please consider calling Navigate later in your code", attribute.FragmentHostViewType.Name);
+                    throw new MvxException("Fragment.View is null. Please consider calling Navigate later in your code", 
+                        attribute.FragmentHostViewType.Name);
 
                 viewPager = fragment.View.FindViewById<ViewPager>(attribute.ViewPagerResourceId);
                 fragmentManager = fragment.ChildFragmentManager;
@@ -521,7 +525,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         #region Close implementations
         protected override Task<bool> CloseFragmentDialog(IMvxViewModel viewModel, MvxDialogFragmentPresentationAttribute attribute)
         {
-            string tag = attribute.ViewType.FragmentJavaName();
+            var fragmentName = attribute.ViewType.FragmentJavaName();
+            var tag = attribute.Tag ?? fragmentName;
             var toClose = CurrentFragmentManager.FindFragmentByTag(tag);
             if (toClose != null && toClose is DialogFragment dialog)
             {
@@ -627,6 +632,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             MvxFragmentPresentationAttribute fragmentAttribute)
         {
             var fragmentName = fragmentAttribute.ViewType.FragmentJavaName();
+            var tag = fragmentAttribute.Tag ?? fragmentName;
 
             if (fragmentManager.BackStackEntryCount > 0)
             {
@@ -635,10 +641,10 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
                 return true;
             }
-            else if (fragmentManager.Fragments.Count > 0 && fragmentManager.FindFragmentByTag(fragmentName) != null)
+            else if (fragmentManager.Fragments.Count > 0 && fragmentManager.FindFragmentByTag(tag) != null)
             {
                 var ft = fragmentManager.BeginTransaction();
-                var fragment = fragmentManager.FindFragmentByTag(fragmentName);
+                var fragment = fragmentManager.FindFragmentByTag(tag);
 
                 if (!fragmentAttribute.EnterAnimation.Equals(int.MinValue) && !fragmentAttribute.ExitAnimation.Equals(int.MinValue))
                 {

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -583,9 +583,19 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             if (fragmentInfo == null)
             {
-                fragmentInfo = adapter.FragmentsInfo.Find(x =>
-                x.FragmentType == attribute.ViewType &&
-                x.ViewModelType == attribute.ViewModelType);
+                bool IsMatch(MvxViewPagerFragmentInfo info)
+                {
+                    if (attribute.ViewType == null) return false;
+
+                    var viewTypeMatches = info.FragmentType == attribute.ViewType;
+
+                    if (attribute.ViewModelType != null)
+                        return viewTypeMatches && info.ViewModelType == attribute.ViewModelType;
+
+                    return viewTypeMatches;
+                }
+
+                fragmentInfo = adapter.FragmentsInfo.FirstOrDefault(IsMatch);
             }
 
             return fragmentInfo;

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -24,7 +24,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             int popExitAnimation = int.MinValue,
             int transitionStyle = int.MinValue,
             Type fragmentHostViewType = null,
-            bool isCacheableFragment = false
+            bool isCacheableFragment = false,
+            string tag = null
         )
         {
             ActivityHostViewModelType = activityHostViewModelType;
@@ -37,6 +38,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             TransitionStyle = transitionStyle;
             FragmentHostViewType = fragmentHostViewType;
             IsCacheableFragment = isCacheableFragment;
+            Tag = tag;
         }
 
         public MvxFragmentPresentationAttribute(
@@ -49,7 +51,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             string popExitAnimation = null,
             string transitionStyle = null,
             Type fragmentHostViewType = null,
-            bool isCacheableFragment = false
+            bool isCacheableFragment = false,
+            string tag = null
         )
         {
             var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
@@ -64,6 +67,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             TransitionStyle = !string.IsNullOrEmpty(transitionStyle) ? context.Resources.GetIdentifier(transitionStyle, "style", context.PackageName) : int.MinValue;
             FragmentHostViewType = fragmentHostViewType;
             IsCacheableFragment = isCacheableFragment;
+            Tag = tag;
         }
 
         /// <summary>
@@ -116,5 +120,10 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
         /// Indicates if the fragment can be cached. False by default.
         /// </summary>
         public bool IsCacheableFragment { get; set; } = DefaultIsCacheableFragment;
+
+        /// <summary>
+        /// Tag for the Fragment. Used in transactions and for finding the Fragment at a later time
+        /// </summary>
+        public string Tag { get; set; }
     }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxViewPagerFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxViewPagerFragmentPresentationAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,9 +15,10 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
 
         public MvxViewPagerFragmentPresentationAttribute(string title, int viewPagerResourceId,
             Type activityHostViewModelType = null, bool addToBackStack = false, Type fragmentHostViewType = null,
-            bool isCacheableFragment = false) : base(activityHostViewModelType, int.MinValue, addToBackStack,
-            int.MinValue, int.MinValue, int.MinValue, int.MinValue, int.MinValue, fragmentHostViewType,
-            isCacheableFragment)
+            bool isCacheableFragment = false, string tag = null) 
+            : base(activityHostViewModelType, int.MinValue, addToBackStack, 
+                  int.MinValue, int.MinValue, int.MinValue, int.MinValue, int.MinValue, fragmentHostViewType, 
+                  isCacheableFragment, tag)
         {
             Title = title;
             ViewPagerResourceId = viewPagerResourceId;
@@ -25,8 +26,9 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
 
         public MvxViewPagerFragmentPresentationAttribute(string title, string viewPagerResourceName,
             Type activityHostViewModelType = null, bool addToBackStack = false, Type fragmentHostViewType = null,
-            bool isCacheableFragment = false) : base(activityHostViewModelType, null, addToBackStack, null, null, null,
-            null, null, fragmentHostViewType, isCacheableFragment)
+            bool isCacheableFragment = false, string tag = null) 
+            : base(activityHostViewModelType, null, addToBackStack, null, null, null,
+                null, null, fragmentHostViewType, isCacheableFragment, tag)
         {
             var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
 
@@ -37,12 +39,12 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
         }
 
         /// <summary>
-        ///     The title for the ViewPager. Also used as Title for TabLayout when using MvxTabLayoutPresentationAttribute
+        /// The title for the ViewPager. Also used as Title for TabLayout when using MvxTabLayoutPresentationAttribute
         /// </summary>
         public string Title { get; set; }
 
         /// <summary>
-        ///     The resource used to get the ViewPager from the view
+        /// The resource used to get the ViewPager from the view
         /// </summary>
         public int ViewPagerResourceId { get; set; }
     }

--- a/build.cake
+++ b/build.cake
@@ -106,8 +106,6 @@ Task("Build")
     .Does(() =>  {
 
     var settings = GetDefaultBuildSettings()
-        .WithProperty("DebugSymbols", "True")
-        .WithProperty("DebugType", "Embedded")
         .WithProperty("Version", versionInfo.SemVer)
         .WithProperty("PackageVersion", versionInfo.SemVer)
         .WithProperty("InformationalVersion", versionInfo.InformationalVersion)

--- a/docs/_documentation/platform/android/android-view-presenter.md
+++ b/docs/_documentation/platform/android/android-view-presenter.md
@@ -56,6 +56,7 @@ Use this attribute over a Fragment view class and customize its presentation by 
 | PopExitAnimation | `int` | Resource id for the animation that will be run when the fragment is retrieved from foreground. |
 | TransitionStyle | `int` | In case you want to use a Transition Style, use this property by setting its resource id. |
 | IsCacheableFragment | `bool` | Default value is false. You should leave it that way unless you really want/need to reuse a fragment view (for example, in case you are displaying a WebView, you might want to cache the already loaded URL). If it is set to `true`, the ViewPresenter will try to find a Fragment instance already present in the FragmentManager object before instantiating a new one and will reuse that object. |
+| Tag | `string` | Tag to use for the Fragment. The presenter uses this to add fragments to the fragment transactions and to find fragments again later. This is useful to use, if you want to use the same fragment in the same view multiple times. In such cases you would need to provide your own tag for each instance. Defaults to the Java class name of the Fragment. |
 
 When providing a value for EnterAnimation you need to provide one for ExitAnimation as well, otherwise the animation won't work (same applies in the other way around). 
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix/feature

When customizing the AppCompat presenters on Android, it is unclear how tags are set on ViewPager fragments, since there is a default fallback to title. So this PR removes the overload constructors which do the fallback, so the presenter does this more explicitly now.

This PR also adds the ability to set a tag in the presentation attributes on Android, such that it eases reuse of fragment classes that use different viewmodels. Because fallback tag before was simply the title.

Default tag if not set in the attribute is now the java class name for the fragment.

### :boom: Does this PR introduce a breaking change?
Not really, adds a tag argument on the presentation attribute on fragments.

### :bug: Recommendations for testing
Navigate between fragments.

Test change presentation i.e. for navigating between tabs

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
