### PR TITLE
Added a button to the Forms SplitDetail UI to replicate a navigation issue

### DIFF
--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailViewModel.cs
@@ -14,11 +14,13 @@ namespace Playground.Core.ViewModels
         public SplitDetailViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {
             ShowChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitDetailNavViewModel>());
-            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootBViewModel>());
+            ShowTabbedChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
         }
 
         public IMvxAsyncCommand ShowChildCommand { get; private set; }
         public IMvxAsyncCommand ShowTabsCommand { get; private set; }
+        public IMvxAsyncCommand ShowTabbedChildCommand { get; private set; }
 
         public string ContentText => "Text for the Content Area";
 

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/SplitDetailViewModel.cs
@@ -14,7 +14,7 @@ namespace Playground.Core.ViewModels
         public SplitDetailViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {
             ShowChildCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitDetailNavViewModel>());
-            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootBViewModel>());
+            ShowTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<TabsRootViewModel>());
         }
 
         public IMvxAsyncCommand ShowChildCommand { get; private set; }

--- a/Projects/Playground/Playground.Forms.UI/Pages/SplitDetailPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/SplitDetailPage.xaml
@@ -1,18 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<views:MvxContentPage x:TypeArguments="viewModels:SplitDetailViewModel"
-                      xmlns="http://xamarin.com/schemas/2014/forms"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                      xmlns:views="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
-                      xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
-                      xmlns:viewModels="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
-                      x:Class="Playground.Forms.UI.Pages.SplitDetailPage"
-                      Title="SplitDetail page"
-                        Icon="hamburger.png">
+<?xml version="1.0" encoding="UTF-8" ?>
+<views:MvxContentPage
+    x:Class="Playground.Forms.UI.Pages.SplitDetailPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
+    xmlns:viewModels="clr-namespace:Playground.Core.ViewModels;assembly=Playground.Core"
+    xmlns:views="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
+    Title="SplitDetail page"
+    x:TypeArguments="viewModels:SplitDetailViewModel"
+    Icon="hamburger.png">
     <ContentPage.Content>
         <StackLayout Margin="10">
             <Label Text="I'm a detail navigation page" />
-            <Button Text="Show Child"
-                    mvx:Bi.nd="Command ShowChildCommand" />
+            <Button mvx:Bi.nd="Command ShowChildCommand" Text="Show Child" />
+            <Button mvx:Bi.nd="Command ShowTabsCommand" Text="Show Tabbed Child" />
         </StackLayout>
     </ContentPage.Content>
 </views:MvxContentPage>

--- a/Projects/Playground/Playground.Forms.UI/Pages/SplitDetailPage.xaml
+++ b/Projects/Playground/Playground.Forms.UI/Pages/SplitDetailPage.xaml
@@ -12,8 +12,10 @@
     <ContentPage.Content>
         <StackLayout Margin="10">
             <Label Text="I'm a detail navigation page" />
-            <Button mvx:Bi.nd="Command ShowChildCommand" Text="Show Child" />
-            <Button mvx:Bi.nd="Command ShowTabsCommand" Text="Show Tabbed Child" />
+            <Button mvx:Bi.nd="Command ShowChildCommand" 
+                    Text="Show Child" />
+            <Button mvx:Bi.nd="Command ShowTabbedChildCommand" 
+                    Text="Show Tabbed Child" />
         </StackLayout>
     </ContentPage.Content>
 </views:MvxContentPage>

--- a/Projects/Playground/Playground.Forms.UI/Pages/TabsRootPage.xaml.cs
+++ b/Projects/Playground/Playground.Forms.UI/Pages/TabsRootPage.xaml.cs
@@ -8,7 +8,7 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Forms.UI.Pages
 {
-    [MvxTabbedPagePresentation(TabbedPosition.Root, NoHistory = true)]
+    [MvxTabbedPagePresentation(TabbedPosition.Root, NoHistory = false)]
     public partial class TabsRootPage : MvxTabbedPage<TabsRootViewModel>
     {
         public TabsRootPage()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Added a button into the Forms Playground inside the SplitDetail. This button now opens the TabsRoot to display a tabbed page.

Also, I changed the `NoHistory` property of the `MvxTabbedPagePresentation` attribute to false to trigger the navigation bug.

### :arrow_heading_down: What is the current behavior?

Unexpected navigation behavior

### :new: What is the new behavior (if this is a feature change)?

Still behaves unexpected but now there is a button to repliacte this issue

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

- Run the Playground Forms app
- Press the "Show master / Detail" button
- Press the "Show Tabbed Child" button
- Press the "Show Modal" button
- Press the "Close" button
- Now the unexpected behavior happens

### :memo: Links to relevant issues/docs

[#3170](https://github.com/MvvmCross/MvvmCross/issues/3170)

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
