### PR TITLE
Set default logging to false

### DIFF
--- a/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
@@ -61,7 +61,7 @@ namespace MvvmCross.ViewModels
             ShouldAlwaysRaiseInpcOnUserInterfaceThread(alwaysOnUIThread);
             var raisePropertyChanging = MvxSingletonCache.Instance == null || MvxSingletonCache.Instance.Settings.ShouldRaisePropertyChanging;
             ShouldRaisePropertyChanging(raisePropertyChanging);
-            var shouldLogInpc = MvxSingletonCache.Instance == null || MvxSingletonCache.Instance.Settings.ShouldLogInpc;
+            var shouldLogInpc = MvxSingletonCache.Instance != null && MvxSingletonCache.Instance.Settings.ShouldLogInpc;
             ShouldLogInpc(shouldLogInpc);
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

MvxNotifyPropertyChanged sets logging to true by default. This causes my tests to fail when there is no MvxLog configured.

### :new: What is the new behavior (if this is a feature change)?

MvxNotifyPropertyChanged won't log by default, but instead read the value from settings.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
