### PR TITLE
Adds ability to navigate to an activity if no top activity is available

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -260,7 +260,9 @@ namespace MvvmCross.Platforms.Android.Presenters
             var activity = CurrentActivity;
             if (activity == null)
             {
-                MvxLog.Instance.Warn("Cannot Resolve current top activity");
+                MvxLog.Instance.Warn("Cannot Resolve current top activity. Creating new activity from Application Context");
+                intent.AddFlags(ActivityFlags.NewTask);
+                Application.Context.StartActivity(intent, bundle);
                 return;
             }
             activity.StartActivity(intent, bundle);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
You can't navigate to an activity if there is no active top activity.

### :new: What is the new behavior (if this is a feature change)?
Allows navigation to an activity in a new task if there is no active top activity.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Show a notification with a `PendingIntent` to trigger a `BroadcastReceiver`. Try to navigate to a ViewModel from the `BroadcastReceiver` while the app is in the background or not running.

### :memo: Links to relevant issues/docs
#3311

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
