### PR TITLE
Fix Tibet binding expression throw exception in wpf xaml designer.

### DIFF
--- a/MvvmCross/Platforms/Wpf/Binding/Bi.n.d.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/Bi.n.d.cs
@@ -66,7 +66,6 @@ namespace MvvmCross.Platforms.Wpf.Binding
             object sender,
             DependencyPropertyChangedEventArgs args)
         {
-
             var bindingCreator = BindingCreator;
 
             bindingCreator?.CreateBindings(sender, args, ParseBindingDescriptions);

--- a/MvvmCross/Platforms/Wpf/Binding/Bi.n.d.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/Bi.n.d.cs
@@ -66,7 +66,7 @@ namespace MvvmCross.Platforms.Wpf.Binding
             object sender,
             DependencyPropertyChangedEventArgs args)
         {
-            // bindingCreator may be null in the designer currently
+
             var bindingCreator = BindingCreator;
 
             bindingCreator?.CreateBindings(sender, args, ParseBindingDescriptions);

--- a/MvvmCross/Platforms/Wpf/Binding/MvxDesignTimeChecker.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/MvxDesignTimeChecker.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using System.Windows;
-using MvvmCross.Base;
-using MvvmCross.IoC;
 using MvvmCross.Binding.Parse.Binding;
 
 namespace MvvmCross.Platforms.Wpf.Binding
@@ -20,15 +16,10 @@ namespace MvvmCross.Platforms.Wpf.Binding
                 return;
 
             _checked = true;
-
-            if (!(bool)DesignerProperties.IsInDesignModeProperty.GetMetadata(typeof(DependencyObject)).DefaultValue)
+            if (!MvxDesignTimeHelper.IsInDesignTime)
                 return;
 
-            if (MvxSingleton<IMvxIoCProvider>.Instance == null)
-            {
-                var iocProvider = MvxIoCProvider.Initialize();
-                Mvx.IoCProvider.RegisterSingleton(iocProvider);
-            }
+            MvxDesignTimeHelper.Initialize();
 
             if (!Mvx.IoCProvider.CanResolve<IMvxBindingParser>())
             {

--- a/MvvmCross/Platforms/Wpf/MvxDesignTimeHelper.cs
+++ b/MvvmCross/Platforms/Wpf/MvxDesignTimeHelper.cs
@@ -4,28 +4,19 @@
 
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Controls;
 using MvvmCross.Base;
+using MvvmCross.Core;
 using MvvmCross.IoC;
+using MvvmCross.Platforms.Wpf.Core;
 
 namespace MvvmCross.Platforms.Wpf
 {
-    public abstract class MvxDesignTimeHelper
+    internal static class MvxDesignTimeHelper
     {
-        protected MvxDesignTimeHelper()
-        {
-            if (!IsInDesignTime)
-                return;
-
-            if (MvxSingleton<IMvxIoCProvider>.Instance == null)
-            {
-                var iocProvider = MvxIoCProvider.Initialize();
-                Mvx.IoCProvider.RegisterSingleton(iocProvider);
-            }
-        }
-
         private static bool? _isInDesignTime;
 
-        protected static bool IsInDesignTime
+        public static bool IsInDesignTime
         {
             get
             {
@@ -34,12 +25,41 @@ namespace MvvmCross.Platforms.Wpf
                     _isInDesignTime =
                         (bool)
                         DesignerProperties.IsInDesignModeProperty
-                                          .GetMetadata(typeof(DependencyObject))
-                                          .DefaultValue;
+                            .GetMetadata(typeof(DependencyObject))
+                            .DefaultValue;
                 }
 
                 return _isInDesignTime.Value;
             }
         }
+
+        public static void Initialize()
+        {
+
+            if (!IsInDesignTime)
+                return;
+
+
+            if (MvxSingleton<IMvxIoCProvider>.Instance == null)
+            {
+                var iocProvider = MvxIoCProvider.Initialize();
+                Mvx.IoCProvider.RegisterSingleton(iocProvider);
+            }
+
+            MvxSetup.RegisterSetupType<MvxWpfSetup<App>>(System.Reflection.Assembly.GetExecutingAssembly());
+            var instance = MvxWpfSetupSingleton.EnsureSingletonAvailable(Application.Current.Dispatcher, new Content());
+            instance.InitializeAndMonitor(null);
+
+        }
+
+
+        class App : ViewModels.MvxApplication
+        {
+        }
+
+        class Content : ContentControl
+        {
+        }
+
     }
 }

--- a/MvvmCross/Platforms/Wpf/MvxDesignTimeHelper.cs
+++ b/MvvmCross/Platforms/Wpf/MvxDesignTimeHelper.cs
@@ -35,10 +35,8 @@ namespace MvvmCross.Platforms.Wpf
 
         public static void Initialize()
         {
-
             if (!IsInDesignTime)
                 return;
-
 
             if (MvxSingleton<IMvxIoCProvider>.Instance == null)
             {
@@ -49,9 +47,7 @@ namespace MvvmCross.Platforms.Wpf
             MvxSetup.RegisterSetupType<MvxWpfSetup<App>>(System.Reflection.Assembly.GetExecutingAssembly());
             var instance = MvxWpfSetupSingleton.EnsureSingletonAvailable(Application.Current.Dispatcher, new Content());
             instance.InitializeAndMonitor(null);
-
         }
-
 
         class App : ViewModels.MvxApplication
         {
@@ -60,6 +56,5 @@ namespace MvvmCross.Platforms.Wpf
         class Content : ContentControl
         {
         }
-
     }
 }

--- a/MvvmCross/Platforms/Wpf/Views/IMvxWpfView.cs
+++ b/MvvmCross/Platforms/Wpf/Views/IMvxWpfView.cs
@@ -1,14 +1,15 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 
 namespace MvvmCross.Platforms.Wpf.Views
 {
     public interface IMvxWpfView
-        : IMvxView
+        : IMvxView, IMvxBindingContextOwner
     {
     }
 

--- a/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Windows;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Wpf.Views
@@ -11,6 +12,7 @@ namespace MvvmCross.Platforms.Wpf.Views
     public class MvxWindow : Window, IMvxWindow, IMvxWpfView, IDisposable
     {
         private IMvxViewModel _viewModel;
+        private IMvxBindingContext _bindingContext;
 
         public IMvxViewModel ViewModel
         {
@@ -19,10 +21,26 @@ namespace MvvmCross.Platforms.Wpf.Views
             {
                 _viewModel = value;
                 DataContext = value;
+                BindingContext.DataContext = value;
             }
         }
 
         public string Identifier { get; set; }
+
+        public IMvxBindingContext BindingContext
+        {
+            get
+            {
+                if (_bindingContext != null)
+                    return _bindingContext;
+
+                if (Mvx.IoCProvider != null)
+                    this.CreateBindingContext();
+
+                return _bindingContext;
+            }
+            set => _bindingContext = value;
+        }
 
         public MvxWindow()
         {

--- a/MvvmCross/Platforms/Wpf/Views/MvxWpfView.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWpfView.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Wpf.Views
@@ -12,6 +13,7 @@ namespace MvvmCross.Platforms.Wpf.Views
     public class MvxWpfView : UserControl, IMvxWpfView, IDisposable
     {
         private IMvxViewModel _viewModel;
+        private IMvxBindingContext _bindingContext;
 
         public IMvxViewModel ViewModel
         {
@@ -20,7 +22,23 @@ namespace MvvmCross.Platforms.Wpf.Views
             {
                 _viewModel = value;
                 DataContext = value;
+                BindingContext.DataContext = value;
             }
+        }
+
+        public IMvxBindingContext BindingContext
+        {
+            get
+            {
+                if (_bindingContext != null)
+                    return _bindingContext;
+
+                if (Mvx.IoCProvider != null)
+                    this.CreateBindingContext();
+
+                return _bindingContext;
+            }
+            set => _bindingContext = value;
         }
 
         public MvxWpfView()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
Tibet and Rio in wpf Xaml designer, a binding like 

    mvx:Bi.nd="Text Name"

 will throw exception "Failed to resolve the type IMvxLogProvider".

### :new: What is the new behavior (if this is a feature change)?
a binding like 

    mvx:Bi.nd="Text Name"

will not throw any exception.

### :boom: Does this PR introduce a breaking change?
no.

### :bug: Recommendations for testing
none.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
