### PR TITLE
Fix attribute for Mac windows presentation

### DIFF
--- a/MvvmCross/Platforms/Mac/Presenters/Attributes/MvxWindowPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/Attributes/MvxWindowPresentationAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -18,36 +18,27 @@ namespace MvvmCross.Platforms.Mac.Presenters.Attributes
         public static NSWindowTitleVisibility DefaultTitleVisibility = NSWindowTitleVisibility.Visible;
         public static bool DefaultShouldCascadeWindows = true;
 
-        public static float InitialPositionX { get; } = float.MinValue;
-        public static float InitialPositionY { get; } = float.MinValue;
-        public static float InitialWidth { get; } = float.MinValue;
-        public static float InitialHeight { get; } = float.MinValue;
-        public static NSWindowStyle? InitialWindowStyle { get; } = null;
-        public static NSBackingStore? InitialBufferingType { get; } = null;
-        public static NSWindowTitleVisibility? InitialTitleVisibilty { get; } = null;
-        public static bool? InitialShouldCascadeWindows { get; } = null;
-
         public MvxWindowPresentationAttribute(string windowControllerName = null, string storyboardName = null)
         {
             WindowControllerName = windowControllerName;
             StoryboardName = storyboardName;
         }
 
-        public float PositionX { get; set; } = InitialPositionX;
+        public float PositionX { get; set; } = DefaultPositionX;
 
-        public float PositionY { get; set; } = InitialPositionY;
+        public float PositionY { get; set; } = DefaultPositionY;
 
-        public float Width { get; set; } = InitialWidth;
+        public float Width { get; set; } = DefaultWidth;
 
-        public float Height { get; set; } = InitialHeight;
+        public float Height { get; set; } = DefaultHeight;
 
-        public NSWindowStyle? WindowStyle { get; set; } = InitialWindowStyle;
+        public NSWindowStyle WindowStyle { get; set; } = DefaultWindowStyle;
 
-        public NSBackingStore? BufferingType { get; set; } = InitialBufferingType;
+        public NSBackingStore BufferingType { get; set; } = DefaultBufferingType;
 
-        public NSWindowTitleVisibility? TitleVisibility { get; set; } = InitialTitleVisibilty;
+        public NSWindowTitleVisibility TitleVisibility { get; set; } = DefaultTitleVisibility;
 
-        public bool? ShouldCascadeWindows { get; set; } = InitialShouldCascadeWindows;
+        public bool ShouldCascadeWindows { get; set; } = DefaultShouldCascadeWindows;
 
         public string Identifier { get; set; }
 

--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -131,7 +131,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
                 if (windowController == null)
                 {
                     windowController = CreateWindowController(window);
-                    windowController.ShouldCascadeWindows = attribute.ShouldCascadeWindows ?? MvxWindowPresentationAttribute.DefaultShouldCascadeWindows;
+                    windowController.ShouldCascadeWindows = attribute.ShouldCascadeWindows;
                 }
                 windowController.Window = window;
             }
@@ -153,35 +153,35 @@ namespace MvvmCross.Platforms.Mac.Presenters
 
         protected virtual void UpdateWindow(MvxWindowPresentationAttribute attribute, NSWindow window)
         {
-            var positionX = attribute.PositionX != MvxWindowPresentationAttribute.InitialPositionX ? attribute.PositionX : (float)window.Frame.X;
-            var positionY = attribute.PositionY != MvxWindowPresentationAttribute.InitialPositionY ? attribute.PositionY : (float)window.Frame.Y;
-            var width = attribute.Width != MvxWindowPresentationAttribute.InitialWidth ? attribute.Width : (float)window.Frame.Width;
-            var height = attribute.Height != MvxWindowPresentationAttribute.InitialHeight ? attribute.Height : (float)window.Frame.Height;
+            var positionX = (float)window.Frame.X;
+            var positionY = (float)window.Frame.Y;
+            var width = (float)window.Frame.Width;
+            var height = (float)window.Frame.Height;
 
             var newFrame = new CGRect(positionX, positionY, width, height);
             window.SetFrame(newFrame, false);
 
-            window.StyleMask = attribute.WindowStyle ?? window.StyleMask;
-            window.BackingType = attribute.BufferingType ?? window.BackingType;
-            window.TitleVisibility = attribute.TitleVisibility ?? window.TitleVisibility;
+            window.StyleMask = attribute.WindowStyle;
+            window.BackingType = attribute.BufferingType;
+            window.TitleVisibility = attribute.TitleVisibility;
         }
 
         protected virtual NSWindow CreateWindow(MvxWindowPresentationAttribute attribute)
         {
             NSWindow window;
-            var positionX = attribute.PositionX != MvxWindowPresentationAttribute.InitialPositionX ? attribute.PositionX : MvxWindowPresentationAttribute.DefaultPositionX;
-            var positionY = attribute.PositionY != MvxWindowPresentationAttribute.InitialPositionY ? attribute.PositionY : MvxWindowPresentationAttribute.DefaultPositionY;
-            var width = attribute.Width != MvxWindowPresentationAttribute.InitialWidth ? attribute.Width : MvxWindowPresentationAttribute.DefaultWidth;
-            var height = attribute.Height != MvxWindowPresentationAttribute.InitialHeight ? attribute.Height : MvxWindowPresentationAttribute.DefaultHeight;
+            var positionX = attribute.PositionX;
+            var positionY = attribute.PositionY;
+            var width = attribute.Width;
+            var height = attribute.Height;
 
             window = new NSWindow(
                 new CGRect(positionX, positionY, width, height),
-                attribute.WindowStyle ?? MvxWindowPresentationAttribute.DefaultWindowStyle,
-                attribute.BufferingType ?? MvxWindowPresentationAttribute.DefaultBufferingType,
+                attribute.WindowStyle,
+                attribute.BufferingType,
                 false,
                 NSScreen.MainScreen)
             {
-                TitleVisibility = attribute.TitleVisibility ?? MvxWindowPresentationAttribute.DefaultTitleVisibility,
+                TitleVisibility = attribute.TitleVisibility,
             };
             return window;
         }
@@ -200,7 +200,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
                 // Instantiate using Reflection - failure is possible if blank constructor is missing
                 windowController = (MvxWindowController)Activator.CreateInstance(Type.GetType(attribute.WindowControllerName));
             }
-            windowController.ShouldCascadeWindows = attribute.ShouldCascadeWindows ?? windowController.ShouldCascadeWindows;
+            windowController.ShouldCascadeWindows = attribute.ShouldCascadeWindows;
             return windowController;
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix

### :arrow_heading_down: What is the current behavior?

Cannot use attribute for windows on Mac

### :new: What is the new behavior (if this is a feature change)?

It is possible

### :boom: Does this PR introduce a breaking change?

Maybe. No real life reproduction case.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Fixes https://github.com/MvvmCross/MvvmCross/issues/3336

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
