### PR TITLE
Enhanced tap compatibility for UITextField in MvxGestureRecognizerBeh…

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/Gestures/MvxGestureRecognizerBehavior.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/Gestures/MvxGestureRecognizerBehavior.cs
@@ -7,7 +7,7 @@ using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views.Gestures
 {
-    public abstract class MvxGestureRecognizerBehavior
+    public abstract class MvxGestureRecognizerBehavior : UIGestureRecognizerDelegate
     {
         public ICommand Command { get; set; }
 
@@ -22,7 +22,15 @@ namespace MvvmCross.Platforms.Ios.Binding.Views.Gestures
             if (!target.UserInteractionEnabled)
                 target.UserInteractionEnabled = true;
 
+            if (target is UITextField && tap is UITapGestureRecognizer)
+                tap.WeakDelegate = this;
+
             target.AddGestureRecognizer(tap);
+        }
+
+        public override bool ShouldBeRequiredToFailBy(UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer)
+        {
+            return true;
         }
     }
 


### PR DESCRIPTION
…avior.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
UITextField MvxTapGestureBehaviour doesn't work in iOS 10.

### :new: What is the new behavior (if this is a feature change)?
UITextField MvxTapGestureBehaviour works in all iOS versions.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Create a binding on a UITextField that is connected to a view model command using the Tap() behaviour. Confirm the command is executed in both iOS 10 and iOS 12.

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/3381

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
