### PR TITLE
Fix: Typo: Remove extra period

### DIFF
--- a/docs/_documentation/advanced/customizing-using-App-and-Setup.md
+++ b/docs/_documentation/advanced/customizing-using-App-and-Setup.md
@@ -146,7 +146,7 @@ These two placeholders provide key places for you to create and register service
 For example, if you wanted to implement an EncryptionService which would provide native data-encryption for your application, then you could do this during Setup.InitializeFirstChance using:
 
 ```c#
- Mvx.IoCProvider..RegisterType<IEncryption, MyEncryption>();
+ Mvx.IoCProvider.RegisterType<IEncryption, MyEncryption>();
 ```
 This would then allow all of your App code - including code executed during App.Initialize() to use calls like:
 
@@ -157,7 +157,7 @@ var safe = encryption.Encode(raw);
 
 Alternatively, if you wanted to implement a DialogService which would be used during normal UI flow, then you might choose to register this during Setup.InitializeLastChance as:
 ```c#
-Mvx.IoCProvider..RegisterSingleton<IDialogService>(new MyDialogService());
+Mvx.IoCProvider.RegisterSingleton<IDialogService>(new MyDialogService());
 ```
 
 For many objects the choice of when to initialize - first or last - doesn't matter. For others, the key choice is whether the service needs to be available before or after the App is created and initialized.


### PR DESCRIPTION
It is possible that just I don't understand C# grammar deeply.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
docs fix

### :arrow_heading_down: What is the current behavior?
TYPO: maybe there is an extra period 

### :new: What is the new behavior (if this is a feature change)?
become correct

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Grammatical check

### :memo: Links to relevant issues/docs
nothing

### :thinking: Checklist before submitting

- [ ] All projects build : _not related_
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop : _I don't know whether this PR is correct_
