### PR TITLE
Fix NRE in MvxCommandBase when running in UnitTest suite

### DIFF
--- a/MvvmCross.Tests/MvxIoCSupportingTest.cs
+++ b/MvvmCross.Tests/MvxIoCSupportingTest.cs
@@ -23,6 +23,7 @@ namespace MvvmCross.Tests
         public void Reset()
         {
             MvxSingleton.ClearAllSingletons();
+            Ioc = null;
         }
 
         protected virtual IMvxIocOptions CreateIocOptions()

--- a/MvvmCross/Base/MvxMainThreadDispatchingObject.cs
+++ b/MvvmCross/Base/MvxMainThreadDispatchingObject.cs
@@ -18,7 +18,25 @@ namespace MvvmCross.Base
 
         protected Task InvokeOnMainThreadAsync(Action action, bool maskExceptions = true)
         {
-            return AsyncDispatcher?.ExecuteOnMainThreadAsync(action, maskExceptions);
+            // this corner case should only happen when there is no IoC
+            // i.e. when running in a UnitTest environment, falling back
+            // to just executing action
+            if (AsyncDispatcher == null)
+            {
+                try
+                {
+                    action();
+                }
+                catch
+                {
+                    if (!maskExceptions)
+                        throw;
+                }
+                
+                return Task.CompletedTask;
+            }
+
+            return AsyncDispatcher.ExecuteOnMainThreadAsync(action, maskExceptions);
         }
     }
 }

--- a/MvvmCross/Commands/MvxCommand.cs
+++ b/MvvmCross/Commands/MvxCommand.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -105,7 +105,8 @@ namespace MvvmCross.Commands
 
         public MvxCommandBase()
         {
-            if (!Mvx.IoCProvider.TryResolve<IMvxCommandHelper>(out _commandHelper))
+            // fallback on MvxWeakCommandHelper if no IoC has been set up
+            if (!Mvx.IoCProvider?.TryResolve(out _commandHelper) ?? true)
                 _commandHelper = new MvxWeakCommandHelper();
 
             var alwaysOnUIThread = MvxSingletonCache.Instance == null || MvxSingletonCache.Instance.Settings.AlwaysRaiseInpcOnUserInterfaceThread;

--- a/MvvmCross/Commands/MvxCommand.cs
+++ b/MvvmCross/Commands/MvxCommand.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -109,7 +109,8 @@ namespace MvvmCross.Commands
             if (!Mvx.IoCProvider?.TryResolve(out _commandHelper) ?? true)
                 _commandHelper = new MvxWeakCommandHelper();
 
-            var alwaysOnUIThread = MvxSingletonCache.Instance == null || MvxSingletonCache.Instance.Settings.AlwaysRaiseInpcOnUserInterfaceThread;
+            // default to true if no Singleton Cache has been set up
+            var alwaysOnUIThread = MvxSingletonCache.Instance?.Settings.AlwaysRaiseInpcOnUserInterfaceThread ?? true;
             ShouldAlwaysRaiseCECOnUserInterfaceThread = alwaysOnUIThread;
         }
 

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollationTestNoIoC.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollationTestNoIoC.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Commands;
+using Xunit;
+
+namespace MvvmCross.UnitTest.ViewModels
+{
+    [Collection("MvxTest")]
+    public class MvxCommandCollationTestNoIoC
+    {
+        private NavigationTestFixture _fixture;
+
+        public MvxCommandCollationTestNoIoC(NavigationTestFixture fixture)
+        {
+            _fixture = fixture;
+            // ensure singletons are cleared, no IoC please :)
+            fixture.Reset();
+        }
+
+        [Fact]
+        public void CanConstructCommand()
+        {
+            var command = new MvxCommand(() => {/* nothing to see here */});
+
+            Assert.NotNull(command);
+        }
+
+        [Fact]
+        public void CanExecuteCommand()
+        {
+            var i = 0;
+            var command = new MvxCommand(() => { ++i; });
+
+            Assert.NotNull(command);
+
+            command.Execute();
+
+            Assert.Equal(1, i);
+        }
+    }
+}

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollationTestNoIoC.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollationTestNoIoC.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using MvvmCross.Commands;
 using Xunit;
 
@@ -37,6 +38,28 @@ namespace MvvmCross.UnitTest.ViewModels
 
             command.Execute();
 
+            Assert.Equal(1, i);
+        }
+
+        [Fact]
+        public void CanExecuteChanged()
+        {
+            var canExecute = false;
+
+            var command = new MvxCommand(() => { }, () => canExecute);
+
+            Assert.False(command.CanExecute());
+
+            var i = 0;
+            command.CanExecuteChanged += (s, e) =>
+            {
+                i++;
+            };
+
+            canExecute = true;
+            command.RaiseCanExecuteChanged();
+
+            Assert.True(command.CanExecute());
             Assert.Equal(1, i);
         }
     }

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollectionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxCommandCollectionTest.cs
@@ -6,9 +6,7 @@ using System.ComponentModel;
 using System.Windows.Input;
 using MvvmCross.Base;
 using MvvmCross.Commands;
-using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
-using MvvmCross.ViewModels;
 using Xunit;
 
 namespace MvvmCross.UnitTest.ViewModels


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When using MvxCommand without having initialized IoC, i.e. in unit tests, stuff blows up.

### :new: What is the new behavior (if this is a feature change)?
- Added null checks and fallbacks in MvxCommandBase.
- Added Unit Test for verifying above

One thing I am not entirely sure whether we actually want is, to fallback just executing the `Action` in `MvxMainThreadDispatchingObject` when there is no `AsyncDispatcher` present. I can't see why this would ever happen in a real App. However, in a UnitTest suite, this may happen in no IoC is initialized or MvxSingletonChache is initialized.

### :boom: Does this PR introduce a breaking change?
Breaking? Not really. However, behavior has changed with `MvxMainThreadDispatchingObject` which can potentially execute on another thread, only if `AsyncDispatcher` is `null`.

### :bug: Recommendations for testing
Run unit tests

### :memo: Links to relevant issues/docs
#3197 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
