### PR TITLE
Pass parameter to command execution method in MvxGestureRecognizerBehavior

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/Gestures/MvxGestureRecognizerBehavior.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/Gestures/MvxGestureRecognizerBehavior.cs
@@ -14,7 +14,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views.Gestures
         protected void FireCommand(object argument = null)
         {
             var command = Command;
-            command?.Execute(null);
+            command?.Execute(argument);
         }
 
         protected void AddGestureRecognizer(UIView target, UIGestureRecognizer tap)

--- a/MvvmCross/Platforms/Tvos/Binding/Views/Gestures/MvxGestureRecognizerBehavior.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/Gestures/MvxGestureRecognizerBehavior.cs
@@ -14,7 +14,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views.Gestures
         protected void FireCommand(object argument = null)
         {
             var command = Command;
-            command?.Execute(null);
+            command?.Execute(argument);
         }
 
         protected void AddGestureRecognizer(UIView target, UIGestureRecognizer tap)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
MvxGestureRecognizerBehavior for iOS and tvOS has a FireCommand method which executes a command attached to the behavior (tap, swipe or custom one). This method accepts a parameter which should be passed to the Command, but currently it's value is ignored - because of it if someone wants to actually pass some parameter in a custom class inheriting from MvxGestureRecognizerBehavior, he needs to call Command.Execute manually.

### :arrow_heading_down: What is the current behavior?
Currently, the argument passed to the FireCommand method is ignored and not passed to the Execute method of attached Command.

### :new: What is the new behavior (if this is a feature change)?
FireCommand's parameter is passed as parameter to the Command?.Execute method.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/3347

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
