### PR TITLE
Add mvx bottom navigation view

### DIFF
--- a/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
+++ b/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using Android.Content;
+using Android.Runtime;
+using Android.Widget;
+using Android.Util;
+using Android.Views;
+using Android.Support.Design.Widget;
+
+namespace MvvmCross.Droid.Support.Design
+{
+    [Register("mvvmcross.droid.support.design.MvxBottomNavigationView")]
+    public class MvxBottomNavigationView : BottomNavigationView, BottomNavigationView.IOnNavigationItemSelectedListener
+    {
+        public List<MvxMenuItem> ItemsSource = new List<MvxMenuItem>();
+
+        public MvxBottomNavigationView(Context context) : base(context)
+        {
+            this.SetOnNavigationItemSelectedListener(this);
+        }
+
+        public MvxBottomNavigationView(Context context, IAttributeSet attrs) : base(context, attrs)
+        {
+            this.SetOnNavigationItemSelectedListener(this);
+        }
+
+        public MvxBottomNavigationView(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
+        {
+            this.SetOnNavigationItemSelectedListener(this);
+        }
+
+        protected MvxBottomNavigationView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+            this.SetOnNavigationItemSelectedListener(this);
+        }
+
+        public void AddItem(IMenuItem item, Type viewModel)
+        {
+            ItemsSource.Add(new MvxMenuItem(item, viewModel));
+
+            // The first item is autoselected
+            if (ItemsSource.Count == 1)
+            {
+                OnNavigationItemSelected(item);
+            }
+        }
+
+        public bool OnNavigationItemSelected(IMenuItem item)
+        {
+            var mvxMenuItem = this.FindItemByMenuItem(item);
+
+            if (mvxMenuItem != null && HandleNavigate.CanExecute(mvxMenuItem.ViewModel))
+            {
+                HandleNavigate.Execute(mvxMenuItem.ViewModel);
+                return true;
+            }
+
+            return false;
+        }
+
+        public MvxMenuItem FindItemByViewModel(Type viewModel)
+        {
+            return ItemsSource.Find(i => i.ViewModel == viewModel);
+        }
+
+        public int FindPositionByViewModel(Type viewModel)
+        {
+            return ItemsSource.FindIndex(i => i.ViewModel == viewModel);
+        }
+
+        public MvxMenuItem FindItemByMenuItem(IMenuItem item)
+        {
+            return ItemsSource.Find(i => i.MenuItem == item);
+        }
+
+        public ICommand HandleNavigate { get; set; }
+    }
+
+    public class MvxMenuItem
+    {
+        public IMenuItem MenuItem { get; set; }
+        public Type ViewModel { get; set; }
+
+        public MvxMenuItem(IMenuItem menuItem, Type viewModel)
+        {
+            this.MenuItem = menuItem;
+            this.ViewModel = viewModel;
+        }
+    }
+}

--- a/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
+++ b/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
@@ -32,7 +32,6 @@ namespace MvvmCross.Droid.Support.Design
 
         protected MvxBottomNavigationView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
         {
-            this.SetOnNavigationItemSelectedListener(this);
         }
 
         public void AddItem(IMenuItem item, Type viewModel)

--- a/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
+++ b/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
@@ -48,11 +48,11 @@ namespace MvvmCross.Droid.Support.Design
 
         public bool OnNavigationItemSelected(IMenuItem item)
         {
-            var mvxMenuItem = this.FindItemByMenuItem(item);
+            var menuItem = this.FindItemByMenuItem(item);
 
-            if (mvxMenuItem != null && HandleNavigate.CanExecute(mvxMenuItem.ViewModel))
+            if (menuItem != null && HandleNavigate.CanExecute(menuItem.ViewModel))
             {
-                HandleNavigate.Execute(mvxMenuItem.ViewModel);
+                HandleNavigate.Execute(menuItem.ViewModel);
                 return true;
             }
 

--- a/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
+++ b/MvvmCross.DroidX/Material/MvxBottomNavigationView.cs
@@ -74,6 +74,16 @@ namespace MvvmCross.Droid.Support.Design
         }
 
         public ICommand HandleNavigate { get; set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                SetOnNavigationItemSelectedListener(null);
+            }
+
+            base.Dispose(disposing);
+        }
     }
 
     public class MvxMenuItem

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxBottomNavigationViewPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxBottomNavigationViewPresentationAttribute.cs
@@ -8,84 +8,52 @@ using System;
 namespace MvvmCross.Platforms.Android.Presenters.Attributes
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    public class MvxBottomNavigationViewPresentationAttribute : MvxFragmentPresentationAttribute
+    public class MvxBottomNavigationViewPresentationAttribute : MvxViewPagerFragmentPresentationAttribute
     {
+        
         public MvxBottomNavigationViewPresentationAttribute(
-            int bottomNavigationResourceId, 
             string title,
-            int drawableItemId = int.MinValue,
-            Type activityHostViewModelType = null!,
-            int fragmentContentId = int.MinValue,
+            int viewPagerResourceId,
+            int bottomNavigationViewResourceId,
+            int iconDrawableResourceId = int.MinValue,
+            Type activityHostViewModelType = null,
             bool addToBackStack = false,
-            Type fragmentHostViewType = null!,
-            bool isCacheableFragment = false,
-            string tag = null!)
-            : base(activityHostViewModelType,
-                fragmentContentId,
-                addToBackStack,
-                int.MinValue,
-                int.MinValue,
-                int.MinValue,
-                int.MinValue,
-                int.MinValue,
-                fragmentHostViewType,
-                isCacheableFragment,
-                tag)
+            Type fragmentHostViewType = null,
+            bool isCacheableFragment = false) : base(title, viewPagerResourceId, activityHostViewModelType,
+            addToBackStack, fragmentHostViewType, isCacheableFragment)
         {
-            BottomNavigationResourceId = bottomNavigationResourceId;
-            DrawableItemId = drawableItemId;
-            Title = title;
+            BottomNavigationViewResourceId = bottomNavigationViewResourceId;
+            IconDrawableResourceId = iconDrawableResourceId;
         }
 
         public MvxBottomNavigationViewPresentationAttribute(
-            string bottomNavigationResourceName,
             string title,
-            int drawableItemId = int.MinValue,
-            Type activityHostViewModelType = null!,
+            string viewPagerResourceId,
+            string bottomNavigationViewResourceId,
+            int iconDrawableResourceId = int.MinValue,
+            Type activityHostViewModelType = null,
             bool addToBackStack = false,
-            Type fragmentHostViewType = null!,
-            bool isCacheableFragment = false,
-            string tag = null!)
-            : base(
-                activityHostViewModelType,
-                null,
-                addToBackStack,
-                null,
-                null,
-                null,
-                null,
-                null,
-                fragmentHostViewType,
-                isCacheableFragment,
-                tag)
+            Type fragmentHostViewType = null,
+            bool isCacheableFragment = false) : base(title, viewPagerResourceId,
+            activityHostViewModelType, addToBackStack, fragmentHostViewType, isCacheableFragment)
         {
-            if (Mvx.IoCProvider.TryResolve(out IMvxAndroidGlobals globals) &&
-                globals.ApplicationContext.Resources != null)
-            {
-                var context = globals.ApplicationContext;
+            var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
 
-                BottomNavigationResourceId = !string.IsNullOrEmpty(bottomNavigationResourceName)
-                    ? context.Resources.GetIdentifier(bottomNavigationResourceName, "id", context.PackageName)
-                    : global::Android.Resource.Id.Content;
-            }
+            BottomNavigationViewResourceId = !string.IsNullOrEmpty(bottomNavigationViewResourceId)
+                ? context.Resources!.GetIdentifier(bottomNavigationViewResourceId, "id", context.PackageName)
+                : global::Android.Resource.Id.Content;
 
-            DrawableItemId = drawableItemId;
-            Title = title;
+            IconDrawableResourceId = iconDrawableResourceId;
         }
 
         /// <summary>
-        ///     The resource used to get the BottomNavigation from the view
+        /// The resource id used to get the BottomNavigationView from the view
         /// </summary>
-        public int BottomNavigationResourceId { get; set; }
+        public int BottomNavigationViewResourceId { get; set; }
 
         /// <summary>
-        ///     The resource used to get the menu item from the view
+        /// The resource id used to get the menu item from the view
         /// </summary>
-        public int DrawableItemId { get; set; }
-
-        /// <summary>
-        ///     The title for the bottom navigation menu item
-        /// </summary>
-        public string Title { get; set; }
+        public int IconDrawableResourceId { get; set; }
     }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxBottomNavigationViewPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxBottomNavigationViewPresentationAttribute.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using MvvmCross;
+using MvvmCross.Platforms.Android;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.Presenters.Attributes;
+
+namespace MvvmCross.Platforms.Android.Presenters.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class MvxBottomNavigationViewPresentationAttribute : MvxFragmentPresentationAttribute
+    {
+        public MvxBottomNavigationViewPresentationAttribute()
+        {
+        }
+
+        public MvxBottomNavigationViewPresentationAttribute(int bottomNavigationResourceId, string title, int drawableItemId = int.MinValue,
+            Type activityHostViewModelType = null, int fragmentContentId = int.MinValue, bool addToBackStack = false, Type fragmentHostViewType = null,
+            bool isCacheableFragment = false, string tag = null)
+            : base(activityHostViewModelType, fragmentContentId, addToBackStack,
+                  int.MinValue, int.MinValue, int.MinValue, int.MinValue, int.MinValue, fragmentHostViewType,
+                  isCacheableFragment, tag)
+        {
+            BottomNavigationResourceId = bottomNavigationResourceId;
+            DrawableItemId = drawableItemId;
+            Title = title;
+        }
+
+        public MvxBottomNavigationViewPresentationAttribute(string bottomNavigationResourceName, string title, int drawableItemId = int.MinValue,
+            Type activityHostViewModelType = null, bool addToBackStack = false, Type fragmentHostViewType = null,
+            bool isCacheableFragment = false, string tag = null)
+            : base(activityHostViewModelType, null, addToBackStack, null, null, null,
+                null, null, fragmentHostViewType, isCacheableFragment, tag)
+        {
+            var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
+
+            BottomNavigationResourceId = !string.IsNullOrEmpty(bottomNavigationResourceName)
+                ? context.Resources.GetIdentifier(bottomNavigationResourceName, "id", context.PackageName)
+                : global::Android.Resource.Id.Content;
+            DrawableItemId = drawableItemId;
+            Title = title;
+        }
+
+        /// <summary>
+        ///     The resource used to get the BottomNavigation from the view
+        /// </summary>
+        public int BottomNavigationResourceId { get; set; }
+
+        /// <summary>
+        ///     The resource used to get the menu item from the view
+        /// </summary>
+        public int DrawableItemId { get; set; }
+
+        /// <summary>
+        ///     The title for the bottom navigation menu item
+        /// </summary>
+        public string Title { get; set; }
+    }
+}

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxBottomNavigationViewPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxBottomNavigationViewPresentationAttribute.cs
@@ -1,41 +1,74 @@
-﻿using System;
-using MvvmCross;
-using MvvmCross.Platforms.Android;
-using MvvmCross.Platforms.Android.Presenters.Attributes;
-using MvvmCross.Presenters.Attributes;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+using System;
 
 namespace MvvmCross.Platforms.Android.Presenters.Attributes
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class MvxBottomNavigationViewPresentationAttribute : MvxFragmentPresentationAttribute
     {
-        public MvxBottomNavigationViewPresentationAttribute()
-        {
-        }
-
-        public MvxBottomNavigationViewPresentationAttribute(int bottomNavigationResourceId, string title, int drawableItemId = int.MinValue,
-            Type activityHostViewModelType = null, int fragmentContentId = int.MinValue, bool addToBackStack = false, Type fragmentHostViewType = null,
-            bool isCacheableFragment = false, string tag = null)
-            : base(activityHostViewModelType, fragmentContentId, addToBackStack,
-                  int.MinValue, int.MinValue, int.MinValue, int.MinValue, int.MinValue, fragmentHostViewType,
-                  isCacheableFragment, tag)
+        public MvxBottomNavigationViewPresentationAttribute(
+            int bottomNavigationResourceId, 
+            string title,
+            int drawableItemId = int.MinValue,
+            Type activityHostViewModelType = null!,
+            int fragmentContentId = int.MinValue,
+            bool addToBackStack = false,
+            Type fragmentHostViewType = null!,
+            bool isCacheableFragment = false,
+            string tag = null!)
+            : base(activityHostViewModelType,
+                fragmentContentId,
+                addToBackStack,
+                int.MinValue,
+                int.MinValue,
+                int.MinValue,
+                int.MinValue,
+                int.MinValue,
+                fragmentHostViewType,
+                isCacheableFragment,
+                tag)
         {
             BottomNavigationResourceId = bottomNavigationResourceId;
             DrawableItemId = drawableItemId;
             Title = title;
         }
 
-        public MvxBottomNavigationViewPresentationAttribute(string bottomNavigationResourceName, string title, int drawableItemId = int.MinValue,
-            Type activityHostViewModelType = null, bool addToBackStack = false, Type fragmentHostViewType = null,
-            bool isCacheableFragment = false, string tag = null)
-            : base(activityHostViewModelType, null, addToBackStack, null, null, null,
-                null, null, fragmentHostViewType, isCacheableFragment, tag)
+        public MvxBottomNavigationViewPresentationAttribute(
+            string bottomNavigationResourceName,
+            string title,
+            int drawableItemId = int.MinValue,
+            Type activityHostViewModelType = null!,
+            bool addToBackStack = false,
+            Type fragmentHostViewType = null!,
+            bool isCacheableFragment = false,
+            string tag = null!)
+            : base(
+                activityHostViewModelType,
+                null,
+                addToBackStack,
+                null,
+                null,
+                null,
+                null,
+                null,
+                fragmentHostViewType,
+                isCacheableFragment,
+                tag)
         {
-            var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
+            if (Mvx.IoCProvider.TryResolve(out IMvxAndroidGlobals globals) &&
+                globals.ApplicationContext.Resources != null)
+            {
+                var context = globals.ApplicationContext;
 
-            BottomNavigationResourceId = !string.IsNullOrEmpty(bottomNavigationResourceName)
-                ? context.Resources.GetIdentifier(bottomNavigationResourceName, "id", context.PackageName)
-                : global::Android.Resource.Id.Content;
+                BottomNavigationResourceId = !string.IsNullOrEmpty(bottomNavigationResourceName)
+                    ? context.Resources.GetIdentifier(bottomNavigationResourceName, "id", context.PackageName)
+                    : global::Android.Resource.Id.Content;
+            }
+
             DrawableItemId = drawableItemId;
             Title = title;
         }

--- a/MvvmCross/Platforms/Android/Views/IMvxBottomNavigationView.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxBottomNavigationView.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Android.Views;
+
+namespace MvvmCross.Platforms.Android.Views
+{
+    public interface IMvxBottomNavigationView
+    {
+        public AndroidX.ViewPager.Widget.ViewPager ViewPager { get; set; }
+        public bool DidRegisterViewModelType(Type viewModelType);
+        public void RegisterViewModel(IMenuItem menuItem, Type viewModelType);
+    }
+}

--- a/MvvmCross/Platforms/Android/Views/MvxBottomNavigationView.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxBottomNavigationView.cs
@@ -1,34 +1,36 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Input;
 using Android.Content;
 using Android.Runtime;
-using Android.Widget;
 using Android.Util;
 using Android.Views;
-using Android.Support.Design.Widget;
-using System.Linq;
+using Google.Android.Material.BottomNavigation;
 
-namespace MvvmCross.Droid.Support.Design
+namespace MvvmCross.Platforms.Android.Views
 {
-    [Register("mvvmcross.droid.support.design.MvxBottomNavigationView")]
+    [Register("mvvmcross.platforms.android.views.MvxBottomNavigationView")]
     public class MvxBottomNavigationView : BottomNavigationView, BottomNavigationView.IOnNavigationItemSelectedListener
     {
         private readonly Dictionary<IMenuItem, Type> _lookup = new Dictionary<IMenuItem, Type>();
 
+        private bool _didSetListener;
+
         public MvxBottomNavigationView(Context context) : base(context)
         {
-            this.SetOnNavigationItemSelectedListener(this);
         }
 
         public MvxBottomNavigationView(Context context, IAttributeSet attrs) : base(context, attrs)
         {
-            this.SetOnNavigationItemSelectedListener(this);
         }
 
         public MvxBottomNavigationView(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
         {
-            this.SetOnNavigationItemSelectedListener(this);
         }
 
         protected MvxBottomNavigationView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
@@ -37,9 +39,14 @@ namespace MvvmCross.Droid.Support.Design
 
         public void AddItem(IMenuItem item, Type viewModel)
         {
+            if (!_didSetListener)
+            {
+                SetOnNavigationItemSelectedListener(this);
+                _didSetListener = true;
+            }
             _lookup.Add(item, viewModel);
 
-            // The first item is autoselected
+            // The first item is auto-selected
             if (_lookup.Count == 1)
             {
                 OnNavigationItemSelected(item);
@@ -48,7 +55,7 @@ namespace MvvmCross.Droid.Support.Design
 
         public bool OnNavigationItemSelected(IMenuItem item)
         {
-            var viewModelType = this.FindItemByMenuItem(item);
+            var viewModelType = FindItemByMenuItem(item);
 
             if (viewModelType != null && HandleNavigate.CanExecute(viewModelType))
             {
@@ -76,6 +83,7 @@ namespace MvvmCross.Droid.Support.Design
             if (disposing)
             {
                 SetOnNavigationItemSelectedListener(null);
+                _didSetListener = false;
             }
 
             base.Dispose(disposing);

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab1ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab1ViewModel.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using MvvmCross.Commands;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+using MvvmCross.Presenters.Hints;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class BottomTab1ViewModel : MvxNavigationViewModel
+    {
+        public BottomTab1ViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
+        {
+            OpenBottomTab2Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab2ViewModel))));
+
+            OpenBottomTab3Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab3ViewModel))));
+        }
+
+        public override void ViewAppeared()
+        {
+            base.ViewAppeared();
+        }
+
+        public IMvxAsyncCommand OpenBottomTab2Command { get; private set; }
+
+        public IMvxAsyncCommand OpenBottomTab3Command { get; private set; }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab1ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab1ViewModel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading.Tasks;
 using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
@@ -20,12 +18,6 @@ namespace Playground.Core.ViewModels
 
             OpenBottomTab3Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab3ViewModel))));
         }
-
-        public override void ViewAppeared()
-        {
-            base.ViewAppeared();
-        }
-
         public IMvxAsyncCommand OpenBottomTab2Command { get; private set; }
 
         public IMvxAsyncCommand OpenBottomTab3Command { get; private set; }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab2ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab2ViewModel.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Commands;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+using MvvmCross.Presenters.Hints;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class BottomTab2ViewModel : MvxNavigationViewModel
+    {
+        public BottomTab2ViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
+        {
+            OpenBottomTab1Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab1ViewModel))));
+
+            OpenBottomTab3Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab3ViewModel))));
+        }
+
+        public IMvxAsyncCommand OpenBottomTab1Command { get; private set; }
+
+        public IMvxAsyncCommand OpenBottomTab3Command { get; private set; }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab3ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab3ViewModel.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Commands;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+using MvvmCross.Presenters.Hints;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class BottomTab3ViewModel : MvxNavigationViewModel
+    {
+        public BottomTab3ViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
+        {
+            OpenBottomTab1Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab1ViewModel))));
+
+            OpenBottomTab2Command = new MvxAsyncCommand(async () => await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab2ViewModel))));
+        }
+
+        public IMvxAsyncCommand OpenBottomTab1Command { get; private set; }
+
+        public IMvxAsyncCommand OpenBottomTab2Command { get; private set; }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab3ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTab3ViewModel.cs
@@ -7,6 +7,7 @@ using MvvmCross.Logging;
 using MvvmCross.Navigation;
 using MvvmCross.Presenters.Hints;
 using MvvmCross.ViewModels;
+using Playground.Core.ViewModels.Navigation;
 
 namespace Playground.Core.ViewModels
 {

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTabsRootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTabsRootViewModel.cs
@@ -43,13 +43,15 @@ namespace Playground.Core.ViewModels
 
         public IMvxAsyncCommand ShowInitialViewModelsCommand { get; private set; }
 
-        private async Task ShowInitialViewModels()
+        private Task ShowInitialViewModels()
         {
-            var tasks = new List<Task>();
-            tasks.Add(NavigationService.Navigate<BottomTab1ViewModel>());
-            tasks.Add(NavigationService.Navigate<BottomTab2ViewModel>());
-            tasks.Add(NavigationService.Navigate<BottomTab3ViewModel>());
-            await Task.WhenAll(tasks);
+            var tasks = new List<Task>
+            {
+                NavigationService.Navigate<BottomTab1ViewModel>(),
+                NavigationService.Navigate<BottomTab2ViewModel>(),
+                NavigationService.Navigate<BottomTab3ViewModel>()
+            };
+            return Task.WhenAll(tasks);
         }
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTabsRootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTabsRootViewModel.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MvvmCross.Commands;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+using MvvmCross.Presenters.Hints;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels
+{
+    public class BottomTabsRootViewModel : MvxNavigationViewModel
+    {
+        public BottomTabsRootViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
+        {
+            ShowInitialViewModelsCommand = new MvxAsyncCommand(ShowInitialViewModels);
+
+            NavigateCommand = new MvxAsyncCommand<Type>(async (viewModelType) =>
+            {
+                if (viewModelType == typeof(BottomTab1ViewModel))
+                {
+                    await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab1ViewModel)));
+                    return;
+                }
+                if (viewModelType == typeof(BottomTab2ViewModel))
+                {
+                    await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab2ViewModel)));
+                    return;
+                }
+                if (viewModelType == typeof(BottomTab3ViewModel))
+                {
+                    await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab3ViewModel)));
+                    return;
+                }
+            });
+        }
+
+        public IMvxAsyncCommand<Type> NavigateCommand { get; private set; }
+
+        public IMvxAsyncCommand ShowInitialViewModelsCommand { get; private set; }
+
+        private async Task ShowInitialViewModels()
+        {
+            var tasks = new List<Task>();
+            tasks.Add(NavigationService.Navigate<BottomTab1ViewModel>());
+            tasks.Add(NavigationService.Navigate<BottomTab2ViewModel>());
+            tasks.Add(NavigationService.Navigate<BottomTab3ViewModel>());
+            await Task.WhenAll(tasks);
+        }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTabsRootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/BottomTabsRootViewModel.cs
@@ -18,29 +18,8 @@ namespace Playground.Core.ViewModels
         public BottomTabsRootViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {
             ShowInitialViewModelsCommand = new MvxAsyncCommand(ShowInitialViewModels);
-
-            NavigateCommand = new MvxAsyncCommand<Type>(async (viewModelType) =>
-            {
-                if (viewModelType == typeof(BottomTab1ViewModel))
-                {
-                    await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab1ViewModel)));
-                    return;
-                }
-                if (viewModelType == typeof(BottomTab2ViewModel))
-                {
-                    await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab2ViewModel)));
-                    return;
-                }
-                if (viewModelType == typeof(BottomTab3ViewModel))
-                {
-                    await NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(BottomTab3ViewModel)));
-                    return;
-                }
-            });
         }
-
-        public IMvxAsyncCommand<Type> NavigateCommand { get; private set; }
-
+        
         public IMvxAsyncCommand ShowInitialViewModelsCommand { get; private set; }
 
         private Task ShowInitialViewModels()

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -66,6 +66,8 @@ namespace Playground.Core.ViewModels
 
             ShowPagesCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<PagesRootViewModel>());
 
+            ShowBottomTabsCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<BottomTabsRootViewModel>());
+
             ShowSplitCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<SplitRootViewModel>());
 
             ShowNativeCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<NativeViewModel>());
@@ -121,6 +123,8 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowTabsCommand { get; }
 
         public IMvxAsyncCommand ShowPagesCommand { get; }
+
+        public IMvxAsyncCommand ShowBottomTabsCommand { get; }
 
         public IMvxAsyncCommand ShowSplitCommand { get; }
 

--- a/Projects/Playground/Playground.Droid/Activities/BottomTabsRootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/BottomTabsRootView.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Android.App;
+using Android.OS;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Core.ViewModels;
+
+namespace Playground.Droid.Activities
+{
+    [MvxActivityPresentation]
+    [Activity(Theme = "@style/AppTheme", ConfigurationChanges = Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
+    public class BottomTabsRootView : MvxAppCompatActivity<BottomTabsRootViewModel>
+    {
+        protected override void OnCreate(Bundle bundle)
+        {
+            base.OnCreate(bundle);
+
+            SetContentView(Resource.Layout.BottomTabsRootView);
+
+            if (bundle == null)
+            {
+                ViewModel.ShowInitialViewModelsCommand.Execute();
+            }
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Activities/BottomTabsRootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/BottomTabsRootView.cs
@@ -2,18 +2,17 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using Android.App;
 using Android.OS;
-using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.Platforms.Android.Views;
 using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Activities
 {
     [MvxActivityPresentation]
     [Activity(Theme = "@style/AppTheme", ConfigurationChanges = Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
-    public class BottomTabsRootView : MvxAppCompatActivity<BottomTabsRootViewModel>
+    public class BottomTabsRootView : MvxActivity<BottomTabsRootViewModel>
     {
         protected override void OnCreate(Bundle bundle)
         {

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab1View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab1View.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Core.ViewModels;
+
+namespace Playground.Droid.Fragments
+{
+    [MvxBottomNavigationViewPresentation(Resource.Id.navigation, "Tab 1", ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
+    [Register(nameof(BottomTab1View))]
+    public class BottomTab1View : MvxFragment<BottomTab1ViewModel>
+    {
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            // Create your fragment here
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(Resource.Layout.BottomTab1View, null);
+
+            return view;
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab1View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab1View.cs
@@ -5,9 +5,9 @@
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
-using MvvmCross.Droid.Support.V4;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.Platforms.Android.Views.Fragments;
 using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
@@ -16,13 +16,7 @@ namespace Playground.Droid.Fragments
     [Register(nameof(BottomTab1View))]
     public class BottomTab1View : MvxFragment<BottomTab1ViewModel>
     {
-        public override void OnCreate(Bundle savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
-
-            // Create your fragment here
-        }
-
+        
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             base.OnCreateView(inflater, container, savedInstanceState);

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab1View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab1View.cs
@@ -12,7 +12,7 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
 {
-    [MvxBottomNavigationViewPresentation(Resource.Id.navigation, "Tab 1", ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
+    [MvxBottomNavigationViewPresentation("Tab 1", Resource.Id.viewpager, Resource.Id.navigation, ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
     [Register(nameof(BottomTab1View))]
     public class BottomTab1View : MvxFragment<BottomTab1ViewModel>
     {

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab2View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab2View.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Core.ViewModels;
+
+namespace Playground.Droid.Fragments
+{
+    [MvxBottomNavigationViewPresentation(Resource.Id.navigation, "Tab 2", ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
+    [Register(nameof(BottomTab2View))]
+    public class BottomTab2View : MvxFragment<BottomTab2ViewModel>
+    {
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            // Create your fragment here
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(Resource.Layout.BottomTab2View, null);
+
+            return view;
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab2View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab2View.cs
@@ -5,9 +5,9 @@
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
-using MvvmCross.Droid.Support.V4;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.Platforms.Android.Views.Fragments;
 using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
@@ -16,13 +16,6 @@ namespace Playground.Droid.Fragments
     [Register(nameof(BottomTab2View))]
     public class BottomTab2View : MvxFragment<BottomTab2ViewModel>
     {
-        public override void OnCreate(Bundle savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
-
-            // Create your fragment here
-        }
-
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             base.OnCreateView(inflater, container, savedInstanceState);

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab2View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab2View.cs
@@ -12,7 +12,7 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
 {
-    [MvxBottomNavigationViewPresentation(Resource.Id.navigation, "Tab 2", ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
+    [MvxBottomNavigationViewPresentation("Tab 2", Resource.Id.viewpager, Resource.Id.navigation, ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
     [Register(nameof(BottomTab2View))]
     public class BottomTab2View : MvxFragment<BottomTab2ViewModel>
     {

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab3View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab3View.cs
@@ -5,9 +5,9 @@
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
-using MvvmCross.Droid.Support.V4;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.Platforms.Android.Views.Fragments;
 using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
@@ -16,13 +16,6 @@ namespace Playground.Droid.Fragments
     [Register(nameof(BottomTab3View))]
     public class BottomTab3View : MvxFragment<BottomTab3ViewModel>
     {
-        public override void OnCreate(Bundle savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
-
-            // Create your fragment here
-        }
-
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             base.OnCreateView(inflater, container, savedInstanceState);

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab3View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab3View.cs
@@ -12,7 +12,7 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
 {
-    [MvxBottomNavigationViewPresentation(Resource.Id.navigation, "Tab 3", ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
+    [MvxBottomNavigationViewPresentation("Tab 3", Resource.Id.viewpager, Resource.Id.navigation, ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
     [Register(nameof(BottomTab3View))]
     public class BottomTab3View : MvxFragment<BottomTab3ViewModel>
     {

--- a/Projects/Playground/Playground.Droid/Fragments/BottomTab3View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BottomTab3View.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using MvvmCross.Droid.Support.V4;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Playground.Core.ViewModels;
+
+namespace Playground.Droid.Fragments
+{
+    [MvxBottomNavigationViewPresentation(Resource.Id.navigation, "Tab 3", ActivityHostViewModelType = typeof(BottomTabsRootViewModel), FragmentContentId = Resource.Id.content_frame)]
+    [Register(nameof(BottomTab3View))]
+    public class BottomTab3View : MvxFragment<BottomTab3ViewModel>
+    {
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            // Create your fragment here
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            base.OnCreateView(inflater, container, savedInstanceState);
+
+            var view = this.BindingInflate(Resource.Layout.BottomTab3View, null);
+
+            return view;
+        }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -50,12 +50,16 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Activities\BottomTabsRootView.cs" />
     <Compile Include="Activities\CustomBindingView.cs" />
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.cs" />
     <Compile Include="Adapter\SelectedItemRecyclerAdapter.SelectedItemEventArgs.cs" />
     <Compile Include="Bindings\BinaryEditTargetBinding.cs" />
     <Compile Include="Controls\BinaryEdit.cs" />
     <Compile Include="Fragments\BaseSplitDetailView.cs" />
+    <Compile Include="Fragments\BottomTab1View.cs" />
+    <Compile Include="Fragments\BottomTab2View.cs" />
+    <Compile Include="Fragments\BottomTab3View.cs" />
     <Compile Include="Fragments\FluentBindingView.cs" />
     <Compile Include="Fragments\FragmentCloseView.cs" />
     <Compile Include="Fragments\TabsRootBView.cs" />
@@ -97,6 +101,10 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Assets\AboutAssets.txt" />
+    <AndroidResource Include="Resources\layout\BottomTab1View.axml" />
+    <AndroidResource Include="Resources\layout\BottomTab2View.axml" />
+    <AndroidResource Include="Resources\layout\BottomTab3View.axml" />
+    <AndroidResource Include="Resources\layout\BottomTabsRootView.axml" />
     <AndroidResource Include="Resources\layout\dictionary_view.axml" />
     <AndroidResource Include="Resources\layout\CollectionView.axml">
       <SubType>Designer</SubType>

--- a/Projects/Playground/Playground.Droid/Resources/layout/BottomTab1View.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/BottomTab1View.axml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main_frame"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show bottom tab 2"
+        local:MvxBind="Click OpenBottomTab2Command;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show bottom tab 3"
+        local:MvxBind="Click OpenBottomTab3Command;" />
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/BottomTab2View.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/BottomTab2View.axml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:local="http://schemas.android.com/apk/res-auto"
+	android:id="@+id/main_frame"
+	android:orientation="vertical"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show bottom tab 1"
+        local:MvxBind="Click OpenBottomTab1Command;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show bottom tab 3"
+        local:MvxBind="Click OpenBottomTab3Command;" />
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/BottomTab3View.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/BottomTab3View.axml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:local="http://schemas.android.com/apk/res-auto"
+	android:id="@+id/main_frame"
+	android:orientation="vertical"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show bottom tab 1"
+        local:MvxBind="Click OpenBottomTab1Command;" />
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Show bottom tab 2"
+        local:MvxBind="Click OpenBottomTab2Command;" />
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/BottomTabsRootView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/BottomTabsRootView.axml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+    <FrameLayout
+        android:id="@+id/content_frame"
+        android:layout_centerInParent="true"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/navigation" 
+        android:layout_marginTop="20dp"/>
+    <mvvmcross.droid.support.design.MvxBottomNavigationView
+        android:id="@+id/navigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="0dp"
+        android:layout_marginStart="0dp"
+        android:layout_alignParentBottom="true"
+        local:itemIconSize="20dp"
+        local:labelVisibilityMode="labeled"
+        local:MvxBind="HandleNavigate NavigateCommand"/>
+</RelativeLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/BottomTabsRootView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/BottomTabsRootView.axml
@@ -5,13 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-    <FrameLayout
-        android:id="@+id/content_frame"
-        android:layout_centerInParent="true"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@+id/navigation" 
-        android:layout_marginTop="20dp"/>
+    <androidx.viewpager.widget.ViewPager
+            android:id="@+id/viewpager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            android:layout_above="@+id/navigation"/>
     <mvvmcross.platforms.android.views.MvxBottomNavigationView
         android:id="@+id/navigation"
         android:layout_width="match_parent"

--- a/Projects/Playground/Playground.Droid/Resources/layout/BottomTabsRootView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/BottomTabsRootView.axml
@@ -12,7 +12,7 @@
         android:layout_height="match_parent"
         android:layout_above="@+id/navigation" 
         android:layout_marginTop="20dp"/>
-    <mvvmcross.droid.support.design.MvxBottomNavigationView
+    <mvvmcross.platforms.android.views.MvxBottomNavigationView
         android:id="@+id/navigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/Projects/Playground/Playground.Droid/Resources/layout/RootView.axml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/RootView.axml
@@ -41,6 +41,12 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
+                android:text="Show Bottom Tabs"
+                local:MvxBind="Click ShowBottomTabsCommand;" />
+            <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
                 android:text="Show Master/Detail"
                 local:MvxBind="Click ShowSplitCommand;" />
             <Button


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Showing the bottom navigation can't be navigated using page presentation hints

### :new: What is the new behavior (if this is a feature change)?
Introduced the MvxBottomNavigationView (on Android), so we can create a bottom navigation which will listen to page presentation hints. It can be populated the same way a tab layout can be populated,  using attributes and a ShowInitialViewModelsCommand. To do this I added a MvxBottomNavigationViewPresentationAttribute.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See the added sample in the Playground

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/2358
https://github.com/MvvmCross/MvvmCross/issues/2114

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop