### PR TITLE
Modal Popover Presentation Crash

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -352,6 +352,12 @@ namespace MvvmCross.Platforms.Ios.Presenters
             MvxModalPresentationAttribute attribute,
             MvxViewModelRequest request)
         {
+            // Content size should be set to a target view controller, not the navigation one
+            if (attribute.PreferredContentSize != default(CGSize))
+            {
+                viewController.PreferredContentSize = attribute.PreferredContentSize;
+            }
+
             // setup modal based on attribute
             if (attribute.WrapInNavigationController)
             {
@@ -360,8 +366,6 @@ namespace MvvmCross.Platforms.Ios.Presenters
 
             viewController.ModalPresentationStyle = attribute.ModalPresentationStyle;
             viewController.ModalTransitionStyle = attribute.ModalTransitionStyle;
-            if (attribute.PreferredContentSize != default(CGSize))
-                viewController.PreferredContentSize = attribute.PreferredContentSize;
 
             // Check if there is a modal already presented first. Otherwise use the window root
             var modalHost = ModalViewControllers.LastOrDefault() ?? _window.RootViewController;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Set view controller preferred content size before wrapping in navigation controller.

### :arrow_heading_down: What is the current behavior?
Content size set after the wrapping in navigation controller and leads to crash.

### :new: What is the new behavior (if this is a feature change)?
None

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
None

### :memo: Links to relevant issues/docs
#3515.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop