### PR TITLE
fix FindPropertyInfo method throw AmbiguousMatchException

### DIFF
--- a/MvvmCross/Binding/Bindings/Source/Construction/MvxPropertySourceBindingFactoryExtension.cs
+++ b/MvvmCross/Binding/Bindings/Source/Construction/MvxPropertySourceBindingFactoryExtension.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -98,16 +98,17 @@ namespace MvvmCross.Binding.Bindings.Source.Construction
             PropertyInfo pi;
             if (PropertyInfoCache.TryGetValue(key, out pi))
                 return pi;
-            
-            //Try top level properties first
-            //This extension method "GetProperty" always uses the DeclaredOnly flag
-            pi = sourceType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
 
-            if (pi == null)
+            //Get lowest property
+            while (sourceType != null)
             {
-                //Try base properties. 
-                //This extension method "GetProperty" uses runtime properties instead of simple non declared properties (ie: in hierarchy)
-                pi = sourceType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+                //Use BindingFlags.DeclaredOnly to avoid AmbiguousMatchException
+                pi = sourceType.GetProperty(propertyName, BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
+                if (pi != null)
+                {
+                    break;
+                }
+                sourceType = sourceType.BaseType;
             }
 
             PropertyInfoCache.TryAdd(key, pi);


### PR DESCRIPTION
fix MvxPropertySourceBindingFactoryExtension.FindPropertyInfo method throw AmbiguousMatchException

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
let's say you have:

    public class TypeA
    {
        public object SomeProperty { get; set; }
    }
    public class TypeB<T> : TypeA
    {
        public new T SomeProperty { get; set; }
    }
    public class TypeC : TypeB
    {

    }

When you try to get property through reflection:

    typeof(TypeC).GetProperty("SomeProperty", BindingFlags.Public | indingFlags.Instance);

or

    typeof(TypeC).GetProperty("SomeProperty", BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);

will throw [__AmbiguousMatchException__](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.ambiguousmatchexception?view=netframework-4.7.2).

### :new: What is the new behavior (if this is a feature change)?

use below code to avoid AmbiguousMatchException:

    while (sourceType != null)
    {
        //Use BindingFlags.DeclaredOnly to avoid AmbiguousMatchException
        pi = sourceType.GetProperty(propertyName, BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
        if (pi != null)
        {
            break;
        }
        sourceType = sourceType.BaseType;
    }


According to [this](https://stackoverflow.com/questions/994698/ambiguousmatchexception-type-getproperty-c-sharp-reflection) 

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

None.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
