### PR TITLE
Prepare MvxIoCTest to allow other IoC providers

### DIFF
--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -234,7 +234,7 @@ namespace MvvmCross.UnitTest.Base
         #endregion
 
         [Fact]
-        public void TryResolve_CircularButSafeDynamicWithOptionOff_ReturnsTrue()
+        public virtual void TryResolve_CircularButSafeDynamicWithOptionOff_ReturnsTrue()
         {
             COdd.FirstTime = true;
             
@@ -251,7 +251,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void TryResolve_CircularButSafeDynamicWithOptionOn_ReturnsFalse()
+        public virtual void TryResolve_CircularButSafeDynamicWithOptionOn_ReturnsFalse()
         {
             COdd.FirstTime = true;
 
@@ -265,7 +265,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void TryResolve_CircularLazyRegistration_ReturnsFalse()
+        public virtual void TryResolve_CircularLazyRegistration_ReturnsFalse()
         {
             _iocProvider.LazyConstructAndRegisterSingleton<IA, A>();
             _iocProvider.LazyConstructAndRegisterSingleton<IB, B>();
@@ -277,7 +277,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void TryResolve_NonCircularRegistration_ReturnsTrue()
+        public virtual void TryResolve_NonCircularRegistration_ReturnsTrue()
         {
             _iocProvider.LazyConstructAndRegisterSingleton<IA, A>();
             _iocProvider.LazyConstructAndRegisterSingleton<IB, B>();
@@ -289,7 +289,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void TryResolve_LazySingleton_ReturnsSameSingletonEachTime()
+        public virtual void TryResolve_LazySingleton_ReturnsSameSingletonEachTime()
         {
             _iocProvider.LazyConstructAndRegisterSingleton<IA, A>();
             _iocProvider.LazyConstructAndRegisterSingleton<IB, B>();
@@ -308,7 +308,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void TryResolve_NonLazySingleton_ReturnsSameSingletonEachTime()
+        public virtual void TryResolve_NonLazySingleton_ReturnsSameSingletonEachTime()
         {
             _iocProvider.LazyConstructAndRegisterSingleton<IB, B>();
             _iocProvider.LazyConstructAndRegisterSingleton<IC, C2>();
@@ -327,7 +327,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void TryResolve_Dynamic_ReturnsDifferentInstanceEachTime()
+        public virtual void TryResolve_Dynamic_ReturnsDifferentInstanceEachTime()
         {
             _iocProvider.LazyConstructAndRegisterSingleton<IB, B>();
             _iocProvider.LazyConstructAndRegisterSingleton<IC, C2>();
@@ -346,7 +346,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void TryResolve_ParameterConstructors_CreatesParametersUsingIocResolution()
+        public virtual void TryResolve_ParameterConstructors_CreatesParametersUsingIocResolution()
         {
             _iocProvider.RegisterType<IB, B>();
             _iocProvider.LazyConstructAndRegisterSingleton<IC, C2>();
@@ -360,7 +360,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void RegisterType_with_constructor_creates_different_objects()
+        public virtual void RegisterType_with_constructor_creates_different_objects()
         {
             _iocProvider.RegisterType<IC>(() => new C2());
 
@@ -374,7 +374,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void RegisterType_with_no_reflection_creates_different_objects()
+        public virtual void RegisterType_with_no_reflection_creates_different_objects()
         {
             _iocProvider.RegisterType<IA, IB>(b => new A(b));
             _iocProvider.RegisterType<IB, IC>(c => new B(c));
@@ -394,7 +394,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void RegisterType_with_no_reflection_with_up_to_5_parameters()
+        public virtual void RegisterType_with_no_reflection_with_up_to_5_parameters()
         {
             _iocProvider.RegisterType<IA, IB>(b => new A(b));
             _iocProvider.RegisterType<IB, IC>(c => new B(c));
@@ -427,7 +427,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Non_generic_RegisterType_with_constructor_creates_different_objects()
+        public virtual void Non_generic_RegisterType_with_constructor_creates_different_objects()
         {
             _iocProvider.RegisterType(typeof(IC), () => new C2());
 
@@ -441,7 +441,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Non_generic_RegisterType_with_constructor_throws_if_constructor_returns_incompatible_reference()
+        public virtual void Non_generic_RegisterType_with_constructor_throws_if_constructor_returns_incompatible_reference()
         {
             _iocProvider.RegisterType(typeof(IC), () => "Fail");
 
@@ -449,7 +449,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Non_generic_RegisterType_with_constructor_throws_if_constructor_returns_incompatible_value()
+        public virtual void Non_generic_RegisterType_with_constructor_throws_if_constructor_returns_incompatible_value()
         {
             _iocProvider.RegisterType(typeof(IC), () => 36);
 
@@ -459,7 +459,7 @@ namespace MvvmCross.UnitTest.Base
         #region Open-Generics
 
         [Fact]
-        public void Resolves_successfully_when_registered_open_generic_with_one_generic_type_parameter()
+        public virtual void Resolves_successfully_when_registered_open_generic_with_one_generic_type_parameter()
         {
             _iocProvider.RegisterType(typeof(IOG<>), typeof(OG<>));
 
@@ -471,7 +471,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Resolves_successfully_when_registered_closed_generic_with_one_generic_type_parameter()
+        public virtual void Resolves_successfully_when_registered_closed_generic_with_one_generic_type_parameter()
         {
             _iocProvider.RegisterType(typeof(IOG<C2>), typeof(OG<C2>));
 
@@ -483,7 +483,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Resolves_successfully_when_registered_open_generic_with_two_generic_type_parameter()
+        public virtual void Resolves_successfully_when_registered_open_generic_with_two_generic_type_parameter()
         {
             _iocProvider.RegisterType(typeof(IOG2<,>), typeof(OG2<,>));
 
@@ -495,7 +495,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Resolves_successfully_when_registered_closed_generic_with_two_generic_type_parameter()
+        public virtual void Resolves_successfully_when_registered_closed_generic_with_two_generic_type_parameter()
         {
             _iocProvider.RegisterType(typeof(IOG2<C2, C>), typeof(OG2<C2, C>));
 
@@ -507,7 +507,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Resolves_unsuccessfully_when_registered_open_generic_with_one_generic_parameter_that_was_not_registered()
+        public virtual void Resolves_unsuccessfully_when_registered_open_generic_with_one_generic_parameter_that_was_not_registered()
         {
             var isResolved = _iocProvider.TryResolve(out IOG<C2> toResolve);
 
@@ -516,7 +516,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void Resolves_successfully_when_resolving_entity_that_has_injected_an_open_generic_parameter()
+        public virtual void Resolves_successfully_when_resolving_entity_that_has_injected_an_open_generic_parameter()
         {
             _iocProvider.RegisterType<IHasOGParameter, HasOGParameter>();
             _iocProvider.RegisterType(typeof(IOG<>), typeof(OG<>));
@@ -535,7 +535,7 @@ namespace MvvmCross.UnitTest.Base
         #region Child Container
 
         [Fact]
-        public void Resolves_successfully_when_using_childcontainer()
+        public virtual void Resolves_successfully_when_using_childcontainer()
         {
             _iocProvider.RegisterType<IC, C2>();
             var childContainer = _iocProvider.CreateChildContainer();
@@ -555,7 +555,7 @@ namespace MvvmCross.UnitTest.Base
         #endregion Child Container
 
         [Fact]
-        public void IocConstruct_WithDictionaryArguments_CreatesObject()
+        public virtual void IocConstruct_WithDictionaryArguments_CreatesObject()
         {
             var c = new C2();
             var arguments = new Dictionary<string, object> {["c"] = c};
@@ -563,14 +563,14 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void IocConstruct_WithAnonymousTypeArguments_CreatesObject()
+        public virtual void IocConstruct_WithAnonymousTypeArguments_CreatesObject()
         {
             var c = new C2();
             _iocProvider.IoCConstruct<B>(new {c});
         }
 
         [Fact]
-        public void IocConstruct_WithMultipleDictionaryArguments_CreatesObject()
+        public virtual void IocConstruct_WithMultipleDictionaryArguments_CreatesObject()
         {
             var title = "The title";
             var subtitle = "The subtitle";
@@ -585,7 +585,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void IocConstruct_WithMultipleAnonymousArguments_CreatesObject()
+        public virtual void IocConstruct_WithMultipleAnonymousArguments_CreatesObject()
         {
             var title = "The title";
             var subtitle = "The subtitle";
@@ -600,7 +600,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void IocConstruct_WithMultipleTypedArguments_CreatesObject()
+        public virtual void IocConstruct_WithMultipleTypedArguments_CreatesObject()
         {
             var title = "The title";
             var amount = 5;
@@ -614,7 +614,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void IocConstruct_WithMultipleTypedArguments_ThrowsFailedToFindCtor()
+        public virtual void IocConstruct_WithMultipleTypedArguments_ThrowsFailedToFindCtor()
         {
             var title = "The title";
             var subtitle = "The subtitle";
@@ -624,7 +624,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public void MvxIocProvider_NonLazySingleton_ReturnsSameSingleton()
+        public virtual void MvxIocProvider_NonLazySingleton_ReturnsSameSingleton()
         {
             Mvx.IoCProvider.LazyConstructAndRegisterSingleton<IB, B>();
             Mvx.IoCProvider.LazyConstructAndRegisterSingleton<IC, C2>();

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -36,67 +36,67 @@ namespace MvvmCross.UnitTest.Base
 
         #region Test data
 
-        private interface IA
+        protected interface IA
         {
             IB B { get; }
         }
 
-        private interface IB
+        protected interface IB
         {
             IC C { get; }
         }
 
-        private interface IC
+        protected interface IC
         {
         }
 
-        private interface ID
+        protected interface ID
         {
         }
 
-        private interface IE
+        protected interface IE
         {
         }
 
-        private interface IOG<T>
+        protected interface IOG<T>
         {
         }
 
-        private interface IOG2<T, T2>
+        protected interface IOG2<T, T2>
         {
         }
 
-        private interface IHasOGParameter
+        protected interface IHasOGParameter
         {
             IOG<C> OpenGeneric { get; }
         }
 
-        private interface IHasOneParameter
+        protected interface IHasOneParameter
         {
             IA A { get; }
         }
 
-        private interface IHasTwoParameters : IHasOneParameter
+        protected interface IHasTwoParameters : IHasOneParameter
         {
             IB B { get; }
         }
 
-        private interface IHasThreeParameters : IHasTwoParameters
+        protected interface IHasThreeParameters : IHasTwoParameters
         {
             IC C { get; }
         }
 
-        private interface IHasFourParameters : IHasThreeParameters
+        protected interface IHasFourParameters : IHasThreeParameters
         {
             ID D { get; }
         }
 
-        private interface IHasFiveParameters : IHasFourParameters
+        protected interface IHasFiveParameters : IHasFourParameters
         {
             IE E { get; }
         }
 
-        private class A : IA
+        protected class A : IA
         {
             public A(IB b)
             {
@@ -106,7 +106,7 @@ namespace MvvmCross.UnitTest.Base
             public IB B { get; set; }
         }
 
-        private class B : IB
+        protected class B : IB
         {
             public B(IC c)
             {
@@ -116,21 +116,21 @@ namespace MvvmCross.UnitTest.Base
             public IC C { get; set; }
         }
 
-        private class C : IC
+        protected class C : IC
         {
             public C(IA a)
             {
             }
         }
 
-        private class C2 : IC
+        protected class C2 : IC
         {
             public C2()
             {
             }
         }
 
-        private class D : ID
+        protected class D : ID
         {
             public string Title { get; }
 
@@ -157,11 +157,11 @@ namespace MvvmCross.UnitTest.Base
             }
         }
 
-        private class E : IE
+        protected class E : IE
         {
         }
 
-        private class COdd : IC
+        protected class COdd : IC
         {
             public static bool FirstTime = true;
 
@@ -175,15 +175,15 @@ namespace MvvmCross.UnitTest.Base
             }
         }
 
-        private class OG<T> : IOG<T>
+        protected class OG<T> : IOG<T>
         {
         }
 
-        private class OG2<T, T2> : IOG2<T, T2>
+        protected class OG2<T, T2> : IOG2<T, T2>
         {
         }
 
-        private class HasOGParameter : IHasOGParameter
+        protected class HasOGParameter : IHasOGParameter
         {
             public HasOGParameter(IOG<C> openGeneric)
             {
@@ -193,7 +193,7 @@ namespace MvvmCross.UnitTest.Base
             public IOG<C> OpenGeneric { get; }
         }
 
-        private class HasMultipleConstructors : IHasFiveParameters
+        protected class HasMultipleConstructors : IHasFiveParameters
         {
             public IA A { get; }
 

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -624,7 +624,7 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact]
-        public static void MvxIocProvider_NonLazySingleton_ReturnsSameSingleton()
+        public void MvxIocProvider_NonLazySingleton_ReturnsSameSingleton()
         {
             Mvx.IoCProvider.LazyConstructAndRegisterSingleton<IB, B>();
             Mvx.IoCProvider.LazyConstructAndRegisterSingleton<IC, C2>();


### PR DESCRIPTION
* Move the references to the specific implementation of `MvxIoCProvider` to a single method
* Cleanup the class for consistency: make classes private where appropriate, use var where type is clear, remove the dependency on another fixture
* Use built-in xUnit mechanisms for setup and cleanup
* Add a separate unit test to verify if the IoCProvider is correctly registered
* Make the `CreateIoCProvider` virtual so that the tests can be used for other IoCProviders

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
