### PR TITLE
Fixes #3284.

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxGridView.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Windows.Input;
 using Android.Content;
+using Android.OS;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
@@ -169,6 +170,12 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 
         protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
         {
+            if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
+            {
+                base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+                return;
+            }
+
             if (NestedScrollingEnabled)
                 base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
             else


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MvxGridView throws a NoSuchMethodError if running on Android KitKat or lower because it's calling an Android API21 API without checking `Build.VERSION.SdkInt`.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Add a MvxGridView to a layout and run on Android KitKat emulator/phone.

### :memo: Links to relevant issues/docs
#3284 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
