### PR TITLE
Added constructor with MvxBundle argument to MvxPopToRootPresentation…

### DIFF
--- a/MvvmCross/Presenters/Hints/MvxPopToRootPresentationHint.cs
+++ b/MvvmCross/Presenters/Hints/MvxPopToRootPresentationHint.cs
@@ -14,6 +14,10 @@ namespace MvvmCross.Presenters.Hints
             Animated = animated;
         }
 
+        public MvxPopToRootPresentationHint(MvxBundle body, bool animated = true) : this(animated)
+        {
+        }
+
         public bool Animated { get; set; }
     }
 }

--- a/MvvmCross/Presenters/Hints/MvxPopToRootPresentationHint.cs
+++ b/MvvmCross/Presenters/Hints/MvxPopToRootPresentationHint.cs
@@ -14,8 +14,9 @@ namespace MvvmCross.Presenters.Hints
             Animated = animated;
         }
 
-        public MvxPopToRootPresentationHint(MvxBundle body, bool animated = true) : this(animated)
+        public MvxPopToRootPresentationHint(MvxBundle body, bool animated = true) : base(body)
         {
+            Animated = animated;
         }
 
         public bool Animated { get; set; }


### PR DESCRIPTION
…Hint.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Added constructor with `MvxBundle` argument to `MvxPopToRootPresentation`…
Since `MvxPopToRootPresentation` is-a `MvxPresentationHint`  one should be able to somehow set the `Body` property. Functionality useful in multi-window scenarios.

### :arrow_heading_down: What is the current behavior?
No way to set `Body` property of `MvxPopToRootPresentation` instance.

### :new: What is the new behavior (if this is a feature change)?
An `MvxBundle` instance can be given as an argument via the added constructor.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/3134

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
