### PR TITLE
Fix log format crashing for MvxBindingLog

### DIFF
--- a/MvvmCross/Binding/MvxBindingLog.cs
+++ b/MvvmCross/Binding/MvxBindingLog.cs
@@ -16,7 +16,7 @@ namespace MvvmCross.Binding
         {
             if (level < TraceBindingLevel) return;
 
-            Instance.Log(level, () => string.Format(message, args));
+            Instance.Log(level, () => message, null, args);
         }
 
         public static void Trace(string message, params object[] args)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
See #3337

### :arrow_heading_down: What is the current behavior?
See #3337

When a message containing '{some number}' is formatted by this class, it crashes because it has no guard against it.
This crash is reported by the log, the original crash captured by this class is lost.

### :new: What is the new behavior (if this is a feature change)?
See #3337

Delegates the formatting of the error message to MvxLog classes, instead of formatting it there.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
