### PR TITLE
3158 ViewDestroy lifecycle method is broken

### DIFF
--- a/MvvmCross.Forms/Core/MvxFormsApplication.cs
+++ b/MvvmCross.Forms/Core/MvxFormsApplication.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using MvvmCross.Forms.Views;
+using MvvmCross.ViewModels;
 using Xamarin.Forms;
 
 namespace MvvmCross.Forms.Core
@@ -11,6 +13,7 @@ namespace MvvmCross.Forms.Core
     {
         protected MvxFormsApplication()
         {
+            this.ModalPopped += OnModalPopped;
         }
 
         public event EventHandler Start;
@@ -32,6 +35,14 @@ namespace MvvmCross.Forms.Core
         protected override void OnResume()
         {
             Resume?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void OnModalPopped(object sender, ModalPoppedEventArgs e)
+        {
+            if (e.Modal is IMvxPage mvxPage && mvxPage.ViewModel is IMvxViewModel modalViewModel)
+            {
+                modalViewModel.ViewDestroy(true);
+            }
         }
     }
 }

--- a/MvvmCross.Forms/Core/MvxFormsApplication.cs
+++ b/MvvmCross.Forms/Core/MvxFormsApplication.cs
@@ -13,7 +13,7 @@ namespace MvvmCross.Forms.Core
     {
         protected MvxFormsApplication()
         {
-            this.ModalPopped += OnModalPopped;
+            ModalPopped += OnModalPopped;
         }
 
         public event EventHandler Start;
@@ -37,12 +37,20 @@ namespace MvvmCross.Forms.Core
             Resume?.Invoke(this, EventArgs.Empty);
         }
 
+        protected override void OnPropertyChanging(string propertyName = null)
+        {
+            if (propertyName == nameof(MainPage)
+                && MainPage is IMvxPage mvxPage
+                && mvxPage.ViewModel is IMvxViewModel mvxViewModel)
+                mvxViewModel.ViewDestroy(true);
+
+            base.OnPropertyChanging(propertyName);
+        }
+
         private void OnModalPopped(object sender, ModalPoppedEventArgs e)
         {
             if (e.Modal is IMvxPage mvxPage && mvxPage.ViewModel is IMvxViewModel modalViewModel)
-            {
                 modalViewModel.ViewDestroy(true);
-            }
         }
     }
 }

--- a/MvvmCross.Forms/Views/MvxCarouselPage.cs
+++ b/MvvmCross.Forms/Views/MvxCarouselPage.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxContentPage.cs
+++ b/MvvmCross.Forms/Views/MvxContentPage.cs
@@ -90,7 +90,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxEntryCell.cs
+++ b/MvvmCross.Forms/Views/MvxEntryCell.cs
@@ -88,7 +88,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxImageCell.cs
+++ b/MvvmCross.Forms/Views/MvxImageCell.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxMasterDetailPage.cs
+++ b/MvvmCross.Forms/Views/MvxMasterDetailPage.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxNavigationPage.cs
+++ b/MvvmCross.Forms/Views/MvxNavigationPage.cs
@@ -14,11 +14,15 @@ namespace MvvmCross.Forms.Views
         public MvxNavigationPage() : base()
         {
             this.AdaptForBinding();
+
+            this.Popped += OnViewPopped;
         }
 
         public MvxNavigationPage(Page root) : base(root)
         {
             this.AdaptForBinding();
+            
+            this.Popped += OnViewPopped;
         }
 
         public object DataContext
@@ -76,7 +80,7 @@ namespace MvvmCross.Forms.Views
                 OnViewModelSet();
             }
         }
-
+        
         protected virtual void OnViewModelSet()
         {
             ViewModel?.ViewCreated();
@@ -94,7 +98,15 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
+        }
+
+        private void OnViewPopped(object sender, NavigationEventArgs e)
+        {
+            if (e.Page is IMvxPage mvxPage
+                && mvxPage.ViewModel is IMvxViewModel pageViewModel)
+            {
+                pageViewModel.ViewDestroy(true);
+            }
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxPage.cs
+++ b/MvvmCross.Forms/Views/MvxPage.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxSwitchCell.cs
+++ b/MvvmCross.Forms/Views/MvxSwitchCell.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxTabbedPage.cs
+++ b/MvvmCross.Forms/Views/MvxTabbedPage.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxTextCell.cs
+++ b/MvvmCross.Forms/Views/MvxTextCell.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 

--- a/MvvmCross.Forms/Views/MvxViewCell.cs
+++ b/MvvmCross.Forms/Views/MvxViewCell.cs
@@ -89,7 +89,6 @@ namespace MvvmCross.Forms.Views
             base.OnDisappearing();
             ViewModel?.ViewDisappearing();
             ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
         }
     }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
ViewDestroy is called when view disappears and doesn't reflect an actual view destroy.

### :new: What is the new behavior (if this is a feature change)?
ViewDestroy is called when the view is popped from a `MvxNavigationPage` or from a application wide modal pop.

I have implemented this for pages not really sure about `MvxEntryCell , MvxImageCell ... etc` as they still call `ViewDestroy` in `Disappear`

### :boom: Does this PR introduce a breaking change?
Yes (Different behavior)

### :bug: Recommendations for testing
One way to notice this is by showing a viewmodel that returns a result and the go to another app (or load another view model) the view model will issue a cancel result because it thinks it got destroyed.

### :memo: Links to relevant issues/docs
#3158 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
- [x] Implementing something similar  for `IMvxCell` if it's possible
- [x] Implementing `ViewDestroy` for `MainPage`