### PR TITLE
Displays logging timestamp in 24h format

### DIFF
--- a/MvvmCross/Logging/LogProviders/ConsoleLogProvider.cs
+++ b/MvvmCross/Logging/LogProviders/ConsoleLogProvider.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Logging.LogProviders
         private static string MessageFormatter(string loggerName, MvxLogLevel level, object message, Exception e)
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append(DateTime.Now.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture));
+            stringBuilder.Append(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
             stringBuilder.Append(" ");
 
             // Append a readable representation of the log level


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Logging times are in 12h format but without AM/PM.

### :new: What is the new behavior (if this is a feature change)?
Logging times are in 24h format.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
n/a

### :memo: Links to relevant issues/docs
n/a

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] ~~Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))~~ there's no relevant doc
- [x] Rebased onto current develop
