### PR TITLE
Fixed the MvxSimpleTableViewSource; now can work with both storyboard and xib-cells

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs
@@ -23,21 +23,17 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             MvxLog.Instance.Warn("MvxSimpleTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
-        public MvxSimpleTableViewSource(UITableView tableView, string cellIdentifier)
-            : base(tableView)
-        {
-            _cellIdentifier = new NSString(cellIdentifier);
-            tableView.RegisterNibForCellReuse(UINib.FromName(cellIdentifier, NSBundle.MainBundle), cellIdentifier);
-        }
-
         public MvxSimpleTableViewSource(UITableView tableView, string nibName, string cellIdentifier = null,
-                                        NSBundle bundle = null)
+                                        NSBundle bundle = null, bool registerNibForCellReuse = true)
             : base(tableView)
         {
             // if no cellIdentifier supplied, then use the nibName as cellId
             cellIdentifier = cellIdentifier ?? nibName;
             _cellIdentifier = new NSString(cellIdentifier);
-            tableView.RegisterNibForCellReuse(UINib.FromName(nibName, bundle ?? NSBundle.MainBundle), cellIdentifier);
+
+            if (registerNibForCellReuse) {
+                tableView.RegisterNibForCellReuse(UINib.FromName(nibName, bundle ?? NSBundle.MainBundle), cellIdentifier);
+            }
         }
 
         public MvxSimpleTableViewSource(UITableView tableView, Type cellType, string cellIdentifier = null)

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxSimpleTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxSimpleTableViewSource.cs
@@ -23,21 +23,17 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             MvxLog.Instance.Warn("MvxSimpleTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
-        public MvxSimpleTableViewSource(UITableView tableView, string cellIdentifier)
-            : base(tableView)
-        {
-            _cellIdentifier = new NSString(cellIdentifier);
-            tableView.RegisterNibForCellReuse(UINib.FromName(cellIdentifier, NSBundle.MainBundle), cellIdentifier);
-        }
-
         public MvxSimpleTableViewSource(UITableView tableView, string nibName, string cellIdentifier = null,
-                                        NSBundle bundle = null)
+                                        NSBundle bundle = null, bool registerNibForCellReuse = true)
             : base(tableView)
         {
             // if no cellIdentifier supplied, then use the nibName as cellId
             cellIdentifier = cellIdentifier ?? nibName;
             _cellIdentifier = new NSString(cellIdentifier);
-            tableView.RegisterNibForCellReuse(UINib.FromName(nibName, bundle ?? NSBundle.MainBundle), cellIdentifier);
+
+            if (registerNibForCellReuse) {
+                tableView.RegisterNibForCellReuse(UINib.FromName(nibName, bundle ?? NSBundle.MainBundle), cellIdentifier);
+            }
         }
 
         public MvxSimpleTableViewSource(UITableView tableView, Type cellType, string cellIdentifier = null)


### PR DESCRIPTION
Removed the extra constructor for the MvxSimpleTableViewSource added in https://github.com/MvvmCross/MvvmCross/pull/2897, since it blocks the standard constructor which was already there. The two constructors now virtually did the same. The functionality added in 2897 was broken again in https://github.com/MvvmCross/MvvmCross/issues/3175.

Added a boolean to the second constructor, so you can actually set whether or not you want to register the nib cell for reuse, where true is the current value (and thus the standard) and false can be used if you use storyboard nibs.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
In 2897 we added functionality to use SB cells instead of just xib-cells. This was broken again in 3175, because for the SB views we do not need to register the nib for cell reuse. So I removed the first constructor and added the boolean to the standard constructor which was already there before 2897. Doing this I virtually revert 3175 and implemented 2897 in a way which is non-blocking for the standard xib files.

### :arrow_heading_down: What is the current behavior?
The SB view-cells will not work at this moment, they can not be found when we dequeue the cells.

### :new: What is the new behavior (if this is a feature change)?
The SB views will work correctly again, if you add the bool false to the constructor for the MvxSimpleTableViewSource

### :boom: Does this PR introduce a breaking change?
It does not, although it can break functionality which depends on 2897, but that is already broken in mvvmcross 6.2.3 because of 3175.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
