### PR TITLE
View model life cycle examples in docs are outdated

### DIFF
--- a/docs/_documentation/fundamentals/viewmodel-lifecycle.md
+++ b/docs/_documentation/fundamentals/viewmodel-lifecycle.md
@@ -57,7 +57,7 @@ public class MyViewModel : MvxViewModel<MyParameterModel>
         _myService = myService;
     }
 
-    public void Prepare(MyParameterModel parameter)
+    public override void Prepare(MyParameterModel parameter)
     {
 
     }
@@ -139,19 +139,18 @@ public class MyViewModel : MvxViewModel<MyParameterModel>
         _initialParameter = _jsonSerializer.Deserialize<MyParameterModel>(serializedParameter);
     }
 
-    public void Prepare()
+    public override void Prepare()
     {
     }
 
-    public void Prepare(MyParameterModel parameter)
+    public override void Prepare(MyParameterModel parameter)
     {
         _initialParameter = parameter;
     }
 
-    public async Task Initialize()
+    public override async Task Initialize()
     {
-        await base.Initialize();
-
+        await base.Initialize();        
         // do something with _initialParameter
     }
 
@@ -174,7 +173,7 @@ void ViewDisappearing();
 
 void ViewDisappeared();
 
-void ViewDestroy();
+void ViewDestroy (bool viewFinishing = true);
 ```
 
 The MvxViewController, MvxFragment(s), MvxActivity and the UWP views will call those methods when the platform specific events are fired. This will give you a more refined control of the ViewModel and its state. There may be certain bindings that you want to update or resources that you want to clean up in these calls.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
Examples of life cycle methods for view models are out of date, see #3301 

### :new: What is the new behavior (if this is a feature change)?
Updated to latest methods as of 6.2.3

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Check the code examples for "ViewModel Lifecycle" section [here](https://www.mvvmcross.com/documentation/fundamentals/viewmodel-lifecycle)

### :memo: Links to relevant issues/docs
https://www.mvvmcross.com/documentation/fundamentals/viewmodel-lifecycle

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
