### PR TITLE
Return the task to properly await showing view model

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/MvxIosViewDispatcher.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxIosViewDispatcher.cs
@@ -23,10 +23,10 @@ namespace MvvmCross.Platforms.Ios.Views
 
         public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
-            Action action = () =>
+            Func<Task> action = () =>
                 {
                     MvxLog.Instance.Trace("iOSNavigation", "Navigate requested");
-                    _presenter.Show(request);
+                    return _presenter.Show(request);
                 };
             await ExecuteOnMainThreadAsync(action);
             return true;

--- a/MvvmCross/Platforms/Mac/Views/MvxMacViewDispatcher.cs
+++ b/MvvmCross/Platforms/Mac/Views/MvxMacViewDispatcher.cs
@@ -24,10 +24,10 @@ namespace MvvmCross.Platforms.Mac.Views
 
         public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
-            Action action = () =>
+            Func<Task> action = () =>
             {
                 MvxLog.Instance.Trace("MacNavigation", "Navigate requested");
-                _presenter.Show(request);
+                return _presenter.Show(request);
             };
             await ExecuteOnMainThreadAsync(action);
             return true;
@@ -35,10 +35,10 @@ namespace MvvmCross.Platforms.Mac.Views
 
         public async Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
-            Action action = () =>
+            Func<Task> action = () =>
                                 {
                                     MvxLog.Instance.Trace("MacNavigation", "Change presentation requested");
-                                    _presenter.ChangePresentation(hint);
+                                    return _presenter.ChangePresentation(hint);
                                 };
             await ExecuteOnMainThreadAsync(action);
             return true;

--- a/MvvmCross/Platforms/Tizen/Views/MvxTizenViewDispatcher.cs
+++ b/MvvmCross/Platforms/Tizen/Views/MvxTizenViewDispatcher.cs
@@ -23,10 +23,10 @@ namespace MvvmCross.Platforms.Tizen.Views
 
         public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
-            Action action = () =>
+            Func<Task> action = () =>
             {
                 MvxLog.Instance.Trace("TizenNavigation", "Navigate requested");
-                _presenter.Show(request);
+                return _presenter.Show(request);
             };
             await ExecuteOnMainThreadAsync(action);
             return true;

--- a/MvvmCross/Platforms/Tvos/Views/MvxTvosViewDispatcher.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxTvosViewDispatcher.cs
@@ -23,10 +23,10 @@ namespace MvvmCross.Platforms.Tvos.Views
 
         public async Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
-            Action action = () =>
+            Func<Task> action = () =>
                 {
                     MvxLog.Instance.Trace("tvOSNavigation", "Navigate requested");
-                    _presenter.Show(request);
+                    return _presenter.Show(request);
                 };
             await ExecuteOnMainThreadAsync(action);
             return true;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
NavigationService doesn't wait for the view to appear in ios

### :new: What is the new behavior (if this is a feature change)?
NavigationService is now aware of the showing task and will properly wait for it to complete before returning

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#3289 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
