### PR TITLE
IocConstruct constructor lookup & constructor injection

### DIFF
--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -247,13 +247,21 @@ namespace MvvmCross.IoC
             {
                 return constructors.OrderBy(c => c.GetParameters().Length).FirstOrDefault();
             }
-            
-            var names = arguments.Keys;
 
+            var unusedKeys = new List<string>(arguments.Keys);
+            
             foreach (var constructor in constructors)
             {
                 var parameters = constructor.GetParameters();
-                if (parameters.All(p => names.Contains(p.Name)))
+                foreach (var parameter in parameters)
+                {
+                    if (unusedKeys.Contains(parameter.Name) && parameter.ParameterType.IsInstanceOfType(arguments[parameter.Name]))
+                    {
+                        unusedKeys.Remove(parameter.Name);
+                    }
+                }
+
+                if (unusedKeys.Count == 0)
                 {
                     return constructor;
                 }

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -239,5 +239,54 @@ namespace MvvmCross.IoC
 
             return Activator.CreateInstance(type);
         }
+        
+        public static ConstructorInfo FindApplicableConstructor(this Type type, IDictionary<string, object> arguments)
+        {
+            var constructors = type.GetConstructors();
+            if (arguments == null || arguments.Count == 0)
+            {
+                return constructors.FirstOrDefault();
+            }
+            
+            var names = arguments.Keys;
+
+            foreach (var constructor in constructors)
+            {
+                var parameters = constructor.GetParameters();
+                if (parameters.All(p => names.Contains(p.Name)))
+                {
+                    return constructor;
+                }
+            }
+
+            return constructors.FirstOrDefault();
+        }
+        
+        public static ConstructorInfo FindApplicableConstructor(this Type type, object[] arguments)
+        {
+            var constructors = type.GetConstructors();
+            
+            foreach (var constructor in constructors)
+            {
+                var parameterTypes = constructor.GetParameters().Select(p => p.ParameterType);
+                var unusedArguments = arguments.ToList();
+
+                foreach (var parameterType in parameterTypes)
+                {
+                    var argumentMatch = unusedArguments.FirstOrDefault(arg => parameterType.IsInstanceOfType(arg));
+                    if (argumentMatch != null)
+                    {
+                        unusedArguments.Remove(argumentMatch);
+                    }
+                }
+
+                if (unusedArguments.Count == 0)
+                {
+                    return constructor;
+                }
+            }
+
+            return constructors.FirstOrDefault();
+        }
     }
 }

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -259,7 +259,7 @@ namespace MvvmCross.IoC
                 }
             }
 
-            return constructors.FirstOrDefault();
+            return null;
         }
         
         public static ConstructorInfo FindApplicableConstructor(this Type type, object[] arguments)
@@ -286,7 +286,7 @@ namespace MvvmCross.IoC
                 }
             }
 
-            return constructors.FirstOrDefault();
+            return null;
         }
     }
 }

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -245,7 +245,7 @@ namespace MvvmCross.IoC
             var constructors = type.GetConstructors();
             if (arguments == null || arguments.Count == 0)
             {
-                return null;
+                return constructors.OrderBy(c => c.GetParameters().Length).FirstOrDefault();
             }
             
             var names = arguments.Keys;
@@ -265,6 +265,10 @@ namespace MvvmCross.IoC
         public static ConstructorInfo FindApplicableConstructor(this Type type, object[] arguments)
         {
             var constructors = type.GetConstructors();
+            if (arguments == null || arguments.Length == 0)
+            {
+                return constructors.OrderBy(c => c.GetParameters().Length).FirstOrDefault();
+            }
             
             foreach (var constructor in constructors)
             {

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -245,7 +245,7 @@ namespace MvvmCross.IoC
             var constructors = type.GetConstructors();
             if (arguments == null || arguments.Count == 0)
             {
-                return constructors.FirstOrDefault();
+                return null;
             }
             
             var names = arguments.Keys;

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxIoCTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -159,6 +159,29 @@ namespace MvvmCross.UnitTest.Base
 
         protected class E : IE
         {
+        }
+
+        protected class F
+        {
+            private readonly IC _c;
+            private readonly string _first;
+            private readonly int _second;
+
+            public F(IC c, string first, int second)
+            {
+                _c = c;
+                _first = first;
+                _second = second;
+            }
+
+            public F(string first)
+            {
+                _first = first;
+            }
+
+            public string First => _first;
+            public int Second => _second;
+            public IC C => _c;
         }
 
         protected class COdd : IC
@@ -621,6 +644,21 @@ namespace MvvmCross.UnitTest.Base
             var enabled = true;
 
             Assert.Throws<MvxIoCResolveException>(() => { _iocProvider.IoCConstruct<D>(title, subtitle, enabled); });
+        }
+
+        [Fact]
+        public virtual void IocConstruct_WithMultipleTypedArgumentsAndInjectedArgument_CreatesObject()
+        {
+            _iocProvider.RegisterType<IC, C2>();
+            var first = "first";
+            var second = 2;
+
+            var f = _iocProvider.IoCConstruct<F>(first, second);
+            
+            Assert.NotNull(f);
+            Assert.NotNull(f.C);
+            Assert.Equal(first, f.First);
+            Assert.Equal(second, f.Second);
         }
 
         [Fact]


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
**Feature**: IocConstruct now tries harder to look for the best-matching constructor instead of the .FirstOrDefault() that it sometimes fell back to. It can now also do constructor injection mixed with provided arguments. Added 1 unit test for this specific scenario.

Note that I built this PR on top of #3484 so make sure to either merge or decline that PR first. The refactored unit tests for IoC were a lot easier to work with while I was working on this.

### :arrow_heading_down: What is the current behavior?
You can't do this now. It throws an exception saying that it couldn't find a matching constructor.

### :new: What is the new behavior (if this is a feature change)?
MvvmCross can now do `IocConstruct` with constructor injection and supplied arguments when you're using the overload with the array.

### :boom: Does this PR introduce a breaking change?
It used to throw an exception where it can now handle this scenario. IMHO, not really a breaking change.

### :bug: Recommendations for testing
¯\_(ツ)_/¯ Suggest more unit tests?

### :memo: Links to relevant issues/docs
Maybe #2069 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop