### PR TITLE
Mvxgridview toggle nestedscrolling

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using Android.Content;
 using Android.Runtime;
 using Android.Util;
+using Android.Views;
 using Android.Widget;
 using MvvmCross.Binding.Attributes;
 
@@ -122,7 +123,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             {
                 _itemLongClick = value;
                 if (_itemLongClick != null)
-                    EnsureItemLongClickOverloaded(); 
+                    EnsureItemLongClickOverloaded();
             }
         }
 
@@ -164,6 +165,19 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             }
 
             base.Dispose(disposing);
+        }
+
+        protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+        {
+            if (NestedScrollingEnabled)
+                base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+
+            else
+            {
+                var expandSpec = MeasureSpec.MakeMeasureSpec(MeasuredSizeMask, MeasureSpecMode.AtMost);
+                base.OnMeasure(widthMeasureSpec, expandSpec);
+                LayoutParameters.Height = MeasuredHeight;
+            }
         }
     }
 }

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
@@ -171,7 +171,6 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         {
             if (NestedScrollingEnabled)
                 base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-
             else
             {
                 //expand the view to the full height of it's contents to disable scrolling

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
@@ -174,6 +174,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 
             else
             {
+                //expand the view to the full height of it's contents to disable scrolling
                 var expandSpec = MeasureSpec.MakeMeasureSpec(MeasuredSizeMask, MeasureSpecMode.AtMost);
                 base.OnMeasure(widthMeasureSpec, expandSpec);
                 LayoutParameters.Height = MeasuredHeight;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Setting NestedScrollingEnabled on the MvxGridView does not affect behavior.

### :new: What is the new behavior (if this is a feature change)?
MvxGridView will now expand to the height of its contents in nested scrolling is disabled.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Have a MvxGridView or 2 inside of a NestedScrollView and set NestedScrollingEnabled to false on both. You should be able to scroll the NestedScrollView normally and the whole of each of the grid views should be reachable.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
-- This adds functionality in line with other scrolling views, rather than adding new behavior, not sure if/where to document.
- [X] Rebased onto current develop
