### PR TITLE
Facade MvxViewModelInstanceRequest instance overwritten

### DIFF
--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -169,7 +169,14 @@ namespace MvvmCross.Navigation
                         request.ParameterValues = facadeRequest.ParameterValues;
                     }
 
-                    request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, null);
+                    if (facadeRequest is MvxViewModelInstanceRequest instanceRequest)
+                    {
+                        request.ViewModelInstance = instanceRequest.ViewModelInstance ?? ViewModelLoader.LoadViewModel(request, null);
+                    }
+                    else
+                    {
+                        request.ViewModelInstance = ViewModelLoader.LoadViewModel(request, null);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
If facade request returns a MvxViewModelInstanceRequest with an instance of a ViewModel, use that instance rather than load a new one for NavigationRouteRequest

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Returning a MvxViewModelInstanceRequest (with a VM instance) in an IMvxNavigationFacade results in that instance not being used for the resulting navigation. This change checks for an existing instance in the request and uses that instance instead of loading a new one.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
