### PR TITLE
Update support fragment default namespace

### DIFF
--- a/MvvmCross.Android.Support/Fragment/MvvmCross.Droid.Support.Fragment.csproj
+++ b/MvvmCross.Android.Support/Fragment/MvvmCross.Droid.Support.Fragment.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid81</TargetFrameworks>
     <AssemblyName>MvvmCross.Droid.Support.Fragment</AssemblyName>
-    <RootNamespace>MvvmCross.Droid.Support.Fragment</RootNamespace>
+    <RootNamespace>MvvmCross.Droid.Support.Fragments</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.
 
 This package contains Support Fragment support for MvvmCross.</Description>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?

Design time errors `Error	CS0118	'Fragment' is a namespace but is used like a type'` is throw with intellisense relating to Android `Fragment` classes matching the default namespace of support `Fragments` project.

### :new: What is the new behavior (if this is a feature change)?

No errors.
### :boom: Does this PR introduce a breaking change?

No, there were no Mvx classes were using this namespace.
### :bug: Recommendations for testing

Check the android presenters should no longer throw errors with `Fragment` usage.
### :memo: Links to relevant issues/docs
Closes #3168 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
