### PR TITLE
Enhancing SetProperty with Action parameter

### DIFF
--- a/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
@@ -142,6 +142,18 @@ namespace MvvmCross.ViewModels
         }
 
         [NotifyPropertyChangedInvocator]
+        protected virtual bool SetProperty<T>(ref T storage, T value, Action afterAction, [CallerMemberName] string propertyName = null)
+        {
+            if (!SetProperty(ref storage, value, propertyName))
+            {
+                return false;
+            }
+
+            afterAction?.Invoke();
+            return true;
+        }
+
+        [NotifyPropertyChangedInvocator]
         protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
         {
             if (EqualityComparer<T>.Default.Equals(storage, value))
@@ -160,6 +172,7 @@ namespace MvvmCross.ViewModels
             RaisePropertyChanged(propertyName);
             return true;
         }
+
         protected virtual MvxInpcInterceptionResult InterceptRaisePropertyChanged(PropertyChangedEventArgs changedArgs)
         {
             if (MvxSingletonCache.Instance != null)

--- a/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
@@ -142,15 +142,21 @@ namespace MvvmCross.ViewModels
         }
 
         [NotifyPropertyChangedInvocator]
+        protected virtual void SetProperty<T>(ref T storage, T value, Action<bool> action, [CallerMemberName] string propertyName = null)
+        {
+            action?.Invoke(SetProperty(ref storage, value, propertyName));
+        }
+
+        [NotifyPropertyChangedInvocator]
         protected virtual bool SetProperty<T>(ref T storage, T value, Action afterAction, [CallerMemberName] string propertyName = null)
         {
-            if (!SetProperty(ref storage, value, propertyName))
+            if (SetProperty(ref storage, value, propertyName))
             {
-                return false;
+                afterAction?.Invoke();
+                return true;
             }
 
-            afterAction?.Invoke();
-            return true;
+            return false;
         }
 
         [NotifyPropertyChangedInvocator]

--- a/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
+++ b/MvvmCross/ViewModels/MvxNotifyPropertyChanged.cs
@@ -144,7 +144,12 @@ namespace MvvmCross.ViewModels
         [NotifyPropertyChangedInvocator]
         protected virtual void SetProperty<T>(ref T storage, T value, Action<bool> action, [CallerMemberName] string propertyName = null)
         {
-            action?.Invoke(SetProperty(ref storage, value, propertyName));
+            if (action == null)
+            {
+                throw new ArgumentException($"{nameof(action)} should not be null", nameof(action));
+            }
+
+            action.Invoke(SetProperty(ref storage, value, propertyName));
         }
 
         [NotifyPropertyChangedInvocator]

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
@@ -63,6 +63,21 @@ namespace MvvmCross.UnitTest.ViewModels
             }
         }
 
+        public class TestInpc4 : MvxNotifyPropertyChanged
+        {
+            public int TestActionValue;
+
+            private string _foo;
+
+            public Action<bool> IncreaseTestActionValue = null;
+
+            public string Foo
+            {
+                get => _foo;
+                set => SetProperty(ref _foo, value, IncreaseTestActionValue);
+            }
+        }
+
         [Fact]
         public void Test_RaisePropertyChangingForExpression()
         {
@@ -280,6 +295,24 @@ namespace MvvmCross.UnitTest.ViewModels
             t3.Foo = "Foobar";
             Assert.Equal(2, t3.TestActionValue);
             Assert.NotEqual(0, t3.TestActionValue);
+
+            var t4 = new TestInpc4();
+            Assert.Equal(0, t4.TestActionValue);
+            Assert.Throws<ArgumentException>(() => t4.Foo = "Foo");
+            t4.IncreaseTestActionValue = setPropertyResult =>
+            {
+                if (setPropertyResult)
+                {
+                    t4.TestActionValue++;
+                }
+            };
+            t4.Foo = "Foo";
+            Assert.Equal(1, t4.TestActionValue);
+            t4.Foo = "Foo";
+            Assert.Equal(1, t4.TestActionValue);
+            t4.Foo = "Foobar";
+            Assert.Equal(2, t4.TestActionValue);
+            Assert.NotEqual(0, t4.TestActionValue);
         }
 
         public class Interceptor : IMvxInpcInterceptor

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
@@ -44,6 +44,25 @@ namespace MvvmCross.UnitTest.ViewModels
             }
         }
 
+        public class TestInpc3 : MvxNotifyPropertyChanged
+        {
+            public int TestActionValue;
+
+            private string _foo;
+
+            public string Foo
+            {
+                get => _foo;
+                set => SetProperty(ref _foo, value, (setPropertyResult) =>
+                {
+                    if (setPropertyResult)
+                    {
+                        TestActionValue++;
+                    }
+                });
+            }
+        }
+
         [Fact]
         public void Test_RaisePropertyChangingForExpression()
         {
@@ -242,13 +261,25 @@ namespace MvvmCross.UnitTest.ViewModels
             var dispatcher = new InlineMockMainThreadDispatcher();
             _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
 
-            var t = new TestInpc2();
-            Assert.Equal(0, t.TestActionValue);
-            t.Foo = "Foo";
-            Assert.Equal(1, t.TestActionValue);
-            t.Foo = "Foobar";
-            Assert.Equal(2, t.TestActionValue);
-            Assert.NotEqual(0, t.TestActionValue);
+            var t2 = new TestInpc2();
+            Assert.Equal(0, t2.TestActionValue);
+            t2.Foo = "Foo";
+            Assert.Equal(1, t2.TestActionValue);
+            t2.Foo = "Foo";
+            Assert.Equal(1, t2.TestActionValue);
+            t2.Foo = "Foobar";
+            Assert.Equal(2, t2.TestActionValue);
+            Assert.NotEqual(0, t2.TestActionValue);
+
+            var t3 = new TestInpc3();
+            Assert.Equal(0, t3.TestActionValue);
+            t3.Foo = "Foo";
+            Assert.Equal(1, t3.TestActionValue);
+            t3.Foo = "Foo";
+            Assert.Equal(1, t3.TestActionValue);
+            t3.Foo = "Foobar";
+            Assert.Equal(2, t3.TestActionValue);
+            Assert.NotEqual(0, t3.TestActionValue);
         }
 
         public class Interceptor : IMvxInpcInterceptor

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxNotifyPropertyChangedTest.cs
@@ -31,6 +31,19 @@ namespace MvvmCross.UnitTest.ViewModels
             public string Foo { get => _foo; set => SetProperty(ref _foo, value); }
         }
 
+        public class TestInpc2 : MvxNotifyPropertyChanged
+        {
+            public int TestActionValue;
+
+            private string _foo;
+
+            public string Foo
+            {
+                get => _foo;
+                set => SetProperty(ref _foo, value, () => TestActionValue++);
+            }
+        }
+
         [Fact]
         public void Test_RaisePropertyChangingForExpression()
         {
@@ -220,6 +233,22 @@ namespace MvvmCross.UnitTest.ViewModels
             Assert.Equal(1, dispatcher.Count);
             Assert.True(notified.Count == 2);
             Assert.True(notified[0] == "Foo");
+        }
+
+        [Fact]
+        public void Test_SetPropertyAfterActionCalledAfterPropertyChanged()
+        {
+            _fixture.ClearAll();
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            _fixture.Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
+
+            var t = new TestInpc2();
+            Assert.Equal(0, t.TestActionValue);
+            t.Foo = "Foo";
+            Assert.Equal(1, t.TestActionValue);
+            t.Foo = "Foobar";
+            Assert.Equal(2, t.TestActionValue);
+            Assert.NotEqual(0, t.TestActionValue);
         }
 
         public class Interceptor : IMvxInpcInterceptor

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -552,22 +552,14 @@ private string _firstName;
 public string FirstName
 {
     get => _firstName;
-    set 
-    { 
-        if (SetProperty(ref _firstName, value))
-            RaisePropertyChanged(() => FullName);
-    }
+    set => SetProperty(ref _firstName, value, () => RaisePropertyChanged(() => FullName));
 }
 
 private string _lastName;
 public string LastName
 {
     get => _lastName;
-    set 
-    { 
-        if (SetProperty(ref _lastName, value))
-            RaisePropertyChanged(() => FullName);
-    }
+    set => SetProperty(ref _lastName, value, () => RaisePropertyChanged(() => FullName));
 }
 
 public string FullName => _firstName + " " + _lastName;

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -559,7 +559,13 @@ private string _lastName;
 public string LastName
 {
     get => _lastName;
-    set => SetProperty(ref _lastName, value, () => RaisePropertyChanged(() => FullName));
+    set => SetProperty(ref _lastName, value, (setPropertyResult) => 
+    {
+        if (setPropertyResult)
+        {
+            RaisePropertyChanged(() => FullName);
+        }
+    }
 }
 
 public string FullName => _firstName + " " + _lastName;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
SetProperty doesn't have overloaded method with action parameter to run extra lines of codes easily.

### :new: What is the new behavior (if this is a feature change)?
SetProperty has new overloaded method with new parameter which is afterAction. This parameter makes multi binding easier than before. Check last commit on [data-binding.md](https://github.com/dogukandemir/MvvmCross/commit/3a68afd8598013bb94ef32cc0f70ea6a800f9a9a).

Before:
```
private string _foo;
public string Foo
{
    get => _foo;
    set
    {
        if (SetProperty(ref _foo, value))
        {
            Debug.WriteLine("some action");
            // more action
        }
    }
}
```

After:
```
private string _foo;
public string Foo
{
    get => _foo;
    set => SetProperty(ref _foo, value, () => { Debug.WriteLine("some action"); /* more action */ }); }
}
```

or
```
public void MyAction()
{
    Debug.WriteLine("some action"); 
    // more action
}

private string _foo;
public string Foo
{
    get => _foo;
    set => SetProperty(ref _foo, value, MyAction); }
}
```
### :boom: Does this PR introduce a breaking change?
This PR is not a breaking change. It only has new overloaded method.

### :bug: Recommendations for testing
If you assign any action to SetProperty method, check your method is invoked or not.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop