### PR TITLE
Fixed recursion issue: used result of recursive call

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -726,14 +726,17 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 //let's try again finding it
                 var frag = fragment?.ChildFragmentManager?.FindFragmentByTag(fragmentName);
 
+                if (frag == null)
+                {
+                    //re-loop for other fragments
+                    frag = FindFragmentInChildren(fragmentName, fragment?.ChildFragmentManager);
+                }
+
                 //if we found the frag lets return it!
                 if (frag != null)
                 {
                     return frag;
-                }
-
-                //re-loop for other fragments
-                FindFragmentInChildren(fragmentName, fragment?.ChildFragmentManager);
+                }                
             }
 
             return null;

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -621,14 +621,17 @@ namespace MvvmCross.Platforms.Android.Presenters
                 //let's try again finding it
                 var frag = parentFrag?.ChildFragmentManager?.FindFragmentByTag(fragmentName);
 
+                if (frag == null)
+                {
+                    //reloop for other fragments
+                    frag = FindFragmentInChildren(fragmentName, parentFrag?.ChildFragmentManager);
+                }
+
                 //if we found the frag lets return it!
                 if (frag != null)
                 {
                     return frag;
                 }
-
-                //reloop for other fragments
-                FindFragmentInChildren(fragmentName, parentFrag?.ChildFragmentManager);
             }
 
             return null;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
 In MvxAppCompatViewPresenter.cs. The result of the function FindFragmentInChildren is not being used when making the recursive call. Its a code review defect. This can lead to an issue.

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?
Hopefully not.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #3250


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
