### PR TITLE
Fix for #3294: MvxAndroidLifetimeMonitor should lock when accessing _createdActivityCount

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxAndroidLifeTimeMonitor.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidLifeTimeMonitor.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using Android.App;
 using Android.OS;
 using MvvmCross.Core;
@@ -18,7 +19,8 @@ namespace MvvmCross.Platforms.Android.Views
 
         public virtual void OnCreate(Activity activity, Bundle eventArgs)
         {
-            _createdActivityCount++;
+            Interlocked.Increment(ref _createdActivityCount);
+            
             if (_createdActivityCount == 1)
             {
                 FireLifetimeChange(MvxLifetimeEvent.ActivatedFromDisk);
@@ -53,7 +55,8 @@ namespace MvvmCross.Platforms.Android.Views
 
         public virtual void OnDestroy(Activity activity)
         {
-            _createdActivityCount--;
+            Interlocked.Decrement(ref _createdActivityCount);
+
             if (_createdActivityCount == 0)
             {
                 FireLifetimeChange(MvxLifetimeEvent.Closing);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix for issue #3294

### :arrow_heading_down: What is the current behavior?
Non-threadsafe increment/decrement operation.

### :new: What is the new behavior (if this is a feature change)?
Use of `Interlocked` for increments/decrements.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#3294 

### :thinking: Checklist before submitting

- [X] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
