### PR TITLE
Add FillTargetFactories and FillBindingNames in Platforms.Forms.WPF Setup

### DIFF
--- a/MvvmCross.Forms.Wpf/Platforms/Wpf/Core/MvxFormsWindowsSetup.cs
+++ b/MvvmCross.Forms.Wpf/Platforms/Wpf/Core/MvxFormsWindowsSetup.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Windows.Controls;
 using MvvmCross.Binding;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Forms.Core;
 using MvvmCross.Forms.Platforms.Wpf.Bindings;
@@ -60,6 +61,18 @@ namespace MvvmCross.Forms.Platforms.Wpf.Core
         }
 
         protected override MvxBindingBuilder CreateBindingBuilder() => new MvxFormsWindowsBindingBuilder();
+
+        protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+        {
+            MvxFormsSetupHelper.FillTargetFactories(registry);
+            base.FillTargetFactories(registry);
+        }
+
+        protected override void FillBindingNames(IMvxBindingNameRegistry registry)
+        {
+            MvxFormsSetupHelper.FillBindingNames(registry);
+            base.FillBindingNames(registry);
+        }
     }
 
     public class MvxFormsWpfSetup<TApplication, TFormsApplication> : MvxFormsWpfSetup


### PR DESCRIPTION
Small fix here, hopefully ok! Looks like these two calls are missing, please see diff.  I noticed this when my ItemClick commands weren't being called for the new forms WPF stuff.
 
### ✨ What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
### ⤵️ What is the current behavior?
`MvvmCross.Forms.Platforms.Wpf.Core.MvxFormsWpfSetup` doesn't set up TargetFactories or BindingNames using `MvxFormsSetupHelper` as other platform setup classes do.
### 🆕 What is the new behavior (if this is a feature change)?
`MvvmCross.Forms.Platforms.Wpf.Core.MvxFormsWpfSetup` now overrides `FillTargetFactories` and `FillBindingNames` with calls to `MvxFormsSetupHelper`
### 💥 Does this PR introduce a breaking change?
No
### 🐛 Recommendations for testing
### 📝 Links to relevant issues/docs
### 🤔 Checklist before submitting
 * [x]  All projects build 
 * [x]  Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
 * [ ]  Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide)) 
 * [x]  Rebased onto current develop
