### PR TITLE
Initialize async issue on Playground.UWP apps

### DIFF
--- a/Projects/Eventhooks/Eventhooks.Uwp/Eventhooks.Uwp.csproj
+++ b/Projects/Eventhooks/Eventhooks.Uwp/Eventhooks.Uwp.csproj
@@ -162,7 +162,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.2.2</Version>
+      <Version>6.2.3</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Projects/PageRenderer/PageRenderer.UWP/PageRendererExample.WindowsUWP.csproj
+++ b/Projects/PageRenderer/PageRenderer.UWP/PageRendererExample.WindowsUWP.csproj
@@ -168,7 +168,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.2.2</Version>
+      <Version>6.2.3</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>2.5.0.280555</Version>

--- a/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -168,7 +168,7 @@
       <Project>{9a317670-f2d9-4155-9ea7-f8cfd3cfe79f}</Project>
       <Name>Playground.Forms.UI</Name>
     </ProjectReference>
-  <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
+  <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.3" />
   </ItemGroup>
   <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />

--- a/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -194,7 +194,7 @@
       <Project>{fe374d1a-1a19-49bc-8e93-d52399a9c3f3}</Project>
       <Name>Playground.Core</Name>
     </ProjectReference>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.3" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
UWP apps are stucking at splash screen if you use await inside Initialize.

### :new: What is the new behavior (if this is a feature change)?
Looks like Microsoft fixed blocking issue inside Microsoft.NETCore.UniversalWindowsPlatform. After upgrading Microsoft.NETCore.UniversalWindowsPlatform to 6.2.3, it doesn't stuck anymore.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Try to run example UWP projects and make sure it doesn't stuck at splash screen.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
