### PR TITLE
Fix for #3329 - Missing event info in picture chooser

### DIFF
--- a/ContentFiles/iOS/LinkerPleaseInclude.cs
+++ b/ContentFiles/iOS/LinkerPleaseInclude.cs
@@ -123,6 +123,14 @@ namespace $YourNameSpace$
         {
             service = new MvxNavigationService(null, loader);
         }
+        
+        public void Include(UIImagePickerController uIImagePickerController)
+        {
+            var x = uIImagePickerController.SourceType;
+            uIImagePickerController.FinishedPickingMedia += (s, e) => { };
+            uIImagePickerController.FinishedPickingImage += (s, e) => { };
+            uIImagePickerController.Canceled += (s, e) => { };
+        }
 
         public void Include(ConsoleColor color)
         {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix for #3329.

### :bug: Recommendations for testing
The bug only appears on a device build with the linker enabled.

### :memo: Links to relevant issues/docs
#3329
