### PR TITLE
Check for null before trying to Warn in ExceptionSafeGetTypes.

### DIFF
--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using MvvmCross.Exceptions;
@@ -21,8 +22,14 @@ namespace MvvmCross.IoC
             }
             catch (ReflectionTypeLoadException e)
             {
-                MvxLog.Instance.Warn("ReflectionTypeLoadException masked during loading of {0} - error {1}",
+                // MvxLog.Instance can be null, when reflecting for Setup.cs
+                // Check for null
+                MvxLog.Instance?.Warn("ReflectionTypeLoadException masked during loading of {0} - error {1}",
                     assembly.FullName, e.ToLongString());
+
+                if (Debugger.IsAttached)
+                    Debugger.Break();
+
                 return new Type[0];
             }
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Trying to write to log, when instance has not been set yet

### :new: What is the new behavior (if this is a feature change)?
No ArgumentNullException from `Warn`, because null check happens before.

Also breaks if debugger is attached. This method should really not fail.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #3149 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
