### PR TITLE
Prevents multiple taps on image in UIImagePickerController crash app

### DIFF
--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -909,7 +909,7 @@ protected override void InitializeLastChance()
         
  - WPF
 
-    xmlns:mvx="clr-namespace:mvx;assembly=MvvmCross.Binding.Wpf"
+    xmlns:mvx="clr-namespace:MvvmCross.Platforms.Wpf.Binding;assembly=MvvmCross.Platforms.Wpf"
 
 
 - in your Xaml files you can now include bindings within tags such as:

--- a/docs/_documentation/fundamentals/dependency-injection.md
+++ b/docs/_documentation/fundamentals/dependency-injection.md
@@ -6,7 +6,7 @@ order: 6
 ---
 ## Constructor Injection
 
-As well as `Mvx.Resolve<T>`, the `Mvx` static class provides a reflection based mechanism to automatically resolve parameters during object construction.
+As well as `Mvx.IoCProvider.Resolve<T>`, the `Mvx.IoCProvider` singleton instance provides a reflection based mechanism to automatically resolve parameters during object construction.
 
 For example, if we add a class like:
 
@@ -22,14 +22,14 @@ public class Bar
 
 Then you can create this object using:
 
-        Mvx.IocConstruct<Bar>();
+        Mvx.IoCProvider.IocConstruct<Bar>();
 
 What happens during this call is:
 
 - MvvmCross:
   - uses Reflection to find the constructor of `Bar`
   - looks at the parameters for that constructor and sees it needs an `IFoo`
-  - uses `Mvx.Resolve<IFoo>()` to get hold of the registered implementation for `IFoo`
+  - uses `Mvx.IoCProvider.Resolve<IFoo>()` to get hold of the registered implementation for `IFoo`
   - uses Reflection to call the constructor with the `IFoo` parameter
 
 ### Constructor Injection and ViewModels
@@ -48,7 +48,7 @@ public class MyViewModel : MvxViewModel
 }
 ```
 
-then MvvmCross will use the `Mvx` static class to resolve objects for `jsonConverter` and `locationWatcher` when a `MyViewModel` is created.
+then MvvmCross will use the `Mvx.IoCProvider` singleton instance to resolve objects for `jsonConverter` and `locationWatcher` when a `MyViewModel` is created.
 
 **This is important** because:
 
@@ -58,7 +58,7 @@ then MvvmCross will use the `Mvx` static class to resolve objects for `jsonConve
 
 ### Constructor Injection and Chaining
 
-Internally, the `Mvx.Resolve<T>` mechanism uses constructor injection when new objects are needed.
+Internally, the `Mvx.IoCProvider.Resolve<T>` mechanism uses constructor injection when new objects are needed.
 
 This enables you to register implementations which depend on other interfaces like:
 
@@ -81,9 +81,9 @@ public class TaxCalculator
 
 If you then register this calculator as:
 
-         Mvx.RegisterType<ITaxCalculator, TaxCalculator>();
+         Mvx.IoCProvider.RegisterType<ITaxCalculator, TaxCalculator>();
 
-Then when a client calls `Mvx.Resolve<ITaxCalculator>()` then what will happen is that MvvmCross will create a new `TaxCalculator` instance, resolving all of `ICustomerRepository` `IForeignExchange` and `ITaxRuleList` during the operation.
+Then when a client calls `Mvx.IoCProvider.Resolve<ITaxCalculator>()` then what will happen is that MvvmCross will create a new `TaxCalculator` instance, resolving all of `ICustomerRepository` `IForeignExchange` and `ITaxRuleList` during the operation.
 
 Further, this process is **recursive** - so if any of these returned objects requires another object  - e.g. if your `IForeignExchange` implementation requires a `IChargeCommission` object - then MvvmCross will use `Resolve` to provide an `IChargeCommission` instance for you.
 
@@ -136,7 +136,7 @@ public class FooSingleton : IFooSingleton
 
     public void DoFoo()
     {
-        var bar = Mvx.Resolve<IBar>();
+        var bar = Mvx.IoCProvider.Resolve<IBar>();
         bar.DoStuff();
     }
 }

--- a/docs/_documentation/fundamentals/viewmodel-lifecycle.md
+++ b/docs/_documentation/fundamentals/viewmodel-lifecycle.md
@@ -43,7 +43,7 @@ public class MyViewModel : MvxViewModel
 If you need to send some parameters to a ViewModel, you will want to use this method. MvxViewModel can have two Prepare methods:
 
 - Parameterless `Prepare`: Called in every scenario.
-- `Prepare(TParameter parameter)`: Called when you are navigating to a ViewModel with initial parameters. You shouldn't perform any logics on this method more than saving the parameters.
+- `Prepare(TParameter parameter)`: Called when you are navigating to a ViewModel with initial parameters and after the parameterless version of it. You shouldn't perform any logics on this method more than saving the parameters.
 
 This is how a typical ViewModel with initial parameters look like:
 

--- a/docs/_documentation/platform/android/android-recyclerview.md
+++ b/docs/_documentation/platform/android/android-recyclerview.md
@@ -99,7 +99,7 @@ A small example:
 ```csharp
 namespace Zoo.App
 {
-    public class AnimalTemplateSelector : IMvxItemTemplateSelector
+    public class AnimalTemplateSelector : IMvxTemplateSelector
     {
         public int ItemTemplateId { get; set; } // fallback ItemTemplateId 
         
@@ -130,17 +130,17 @@ namespace Zoo.App
 }
 ```
 
-To use this `ItemTemplateSelctor` you will need to provide it in the `MvxItemTemplateSelector` attribute on the `MvxRecylcerView`. It must be of the format: `Fully.Qualified.ClassName,Assembly.Name`. Hence, for the example above. Let us say the assembly will be `Zoo.App.Droid` and as you see the namespace is `Zoo.App` then the string will be: `Zoo.App.AnimalTemplateSelector,Zoo.App.Droid`.
+To use this `ItemTemplateSelctor` you will need to provide it in the `MvxTemplateSelector` attribute on the `MvxRecylcerView`. It must be of the format: `Fully.Qualified.ClassName,Assembly.Name`. Hence, for the example above. Let us say the assembly will be `Zoo.App.Droid` and as you see the namespace is `Zoo.App` then the string will be: `Zoo.App.AnimalTemplateSelector,Zoo.App.Droid`.
 
 ```xml
 <mvvmcross.droid.support.v7.recyclerview.MvxRecyclerView
-    local:MvxItemTemplateSelector="Zoo.App.AnimalTemplateSelector,Zoo.App.Droid"
+    local:MvxTemplateSelector="Zoo.App.AnimalTemplateSelector,Zoo.App.Droid"
     ... />
 ```
 
-The `ItemTemplateId` property in your `ItemTemplateSelector` will get overwritten if you provide both the `MvxItemTemplateSelector` and `MvxItemTemplate`, by the value in `MvxItemTemplate`.
+The `ItemTemplateId` property in your `ItemTemplateSelector` will get overwritten if you provide both the `MvxTemplateSelector` and `MvxItemTemplate`, by the value in `MvxItemTemplate`.
 
-> Note: If you do not provide a `MvxItemTemplateSelector` the `MvxRecyclerAdapter` will fallback to use `MvxDefaultItemTemplateSelector`.
+> Note: If you do not provide a `MvxTemplateSelector` the `MvxRecyclerAdapter` will fallback to use `MvxDefaultItemTemplateSelector`.
 
 ### ItemClick and ItemLongClick commands
 

--- a/docs/_documentation/plugins/color.md
+++ b/docs/_documentation/plugins/color.md
@@ -12,7 +12,7 @@ public interface IMvxNativeColor
 }
 ```
 
-This plugin is available on all platforms.
+This plugin is available on all platforms, but not when using Xamarin.Forms, yet. (you can check this [issue](https://github.com/MvvmCross/MvvmCross/issues/3148#issuecomment-428097084) to find a workaround)
 
 This plugin also provides a number of useful Color-outputting ValueConverters - see [Mvx Color Value Conversion](https://www.mvvmcross.com/documentation/fundamentals/value-converters#the-mvx-color-valueconverters) for information on these. If you wish to create your own Color ValueConverters, then this plugin provides the base classes `MvxColorValueConverter` and `MvxColorValueConverter<T>`.
 

--- a/docs/_posts/2018-9-17-mvvmcross-6.2.0-release.md
+++ b/docs/_posts/2018-9-17-mvvmcross-6.2.0-release.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: MvvmCross 6.2
-date:   2018-4-14 14:00:00 -0300
+date:   2018-09-17 10:00:00 -0300
 categories: mvvmcross
 ---
 


### PR DESCRIPTION
Unsubscribes the UIImagePickerController events after an event is fired, to prevent duplicate event handling.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for #3215 

### :arrow_heading_down: What is the current behavior?
Crash when double-tapping an image in Photos.

### :new: What is the new behavior (if this is a feature change)?
None.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Quickly tap an issue when using the PictureChooser to select one from the Photos gallery on iOS 12. Previously this would cause a crash, right now it shouldn't.

### :memo: Links to relevant issues/docs
Fixes #3215

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
