### PR TITLE
Change MvxItemTemplateSelector to MvxTemplateSelector

### DIFF
--- a/docs/_documentation/platform/android/android-recyclerview.md
+++ b/docs/_documentation/platform/android/android-recyclerview.md
@@ -99,7 +99,7 @@ A small example:
 ```csharp
 namespace Zoo.App
 {
-    public class AnimalTemplateSelector : IMvxItemTemplateSelector
+    public class AnimalTemplateSelector : IMvxTemplateSelector
     {
         public int ItemTemplateId { get; set; } // fallback ItemTemplateId 
         
@@ -130,17 +130,17 @@ namespace Zoo.App
 }
 ```
 
-To use this `ItemTemplateSelctor` you will need to provide it in the `MvxItemTemplateSelector` attribute on the `MvxRecylcerView`. It must be of the format: `Fully.Qualified.ClassName,Assembly.Name`. Hence, for the example above. Let us say the assembly will be `Zoo.App.Droid` and as you see the namespace is `Zoo.App` then the string will be: `Zoo.App.AnimalTemplateSelector,Zoo.App.Droid`.
+To use this `ItemTemplateSelctor` you will need to provide it in the `MvxTemplateSelector` attribute on the `MvxRecylcerView`. It must be of the format: `Fully.Qualified.ClassName,Assembly.Name`. Hence, for the example above. Let us say the assembly will be `Zoo.App.Droid` and as you see the namespace is `Zoo.App` then the string will be: `Zoo.App.AnimalTemplateSelector,Zoo.App.Droid`.
 
 ```xml
 <mvvmcross.droid.support.v7.recyclerview.MvxRecyclerView
-    local:MvxItemTemplateSelector="Zoo.App.AnimalTemplateSelector,Zoo.App.Droid"
+    local:MvxTemplateSelector="Zoo.App.AnimalTemplateSelector,Zoo.App.Droid"
     ... />
 ```
 
-The `ItemTemplateId` property in your `ItemTemplateSelector` will get overwritten if you provide both the `MvxItemTemplateSelector` and `MvxItemTemplate`, by the value in `MvxItemTemplate`.
+The `ItemTemplateId` property in your `ItemTemplateSelector` will get overwritten if you provide both the `MvxTemplateSelector` and `MvxItemTemplate`, by the value in `MvxItemTemplate`.
 
-> Note: If you do not provide a `MvxItemTemplateSelector` the `MvxRecyclerAdapter` will fallback to use `MvxDefaultItemTemplateSelector`.
+> Note: If you do not provide a `MvxTemplateSelector` the `MvxRecyclerAdapter` will fallback to use `MvxDefaultItemTemplateSelector`.
 
 ### ItemClick and ItemLongClick commands
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
Documentation for RecyclerView shows `MvxItemTemplateSelector` this is not correct.

### :new: What is the new behavior (if this is a feature change)?
Changed `MvxItemTemplateSelector` to `MvxTemplateSelector`

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
