### PR TITLE
Android NumberPicker binding documentation

### DIFF
--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -1085,8 +1085,8 @@ using MvvmCross.Platforms.Android.Binding
 using MvvmCross.Binding.Droid
 ```
 
-Base Control | String | Extension method | Mvx version introduced
----- | --------- | --------- | ---------
+Base Control | String | Extension method | Mvx version introduced | Notes
+---- | --------- | --------- | --------- | ---------
 Android.Views.View | Visible | BindVisible()
 Android.Views.View | Hidden | BindHidden()
 Android.Views.View | Click | BindClick()
@@ -1112,6 +1112,8 @@ Android.Widget.EditText | TextFocus | BindTextFocus()
 Android.Widget.SearchView | Query | BindQuery()
 Android.Widget.RatingBar | Rating | BindRating()
 Android.Widget.AdapterView | SelectedItemPosition | BindSelectedItemPosition()
+Android.Widget.NumberPicker | DisplayedValues | BindDisplayedValues() | 6.3 | Must be before `Value` binding
+Android.Widget.NumberPicker | Value | BindValue() | 6.3 | Must be after `DislayedValues` binding
 Android.Preferences.Preference | Value | BindValue()
 Android.Preferences.EditTextPreference | Text | BindText()
 Android.Preferences.ListPreference | Value | BindValue()
@@ -1151,7 +1153,7 @@ MvvmCross.Droid.Support.V7.AppCompat.Widget.MvxAppCompatRadioGroup | SelectedIte
 **Android - `using MvvmCross.Droid.Support.V7.Preference`**
 
 Base Control | String | Extension method | Mvx version introduced
----- | --------- | ---------
+---- | --------- | --------- | ---------
 Android.Support.V7.Preferences.Preference | Value | BindValue()
 Android.Support.V7.Preferences.ListPreference | Value | BindValue()
 Android.Support.V7.Preferences.EditTextPreference | Text | BindText()

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -1112,8 +1112,8 @@ Android.Widget.EditText | TextFocus | BindTextFocus()
 Android.Widget.SearchView | Query | BindQuery()
 Android.Widget.RatingBar | Rating | BindRating()
 Android.Widget.AdapterView | SelectedItemPosition | BindSelectedItemPosition()
-Android.Widget.NumberPicker | DisplayedValues | BindDisplayedValues() | 6.3 | Must be before `Value` binding
-Android.Widget.NumberPicker | Value | BindValue() | 6.3 | Must be after `DislayedValues` binding
+Android.Widget.NumberPicker | DisplayedValues | BindDisplayedValues() | 6.2.3 | Must be before `Value` binding
+Android.Widget.NumberPicker | Value | BindValue() | 6.2.3 | Must be after `DislayedValues` binding
 Android.Preferences.Preference | Value | BindValue()
 Android.Preferences.EditTextPreference | Text | BindText()
 Android.Preferences.ListPreference | Value | BindValue()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
The recently added Android.Widget.NumberPicker bindings are not yet documented.

### :new: What is the new behavior (if this is a feature change)?
Adds documentation for the recently added Android.Widget.NumberPicker `Value` and `DisplayedValues` bindings. 

I added a *Notes* column to the table because the order of the bindings are important; if `Value` is declared before `DisplayedValues` then the NumberPicker will always start at 0. This happens because the default value of `NumberPicker.Max` starts at 0. When the `Value` binding is declared first then `NumberPicker.SetValue()` is being called before `NumberPicker.Max` has been set. I can't think of any reasonable way around this.

I also fixed a minor bug in the MvvmCross.Droid.Support.V7.Preference table which was missing a column header for the *Mvx version introduced* column.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
N/A

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
