### PR TITLE
Breaking up logic for creating view lookup

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -116,8 +116,10 @@ namespace MvvmCross.Core
             InitializeViewModelTypeFinder();
             SetupLog.Trace("Setup: ViewsContainer start");
             InitializeViewsContainer();
+            SetupLog.Trace("Setup: Lookup Dictionary start");
+            var lookup = InitializeLookupDictionary();
             SetupLog.Trace("Setup: Views start");
-            InitializeViewLookup();
+            InitializeViewLookup(lookup);
             SetupLog.Trace("Setup: CommandCollectionBuilder start");
             InitializeCommandCollectionBuilder();
             SetupLog.Trace("Setup: NavigationSerializer start");
@@ -498,11 +500,16 @@ namespace MvvmCross.Core
             return nameMappingStrategy;
         }
 
-        protected virtual IMvxViewsContainer InitializeViewLookup()
+        protected virtual IDictionary<Type, Type> InitializeLookupDictionary()
         {
             var viewAssemblies = GetViewAssemblies();
             var builder = Mvx.IoCProvider.Resolve<IMvxTypeToTypeLookupBuilder>();
             var viewModelViewLookup = builder.Build(viewAssemblies);
+            return viewModelViewLookup;
+        }
+
+        protected virtual IMvxViewsContainer InitializeViewLookup(IDictionary<Type, Type> viewModelViewLookup)
+        {
             if (viewModelViewLookup == null)
                 return null;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Refactor - the motivation here is actually to support XF Shell where we want to be able to intercept and build routes based on the association between view and viewmodels

### :arrow_heading_down: What is the current behavior?
Two steps of startup process are in the same method

### :new: What is the new behavior (if this is a feature change)?
Break steps into two virtual methods so that they can be intercepted.

### :boom: Does this PR introduce a breaking change?
Only if the InitializeViewLookup method has been overridden - it the override method just needs to be extended to include the lookup dictionary.

### :bug: Recommendations for testing
Run the playground app

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting

- [ X ] All projects build
- [ X ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ X ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ X ] Rebased onto current develop
