### PR TITLE
ViewPager ignores Presentation Values

### DIFF
--- a/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
@@ -6,10 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Android.Content;
+using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.App;
 using Java.Lang;
 using MvvmCross.Platforms.Android;
+using MvvmCross.Platforms.Android.Presenters;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
@@ -59,6 +61,8 @@ namespace MvvmCross.Droid.Support.V4
 
             mvxFragment.ViewModel = GetViewModel(fragmentInfo);
 
+            fragmentInfo.CachedFragment.Arguments = GetArguments(fragmentInfo);
+
             return fragment;
         }
 
@@ -87,6 +91,19 @@ namespace MvvmCross.Droid.Support.V4
             var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
 
             return viewModelLoader.LoadViewModel(fragmentInfo.Request, null);
+        }
+        
+        private static Bundle GetArguments(MvxViewPagerFragmentInfo fragmentInfo)
+        {
+            var navigationSerializer = Mvx.IoCProvider.Resolve<IMvxNavigationSerializer>();
+
+            var serializedRequest = navigationSerializer.Serializer.SerializeObject(fragmentInfo.Request);
+
+            var bundle = new Bundle();
+
+            bundle.PutString(MvxAndroidViewPresenter.ViewModelRequestBundleKey, serializedRequest);
+
+            return bundle;
         }
     }
 }

--- a/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
@@ -8,23 +8,25 @@ using System.Linq;
 using Android.Content;
 using Android.Runtime;
 using Android.Support.V4.App;
-using Android.Support.V4.View;
 using Java.Lang;
-using MvvmCross.Core;
 using MvvmCross.Platforms.Android;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
-using String = Java.Lang.String;
+using JavaObject = Java.Lang.Object;
+using JavaString = Java.Lang.String;
 
 namespace MvvmCross.Droid.Support.V4
 {
     [Register("mvvmcross.droid.support.v4.MvxCachingFragmentStatePagerAdapter")]
-    public class MvxCachingFragmentStatePagerAdapter
-		: MvxCachingFragmentPagerAdapter
+    public class MvxCachingFragmentStatePagerAdapter : MvxCachingFragmentPagerAdapter
     {
         private readonly Context _context;
         private readonly Type _activityType;
+
+        public List<MvxViewPagerFragmentInfo> FragmentsInfo { get; }
+
+        public override int Count => FragmentsInfo?.Count ?? 0;
 
         protected MvxCachingFragmentStatePagerAdapter(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
@@ -32,7 +34,7 @@ namespace MvvmCross.Droid.Support.V4
             _activityType = Mvx.IoCProvider.Resolve<IMvxAndroidCurrentTopActivity>().Activity.GetType();
         }
 
-		public MvxCachingFragmentStatePagerAdapter(Context context, FragmentManager fragmentManager,
+        public MvxCachingFragmentStatePagerAdapter(Context context, FragmentManager fragmentManager,
             List<MvxViewPagerFragmentInfo> fragmentsInfo) : base(fragmentManager)
         {
             _context = context;
@@ -40,36 +42,34 @@ namespace MvvmCross.Droid.Support.V4
             _activityType = Mvx.IoCProvider.Resolve<IMvxAndroidCurrentTopActivity>().Activity.GetType();
         }
 
-        public override int Count => FragmentsInfo?.Count() ?? 0;
-
-        public List<MvxViewPagerFragmentInfo> FragmentsInfo { get; }
-
         public override Fragment GetItem(int position, Fragment.SavedState fragmentSavedState = null)
         {
-            var fragInfo = FragmentsInfo.ElementAt(position);
-            var fragment = Fragment.Instantiate(_context, fragInfo.FragmentType.FragmentJavaName());
+            var fragmentInfo = FragmentsInfo.ElementAt(position);
+            var fragment = Fragment.Instantiate(_context, fragmentInfo.FragmentType.FragmentJavaName());
 
-            var mvxFragment = fragment as IMvxFragmentView;
-            if (mvxFragment == null)
+            if (!(fragment is IMvxFragmentView mvxFragment))
+            {
                 return fragment;
+            }
 
-			if (mvxFragment.GetType().IsFragmentCacheable(_activityType) && fragmentSavedState != null)
+            if (mvxFragment.GetType().IsFragmentCacheable(_activityType) && fragmentSavedState != null)
+            {
                 return fragment;
+            }
 
-            var viewModel = fragInfo.ViewModel ?? CreateViewModel(position);
-            mvxFragment.ViewModel = viewModel;
+            mvxFragment.ViewModel = GetViewModel(fragmentInfo);
 
             return fragment;
         }
 
-        public override int GetItemPosition(Java.Lang.Object @object)
+        public override int GetItemPosition(JavaObject @object)
         {
-            return PagerAdapter.PositionNone;
+            return PositionNone;
         }
 
         public override ICharSequence GetPageTitleFormatted(int position)
         {
-            return new String(FragmentsInfo.ElementAt(position).Title);
+            return new JavaString(FragmentsInfo.ElementAt(position).Title);
         }
 
         protected override string GetTag(int position)
@@ -77,17 +77,16 @@ namespace MvvmCross.Droid.Support.V4
             return FragmentsInfo.ElementAt(position).Tag;
         }
 
-        private IMvxViewModel CreateViewModel(int position)
+        private static IMvxViewModel GetViewModel(MvxViewPagerFragmentInfo fragmentInfo)
         {
-            var fragInfo = FragmentsInfo.ElementAt(position);
+            if (fragmentInfo.Request is MvxViewModelInstanceRequest instanceRequest)
+            {
+                return instanceRequest.ViewModelInstance;
+            }
 
-            MvxBundle mvxBundle = null;
-            if (fragInfo.ParameterValuesObject != null)
-                mvxBundle = new MvxBundle(fragInfo.ParameterValuesObject.ToSimplePropertyDictionary());
+            var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
 
-            var request = new MvxViewModelRequest(fragInfo.ViewModelType, mvxBundle, null);
-
-            return Mvx.IoCProvider.Resolve<IMvxViewModelLoader>().LoadViewModel(request, null);
+            return viewModelLoader.LoadViewModel(fragmentInfo.Request, null);
         }
     }
 }

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
@@ -12,8 +12,7 @@ using Android.Support.V4.App;
 using Java.Lang;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
-using MvvmCross.Views;
-using String = Java.Lang.String;
+using JavaString = Java.Lang.String;
 
 namespace MvvmCross.Droid.Support.V4
 {
@@ -22,7 +21,7 @@ namespace MvvmCross.Droid.Support.V4
     {
         private readonly Context _context;
 
-        public IEnumerable<MvxViewPagerFragmentInfo> Fragments { get; private set; }
+        public IEnumerable<MvxViewPagerFragmentInfo> Fragments { get; }
 
         public override int Count => Fragments.Count();
 
@@ -41,31 +40,47 @@ namespace MvvmCross.Droid.Support.V4
 
         public override Fragment GetItem(int position)
         {
-            var fragInfo = Fragments.ElementAt(position);
+            var fragmentInfo = Fragments.ElementAt(position);
 
-            if (fragInfo.CachedFragment == null)
+            if (fragmentInfo.CachedFragment != null)
             {
-                fragInfo.CachedFragment = 
-                    Fragment.Instantiate(_context, fragInfo.FragmentType.FragmentJavaName());
-
-                var fragmentAsView = (IMvxView) fragInfo.CachedFragment;
-
-                fragmentAsView.ViewModel = fragInfo.ViewModel ?? Mvx.IoCProvider.Resolve<IMvxViewModelLoader>()
-                    .LoadViewModel(new MvxViewModelRequest(fragInfo.ViewModelType, null, null), null);
+                return fragmentInfo.CachedFragment;
             }
 
-            return fragInfo.CachedFragment;
+            fragmentInfo.CachedFragment = 
+                Fragment.Instantiate(_context, fragmentInfo.FragmentType.FragmentJavaName());
+
+            if (!(fragmentInfo.CachedFragment is IMvxFragmentView mvxFragment))
+            {
+                return fragmentInfo.CachedFragment;
+            }
+
+            mvxFragment.ViewModel = GetViewModel(fragmentInfo);
+
+            return fragmentInfo.CachedFragment;
         }
 
         public override ICharSequence GetPageTitleFormatted(int position)
         {
-            return new String(Fragments.ElementAt(position).Title);
+            return new JavaString(Fragments.ElementAt(position).Title);
         }
 
         public override void RestoreState(IParcelable state, ClassLoader loader)
         {
             //Don't call restore to prevent crash on rotation
             //base.RestoreState (state, loader);
+        }
+
+        private static IMvxViewModel GetViewModel(MvxViewPagerFragmentInfo fragmentInfo)
+        {
+            if (fragmentInfo.Request is MvxViewModelInstanceRequest instanceRequest)
+            {
+                return instanceRequest.ViewModelInstance;
+            }
+
+            var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
+
+            return viewModelLoader.LoadViewModel(fragmentInfo.Request, null);
         }
     }
 }

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs
@@ -10,6 +10,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.App;
 using Java.Lang;
+using MvvmCross.Platforms.Android.Presenters;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 using JavaString = Java.Lang.String;
@@ -57,6 +58,8 @@ namespace MvvmCross.Droid.Support.V4
 
             mvxFragment.ViewModel = GetViewModel(fragmentInfo);
 
+            fragmentInfo.CachedFragment.Arguments = GetArguments(fragmentInfo);
+
             return fragmentInfo.CachedFragment;
         }
 
@@ -81,6 +84,19 @@ namespace MvvmCross.Droid.Support.V4
             var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
 
             return viewModelLoader.LoadViewModel(fragmentInfo.Request, null);
+        }
+        
+        private static Bundle GetArguments(MvxViewPagerFragmentInfo fragmentInfo)
+        {
+            var navigationSerializer = Mvx.IoCProvider.Resolve<IMvxNavigationSerializer>();
+
+            var serializedRequest = navigationSerializer.Serializer.SerializeObject(fragmentInfo.Request);
+
+            var bundle = new Bundle();
+
+            bundle.PutString(MvxAndroidViewPresenter.ViewModelRequestBundleKey, serializedRequest);
+
+            return bundle;
         }
     }
 }

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
@@ -12,17 +12,15 @@ using Android.Support.V4.App;
 using Java.Lang;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
-using MvvmCross.Views;
-using String = Java.Lang.String;
+using JavaString = Java.Lang.String;
 
 namespace MvvmCross.Droid.Support.V4
 {
     [Register("mvvmcross.droid.support.v4.MvxFragmentStatePagerAdapter")]
-    public class MvxFragmentStatePagerAdapter
-        : FragmentStatePagerAdapter
+    public class MvxFragmentStatePagerAdapter : FragmentStatePagerAdapter
     {
         private readonly Context _context;
-        public IEnumerable<MvxViewPagerFragmentInfo> Fragments { get; private set; }
+        public IEnumerable<MvxViewPagerFragmentInfo> Fragments { get; }
 
         public override int Count => Fragments.Count();
 
@@ -41,31 +39,47 @@ namespace MvvmCross.Droid.Support.V4
 
         public override Fragment GetItem(int position)
         {
-            var fragInfo = Fragments.ElementAt(position);
+            var fragmentInfo = Fragments.ElementAt(position);
 
-            if (fragInfo.CachedFragment == null)
+            if (fragmentInfo.CachedFragment != null)
             {
-                fragInfo.CachedFragment = 
-                    Fragment.Instantiate(_context, fragInfo.FragmentType.FragmentJavaName());
-
-                var fragmentAsView = (IMvxView)fragInfo.CachedFragment;
-
-                fragmentAsView.ViewModel = fragInfo.ViewModel ?? Mvx.IoCProvider.Resolve<IMvxViewModelLoader>()
-                    .LoadViewModel(new MvxViewModelRequest(fragInfo.ViewModelType, null, null), null);
+                return fragmentInfo.CachedFragment;
             }
 
-            return fragInfo.CachedFragment;
+            fragmentInfo.CachedFragment = 
+                Fragment.Instantiate(_context, fragmentInfo.FragmentType.FragmentJavaName());
+
+            if (!(fragmentInfo.CachedFragment is IMvxFragmentView mvxFragment))
+            {
+                return fragmentInfo.CachedFragment;
+            }
+
+            mvxFragment.ViewModel = GetViewModel(fragmentInfo);
+
+            return fragmentInfo.CachedFragment;
         }
 
         public override ICharSequence GetPageTitleFormatted(int position)
         {
-            return new String(Fragments.ElementAt(position).Title);
+            return new JavaString(Fragments.ElementAt(position).Title);
         }
 
         public override void RestoreState (IParcelable state, ClassLoader loader)
         {
             //Don't call restore to prevent crash on rotation
             //base.RestoreState (state, loader);
+        }
+
+        private static IMvxViewModel GetViewModel(MvxViewPagerFragmentInfo fragmentInfo)
+        {
+            if (fragmentInfo.Request is MvxViewModelInstanceRequest instanceRequest)
+            {
+                return instanceRequest.ViewModelInstance;
+            }
+
+            var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
+
+            return viewModelLoader.LoadViewModel(fragmentInfo.Request, null);
         }
     }
 }

--- a/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs
@@ -10,6 +10,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.App;
 using Java.Lang;
+using MvvmCross.Platforms.Android.Presenters;
 using MvvmCross.Platforms.Android.Views;
 using MvvmCross.ViewModels;
 using JavaString = Java.Lang.String;
@@ -56,6 +57,8 @@ namespace MvvmCross.Droid.Support.V4
 
             mvxFragment.ViewModel = GetViewModel(fragmentInfo);
 
+            fragmentInfo.CachedFragment.Arguments = GetArguments(fragmentInfo);
+
             return fragmentInfo.CachedFragment;
         }
 
@@ -80,6 +83,19 @@ namespace MvvmCross.Droid.Support.V4
             var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
 
             return viewModelLoader.LoadViewModel(fragmentInfo.Request, null);
+        }
+        
+        private static Bundle GetArguments(MvxViewPagerFragmentInfo fragmentInfo)
+        {
+            var navigationSerializer = Mvx.IoCProvider.Resolve<IMvxNavigationSerializer>();
+
+            var serializedRequest = navigationSerializer.Serializer.SerializeObject(fragmentInfo.Request);
+
+            var bundle = new Bundle();
+
+            bundle.PutString(MvxAndroidViewPresenter.ViewModelRequestBundleKey, serializedRequest);
+
+            return bundle;
         }
     }
 }

--- a/MvvmCross.Android.Support/Fragment/MvxViewPagerFragmentInfo.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxViewPagerFragmentInfo.cs
@@ -10,34 +10,21 @@ namespace MvvmCross.Droid.Support.V4
 {
     public class MvxViewPagerFragmentInfo
     {
-        public MvxViewPagerFragmentInfo(string title, string tag, Type fragmentType, Type viewModelType,
-            object parameterValuesObject = null)
+        public MvxViewPagerFragmentInfo(string title, string tag, Type fragmentType, MvxViewModelRequest request)
         {
             Title = title;
             Tag = tag;
             FragmentType = fragmentType;
-            ViewModelType = viewModelType;
-            ParameterValuesObject = parameterValuesObject;
-        }
-
-        public MvxViewPagerFragmentInfo(string title, string tag, Type fragmentType, 
-            IMvxViewModel viewModel, object parameterValuesObject = null)
-            : this(title, tag, fragmentType, viewModel.GetType(), parameterValuesObject)
-        {
-            ViewModel = viewModel;
+            Request = request;
         }
 
         public Type FragmentType { get; }
-
-        public object ParameterValuesObject { get; }
 
         public string Tag { get; }
 
         public string Title { get; }
 
-        public Type ViewModelType { get; }
-
-        public IMvxViewModel ViewModel { get; }
+        public MvxViewModelRequest Request { get; }
 
         public Fragment CachedFragment { get; set; }
     }

--- a/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
+++ b/MvvmCross.Android.Support/V7.AppCompat/MvxAppCompatViewPresenter.cs
@@ -441,28 +441,23 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 throw new MvxException("ViewPager not found");
 
             var tag = attribute.Tag ?? attribute.ViewType.FragmentJavaName();
+            var fragmentInfo = new MvxViewPagerFragmentInfo(attribute.Title, tag, attribute.ViewType, request);
+
             if (viewPager.Adapter is MvxCachingFragmentStatePagerAdapter adapter)
             {
-                if (request is MvxViewModelInstanceRequest instanceRequest)
-                    adapter.FragmentsInfo.Add(new MvxViewPagerFragmentInfo(
-                        attribute.Title, tag, attribute.ViewType, instanceRequest.ViewModelInstance));
-                else
-                    adapter.FragmentsInfo.Add(new MvxViewPagerFragmentInfo(
-                        attribute.Title, tag, attribute.ViewType, attribute.ViewModelType));
-
+                adapter.FragmentsInfo.Add(fragmentInfo);
                 adapter.NotifyDataSetChanged();
             }
             else
             {
-                var fragments = new List<MvxViewPagerFragmentInfo>();
-                if (request is MvxViewModelInstanceRequest instanceRequest)
-                    fragments.Add(new MvxViewPagerFragmentInfo(
-                        attribute.Title, tag, attribute.ViewType, instanceRequest.ViewModelInstance));
-                else
-                    fragments.Add(new MvxViewPagerFragmentInfo(
-                        attribute.Title, tag, attribute.ViewType, attribute.ViewModelType));
-
-                viewPager.Adapter = new MvxCachingFragmentStatePagerAdapter(CurrentActivity, fragmentManager, fragments);
+                viewPager.Adapter = new MvxCachingFragmentStatePagerAdapter(
+                    CurrentActivity, 
+                    fragmentManager, 
+                    new List<MvxViewPagerFragmentInfo>
+                    {
+                        fragmentInfo
+                    }
+                );
             }
 
             return Task.FromResult(true);
@@ -584,7 +579,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                 var viewTypeMatches = info.FragmentType == attribute.ViewType;
 
                 if (attribute.ViewModelType != null)
-                    return viewTypeMatches && info.ViewModelType == attribute.ViewModelType;
+                    return viewTypeMatches && info.Request?.ViewModelType == attribute.ViewModelType;
 
                 return viewTypeMatches;
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes ViewPagers ([MvxCachingFragmentStatePagerAdapter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs#L88), [MvxFragmentStatePagerAdapter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross.Android.Support/Fragment/MvxFragmentStatePagerAdapter.cs#L54) and [MvxFragmentPagerAdapter](https://github.com/MvvmCross/MvvmCross/blob/develop/MvvmCross.Android.Support/Fragment/MvxFragmentPagerAdapter.cs#L54)) to use provided `MvxViewModelRequest` instead of creating a new one.

### :arrow_heading_down: What is the current behavior?
- The Presentation values from `MvxViewModelRequest` are ignored
- There is no serialized `MvxViewModelRequest` in Fragment Arguments

### :new: What is the new behavior (if this is a feature change)?
- Add serialized `MvxViewModelRequest` to Fragment Arguments
- Use initial `MvxViewModelRequest` to instantiate the View Model for a Fragment

### :boom: Does this PR introduce a breaking change?
Yes, `MvxViewPagerFragmentInfo` ctor and properties changed to store the `MvxViewModelRequest` itself.

### :bug: Recommendations for testing
None

### :memo: Links to relevant issues/docs
#3497

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop