### PR TITLE
Close any ModalViewControllers that could be open

### DIFF
--- a/MvvmCross.Plugins/Sidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.Plugins/Sidebar/MvxSidebarPresenter.cs
@@ -42,6 +42,8 @@ namespace MvvmCross.Plugin.Sidebar
             MvxSidebarPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
+            if (!await CloseModalViewControllers()) return false;
+            
             if (SideBarViewController == null)
             {
                 if (!await ShowRootViewController(new MvxSidebarViewController(), null, request)) return false;


### PR DESCRIPTION
Close any ModalViewControllers that could be open above the SidebarViewcontroller

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix 

### :arrow_heading_down: What is the current behavior?
When on a Modal View if you navigate to a view with the sidebar attributes the modal view is not closed and you stay on the same view

### :new: What is the new behavior (if this is a feature change)?
When you now navigate to a view with sidebar attributes the modal view is closed.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop