### PR TITLE
Adds default Click binding to FloatingActionButton.

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatPropertyBinding.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatPropertyBinding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,5 +12,6 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         public const string MvxAppCompatRadioGroup_SelectedItem = "SelectedItem";
         public const string SearchView_Query = "Query";
         public const string Toolbar_Subtitle = "Subtitle";
+        public const string FloatingActionButton_Click = "Click";
     }
 }

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetupHelper.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatSetupHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Android.Support.Design.Widget;
 using Android.Support.V7.Widget;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
@@ -44,6 +45,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
         public static void FillDefaultBindingNames(IMvxBindingNameRegistry registry)
         {
             registry.AddOrOverwrite(typeof(SearchView), MvxAppCompatPropertyBinding.SearchView_Query);
+            registry.AddOrOverwrite(typeof(FloatingActionButton), MvxAppCompatPropertyBinding.FloatingActionButton_Click);
         }
     }
 }

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -1006,6 +1006,7 @@ Android.Widget.TextView | Text
 Android.Widget.CompoundButton | Checked
 Android.Widget.SeekBar | Progress
 Android.Widget.SearchView | Query
+Android.Support.Design.Widget.FloatingActionButton | Click
 MvvmCross.Binding.Droid.Views.MvxListView | ItemsSource
 MvvmCross.Binding.Droid.Views.MvxLinearLayout | ItemsSource
 MvvmCross.Binding.Droid.Views.MvxGridView | ItemsSource


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Android FloatingActionButton doesn't provide a [default binding](https://www.mvvmcross.com/documentation/advanced/customizing-using-App-and-Setup#registering-default-binding-names) for the Click event.

### :new: What is the new behavior (if this is a feature change)?
Android FloatingActionButton now provides a default binding for the Click event when using MvxAppCompatSetup.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Add a FloatingActionButton to an Android layout. Then manually apply a binding using CreateBindingSet.

```
var set = this.CreateBindingSet<ActionView, ActionViewModel>();
set.Bind(leftActionButton).To(vm => vm.LeftActionButtonCommand);
set.Apply();
```
Clicking the FloatingActionButton now triggers the LeftActionButtonCommand instead of throwing NullReferenceException.

### :memo: Links to relevant issues/docs
#3238 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
