### PR TITLE
Add support for more control over Android PopBackStackImmediate on fragments

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -641,7 +641,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             if (fragmentManager.BackStackEntryCount > 0)
             {
-                var popBackStackFragmentName = fragmentAttribute.PopBackStackImmediateName == ""
+                var popBackStackFragmentName = fragmentAttribute.PopBackStackImmediateName?.Trim() == ""
                     ? fragmentName
                     : fragmentAttribute.PopBackStackImmediateName;
 

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -86,8 +86,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                         var fragmentHost = GetFragmentByViewType(item.FragmentHostViewType);
 
                         // if the fragment exists, is on top, and (has the ContentId or the attribute is for ViewPager), then use it as current attribute 
-                        if (fragmentHost != null 
-                            && fragmentHost.IsVisible 
+                        if (fragmentHost != null
+                            && fragmentHost.IsVisible
                             && (fragmentHost.View.FindViewById(item.FragmentContentId) != null || item is MvxViewPagerFragmentPresentationAttribute))
                         {
                             attribute = item;
@@ -421,11 +421,11 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             if (attribute.FragmentHostViewType != null)
             {
                 var fragment = GetFragmentByViewType(attribute.FragmentHostViewType);
-                if(fragment == null)
+                if (fragment == null)
                     throw new MvxException("Fragment not found", attribute.FragmentHostViewType.Name);
 
-                if(fragment.View == null)
-                    throw new MvxException("Fragment.View is null. Please consider calling Navigate later in your code", 
+                if (fragment.View == null)
+                    throw new MvxException("Fragment.View is null. Please consider calling Navigate later in your code",
                         attribute.FragmentHostViewType.Name);
 
                 viewPager = fragment.View.FindViewById<ViewPager>(attribute.ViewPagerResourceId);
@@ -438,7 +438,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 var currentActivityViewModelType = GetCurrentActivityViewModelType();
 
                 // if the host Activity is not the top-most Activity, then show it before proceeding, and return false for now
-                if(attribute.ActivityHostViewModelType != currentActivityViewModelType)
+                if (attribute.ActivityHostViewModelType != currentActivityViewModelType)
                 {
                     _pendingRequest = request;
                     ShowHostActivity(attribute);
@@ -477,10 +477,10 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
                 viewPager.Adapter = new MvxCachingFragmentStatePagerAdapter(CurrentActivity, fragmentManager, fragments);
             }
-        
+
             return Task.FromResult(true);
         }
-        
+
         protected virtual async Task<bool> ShowTabLayout(
             Type view,
             MvxTabLayoutPresentationAttribute attribute,
@@ -489,7 +489,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             var showViewPagerFragment = await ShowViewPagerFragment(view, attribute, request);
             if (!showViewPagerFragment)
                 return false;
-            
+
             ViewPager viewPager = null;
             TabLayout tabLayout = null;
 
@@ -511,7 +511,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             if (viewPager == null || tabLayout == null)
                 throw new MvxException("ViewPager or TabLayout not found");
-            
+
             tabLayout.SetupWithViewPager(viewPager);
             return true;
 
@@ -519,7 +519,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         #endregion
 
         #region Close implementations
-        protected override Task<bool> CloseFragmentDialog(IMvxViewModel viewModel, 
+        protected override Task<bool> CloseFragmentDialog(IMvxViewModel viewModel,
             MvxDialogFragmentPresentationAttribute attribute)
         {
             var fragmentName = attribute.ViewType.FragmentJavaName();
@@ -533,7 +533,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             return Task.FromResult(false);
         }
 
-        protected virtual Task<bool> CloseViewPagerFragment(IMvxViewModel viewModel, 
+        protected virtual Task<bool> CloseViewPagerFragment(IMvxViewModel viewModel,
             MvxViewPagerFragmentPresentationAttribute attribute)
         {
             ViewPager viewPager = null;
@@ -641,12 +641,16 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             if (fragmentManager.BackStackEntryCount > 0)
             {
-                fragmentManager.PopBackStackImmediate(fragmentName, 1);
+                var popBackStackFragmentName = fragmentAttribute.PopBackStackImmediateName == ""
+                    ? fragmentName
+                    : fragmentAttribute.PopBackStackImmediateName;
+
+                fragmentManager.PopBackStackImmediate(popBackStackFragmentName, (int)fragmentAttribute.PopBackStackImmediateFlag);
                 OnFragmentPopped(null, null, fragmentAttribute);
 
                 return true;
             }
-            
+
             if (fragmentManager.Fragments.Count > 0 && fragmentManager.FindFragmentByTag(tag) != null)
             {
                 var ft = fragmentManager.BeginTransaction();
@@ -674,8 +678,8 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
             if (attribute == null)
                 return;
-            
-            if (attribute.EnterAnimation != int.MinValue && 
+
+            if (attribute.EnterAnimation != int.MinValue &&
                 attribute.ExitAnimation != int.MinValue)
             {
                 if (attribute.PopEnterAnimation != int.MinValue &&
@@ -694,7 +698,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                         attribute.ExitAnimation);
                 }
             }
-            
+
             if (attribute.TransitionStyle != int.MinValue)
                 fragmentTransaction.SetTransitionStyle(attribute.TransitionStyle);
         }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxAndroidPresentationAttributeExtensions.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxAndroidPresentationAttributeExtensions.cs
@@ -1,13 +1,13 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;
+using Android.App;
 using MvvmCross.Logging;
 using MvvmCross.Presenters;
 using MvvmCross.ViewModels;
-using MvvmCross.Views;
 
 namespace MvvmCross.Platforms.Android.Presenters.Attributes
 {
@@ -34,6 +34,19 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             var currentAttribute = fragmentAttributes.FirstOrDefault(fragmentAttribute => fragmentAttribute.ActivityHostViewModelType == fragmentActivityParentType);
 
             return currentAttribute != null ? currentAttribute.IsCacheableFragment : false;
+        }
+
+        public static PopBackStackFlags ToNativePopBackStackFlags(this MvxPopBackStack mvxPopBackStack)
+        {
+            switch (mvxPopBackStack)
+            {
+                case MvxPopBackStack.None:
+                    return PopBackStackFlags.None;
+                case MvxPopBackStack.Inclusive:
+                    return PopBackStackFlags.Inclusive;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mvxPopBackStack), mvxPopBackStack, $"No matching {nameof(PopBackStackFlags)} enum is defined");
+            }
         }
     }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             bool isCacheableFragment = false,
             string tag = null,
             string popBackStackImmediateName = "",
-            int popBackStackImmediateFlag = 1
+            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive
         )
         {
             ActivityHostViewModelType = activityHostViewModelType;
@@ -41,6 +41,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             FragmentHostViewType = fragmentHostViewType;
             IsCacheableFragment = isCacheableFragment;
             Tag = tag;
+            PopBackStackImmediateName = popBackStackImmediateName;
+            PopBackStackImmediateFlag = popBackStackImmediateFlag;
         }
 
         public MvxFragmentPresentationAttribute(
@@ -56,7 +58,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             bool isCacheableFragment = false,
             string tag = null,
             string popBackStackImmediateName = "",
-            int popBackStackImmediateFlag = 1
+            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive
         )
         {
             var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
@@ -72,6 +74,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             FragmentHostViewType = fragmentHostViewType;
             IsCacheableFragment = isCacheableFragment;
             Tag = tag;
+            PopBackStackImmediateName = popBackStackImmediateName;
+            PopBackStackImmediateFlag = popBackStackImmediateFlag;
         }
 
         /// <summary>

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -25,7 +25,9 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             int transitionStyle = int.MinValue,
             Type fragmentHostViewType = null,
             bool isCacheableFragment = false,
-            string tag = null
+            string tag = null,
+            string popBackStackImmediateName = "",
+            int popBackStackImmediateFlag = 1
         )
         {
             ActivityHostViewModelType = activityHostViewModelType;
@@ -52,7 +54,9 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             string transitionStyle = null,
             Type fragmentHostViewType = null,
             bool isCacheableFragment = false,
-            string tag = null
+            string tag = null,
+            string popBackStackImmediateName = "",
+            int popBackStackImmediateFlag = 1
         )
         {
             var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
@@ -125,5 +129,19 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
         /// Tag for the Fragment. Used in transactions and for finding the Fragment at a later time
         /// </summary>
         public string Tag { get; set; }
+
+        public static string DefaultPopBackStackImmediateName = "";
+        /// <summary>
+        /// The name to be passed into PopBackStackImmediate.
+        /// Assigning an empty string will default to using the FragmentJavaName
+        /// Assigning a null will pop the top fragment
+        /// </summary>
+        public string PopBackStackImmediateName { get; set; } = DefaultPopBackStackImmediateName;
+
+        public static MvxPopBackStack DefaultPopBackStackImmediateFlag = MvxPopBackStack.Inclusive;
+        /// <summary>
+        /// Flag to be used with PopBackStackImmediate. 
+        /// </summary>
+        public MvxPopBackStack PopBackStackImmediateFlag { get; set; } = DefaultPopBackStackImmediateFlag;
     }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxPopBackStack.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxPopBackStack.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.Platforms.Android.Presenters.Attributes
+{
+    public enum MvxPopBackStack
+    {
+        /// <summary>
+        /// All entries up to but not including that entry will be removed.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// All matching entries will be consumed until one that doesn't match is found or the bottom of the stack is reached.
+        /// </summary>
+        Inclusive = 1
+    }
+}

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -568,7 +568,7 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             if (fragmentManager.BackStackEntryCount > 0)
             {
-                var popBackStackFragmentName = fragmentAttribute.PopBackStackImmediateName == "" 
+                var popBackStackFragmentName = fragmentAttribute.PopBackStackImmediateName?.Trim() == "" 
                     ? fragmentName 
                     : fragmentAttribute.PopBackStackImmediateName;
 

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -568,7 +568,11 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             if (fragmentManager.BackStackEntryCount > 0)
             {
-                fragmentManager.PopBackStackImmediate(fragmentName, PopBackStackFlags.Inclusive);
+                var popBackStackFragmentName = fragmentAttribute.PopBackStackImmediateName == "" 
+                    ? fragmentName 
+                    : fragmentAttribute.PopBackStackImmediateName;
+
+                fragmentManager.PopBackStackImmediate(popBackStackFragmentName, fragmentAttribute.PopBackStackImmediateFlag.ToNativePopBackStackFlags());
 
                 OnFragmentPopped(null, null, fragmentAttribute);
                 return true;

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/FragmentCloseViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/FragmentCloseViewModel.cs
@@ -1,0 +1,30 @@
+﻿using MvvmCross.Commands;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+
+namespace Playground.Core.ViewModels.Navigation
+{
+    public class FragmentCloseViewModel : BaseViewModel
+    {
+        private static int _counter = 0;
+
+        public FragmentCloseViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService)
+            : base(logProvider, navigationService)
+        {
+            ForwardCommand = new MvxAsyncCommand(() => NavigationService.Navigate<FragmentCloseViewModel>());
+            CloseCommand = new MvxAsyncCommand(() => NavigationService.Close(this));
+
+            Description = $"View number {_counter++}";
+        }
+
+        private string _description;
+        public string Description
+        {
+            get => _description;
+            set => SetProperty(ref _description, value);
+        }
+
+        public IMvxAsyncCommand ForwardCommand { get; }
+        public IMvxAsyncCommand CloseCommand { get; }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,6 +15,7 @@ using MvvmCross.Plugin.Network.Rest;
 using MvvmCross.ViewModels;
 using Playground.Core.Models;
 using Playground.Core.ViewModels.Bindings;
+using Playground.Core.ViewModels.Navigation;
 using Playground.Core.ViewModels.Samples;
 
 namespace Playground.Core.ViewModels
@@ -95,6 +96,8 @@ namespace Playground.Core.ViewModels
 
             TriggerVisibilityCommand =
                 new MvxCommand(() => IsVisible = !IsVisible);
+
+            FragmentCloseCommand = new MvxAsyncCommand(() => NavigationService.Navigate<FragmentCloseViewModel>());
         }
 
         public MvxNotifyTask MyTask { get; set; }
@@ -145,6 +148,8 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowFluentBindingCommand { get; }
 
         public IMvxCommand TriggerVisibilityCommand { get; }
+
+        public IMvxCommand FragmentCloseCommand { get; }
 
         private bool _isVisible;
         public bool IsVisible

--- a/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
@@ -1,0 +1,24 @@
+﻿using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Core.ViewModels;
+using Playground.Core.ViewModels.Navigation;
+
+namespace Playground.Droid.Fragments
+{
+    [Register(nameof(FragmentCloseView))]
+    //[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true)]
+    [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true, popBackStackImmediateName: null, popBackStackImmediateFlag: MvxPopBackStack.None)]
+    class FragmentCloseView : MvxFragment<FragmentCloseViewModel>
+    {
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            return this.BindingInflate(Resource.Layout.FragmnetCloseView, null);
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Controls\BinaryEdit.cs" />
     <Compile Include="Fragments\BaseSplitDetailView.cs" />
     <Compile Include="Fragments\FluentBindingView.cs" />
+    <Compile Include="Fragments\FragmentCloseView.cs" />
     <Compile Include="Fragments\TabsRootBView.cs" />
     <Compile Include="LinkerPleaseInclude.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
@@ -227,6 +228,12 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\FluentBindingView.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\FragmnetCloseView.axml">
+      <Generator>MSBuild:UpdateGeneratedFiles</Generator>
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>

--- a/Projects/Playground/Playground.Droid/Resources/layout/FragmnetCloseView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/FragmnetCloseView.axml
@@ -13,7 +13,7 @@
     <Button
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Forward - Default Pop"
+        android:text="Forward"
         local:MvxBind="Click ForwardCommand" />
     <Button
         android:layout_width="match_parent"

--- a/Projects/Playground/Playground.Droid/Resources/layout/FragmnetCloseView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/FragmnetCloseView.axml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/margin_medium">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        local:MvxBind="Text Description"/>
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Forward - Default Pop"
+        local:MvxBind="Click ForwardCommand" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Close"
+        local:MvxBind="Click CloseCommand" />
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/RootView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/RootView.axml
@@ -86,6 +86,12 @@
                 android:layout_marginTop="10dp"
                 android:text="Show Fluent Binding Example"
                 local:MvxBind="Click ShowFluentBindingCommand" />
+             <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Show Fragment Close Example"
+                local:MvxBind="Click FragmentCloseCommand" />
         </LinearLayout>
     </ScrollView>
     <FrameLayout

--- a/docs/_documentation/platform/android/android-view-presenter.md
+++ b/docs/_documentation/platform/android/android-view-presenter.md
@@ -57,6 +57,8 @@ Use this attribute over a Fragment view class and customize its presentation by 
 | TransitionStyle | `int` | In case you want to use a Transition Style, use this property by setting its resource id. |
 | IsCacheableFragment | `bool` | Default value is false. You should leave it that way unless you really want/need to reuse a fragment view (for example, in case you are displaying a WebView, you might want to cache the already loaded URL). If it is set to `true`, the ViewPresenter will try to find a Fragment instance already present in the FragmentManager object before instantiating a new one and will reuse that object. |
 | Tag | `string` | Tag to use for the Fragment. The presenter uses this to add fragments to the fragment transactions and to find fragments again later. This is useful to use, if you want to use the same fragment in the same view multiple times. In such cases you would need to provide your own tag for each instance. Defaults to the Java class name of the Fragment. |
+| PopBackStackImmediateName  | `string` | The name to be passed into PopBackStackImmediate when closing the fragment. Assigning an empty string will default to using the FragmentJavaName. Assigning a null will pop the top fragment when `PopBackStackImmediateFlag` is set to `None`. |
+| PopBackStackImmediateFlag   | `MvxPopBackStack` | Flag to be used with PopBackStackImmediate. `None`, all entries up to but not including that entry will be removed. `Inclusive`, all matching entries will be consumed until one that doesn't match is found or the bottom of the stack is reached. |
 
 When providing a value for EnterAnimation you need to provide one for ExitAnimation as well, otherwise the animation won't work (same applies in the other way around). 
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Defaults to inclusive and the FragmentJavaName. If you have two of the same fragments called after each other both would get closed with a `NavigationService.Close(this)`.

### :new: What is the new behavior (if this is a feature change)?
Users will have more control over how they want the close of a fragment to function.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See sample `Fragment Close Example` in Plaground. You can switch between the different fragment attributes, [default](https://github.com/MvvmCross/MvvmCross/pull/3159/files#diff-4743e86237e08bf75fe3bb341e3da764R13) or [pop top only](https://github.com/MvvmCross/MvvmCross/pull/3159/files#diff-4743e86237e08bf75fe3bb341e3da764R14). 

### :memo: Links to relevant issues/docs
Updated documentation.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
