### PR TITLE
Adding parameter to Register methods to determine whether existing registration should be overwritten

### DIFF
--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -34,26 +34,26 @@ namespace MvvmCross.IoC
 
         object GetSingleton(Type type);
 
-        void RegisterType<TFrom, TTo>()
+        void RegisterType<TFrom, TTo>(bool overrideIfExists = true)
             where TFrom : class
             where TTo : class, TFrom;
 
-        void RegisterType<TInterface>(Func<TInterface> constructor)
+        void RegisterType<TInterface>(Func<TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class;
 
-        void RegisterType(Type t, Func<object> constructor);
+        void RegisterType(Type t, Func<object> constructor, bool overrideIfExists = true);
 
-        void RegisterType(Type tFrom, Type tTo);
+        void RegisterType(Type tFrom, Type tTo, bool overrideIfExists = true);
 
-        void RegisterSingleton<TInterface>(TInterface theObject)
+        void RegisterSingleton<TInterface>(TInterface theObject, bool overrideIfExists = true)
             where TInterface : class;
 
-        void RegisterSingleton(Type tInterface, object theObject);
+        void RegisterSingleton(Type tInterface, object theObject, bool overrideIfExists = true);
 
-        void RegisterSingleton<TInterface>(Func<TInterface> theConstructor)
+        void RegisterSingleton<TInterface>(Func<TInterface> theConstructor, bool overrideIfExists = true)
             where TInterface : class;
 
-        void RegisterSingleton(Type tInterface, Func<object> theConstructor);
+        void RegisterSingleton(Type tInterface, Func<object> theConstructor, bool overrideIfExists = true);
 
         T IoCConstruct<T>()
             where T : class;

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -293,11 +293,11 @@ namespace MvvmCross.IoC
             }
         }
 
-        public void RegisterType<TInterface, TToConstruct>()
+        public void RegisterType<TInterface, TToConstruct>(bool overrideIfExists = true)
             where TInterface : class
             where TToConstruct : class, TInterface
         {
-            RegisterType(typeof(TInterface), typeof(TToConstruct));
+            RegisterType(typeof(TInterface), typeof(TToConstruct), overrideIfExists);
         }
 
         public void RegisterType<TInterface>(Func<TInterface> constructor, bool overrideIfExists = true)
@@ -307,7 +307,7 @@ namespace MvvmCross.IoC
             InternalSetResolver(typeof(TInterface), resolver, overrideIfExists);
         }
 
-        public void RegisterType(Type t, Func<object> constructor)
+        public void RegisterType(Type t, Func<object> constructor, bool overrideIfExists = true)
         {
             var resolver = new FuncConstructingResolver(() =>
             {
@@ -318,10 +318,10 @@ namespace MvvmCross.IoC
                 return ret;
             });
 
-            InternalSetResolver(t, resolver);
+            InternalSetResolver(t, resolver, overrideIfExists);
         }
 
-        public void RegisterType(Type interfaceType, Type constructType)
+        public void RegisterType(Type interfaceType, Type constructType, bool overrideIfExists = true)
         {
             IResolver resolver = null;
             if (interfaceType.GetTypeInfo().IsGenericTypeDefinition)
@@ -333,29 +333,29 @@ namespace MvvmCross.IoC
                 resolver = new ConstructingResolver(constructType, this);
             }
 
-            InternalSetResolver(interfaceType, resolver);
+            InternalSetResolver(interfaceType, resolver, overrideIfExists);
         }
 
-        public void RegisterSingleton<TInterface>(TInterface theObject)
+        public void RegisterSingleton<TInterface>(TInterface theObject, bool overrideIfExists = true)
             where TInterface : class
         {
-            RegisterSingleton(typeof(TInterface), theObject);
+            RegisterSingleton(typeof(TInterface), theObject, overrideIfExists);
         }
 
-        public void RegisterSingleton(Type interfaceType, object theObject)
+        public void RegisterSingleton(Type interfaceType, object theObject, bool overrideIfExists = true)
         {
-            InternalSetResolver(interfaceType, new SingletonResolver(theObject));
+            InternalSetResolver(interfaceType, new SingletonResolver(theObject), overrideIfExists);
         }
 
-        public void RegisterSingleton<TInterface>(Func<TInterface> theConstructor)
+        public void RegisterSingleton<TInterface>(Func<TInterface> theConstructor, bool overrideIfExists = true)
             where TInterface : class
         {
-            RegisterSingleton(typeof(TInterface), theConstructor);
+            RegisterSingleton(typeof(TInterface), theConstructor, overrideIfExists);
         }
 
-        public void RegisterSingleton(Type interfaceType, Func<object> theConstructor)
+        public void RegisterSingleton(Type interfaceType, Func<object> theConstructor, bool overrideIfExists = true)
         {
-            InternalSetResolver(interfaceType, new ConstructingSingletonResolver(theConstructor));
+            InternalSetResolver(interfaceType, new ConstructingSingletonResolver(theConstructor), overrideIfExists);
         }
 
         public object IoCConstruct(Type type)

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -300,11 +300,11 @@ namespace MvvmCross.IoC
             RegisterType(typeof(TInterface), typeof(TToConstruct));
         }
 
-        public void RegisterType<TInterface>(Func<TInterface> constructor)
+        public void RegisterType<TInterface>(Func<TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
         {
             var resolver = new FuncConstructingResolver(constructor);
-            InternalSetResolver(typeof(TInterface), resolver);
+            InternalSetResolver(typeof(TInterface), resolver, overrideIfExists);
         }
 
         public void RegisterType(Type t, Func<object> constructor)
@@ -602,12 +602,16 @@ namespace MvvmCross.IoC
             }
         }
 
-        private void InternalSetResolver(Type interfaceType, IResolver resolver)
+        private void InternalSetResolver(Type interfaceType, IResolver resolver, bool overrideIfExists)
         {
             List<Action> actions;
             lock (_lockObject)
             {
-                _resolvers[interfaceType] = resolver;
+                if (overrideIfExists || !_resolvers.ContainsKey(interfaceType))
+                {
+                    _resolvers[interfaceType] = resolver;
+                }
+
                 if (_waiters.TryGetValue(interfaceType, out actions))
                 {
                     _waiters.Remove(interfaceType);

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -101,28 +101,35 @@ namespace MvvmCross.IoC
             ioc.CallbackWhenRegistered<T>(simpleAction);
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, bool overrideIfExists = true)
+        public static TInterface ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc,
+            bool overrideIfExists = true)
             where TInterface : class
             where TType : class, TInterface
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return ioc.Resolve<TInterface>();
+
             var instance = ioc.IoCConstruct<TType>();
             ioc.RegisterSingleton<TInterface>(instance, overrideIfExists);
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, IDictionary<string, object> arguments, bool overrideIfExists = true)
+        public static TInterface ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, IDictionary<string, object> arguments, bool overrideIfExists = true)
             where TInterface : class
             where TType : class, TInterface
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return ioc.Resolve<TInterface>();
+
             var instance = ioc.IoCConstruct<TType>(arguments);
             ioc.RegisterSingleton<TInterface>(instance, overrideIfExists);
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, object arguments, bool overrideIfExists = true)
+        public static TInterface ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, object arguments, bool overrideIfExists = true)
             where TInterface : class
             where TType : class, TInterface
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return ioc.Resolve<TInterface>();
+
             var instance = ioc.IoCConstruct<TType>(arguments);
             ioc.RegisterSingleton<TInterface>(instance, overrideIfExists);
             return instance;
@@ -137,10 +144,12 @@ namespace MvvmCross.IoC
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingletonNoOverride<TInterface, TType>(this IMvxIoCProvider ioc, params object[] arguments)
+        public static TInterface ConstructAndRegisterSingletonNoOverride<TInterface, TType>(this IMvxIoCProvider ioc, params object[] arguments)
             where TInterface : class
             where TType : class, TInterface
         {
+            if (ioc.CanResolve<TInterface>()) return ioc.Resolve<TInterface>();
+
             var instance = ioc.IoCConstruct<TType>(arguments);
             ioc.RegisterSingleton<TInterface>(instance, false);
             return instance;
@@ -148,6 +157,8 @@ namespace MvvmCross.IoC
 
         public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, bool overrideIfExists = true)
         {
+            if (!overrideIfExists && ioc.CanResolve(type)) return ioc.Resolve(type);
+
             var instance = ioc.IoCConstruct(type);
             ioc.RegisterSingleton(type, instance, overrideIfExists);
             return instance;
@@ -155,6 +166,8 @@ namespace MvvmCross.IoC
 
         public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, IDictionary<string, object> arguments, bool overrideIfExists = true)
         {
+            if (!overrideIfExists && ioc.CanResolve(type)) return ioc.Resolve(type);
+
             var instance = ioc.IoCConstruct(type, arguments);
             ioc.RegisterSingleton(type, instance, overrideIfExists);
             return instance;
@@ -162,6 +175,8 @@ namespace MvvmCross.IoC
 
         public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, object arguments, bool overrideIfExists = true)
         {
+            if (!overrideIfExists && ioc.CanResolve(type)) return ioc.Resolve(type);
+
             var instance = ioc.IoCConstruct(type, arguments);
             ioc.RegisterSingleton(type, instance, overrideIfExists);
             return instance;
@@ -176,6 +191,8 @@ namespace MvvmCross.IoC
 
         public static object ConstructAndRegisterSingletonNoOverride(this IMvxIoCProvider ioc, Type type, params object[] arguments)
         {
+            if (ioc.CanResolve(type)) return ioc.Resolve(type);
+
             var instance = ioc.IoCConstruct(type, arguments);
             ioc.RegisterSingleton(type, instance, false);
             return instance;
@@ -185,17 +202,23 @@ namespace MvvmCross.IoC
             where TInterface : class
             where TType : class, TInterface
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return;
+
             ioc.RegisterSingleton<TInterface>(() => ioc.IoCConstruct<TType>(), overrideIfExists);
         }
 
         public static void LazyConstructAndRegisterSingleton<TInterface>(this IMvxIoCProvider ioc, Func<TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return;
+
             ioc.RegisterSingleton<TInterface>(constructor, overrideIfExists);
         }
 
         public static void LazyConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, Func<object> constructor, bool overrideIfExists = true)
         {
+            if (!overrideIfExists && ioc.CanResolve<Type>()) return;
+
             ioc.RegisterSingleton(type, constructor, overrideIfExists);
         }
 
@@ -203,6 +226,8 @@ namespace MvvmCross.IoC
             where TInterface : class
             where TParameter1 : class
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return;
+
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver, overrideIfExists);
         }
@@ -212,6 +237,8 @@ namespace MvvmCross.IoC
             where TParameter1 : class
             where TParameter2 : class
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return;
+
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver, overrideIfExists);
         }
@@ -222,6 +249,8 @@ namespace MvvmCross.IoC
             where TParameter2 : class
             where TParameter3 : class
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return;
+
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver, overrideIfExists);
         }
@@ -233,6 +262,8 @@ namespace MvvmCross.IoC
             where TParameter3 : class
             where TParameter4 : class
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return;
+
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver, overrideIfExists);
         }
@@ -245,6 +276,8 @@ namespace MvvmCross.IoC
             where TParameter4 : class
             where TParameter5 : class
         {
+            if (!overrideIfExists && ioc.CanResolve<TInterface>()) return;
+
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver, overrideIfExists);
         }

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -101,30 +101,30 @@ namespace MvvmCross.IoC
             ioc.CallbackWhenRegistered<T>(simpleAction);
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
+        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, bool overrideIfExists = true)
             where TInterface : class
             where TType : class, TInterface
         {
             var instance = ioc.IoCConstruct<TType>();
-            ioc.RegisterSingleton<TInterface>(instance);
+            ioc.RegisterSingleton<TInterface>(instance, overrideIfExists);
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, IDictionary<string, object> arguments)
+        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, IDictionary<string, object> arguments, bool overrideIfExists = true)
             where TInterface : class
             where TType : class, TInterface
         {
             var instance = ioc.IoCConstruct<TType>(arguments);
-            ioc.RegisterSingleton<TInterface>(instance);
+            ioc.RegisterSingleton<TInterface>(instance, overrideIfExists);
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, object arguments)
+        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, object arguments, bool overrideIfExists = true)
             where TInterface : class
             where TType : class, TInterface
         {
             var instance = ioc.IoCConstruct<TType>(arguments);
-            ioc.RegisterSingleton<TInterface>(instance);
+            ioc.RegisterSingleton<TInterface>(instance, overrideIfExists);
             return instance;
         }
 
@@ -137,24 +137,33 @@ namespace MvvmCross.IoC
             return instance;
         }
 
-        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type)
+        public static TType ConstructAndRegisterSingletonNoOverride<TInterface, TType>(this IMvxIoCProvider ioc, params object[] arguments)
+            where TInterface : class
+            where TType : class, TInterface
+        {
+            var instance = ioc.IoCConstruct<TType>(arguments);
+            ioc.RegisterSingleton<TInterface>(instance, false);
+            return instance;
+        }
+
+        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, bool overrideIfExists = true)
         {
             var instance = ioc.IoCConstruct(type);
-            ioc.RegisterSingleton(type, instance);
+            ioc.RegisterSingleton(type, instance, overrideIfExists);
             return instance;
         }
 
-        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, IDictionary<string, object> arguments)
+        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, IDictionary<string, object> arguments, bool overrideIfExists = true)
         {
             var instance = ioc.IoCConstruct(type, arguments);
-            ioc.RegisterSingleton(type, instance);
+            ioc.RegisterSingleton(type, instance, overrideIfExists);
             return instance;
         }
 
-        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, object arguments)
+        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, object arguments, bool overrideIfExists = true)
         {
             var instance = ioc.IoCConstruct(type, arguments);
-            ioc.RegisterSingleton(type, instance);
+            ioc.RegisterSingleton(type, instance, overrideIfExists);
             return instance;
         }
 
@@ -165,52 +174,59 @@ namespace MvvmCross.IoC
             return instance;
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
+        public static object ConstructAndRegisterSingletonNoOverride(this IMvxIoCProvider ioc, Type type, params object[] arguments)
+        {
+            var instance = ioc.IoCConstruct(type, arguments);
+            ioc.RegisterSingleton(type, instance, false);
+            return instance;
+        }
+
+        public static void LazyConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, bool overrideIfExists = true)
             where TInterface : class
             where TType : class, TInterface
         {
-            ioc.RegisterSingleton<TInterface>(() => ioc.IoCConstruct<TType>());
+            ioc.RegisterSingleton<TInterface>(() => ioc.IoCConstruct<TType>(), overrideIfExists);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface>(this IMvxIoCProvider ioc, Func<TInterface> constructor)
+        public static void LazyConstructAndRegisterSingleton<TInterface>(this IMvxIoCProvider ioc, Func<TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
         {
-            ioc.RegisterSingleton<TInterface>(constructor);
+            ioc.RegisterSingleton<TInterface>(constructor, overrideIfExists);
         }
 
-        public static void LazyConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, Func<object> constructor)
+        public static void LazyConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, Func<object> constructor, bool overrideIfExists = true)
         {
-            ioc.RegisterSingleton(type, constructor);
+            ioc.RegisterSingleton(type, constructor, overrideIfExists);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1>(this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor)
+        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1>(this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterSingleton(resolver);
+            ioc.RegisterSingleton(resolver, overrideIfExists);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> constructor)
+        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterSingleton(resolver);
+            ioc.RegisterSingleton(resolver, overrideIfExists);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
+        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
             where TParameter3 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterSingleton(resolver);
+            ioc.RegisterSingleton(resolver, overrideIfExists);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3, TParameter4>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
+        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3, TParameter4>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
@@ -218,10 +234,10 @@ namespace MvvmCross.IoC
             where TParameter4 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterSingleton(resolver);
+            ioc.RegisterSingleton(resolver, overrideIfExists);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3, TParameter4, TParameter5>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
+        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3, TParameter4, TParameter5>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
@@ -230,48 +246,48 @@ namespace MvvmCross.IoC
             where TParameter5 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterSingleton(resolver);
+            ioc.RegisterSingleton(resolver, overrideIfExists);
         }
 
-        public static void RegisterType<TType>(this IMvxIoCProvider ioc)
+        public static void RegisterType<TType>(this IMvxIoCProvider ioc, bool overrideIfExists = true)
             where TType : class
         {
-            ioc.RegisterType<TType, TType>();
+            ioc.RegisterType<TType, TType>(overrideIfExists);
         }
 
-        public static void RegisterType(this IMvxIoCProvider ioc, Type tType)
+        public static void RegisterType(this IMvxIoCProvider ioc, Type tType, bool overrideIfExists = true)
         {
-            ioc.RegisterType(tType, tType);
+            ioc.RegisterType(tType, tType, overrideIfExists);
         }
 
-        public static void RegisterType<TInterface, TParameter1>(this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor)
+        public static void RegisterType<TInterface, TParameter1>(this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor, bool overrideIfExists = true)
            where TInterface : class
            where TParameter1 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterType(resolver);
+            ioc.RegisterType(resolver, overrideIfExists);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> constructor)
+        public static void RegisterType<TInterface, TParameter1, TParameter2>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterType(resolver);
+            ioc.RegisterType(resolver, overrideIfExists);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
+        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
             where TParameter3 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterType(resolver);
+            ioc.RegisterType(resolver, overrideIfExists);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3, TParameter4>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
+        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3, TParameter4>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
@@ -279,10 +295,10 @@ namespace MvvmCross.IoC
             where TParameter4 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterType(resolver);
+            ioc.RegisterType(resolver, overrideIfExists);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3, TParameter4, TParameter5>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
+        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3, TParameter4, TParameter5>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
             where TParameter1 : class
             where TParameter2 : class
@@ -291,7 +307,7 @@ namespace MvvmCross.IoC
             where TParameter5 : class
         {
             var resolver = ioc.CreateResolver(constructor);
-            ioc.RegisterType(resolver);
+            ioc.RegisterType(resolver, overrideIfExists);
         }
     }
 }

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -93,49 +93,49 @@ namespace MvvmCross.IoC
             return _provider.Create(t);
         }
 
-        public void RegisterType<TInterface, TToConstruct>()
+        public void RegisterType<TInterface, TToConstruct>(bool overrideIfExists = true)
             where TInterface : class
             where TToConstruct : class, TInterface
         {
-            _provider.RegisterType<TInterface, TToConstruct>();
+            _provider.RegisterType<TInterface, TToConstruct>(overrideIfExists);
         }
 
-        public void RegisterType<TInterface>(Func<TInterface> constructor)
+        public void RegisterType<TInterface>(Func<TInterface> constructor, bool overrideIfExists = true)
             where TInterface : class
         {
-            _provider.RegisterType(constructor);
+            _provider.RegisterType(constructor, overrideIfExists);
         }
 
-        public void RegisterType(Type t, Func<object> constructor)
+        public void RegisterType(Type t, Func<object> constructor, bool overrideIfExists = true)
         {
-            _provider.RegisterType(t, constructor);
+            _provider.RegisterType(t, constructor, overrideIfExists);
         }
 
-        public void RegisterType(Type interfaceType, Type constructType)
+        public void RegisterType(Type interfaceType, Type constructType, bool overrideIfExists = true)
         {
-            _provider.RegisterType(interfaceType, constructType);
+            _provider.RegisterType(interfaceType, constructType, overrideIfExists);
         }
 
-        public void RegisterSingleton<TInterface>(TInterface theObject)
+        public void RegisterSingleton<TInterface>(TInterface theObject, bool overrideIfExists = true)
             where TInterface : class
         {
-            _provider.RegisterSingleton(theObject);
+            _provider.RegisterSingleton(theObject, overrideIfExists);
         }
 
-        public void RegisterSingleton(Type interfaceType, object theObject)
+        public void RegisterSingleton(Type interfaceType, object theObject, bool overrideIfExists = true)
         {
-            _provider.RegisterSingleton(interfaceType, theObject);
+            _provider.RegisterSingleton(interfaceType, theObject, overrideIfExists);
         }
 
-        public void RegisterSingleton<TInterface>(Func<TInterface> theConstructor)
+        public void RegisterSingleton<TInterface>(Func<TInterface> theConstructor, bool overrideIfExists = true)
             where TInterface : class
         {
-            _provider.RegisterSingleton(theConstructor);
+            _provider.RegisterSingleton(theConstructor, overrideIfExists);
         }
 
-        public void RegisterSingleton(Type interfaceType, Func<object> theConstructor)
+        public void RegisterSingleton(Type interfaceType, Func<object> theConstructor, bool overrideIfExists = true)
         {
-            _provider.RegisterSingleton(interfaceType, theConstructor);
+            _provider.RegisterSingleton(interfaceType, theConstructor, overrideIfExists);
         }
 
         public T IoCConstruct<T>()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
With successive calls to RegisterType, each call replaces the registered resolver. This means that if a developer registers a resolver prior to startup, mvvmcross will overwrite the resolver with the default for that type.

### :new: What is the new behavior (if this is a feature change)?
The overrideIfExists parameter determines whether the existing resolver will be overwritten.
This allows for the core of mvvmcross to be updated to only register resolvers where they haven't been already registered, giving more flexibility to developers

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Blocked waiting on PR: https://github.com/MvvmCross/MvvmCross/pull/3356

### :thinking: Checklist before submitting

- [ X ] All projects build
- [ X ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
