### PR TITLE
[WIP] Run StartAsync in a blocking manner

### DIFF
--- a/MvvmCross/Base/MvxAsyncExtensions.cs
+++ b/MvvmCross/Base/MvxAsyncExtensions.cs
@@ -45,7 +45,10 @@ namespace MvvmCross.Base
 
                 task.GetAwaiter().GetResult();
             }
-            finally { SynchronizationContext.SetSynchronizationContext(oldContext); }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
         }
 
         /// <summary>

--- a/MvvmCross/Base/MvxAsyncExtensions.cs
+++ b/MvvmCross/Base/MvxAsyncExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -38,7 +38,10 @@ namespace MvvmCross.Base
                 if (task == null)
                     throw new InvalidOperationException("No task provided.");
 
-                task.ContinueWith(delegate { synchronousContext.Complete(); }, TaskScheduler.Default);
+                task.ContinueWith(delegate 
+                {
+                    synchronousContext.Complete();
+                }, TaskScheduler.Default);
 
                 // Pump continuations and propagate any exceptions
                 synchronousContext.RunOnCurrentThread();
@@ -74,6 +77,9 @@ namespace MvvmCross.Base
             {
                 if (callback == null)
                     throw new ArgumentNullException("d");
+
+                if (_queue.IsAddingCompleted)
+                    return;
 
                 _queue.Add(Tuple.Create(callback, state));
             }

--- a/MvvmCross/Base/MvxAsyncExtensions.cs
+++ b/MvvmCross/Base/MvxAsyncExtensions.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MvvmCross.Base
+{
+    /// <summary>
+    /// Provides a pump that supports running asynchronous methods on the current thread.
+    /// 
+    /// This code is based on Stephen Toub's AsyncPump:
+    /// https://blogs.msdn.microsoft.com/pfxteam/2012/02/02/await-synchronizationcontext-and-console-apps-part-3/
+    /// </summary>
+    internal static class MvxAsyncPump
+    {
+        /// <summary>
+        /// Runs the specified asynchronous method.
+        /// </summary>
+        /// <param name="asyncMethod">The asynchronous method to execute.</param>
+        public static void Run(Func<Task> asyncMethod)
+        {
+            if (asyncMethod == null)
+                throw new ArgumentNullException(nameof(asyncMethod));
+
+            var oldContext = SynchronizationContext.Current;
+            try
+            {
+                // Establish the new context
+                var synchronousContext = new SingleThreadSynchronizationContext();
+                SynchronizationContext.SetSynchronizationContext(synchronousContext);
+
+                // Invoke the function and alert the context to when it completes
+                var task = asyncMethod();
+                if (task == null)
+                    throw new InvalidOperationException("No task provided.");
+
+                task.ContinueWith(delegate { synchronousContext.Complete(); }, TaskScheduler.Default);
+
+                // Pump continuations and propagate any exceptions
+                synchronousContext.RunOnCurrentThread();
+
+                task.GetAwaiter().GetResult();
+            }
+            finally { SynchronizationContext.SetSynchronizationContext(oldContext); }
+        }
+
+        /// <summary>
+        /// Provides a SynchronizationContext that is single-threaded.
+        /// </summary>
+        private sealed class SingleThreadSynchronizationContext : SynchronizationContext
+        {
+            private readonly BlockingCollection<Tuple<SendOrPostCallback, object>> _queue =
+                new BlockingCollection<Tuple<SendOrPostCallback, object>>();
+
+            private readonly Thread _thread = Thread.CurrentThread;
+
+            internal SingleThreadSynchronizationContext()
+            {
+            }
+
+            /// <summary>
+            /// Dispatches an asynchronous message to the synchronization context.
+            /// </summary>
+            /// <param name="callback">The System.Threading.SendOrPostCallback delegate to call.</param>
+            /// <param name="state">The object passed to the delegate.</param>
+            public override void Post(SendOrPostCallback callback, object state)
+            {
+                if (callback == null)
+                    throw new ArgumentNullException("d");
+
+                _queue.Add(Tuple.Create(callback, state));
+            }
+
+            public override void Send(SendOrPostCallback callback, object state) 
+                => throw new NotSupportedException("Synchronously sending is not supported.");
+
+            /// <summary>
+            /// Runs an loop to process all queued work items.
+            /// </summary>
+            public void RunOnCurrentThread()
+            {
+                foreach (var workItem in _queue.GetConsumingEnumerable())
+                    workItem.Item1(workItem.Item2);
+            }
+
+            /// <summary>
+            /// Notifies the context that no more work will arrive.
+            /// </summary>
+            public void Complete() => _queue.CompleteAdding();
+        }
+    }
+}

--- a/MvvmCross/Base/MvxAsyncExtensions.cs
+++ b/MvvmCross/Base/MvxAsyncExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -57,7 +57,7 @@ namespace MvvmCross.Base
         /// <summary>
         /// Provides a SynchronizationContext that is single-threaded.
         /// </summary>
-        private sealed class SingleThreadSynchronizationContext : SynchronizationContext
+        internal sealed class SingleThreadSynchronizationContext : SynchronizationContext
         {
             private readonly BlockingCollection<Tuple<SendOrPostCallback, object>> _queue;
 

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidMainThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidMainThreadDispatcher.cs
@@ -6,13 +6,12 @@ using System;
 using System.Threading;
 using Android.App;
 using MvvmCross.Base;
+using static MvvmCross.Base.MvxAsyncPump;
 
 namespace MvvmCross.Platforms.Android.Views
 {
     public class MvxAndroidMainThreadDispatcher : MvxMainThreadAsyncDispatcher
     {
-        public override bool IsOnMainThread => Application.SynchronizationContext == SynchronizationContext.Current;
-
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
             if (IsOnMainThread)
@@ -26,6 +25,20 @@ namespace MvvmCross.Platforms.Android.Views
             }
 
             return true;
+        }
+
+        public override bool IsOnMainThread
+        {
+            get
+            {
+                if (Application.SynchronizationContext == SynchronizationContext.Current)
+                    return true;
+
+                if (SynchronizationContext.Current is SingleThreadSynchronizationContext)
+                    return true;
+
+                return false;
+            }
         }
     }
 }

--- a/MvvmCross/Platforms/Ios/Views/MvxIosUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxIosUIThreadDispatcher.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using MvvmCross.Base;
 using MvvmCross.Exceptions;
 using UIKit;
+using static MvvmCross.Base.MvxAsyncPump;
 
 namespace MvvmCross.Platforms.Ios.Views
 {
@@ -34,6 +35,18 @@ namespace MvvmCross.Platforms.Ios.Views
             return true;
         }
 
-        public override bool IsOnMainThread => _uiSynchronizationContext == SynchronizationContext.Current;
+        public override bool IsOnMainThread
+        {
+            get
+            {
+                if (_uiSynchronizationContext == SynchronizationContext.Current)
+                    return true;
+
+                if (SynchronizationContext.Current is SingleThreadSynchronizationContext)
+                    return true;
+
+                return false;
+            }
+        }
     }
 }

--- a/MvvmCross/Platforms/Mac/Views/MvxMacUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Mac/Views/MvxMacUIThreadDispatcher.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using AppKit;
 using MvvmCross.Base;
 using MvvmCross.Exceptions;
+using static MvvmCross.Base.MvxAsyncPump;
 
 namespace MvvmCross.Platforms.Mac.Views
 {
@@ -36,6 +37,18 @@ namespace MvvmCross.Platforms.Mac.Views
             return true;
         }
 
-        public override bool IsOnMainThread => _uiSynchronizationContext == SynchronizationContext.Current;
+        public override bool IsOnMainThread
+        {
+            get
+            {
+                if (_uiSynchronizationContext == SynchronizationContext.Current)
+                    return true;
+
+                if (SynchronizationContext.Current is SingleThreadSynchronizationContext)
+                    return true;
+
+                return false;
+            }
+        }
     }
 }

--- a/MvvmCross/Platforms/Tvos/Views/MvxTvosUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxTvosUIThreadDispatcher.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using MvvmCross.Base;
 using MvvmCross.Exceptions;
 using UIKit;
+using static MvvmCross.Base.MvxAsyncPump;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -34,6 +35,18 @@ namespace MvvmCross.Platforms.Tvos.Views
             return true;
         }
 
-        public override bool IsOnMainThread => _uiSynchronizationContext == SynchronizationContext.Current;
+        public override bool IsOnMainThread
+        {
+            get
+            {
+                if (_uiSynchronizationContext == SynchronizationContext.Current)
+                    return true;
+
+                if (SynchronizationContext.Current is SingleThreadSynchronizationContext)
+                    return true;
+
+                return false;
+            }
+        }
     }
 }

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsMainThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsMainThreadDispatcher.cs
@@ -5,6 +5,8 @@
 using System;
 using Windows.UI.Core;
 using MvvmCross.Base;
+using System.Threading;
+using static MvvmCross.Base.MvxAsyncPump;
 
 namespace MvvmCross.Platforms.Uap.Views
 {
@@ -16,8 +18,6 @@ namespace MvvmCross.Platforms.Uap.Views
         {
             _uiDispatcher = uiDispatcher;
         }
-
-        public override bool IsOnMainThread => _uiDispatcher.HasThreadAccess;
 
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
@@ -32,6 +32,20 @@ namespace MvvmCross.Platforms.Uap.Views
                 ExceptionMaskedAction(action, maskExceptions);
             });
             return true;
+        }
+
+        public override bool IsOnMainThread
+        {
+            get
+            {
+                if (_uiDispatcher.HasThreadAccess)
+                    return true;
+
+                if (SynchronizationContext.Current is SingleThreadSynchronizationContext)
+                    return true;
+
+                return false;
+            }
         }
     }
 }

--- a/MvvmCross/Platforms/Wpf/Views/MvxWpfUIThreadDispatcher.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWpfUIThreadDispatcher.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using System.Windows.Threading;
 using MvvmCross.Base;
+using static MvvmCross.Base.MvxAsyncPump;
 
 namespace MvvmCross.Platforms.Wpf.Views
 {
@@ -17,8 +19,6 @@ namespace MvvmCross.Platforms.Wpf.Views
         {
             _dispatcher = dispatcher;
         }
-
-        public override bool IsOnMainThread => _dispatcher.CheckAccess();
 
         public override bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
@@ -36,6 +36,20 @@ namespace MvvmCross.Platforms.Wpf.Views
 
             // TODO - why return bool at all?
             return true;
+        }
+
+        public override bool IsOnMainThread
+        {
+            get
+            {
+                if (_dispatcher.CheckAccess())
+                    return true;
+
+                if (SynchronizationContext.Current is SingleThreadSynchronizationContext)
+                    return true;
+
+                return false;
+            }
         }
     }
 }

--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -34,20 +34,20 @@ namespace MvvmCross.ViewModels
             if (Interlocked.CompareExchange(ref startHasCommenced, 1, 0) == 1)
                 return;
 
-            var applicationHint = await ApplicationStartup(hint);
+            var applicationHint = await ApplicationStartup(hint).ConfigureAwait(false);
             if (applicationHint != null)
             {
                 MvxLog.Instance.Trace("Hint ignored in default MvxAppStart");
             }
 
-            await NavigateToFirstViewModel(applicationHint);
+            await NavigateToFirstViewModel(applicationHint).ConfigureAwait(false);
         }
 
         protected abstract Task NavigateToFirstViewModel(object hint = null);
 
         protected virtual async Task<object> ApplicationStartup(object hint = null)
         {
-            await Application.Startup();
+            await Application.Startup().ConfigureAwait(false);
             return hint;
         }
 
@@ -76,7 +76,7 @@ namespace MvvmCross.ViewModels
         {
             try
             {
-                await NavigationService.Navigate<TViewModel>();
+                await NavigationService.Navigate<TViewModel>().ConfigureAwait(false);
             }
             catch (System.Exception exception)
             {
@@ -93,7 +93,7 @@ namespace MvvmCross.ViewModels
 
         protected override async Task<object> ApplicationStartup(object hint = null)
         {
-            var applicationHint = await base.ApplicationStartup(hint);
+            var applicationHint = await base.ApplicationStartup(hint).ConfigureAwait(false);
             if (applicationHint is TParameter parameter && Application is IMvxApplication<TParameter> typedApplication)
                 return typedApplication.Startup(parameter);
             else
@@ -105,11 +105,13 @@ namespace MvvmCross.ViewModels
             try
             {
                 if (hint is TParameter parameter)
-                    NavigationService.Navigate<TViewModel, TParameter>(parameter).GetAwaiter().GetResult();
+                {
+                    await NavigationService.Navigate<TViewModel, TParameter>(parameter).ConfigureAwait(false);
+                }
                 else
                 {
                     MvxLog.Instance.Trace($"Hint is not matching type of {nameof(TParameter)}. Doing navigation without typed parameter instead.");
-                    await base.NavigateToFirstViewModel(hint);
+                    await base.NavigateToFirstViewModel(hint).ConfigureAwait(false);
                 }
             }
             catch (System.Exception exception)

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -189,10 +189,10 @@ namespace Playground.Core.ViewModels
         {
             Log.Warn(() => "Testing log");
 
-            await base.Initialize().ConfigureAwait(false);
+            await base.Initialize();
 
             // Uncomment this to demonstrate use of StartAsync for async first navigation
-            //await Task.Delay(5000).ConfigureAwait(false);
+            //await Task.Delay(5000);
 
             _mvxViewModelLoader.LoadViewModel(MvxViewModelRequest.GetDefaultRequest(typeof(ChildViewModel)),
                 new SampleModel
@@ -202,7 +202,7 @@ namespace Playground.Core.ViewModels
                 },
                 null);
 
-            await MakeRequest().ConfigureAwait(false);
+            await MakeRequest();
         }
 
         public override void ViewAppearing()

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -189,10 +189,10 @@ namespace Playground.Core.ViewModels
         {
             Log.Warn(() => "Testing log");
 
-            await base.Initialize();
+            await base.Initialize().ConfigureAwait(false);
 
             // Uncomment this to demonstrate use of StartAsync for async first navigation
-            // await Task.Delay(5000);
+            //await Task.Delay(5000).ConfigureAwait(false);
 
             _mvxViewModelLoader.LoadViewModel(MvxViewModelRequest.GetDefaultRequest(typeof(ChildViewModel)),
                 new SampleModel
@@ -202,7 +202,7 @@ namespace Playground.Core.ViewModels
                 },
                 null);
 
-            await MakeRequest();
+            await MakeRequest().ConfigureAwait(false);
         }
 
         public override void ViewAppearing()
@@ -254,7 +254,7 @@ namespace Playground.Core.ViewModels
                 {
                     var task = client.MakeRequestAsync(request);
 
-                    var result = await task;
+                    var result = await task.ConfigureAwait(false);
 
                     return result;
                 }

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -192,7 +192,7 @@ namespace Playground.Core.ViewModels
             await base.Initialize();
 
             // Uncomment this to demonstrate use of StartAsync for async first navigation
-            //await Task.Delay(5000);
+            await Task.Delay(5000);
 
             _mvxViewModelLoader.LoadViewModel(MvxViewModelRequest.GetDefaultRequest(typeof(ChildViewModel)),
                 new SampleModel


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Deadlock on startup when running on UWP.

Currently when simply uncommenting https://github.com/MvvmCross/MvvmCross/blob/develop/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs#L179 or adding a simple `await Task.Delay(500)` in Initialize of the RootViewModel on UWP, then the App never finishes starting up.

It seems like Startup doesn't like content switching a lot, especially not switching back to UI thread.

### :new: What is the new behavior (if this is a feature change)?
Remove `GetAwaiter().GetResult()` for the first navigation which _will_ block as soon as you try to get back to the UI thread. It is the same as calling `.Result`. Since the method is already marked `async` I just await it instead.

Also added `MvxAsyncPump` which is a derivative of Stephen Toub's AsyncPump. This allows us to start a Task, and have all other tasks called as part of it run in a serial manner on the current context. Since, StartAsync is called from the Main thread, everything will run there and block until completion.

What this fixes is, awaiting inside of Initialize, without blowing up the App. However, for the first navigation I guess it wouldn't be stupid to advise people to use `Task.Run` and not awaiting it. Especially on platforms like Android and iOS that will kill off your app if it takes too long to launch.

### :boom: Does this PR introduce a breaking change?
Hopefully not.

### :bug: Recommendations for testing
Reviewers please test other platforms than UWP too!

### :memo: Links to relevant issues/docs
#3209 
#2953
#3221

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
