### PR TITLE
Impliment apply() on dispose of clear binding set

### DIFF
--- a/MvvmCross/Binding/BindingContext/MvxBindingContextOwnerExtensions.Fluent.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBindingContextOwnerExtensions.Fluent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,6 +11,13 @@ namespace MvvmCross.Binding.BindingContext
             where TTarget : class, IMvxBindingContextOwner
         {
             return new MvxFluentBindingDescriptionSet<TTarget, TSource>(target);
+        }
+
+        public static MvxFluentBindingDescriptionSet<TTarget, TSource> CreateBindingSet<TTarget, TSource>(
+            this TTarget target, string clearBindingKey)
+            where TTarget : class, IMvxBindingContextOwner
+        {
+            return new MvxFluentBindingDescriptionSet<TTarget, TSource>(target, clearBindingKey);
         }
 
         /*

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using MvvmCross.Base;
 using MvvmCross.Binding.Bindings;
@@ -9,18 +10,22 @@ using MvvmCross.Binding.Bindings;
 namespace MvvmCross.Binding.BindingContext
 {
     public class MvxFluentBindingDescriptionSet<TOwningTarget, TSource>
-        : MvxApplicable
+        : MvxApplicable, IDisposable
         where TOwningTarget : class, IMvxBindingContextOwner
     {
         private readonly List<IMvxApplicable> _applicables = new List<IMvxApplicable>();
         private readonly TOwningTarget _bindingContextOwner;
+        private readonly string _clearBindingKey;
 
         public MvxFluentBindingDescriptionSet(TOwningTarget bindingContextOwner)
         {
             _bindingContextOwner = bindingContextOwner;
         }
-
-        public MvxFluentBindingDescription<TOwningTarget, TSource> Bind()
+        public MvxFluentBindingDescriptionSet(TOwningTarget bindingContextOwner, string clearBindingKey):this (bindingContextOwner)
+        {
+            _clearBindingKey = clearBindingKey;
+        }
+            public MvxFluentBindingDescription<TOwningTarget, TSource> Bind()
         {
             var toReturn = new MvxFluentBindingDescription<TOwningTarget, TSource>(_bindingContextOwner,
                                                                                    _bindingContextOwner);
@@ -80,6 +85,14 @@ namespace MvvmCross.Binding.BindingContext
             }
 
             base.Apply();
+        }
+
+        public void Dispose()
+        {
+            if (string.IsNullOrEmpty(_clearBindingKey))
+                Apply();
+            else
+                ApplyWithClearBindingKey(_clearBindingKey);
         }
     }
 }

--- a/Projects/Playground/Playground.iOS/Views/RootView.cs
+++ b/Projects/Playground/Playground.iOS/Views/RootView.cs
@@ -21,18 +21,17 @@ namespace Playground.iOS.Views
 
             View.BackgroundColor = UIColor.LightGray;
 
-            var set = this.CreateBindingSet<RootView, RootViewModel>();
-
-            set.Bind(btnTabs).To(vm => vm.ShowTabsCommand);
-            set.Bind(btnPages).To(vm => vm.ShowPagesCommand);
-            set.Bind(btnSplit).To(vm => vm.ShowSplitCommand);
-            set.Bind(btnChild).To(vm => vm.ShowChildCommand);
-            set.Bind(btnModal).To(vm => vm.ShowModalCommand);
-            set.Bind(btnNavModal).To(vm => vm.ShowModalNavCommand);
-            set.Bind(btnOverrideAttribute).To(vm => vm.ShowOverrideAttributeCommand);
-            set.Bind(btnShowCustomBinding).To(vm => vm.ShowCustomBindingCommand);
-
-            set.Apply();
+            using (var set = this.CreateBindingSet<RootView, RootViewModel>())
+            {
+                set.Bind(btnTabs).To(vm => vm.ShowTabsCommand);
+                set.Bind(btnPages).To(vm => vm.ShowPagesCommand);
+                set.Bind(btnSplit).To(vm => vm.ShowSplitCommand);
+                set.Bind(btnChild).To(vm => vm.ShowChildCommand);
+                set.Bind(btnModal).To(vm => vm.ShowModalCommand);
+                set.Bind(btnNavModal).To(vm => vm.ShowModalNavCommand);
+                set.Bind(btnOverrideAttribute).To(vm => vm.ShowOverrideAttributeCommand);
+                set.Bind(btnShowCustomBinding).To(vm => vm.ShowCustomBindingCommand);
+            }
         }
     }
 }

--- a/docs/_documentation/fundamentals/data-binding.md
+++ b/docs/_documentation/fundamentals/data-binding.md
@@ -511,6 +511,16 @@ set.Apply();
 ```
 
  **Note:** when using a fluent binding, always remember to use `.Apply()` - if this is missed then the binding won't ever be created.
+ 
+ ***Alternatively:*** A bindingset can be used as a disposable and wrapped in a using block to automatically call the `.Apply()` method.
+ ```c#
+ using(var set = this.CreateBindingSet<MyView, MyViewModel>())
+ {
+    set.Bind(nameLabel)
+        .For(v => v.Text)
+        .To(vm => vm.Customer.FirstName);
+ }
+ ```
 
 ### MvvmCross Defined Custom bindings
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
You have to call `Apply()` on a binding set explicitly.

### :new: What is the new behavior (if this is a feature change)?
You can use the binding set with the `using()` pattern, and it will call apply when going out of scope of the using statement.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
