### PR TITLE
Incorrectly using TableView reference rather than tableView parameter…

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
@@ -107,7 +107,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             {
                 var bindingContext = bindable.BindingContext as MvxTaskBasedBindingContext;
 
-                var isTaskBasedBindingContextAndHasAutomaticDimension = bindingContext != null && TableView.RowHeight == UITableView.AutomaticDimension;
+                var isTaskBasedBindingContextAndHasAutomaticDimension = bindingContext != null && tableView.RowHeight == UITableView.AutomaticDimension;
 
                 // RunSynchronously must be called before DataContext is set
                 if (isTaskBasedBindingContextAndHasAutomaticDimension)

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxBaseTableViewSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -108,7 +108,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             if (bindable != null)
             {
                 var bindingContext = bindable.BindingContext as MvxTaskBasedBindingContext;
-                if (bindingContext != null && _tableView.RowHeight == UITableView.AutomaticDimension)
+                if (bindingContext != null && tableView.RowHeight == UITableView.AutomaticDimension)
                     bindingContext.RunSynchronously = true;
                 bindable.DataContext = item;
             }


### PR DESCRIPTION
… reference.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

### :arrow_heading_down: What is the current behavior?
Sometimes the TableView property is null.  The method takes a tableView parameter that the method should be using as it does elsewhere in the code.

The result is a null reference exception.

### :new: What is the new behavior (if this is a feature change)?
The method now uses the tableView parameter passed into the method and no longer fails with a null pointer exception.

### :boom: Does this PR introduce a breaking change?
Should not be a breaking change 

### :bug: Recommendations for testing
Hard to reproduce in playground but occurs 100% of times in internal application.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X] All projects build
- [ X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ X] Rebased onto current develop
