### PR TITLE
NLogLogProvider - Support for structured logging in NLog 4.5 

### DIFF
--- a/MvvmCross/Logging/LogProviders/NLogLogProvider.cs
+++ b/MvvmCross/Logging/LogProviders/NLogLogProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
@@ -31,22 +32,56 @@ namespace MvvmCross.Logging.LogProviders
 
         protected override OpenNdc GetOpenNdcMethod()
         {
+            ParameterExpression messageParam = Expression.Parameter(typeof(string), "message");
+
+            Type ndlcContextType = Type.GetType("NLog.NestedDiagnosticsLogicalContext, NLog");
+            if (ndlcContextType != null)
+            {
+                MethodInfo pushObjectMethod = ndlcContextType.GetMethod("PushObject", new[] { typeof(object) });
+                if (pushObjectMethod != null)
+                {
+                    // NLog 4.6 introduces PushObject with correct handling of logical callcontext (NDLC)
+                    MethodCallExpression pushObjectMethodCall = Expression.Call(null, pushObjectMethod, messageParam);
+                    return Expression.Lambda<OpenNdc>(pushObjectMethodCall, messageParam).Compile();
+                }
+            }
+
             Type ndcContextType = Type.GetType("NLog.NestedDiagnosticsContext, NLog");
             MethodInfo pushMethod = ndcContextType.GetMethod("Push", new[] { typeof(string) });
-            ParameterExpression messageParam = Expression.Parameter(typeof(string), "message");
             MethodCallExpression pushMethodCall = Expression.Call(null, pushMethod, messageParam);
             return Expression.Lambda<OpenNdc>(pushMethodCall, messageParam).Compile();
         }
 
         protected override OpenMdc GetOpenMdcMethod()
         {
-            Type mdcContextType = Type.GetType("NLog.MappedDiagnosticsContext, NLog");
+            ParameterExpression keyParam = Expression.Parameter(typeof(string), "key");
 
+            Type ndlcContextType = Type.GetType("NLog.NestedDiagnosticsLogicalContext, NLog");
+            if (ndlcContextType != null)
+            {
+                MethodInfo pushObjectMethod = ndlcContextType.GetMethod("PushObject", new[] { typeof(object) });
+                if (pushObjectMethod != null)
+                {
+                    // NLog 4.6 introduces SetScoped with correct handling of logical callcontext (MDLC)
+                    Type mdlcContextType = Type.GetType("NLog.MappedDiagnosticsLogicalContext, NLog");
+                    if (mdlcContextType != null)
+                    {
+                        MethodInfo setScopedMethod = mdlcContextType.GetMethod("SetScoped", new[] { typeof(string), typeof(object) });
+                        if (setScopedMethod != null)
+                        {
+                            var valueObjParam = Expression.Parameter(typeof(object), "value");
+                            var setScopedMethodCall = Expression.Call(null, setScopedMethod, keyParam, valueObjParam);
+                            var setMethodLambda = Expression.Lambda<Func<string, object, IDisposable>>(setScopedMethodCall, keyParam, valueObjParam).Compile();
+                            return (key, value) => setMethodLambda(key, value);
+                        }
+                    }
+                }
+            }
+
+            Type mdcContextType = Type.GetType("NLog.MappedDiagnosticsContext, NLog");
             MethodInfo setMethod = mdcContextType.GetMethod("Set", new[] { typeof(string), typeof(string) });
             MethodInfo removeMethod = mdcContextType.GetMethod("Remove", new[] { typeof(string) });
-            ParameterExpression keyParam = Expression.Parameter(typeof(string), "key");
             ParameterExpression valueParam = Expression.Parameter(typeof(string), "value");
-
             MethodCallExpression setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
             MethodCallExpression removeMethodCall = Expression.Call(null, removeMethod, keyParam);
 
@@ -78,9 +113,9 @@ namespace MvvmCross.Logging.LogProviders
 
         internal class NLogLogger
         {
-            private readonly dynamic _logger;
+            private readonly object _logger;
 
-            private static Func<string, object, string, Exception, object> _logEventInfoFact;
+            private static readonly Func<string, object, string, object[], Exception, object> _logEventInfoFact;
 
             private static readonly object _levelTrace;
             private static readonly object _levelDebug;
@@ -88,6 +123,38 @@ namespace MvvmCross.Logging.LogProviders
             private static readonly object _levelWarn;
             private static readonly object _levelError;
             private static readonly object _levelFatal;
+
+            private static bool _structuredLoggingEnabled;
+
+            delegate string LoggerNameDelegate(object logger);
+            delegate void LogEventDelegate(object logger, Type wrapperType, object logEvent);
+            delegate bool IsEnabledDelegate(object logger);
+            delegate void LogDelegate(object logger, string message);
+            delegate void LogExceptionDelegate(object logger, string message, Exception exception);
+
+            private static readonly LoggerNameDelegate _loggerNameDelegate;
+            private static readonly LogEventDelegate _logEventDelegate;
+
+            private static readonly IsEnabledDelegate _isTraceEnabledDelegate;
+            private static readonly IsEnabledDelegate _isDebugEnabledDelegate;
+            private static readonly IsEnabledDelegate _isInfoEnabledDelegate;
+            private static readonly IsEnabledDelegate _isWarnEnabledDelegate;
+            private static readonly IsEnabledDelegate _isErrorEnabledDelegate;
+            private static readonly IsEnabledDelegate _isFatalEnabledDelegate;
+
+            private static readonly LogDelegate _traceDelegate;
+            private static readonly LogDelegate _debugDelegate;
+            private static readonly LogDelegate _infoDelegate;
+            private static readonly LogDelegate _warnDelegate;
+            private static readonly LogDelegate _errorDelegate;
+            private static readonly LogDelegate _fatalDelegate;
+
+            private static readonly LogExceptionDelegate _traceExceptionDelegate;
+            private static readonly LogExceptionDelegate _debugExceptionDelegate;
+            private static readonly LogExceptionDelegate _infoExceptionDelegate;
+            private static readonly LogExceptionDelegate _warnExceptionDelegate;
+            private static readonly LogExceptionDelegate _errorExceptionDelegate;
+            private static readonly LogExceptionDelegate _fatalExceptionDelegate;
 
             static NLogLogger()
             {
@@ -112,31 +179,121 @@ namespace MvvmCross.Logging.LogProviders
                     {
                         throw new InvalidOperationException("Type NLog.LogEventInfo was not found.");
                     }
-                    MethodInfo createLogEventInfoMethodInfo = logEventInfoType.GetMethod("Create", new[]
+
+                    var loggingEventConstructor = logEventInfoType.GetConstructor(new []
                     {
                         logEventLevelType,
                         typeof(string),
-                        typeof(Exception),
                         typeof(IFormatProvider),
                         typeof(string),
-                        typeof(object[])
+                        typeof(object[]),
+                        typeof(Exception),
                     });
                     ParameterExpression loggerNameParam = Expression.Parameter(typeof(string));
                     ParameterExpression levelParam = Expression.Parameter(typeof(object));
                     ParameterExpression messageParam = Expression.Parameter(typeof(string));
+                    ParameterExpression messageArgsParam = Expression.Parameter(typeof(object[]));
                     ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
                     UnaryExpression levelCast = Expression.Convert(levelParam, logEventLevelType);
-                    MethodCallExpression createLogEventInfoMethodCall = Expression.Call(null,
-                        createLogEventInfoMethodInfo,
-                        levelCast, loggerNameParam, exceptionParam,
-                        Expression.Constant(null, typeof(IFormatProvider)), messageParam, Expression.Constant(null, typeof(object[])));
-                    _logEventInfoFact = Expression.Lambda<Func<string, object, string, Exception, object>>(createLogEventInfoMethodCall,
-                        loggerNameParam, levelParam, messageParam, exceptionParam).Compile();
+
+                    NewExpression newLoggingEventExpression =
+                        Expression.New(loggingEventConstructor,
+                            levelCast,
+                            loggerNameParam,
+                            Expression.Constant(null, typeof(IFormatProvider)),
+                            messageParam,
+                            messageArgsParam,
+                            exceptionParam
+                        );
+
+                    _logEventInfoFact = Expression.Lambda<Func<string, object, string, object[], Exception, object>>(
+                        newLoggingEventExpression,
+                        loggerNameParam, levelParam, messageParam, messageArgsParam, exceptionParam).Compile();
+
+                    Type loggerType = Type.GetType("NLog.Logger, NLog");
+
+                    _loggerNameDelegate = GetLoggerNameDelegate(loggerType);
+
+                    _logEventDelegate = GetLogEventDelegate(loggerType, logEventInfoType);
+
+                    _isTraceEnabledDelegate = GetIsEnabledDelegate(loggerType, "IsTraceEnabled");
+                    _isDebugEnabledDelegate = GetIsEnabledDelegate(loggerType, "IsDebugEnabled");
+                    _isInfoEnabledDelegate = GetIsEnabledDelegate(loggerType, "IsInfoEnabled");
+                    _isWarnEnabledDelegate = GetIsEnabledDelegate(loggerType, "IsWarnEnabled");
+                    _isErrorEnabledDelegate = GetIsEnabledDelegate(loggerType, "IsErrorEnabled");
+                    _isFatalEnabledDelegate = GetIsEnabledDelegate(loggerType, "IsFatalEnabled");
+
+                    _traceDelegate = GetLogDelegate(loggerType, "Trace");
+                    _debugDelegate = GetLogDelegate(loggerType, "Debug");
+                    _infoDelegate = GetLogDelegate(loggerType, "Info");
+                    _warnDelegate = GetLogDelegate(loggerType, "Warn");
+                    _errorDelegate = GetLogDelegate(loggerType, "Error");
+                    _fatalDelegate = GetLogDelegate(loggerType, "Fatal");
+
+                    _traceExceptionDelegate = GetLogExceptionDelegate(loggerType, "TraceException");
+                    _debugExceptionDelegate = GetLogExceptionDelegate(loggerType, "DebugException");
+                    _infoExceptionDelegate = GetLogExceptionDelegate(loggerType, "InfoException");
+                    _warnExceptionDelegate = GetLogExceptionDelegate(loggerType, "WarnException");
+                    _errorExceptionDelegate = GetLogExceptionDelegate(loggerType, "ErrorException");
+                    _fatalExceptionDelegate = GetLogExceptionDelegate(loggerType, "FatalException");
+
+                    _structuredLoggingEnabled = IsStructuredLoggingEnabled();
                 }
                 catch { }
             }
 
-            internal NLogLogger(dynamic logger)
+            private static IsEnabledDelegate GetIsEnabledDelegate(Type loggerType, string propertyName)
+            {
+                var isEnabledPropertyInfo = loggerType.GetProperty(propertyName);
+                var instanceParam = Expression.Parameter(typeof(object));
+                var instanceCast = Expression.Convert(instanceParam, loggerType);
+                var propertyCall = Expression.Property(instanceCast, isEnabledPropertyInfo);
+                return Expression.Lambda<IsEnabledDelegate>(propertyCall, instanceParam).Compile();
+            }
+
+            private static LoggerNameDelegate GetLoggerNameDelegate(Type loggerType)
+            {
+                var isEnabledPropertyInfo = loggerType.GetProperty("Name");
+                var instanceParam = Expression.Parameter(typeof(object));
+                var instanceCast = Expression.Convert(instanceParam, loggerType);
+                var propertyCall = Expression.Property(instanceCast, isEnabledPropertyInfo);
+                return Expression.Lambda<LoggerNameDelegate>(propertyCall, instanceParam).Compile();
+            }
+
+            private static LogDelegate GetLogDelegate(Type loggerType, string name)
+            {
+                var logMethodInfo = loggerType.GetMethod(name, new Type[] { typeof(string) });
+                var instanceParam = Expression.Parameter(typeof(object));
+                var instanceCast = Expression.Convert(instanceParam, loggerType);
+                var messageParam = Expression.Parameter(typeof(string));
+                var logCall = Expression.Call(instanceCast, logMethodInfo, messageParam);
+                return Expression.Lambda<LogDelegate>(logCall, instanceParam, messageParam).Compile();
+            }
+
+            private static LogEventDelegate GetLogEventDelegate(Type loggerType, Type logEventType)
+            {
+                var logMethodInfo = loggerType.GetMethod("Log", new Type[] { typeof(Type), logEventType });
+                var instanceParam = Expression.Parameter(typeof(object));
+                var instanceCast = Expression.Convert(instanceParam, loggerType);
+                var loggerTypeParam = Expression.Parameter(typeof(Type));
+                var logEventParam = Expression.Parameter(typeof(object));
+                var logEventCast = Expression.Convert(logEventParam, logEventType);
+                var logCall = Expression.Call(instanceCast, logMethodInfo, loggerTypeParam, logEventCast);
+                return Expression.Lambda<LogEventDelegate>(logCall, instanceParam, loggerTypeParam, logEventParam).Compile();
+            }
+
+            private static LogExceptionDelegate GetLogExceptionDelegate(Type loggerType, string name)
+            {
+                var logMethodInfo = loggerType.GetMethod(name, new Type[] { typeof(string), typeof(Exception) });
+                var instanceParam = Expression.Parameter(typeof(object));
+                var instanceCast = Expression.Convert(instanceParam, loggerType);
+                var messageParam = Expression.Parameter(typeof(string));
+                var exceptionParam = Expression.Parameter(typeof(Exception));
+                var logCall = Expression.Call(instanceCast, logMethodInfo, messageParam, exceptionParam);
+                return Expression.Lambda<LogExceptionDelegate>(logCall, instanceParam, messageParam, exceptionParam).Compile();
+            }
+
+            internal NLogLogger(object logger)
             {
                 _logger = logger;
             }
@@ -148,19 +305,32 @@ namespace MvvmCross.Logging.LogProviders
                 {
                     return IsLogLevelEnable(logLevel);
                 }
-                messageFunc = LogMessageFormatter.SimulateStructuredLogging(messageFunc, formatParameters);
 
                 if (_logEventInfoFact != null)
                 {
                     if (IsLogLevelEnable(logLevel))
                     {
+                        var formatMessage = messageFunc();
+                        if (!_structuredLoggingEnabled)
+                        {
+                            IEnumerable<string> _;
+                            formatMessage =
+                                LogMessageFormatter.FormatStructuredMessage(formatMessage,
+                                    formatParameters,
+                                    out _);
+                            formatParameters = null; // Has been formatted, no need for parameters
+                        }
+
                         var nlogLevel = TranslateLevel(logLevel);
-                        _logger.Log(_logEventInfoFact(_logger.Name, nlogLevel, messageFunc(), exception));
+                        var nlogEvent = _logEventInfoFact(_loggerNameDelegate(_logger), nlogLevel, formatMessage, formatParameters, exception);
+                        _logEventDelegate(_logger, typeof(IMvxLog), nlogEvent);
                         return true;
                     }
+
                     return false;
                 }
 
+                messageFunc = LogMessageFormatter.SimulateStructuredLogging(messageFunc, formatParameters);
                 if (exception != null)
                 {
                     return LogException(logLevel, messageFunc, exception);
@@ -168,58 +338,53 @@ namespace MvvmCross.Logging.LogProviders
                 switch (logLevel)
                 {
                     case MvxLogLevel.Debug:
-                        if (_logger.IsDebugEnabled)
+                        if (_isDebugEnabledDelegate(_logger))
                         {
-                            _logger.Debug(messageFunc());
+                            _debugDelegate(_logger, messageFunc());
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Info:
-                        if (_logger.IsInfoEnabled)
+                        if (_isInfoEnabledDelegate(_logger))
                         {
-                            _logger.Info(messageFunc());
+                            _infoDelegate(_logger, messageFunc());
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Warn:
-                        if (_logger.IsWarnEnabled)
+                        if (_isWarnEnabledDelegate(_logger))
                         {
-                            _logger.Warn(messageFunc());
+                            _warnDelegate(_logger, messageFunc());
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Error:
-                        if (_logger.IsErrorEnabled)
+                        if (_isErrorEnabledDelegate(_logger))
                         {
-                            _logger.Error(messageFunc());
+                            _errorDelegate(_logger, messageFunc());
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Fatal:
-                        if (_logger.IsFatalEnabled)
+                        if (_isFatalEnabledDelegate(_logger))
                         {
-                            _logger.Fatal(messageFunc());
+                            _fatalDelegate(_logger, messageFunc());
                             return true;
                         }
+
                         break;
                     default:
-                        if (_logger.IsTraceEnabled)
+                        if (_isTraceEnabledDelegate(_logger))
                         {
-                            _logger.Trace(messageFunc());
+                            _traceDelegate(_logger, messageFunc());
                             return true;
                         }
+
                         break;
-                }
-                return false;
-            }
-
-            private static bool IsInTypeHierarchy(Type currentType, Type checkType)
-            {
-                while (currentType != null && currentType != typeof(object))
-                {
-                    if (currentType == checkType) return true;
-
-                    currentType = currentType.BaseType;
                 }
 
                 return false;
@@ -231,48 +396,55 @@ namespace MvvmCross.Logging.LogProviders
                 switch (logLevel)
                 {
                     case MvxLogLevel.Debug:
-                        if (_logger.IsDebugEnabled)
+                        if (_isDebugEnabledDelegate(_logger))
                         {
-                            _logger.DebugException(messageFunc(), exception);
+                            _debugExceptionDelegate(_logger, messageFunc(), exception);
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Info:
-                        if (_logger.IsInfoEnabled)
+                        if (_isInfoEnabledDelegate(_logger))
                         {
-                            _logger.InfoException(messageFunc(), exception);
+                            _infoExceptionDelegate(_logger, messageFunc(), exception);
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Warn:
-                        if (_logger.IsWarnEnabled)
+                        if (_isWarnEnabledDelegate(_logger))
                         {
-                            _logger.WarnException(messageFunc(), exception);
+                            _warnExceptionDelegate(_logger, messageFunc(), exception);
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Error:
-                        if (_logger.IsErrorEnabled)
+                        if (_isErrorEnabledDelegate(_logger))
                         {
-                            _logger.ErrorException(messageFunc(), exception);
+                            _errorExceptionDelegate(_logger, messageFunc(), exception);
                             return true;
                         }
+
                         break;
                     case MvxLogLevel.Fatal:
-                        if (_logger.IsFatalEnabled)
+                        if (_isFatalEnabledDelegate(_logger))
                         {
-                            _logger.FatalException(messageFunc(), exception);
+                            _fatalExceptionDelegate(_logger, messageFunc(), exception);
                             return true;
                         }
+
                         break;
                     default:
-                        if (_logger.IsTraceEnabled)
+                        if (_isTraceEnabledDelegate(_logger))
                         {
-                            _logger.TraceException(messageFunc(), exception);
+                            _traceExceptionDelegate(_logger, messageFunc(), exception);
                             return true;
                         }
+
                         break;
                 }
+
                 return false;
             }
 
@@ -281,17 +453,17 @@ namespace MvvmCross.Logging.LogProviders
                 switch (logLevel)
                 {
                     case MvxLogLevel.Debug:
-                        return _logger.IsDebugEnabled;
+                        return _isDebugEnabledDelegate(_logger);
                     case MvxLogLevel.Info:
-                        return _logger.IsInfoEnabled;
+                        return _isInfoEnabledDelegate(_logger);
                     case MvxLogLevel.Warn:
-                        return _logger.IsWarnEnabled;
+                        return _isWarnEnabledDelegate(_logger);
                     case MvxLogLevel.Error:
-                        return _logger.IsErrorEnabled;
+                        return _isErrorEnabledDelegate(_logger);
                     case MvxLogLevel.Fatal:
-                        return _logger.IsFatalEnabled;
+                        return _isFatalEnabledDelegate(_logger);
                     default:
-                        return _logger.IsTraceEnabled;
+                        return _isTraceEnabledDelegate(_logger);
                 }
             }
 
@@ -314,6 +486,31 @@ namespace MvvmCross.Logging.LogProviders
                     default:
                         throw new ArgumentOutOfRangeException("logLevel", logLevel, null);
                 }
+            }
+
+            private static bool IsStructuredLoggingEnabled()
+            {
+                Type configFactoryType = Type.GetType("NLog.Config.ConfigurationItemFactory, NLog");
+                if (configFactoryType != null)
+                {
+                    PropertyInfo parseMessagesProperty = configFactoryType.GetProperty("ParseMessageTemplates");
+                    if (parseMessagesProperty != null)
+                    {
+                        var defaultProperty = configFactoryType.GetProperty("Default");
+                        if (defaultProperty != null)
+                        {
+                            var configFactoryDefault = defaultProperty.GetValue(null, null);
+                            if (configFactoryDefault != null)
+                            {
+                                var parseMessageTemplates =
+                                    parseMessagesProperty.GetValue(configFactoryDefault, null) as bool?;
+                                if (parseMessageTemplates != false) return true;
+                            }
+                        }
+                    }
+                }
+
+                return false;
             }
         }
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
- Makes use of NLog 4.5 Message Parser with support for structured logging
- Makes use of NLog 4.6 MDLC + NLDC for async Task-support

### :arrow_heading_down: What is the current behavior?
- Discards structured logging properties
- Fails to capture context correct when using async Tasks

### :new: What is the new behavior (if this is a feature change)?
- Detects NLog 4.5 and allows NLog to parse message properties
- Detects NLog 4.6 and allows NLog to support async Task state

### :boom: Does this PR introduce a breaking change?
- Users that upgrades to NLog 4.6 will have to update their NLog.config from `${mdc}` to `${mdlc}`
- Users that upgrades to NLog 4.6 will have to update their NLog.config from `${ndc}` to `${ndlc}`

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop