### PR TITLE
Add possibility to fire command on deselect

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
@@ -31,6 +31,8 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
 
         public bool DeselectAutomatically { get; set; }
 
+        public bool DeselectChangedEnabled { get; set; }
+
         public ICommand SelectionChangedCommand { get; set; }
 
         public ICommand AccessoryTappedCommand { get; set; }
@@ -76,6 +78,22 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
                 command.Execute(item);
 
             SelectedItem = item;
+        }
+
+        public override void RowDeselected(UITableView tableView, NSIndexPath indexPath)
+        {
+            if (DeselectChangedEnabled && !DeselectAutomatically)
+            {
+                var item = GetItemAt(indexPath);
+
+                var command = SelectionChangedCommand;
+                if (command != null && command.CanExecute(item))
+                    command.Execute(item);
+
+                SelectedItem = null;
+            }
+
+            base.RowDeselected(tableView, indexPath);
         }
 
         private object _selectedItem;

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxBaseTableViewSource.cs
@@ -31,6 +31,8 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
 
         public bool DeselectAutomatically { get; set; }
 
+        public bool DeselectChangedEnabled { get; set; }
+
         public ICommand SelectionChangedCommand { get; set; }
 
         public ICommand AccessoryTappedCommand { get; set; }
@@ -76,6 +78,22 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
                 command.Execute(item);
 
             SelectedItem = item;
+        }
+
+        public override void RowDeselected(UITableView tableView, NSIndexPath indexPath)
+        {
+            if (DeselectChangedEnabled && !DeselectAutomatically)
+            {
+                var item = GetItemAt(indexPath);
+
+                var command = SelectionChangedCommand;
+                if (command != null && command.CanExecute(item))
+                    command.Execute(item);
+
+                SelectedItem = null;
+            }
+
+            base.RowDeselected(tableView, indexPath);
         }
 
         private object _selectedItem;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

No way of attaching a command to a deselect event

### :new: What is the new behavior (if this is a feature change)?

Added the ability to use SelectedChangedCommand to know when a row has been deselected.
### :boom: Does this PR introduce a breaking change?

No, a user would have to explicitly set `DeselectChangedEnabled` to change behavior.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Fixes https://github.com/MvvmCross/MvvmCross/issues/3305

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
