### PR TITLE
Fluent binding for WPF

### DIFF
--- a/MvvmCross/Platforms/Wpf/Views/IMvxWpfView.cs
+++ b/MvvmCross/Platforms/Wpf/Views/IMvxWpfView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 
@@ -9,6 +10,7 @@ namespace MvvmCross.Platforms.Wpf.Views
 {
     public interface IMvxWpfView
         : IMvxView
+          , IMvxBindingContextOwner
     {
     }
 

--- a/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Windows;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Wpf.Views
@@ -23,6 +24,8 @@ namespace MvvmCross.Platforms.Wpf.Views
         }
 
         public string Identifier { get; set; }
+
+        public IMvxBindingContext BindingContext { get; set; }
 
         public MvxWindow()
         {

--- a/MvvmCross/Platforms/Wpf/Views/MvxWpfView.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWpfView.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Wpf.Views
@@ -23,6 +24,8 @@ namespace MvvmCross.Platforms.Wpf.Views
             }
         }
 
+        public IMvxBindingContext BindingContext { get; set; }
+        
         public MvxWpfView()
         {
             Unloaded += MvxWpfView_Unloaded;


### PR DESCRIPTION
Mirror composition of Android view structure -- IMvxView now implements the IMvxBindingContextOwner interface.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?

The MvxWPFView differs from other views in that it does not implement IMvxBindingContextOwner, and therefore cannot use MvxInteraction when attempting to bind a WPF view to view model in the same manner.

### :new: What is the new behavior (if this is a feature change)?

Fluent binding is now capable for WPF similar to other platforms.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

[Issue #2916](https://github.com/MvvmCross/MvvmCross/issues/2916)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
