### PR TITLE
GetAppStartHint() passes hint through instead of always returning null.

### DIFF
--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatActivity.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatActivity.cs
@@ -104,7 +104,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected override void OnDestroy()

--- a/MvvmCross.Forms.Wpf/Platforms/Wpf/Views/MvxFormsWindowsPage.cs
+++ b/MvvmCross.Forms.Wpf/Platforms/Wpf/Views/MvxFormsWindowsPage.cs
@@ -52,7 +52,7 @@ namespace MvvmCross.Forms.Platforms.Wpf.Views
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected virtual void LoadFormsApplication()

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
@@ -121,7 +121,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         public virtual void InitializeForms(Bundle bundle)

--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsApplicationActivity.cs
@@ -117,7 +117,7 @@ namespace MvvmCross.Forms.Platforms.Android.Views
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         public virtual void InitializeForms(Bundle bundle)

--- a/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Ios/Core/MvxFormsApplicationDelegate.cs
@@ -44,7 +44,7 @@ namespace MvvmCross.Forms.Platforms.Ios.Core
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected virtual void LoadFormsApplication()

--- a/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
+++ b/MvvmCross.Forms/Platforms/Mac/Core/MvxFormsApplicationDelegate.cs
@@ -65,7 +65,7 @@ namespace MvvmCross.Forms.Platforms.Mac.Core
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected virtual void LoadFormsApplication()

--- a/MvvmCross.Forms/Platforms/Uap/Views/MvxFormsWindowsPage.cs
+++ b/MvvmCross.Forms/Platforms/Uap/Views/MvxFormsWindowsPage.cs
@@ -39,7 +39,7 @@ namespace MvvmCross.Forms.Platforms.Uap.Views
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected virtual void LoadFormsApplication()

--- a/MvvmCross/Platforms/Android/Views/MvxActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxActivity.cs
@@ -131,7 +131,7 @@ namespace MvvmCross.Platforms.Android.Views
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected override void OnDestroy()

--- a/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
@@ -61,7 +61,7 @@ namespace MvvmCross.Platforms.Ios.Core
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected virtual void RegisterSetup()

--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -49,7 +49,7 @@ namespace MvvmCross.Platforms.Mac.Core
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         public override void WillBecomeActive(Foundation.NSNotification notification)

--- a/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Platforms.Tvos.Core
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         public override void WillEnterForeground(UIApplication application)

--- a/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxApplication.cs
@@ -80,7 +80,7 @@ namespace MvvmCross.Platforms.Uap.Views
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected virtual Frame InitializeFrame(IActivatedEventArgs activationArgs)

--- a/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxApplication.cs
@@ -31,7 +31,7 @@ namespace MvvmCross.Platforms.Wpf.Views
 
         protected virtual object GetAppStartHint(object hint = null)
         {
-            return null;
+            return hint;
         }
 
         protected virtual void RegisterSetup()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
`GetAppStartHint()` always returns null ignoring the hint variable passed into the method.

### :new: What is the new behavior (if this is a feature change)?
`GetAppStartHint()` always returns the passed in hint, which defaults to null.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
This was pointed out on [StackOverflow](https://stackoverflow.com/questions/54593528/how-to-flag-if-closed-app-started-from-push-notification-using-mvvmcross-with-cu)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
