### PR TITLE
RequestTranslator ignores Presentation/Parameter values

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -258,12 +258,12 @@ namespace MvvmCross.Platforms.Android.Presenters
                 return requestTranslator.GetIntentFor(request);
             }
 
-            var instanceRequest = requestTranslator.GetIntentWithKeyFor(
+            var intentWithKey = requestTranslator.GetIntentWithKeyFor(
                 viewModelInstanceRequest.ViewModelInstance,
                 viewModelInstanceRequest
             );
 
-            return instanceRequest.Item1;
+            return intentWithKey.intent;
         }
 
         protected virtual void ShowIntent(Intent intent, Bundle bundle)

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -251,14 +251,19 @@ namespace MvvmCross.Platforms.Android.Presenters
 
         protected virtual Intent CreateIntentForRequest(MvxViewModelRequest request)
         {
-            IMvxAndroidViewModelRequestTranslator requestTranslator = Mvx.IoCProvider.Resolve<IMvxAndroidViewModelRequestTranslator>();
+            var requestTranslator = Mvx.IoCProvider.Resolve<IMvxAndroidViewModelRequestTranslator>();
 
-            if (request is MvxViewModelInstanceRequest viewModelInstanceRequest)
+            if (!(request is MvxViewModelInstanceRequest viewModelInstanceRequest))
             {
-                var instanceRequest = requestTranslator.GetIntentWithKeyFor(viewModelInstanceRequest.ViewModelInstance);
-                return instanceRequest.Item1;
+                return requestTranslator.GetIntentFor(request);
             }
-            return requestTranslator.GetIntentFor(request);
+
+            var instanceRequest = requestTranslator.GetIntentWithKeyFor(
+                viewModelInstanceRequest.ViewModelInstance,
+                viewModelInstanceRequest
+            );
+
+            return instanceRequest.Item1;
         }
 
         protected virtual void ShowIntent(Intent intent, Bundle bundle)

--- a/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
@@ -13,7 +13,7 @@ namespace MvvmCross.Platforms.Android.Views
         Intent GetIntentFor(MvxViewModelRequest request);
 
         // Important: if calling GetIntentWithKeyFor then you must later call RemoveSubViewModelWithKey on the returned key
-        (Intent Intent, int Key) GetIntentWithKeyFor(IMvxViewModel existingViewModelToUse, MvxViewModelRequest request);
+        (Intent intent, int key) GetIntentWithKeyFor(IMvxViewModel existingViewModelToUse, MvxViewModelRequest request);
 
         void RemoveSubViewModelWithKey(int key);
     }

--- a/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
@@ -13,7 +13,7 @@ namespace MvvmCross.Platforms.Android.Views
         Intent GetIntentFor(MvxViewModelRequest request);
 
         // Important: if calling GetIntentWithKeyFor then you must later call RemoveSubViewModelWithKey on the returned key
-        Tuple<Intent, int> GetIntentWithKeyFor(IMvxViewModel existingViewModelToUse);
+        (Intent Intent, int Key) GetIntentWithKeyFor(IMvxViewModel existingViewModelToUse, MvxViewModelRequest request);
 
         void RemoveSubViewModelWithKey(int key);
     }

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
@@ -146,7 +146,7 @@ namespace MvvmCross.Platforms.Android.Views
             //                intent.AddFlags(ActivityFlags.ClearTop);
         }
 
-        public virtual (Intent Intent, int Key) GetIntentWithKeyFor(IMvxViewModel viewModel, MvxViewModelRequest request)
+        public virtual (Intent intent, int key) GetIntentWithKeyFor(IMvxViewModel viewModel, MvxViewModelRequest request)
         {
             request = request ?? MvxViewModelRequest.GetDefaultRequest(viewModel.GetType());
             var intent = GetIntentFor(request);

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
@@ -146,15 +146,16 @@ namespace MvvmCross.Platforms.Android.Views
             //                intent.AddFlags(ActivityFlags.ClearTop);
         }
 
-        public virtual Tuple<Intent, int> GetIntentWithKeyFor(IMvxViewModel viewModel)
+        public virtual (Intent Intent, int Key) GetIntentWithKeyFor(IMvxViewModel viewModel, MvxViewModelRequest request)
         {
-            var request = MvxViewModelRequest.GetDefaultRequest(viewModel.GetType());
+            request = request ?? MvxViewModelRequest.GetDefaultRequest(viewModel.GetType());
             var intent = GetIntentFor(request);
 
-            var key = Mvx.IoCProvider.Resolve<IMvxChildViewModelCache>().Cache(viewModel);
+            var childViewModelCache = Mvx.IoCProvider.Resolve<IMvxChildViewModelCache>();
+            var key = childViewModelCache.Cache(viewModel);
             intent.PutExtra(SubViewModelKey, key);
 
-            return new Tuple<Intent, int>(intent, key);
+            return (intent, key);
         }
 
         public void RemoveSubViewModelWithKey(int key)

--- a/MvvmCross/Platforms/Android/Views/MvxChildViewModelOwnerExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxChildViewModelOwnerExtensions.cs
@@ -33,10 +33,12 @@ namespace MvvmCross.Platforms.Android.Views
 
         public static Intent CreateIntentFor(this IMvxChildViewModelOwner view, IMvxViewModel subViewModel)
         {
-            var intentWithKey =
-                Mvx.IoCProvider.Resolve<IMvxAndroidViewModelRequestTranslator>().GetIntentWithKeyFor(subViewModel);
-            view.OwnedSubViewModelIndicies.Add(intentWithKey.Item2);
-            return intentWithKey.Item1;
+            var requestTranslator = Mvx.IoCProvider.Resolve<IMvxAndroidViewModelRequestTranslator>();
+            var (intent, key) = requestTranslator.GetIntentWithKeyFor(subViewModel, null);
+
+            view.OwnedSubViewModelIndicies.Add(key);
+
+            return intent;
         }
 
         public static void ClearOwnedSubIndicies(this IMvxChildViewModelOwner view)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Use existing `MvxViewModelRequest` instance when getting intent with key for a view model to preserve `MvxBundle`s with Presentation/Parameter value.

### :arrow_heading_down: What is the current behavior?
`MvxViewModelRequest.GetDefaultRequest` always used when getting intent with key.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
Update `IMvxAndroidViewModelRequestTranslator.GetIntentWithKeyFor` signature to use existing request.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#3482

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
