### PR TITLE
Fix circular references for UITableView and UICollectionView

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseCollectionViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseCollectionViewSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -17,7 +17,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
         public static readonly NSString UnknownCellIdentifier = null;
 
         private readonly NSString _cellIdentifier;
-        private readonly UICollectionView _collectionView;
+        [Weak] private UICollectionView _collectionView;
 
         protected virtual NSString DefaultCellIdentifier => _cellIdentifier;
 
@@ -41,7 +41,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
         {
             try
             {
-                _collectionView.ReloadData();
+                CollectionView.ReloadData();
             }
             catch (Exception exception)
             {

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,7 +14,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
 {
     public abstract class MvxBaseTableViewSource : UITableViewSource
     {
-        private readonly UITableView _tableView;
+        [Weak] private UITableView _tableView;
 
         protected MvxBaseTableViewSource(UITableView tableView)
         {
@@ -50,7 +50,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
         {
             try
             {
-                _tableView.ReloadData();
+                TableView.ReloadData();
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Both CollectionViewSource and TableViewSource have strong references to UI widgets (UICollectionView, UITableView). This creates circular references [described here](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/performance#avoid-strong-circular-references).

This is something we were missing and although nobody reported this, I remember having read some complains in the slack channel.

### :new: What is the new behavior (if this is a feature change)?
Above is fixed. Proposed solution is to use weak references through WeakAttribute, [described here](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/performance#avoid-strong-circular-references) and also in this [Xamarin University video](https://www.youtube.com/watch?v=RTfrCwO3aPI).

### :boom: Does this PR introduce a breaking change?
Not really. But this change can potentially unmask issues related to other subscriptions. For example, if the subscription for collection changes of the ItemsSource property lives longer than it should, we will now see NRE because TableView/CollectionView will be null.

### :bug: Recommendations for testing
1. Open any MvvmCross app with a ViewController containing a UITableView / CollectionView.
2. Open that ViewController, override `Dispose` and place a log call there.
3. Run the app, navigate to that ViewController, and then pop it.
4. Nothing happens!
5. Apply the same change as I did, this time `Dispose` will be called and your log will appear.

Note: If you think it's necessary to have a test scenario on the Playground project I can add it, I just didn't do it this time because my VS / VS4Mac are out of sync.

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
