### PR TITLE
Prevent null reference when trying to look up latest binding context

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/BindingContext/MvxAndroidBindingContextHelpers.cs
+++ b/MvvmCross/Platforms/Android/Binding/BindingContext/MvxAndroidBindingContextHelpers.cs
@@ -16,8 +16,13 @@ namespace MvvmCross.Platforms.Android.Binding.BindingContext
         public static T Current<T>()
             where T : class, IMvxBindingContext
         {
-            var stack = Mvx.IoCProvider.Resolve<IMvxBindingContextStack<T>>();
-            return stack.Current;
+            if (Mvx.IoCProvider == null)
+                return null;
+            
+            if (Mvx.IoCProvider.TryResolve<IMvxBindingContextStack<T>>(out var stack))
+                return stack.Current;
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
We have some suspicious crashes in our App because either IoCProvider or the resolved stack is null.

```
Xamarin Exception Stack:
System.NullReferenceException: Object reference not set to an instance of an object
  at MvvmCross.Platforms.Android.Binding.BindingContext.MvxAndroidBindingContextHelpers.Current[T] () [0x00005] in <d4f0f9c16e25440aaf673bb2434bc101>:0
  at MvvmCross.Platforms.Android.Binding.BindingContext.MvxAndroidBindingContextHelpers.Current () [0x00000] in <d4f0f9c16e25440aaf673bb2434bc101>:0
  at MvvmCross.Platforms.Android.Binding.Views.MvxLayoutInflater.Inflate (System.Int32 resource, Android.Views.ViewGroup root, System.Boolean attachToRoot) [0x00014] in <d4f0f9c16e25440aaf673bb2434bc101>:0
  at Android.Views.LayoutInflater.n_Inflate_ILandroid_view_ViewGroup_Z (System.IntPtr jnienv, System.IntPtr native__this, System.Int32 resource, System.IntPtr native_root, System.Boolean attachToRoot) [0x00011] in <70f18a70f76f4ab587e58dfb08221bed>:0
  at (wrapper dynamic-method) System.Object.29(intptr,intptr,int,intptr,bool)

Thread 2:
0   dalvik.system.VMStack.getThreadStackTrace(VMStack.java:-2)
1   java.lang.Thread.getStackTrace(Thread.java:1536)
2   java.lang.Thread.getAllStackTraces(Thread.java:1586)
3   com.microsoft.appcenter.crashes.Crashes.saveUncaughtException(Crashes.java:949)
4   com.microsoft.appcenter.crashes.WrapperSdkExceptionManager.saveWrapperException(WrapperSdkExceptionManager.java:55)
5   mvvmcross.platforms.android.binding.views.MvxLayoutInflater.n_inflate(MvxLayoutInflater.java:-2)
6   mvvmcross.platforms.android.binding.views.MvxLayoutInflater.inflate(MvxLayoutInflater.java:50)
7   android.view.LayoutInflater.inflate(LayoutInflater.java:374)
8   com.android.internal.policy.DecorView.onResourcesLoaded(DecorView.java:2383)
9   com.android.internal.policy.PhoneWindow.generateLayout(PhoneWindow.java:2759)
10  com.android.internal.policy.PhoneWindow.installDecor(PhoneWindow.java:2853)
11  com.android.internal.policy.PhoneWindow.getDecorView(PhoneWindow.java:2184)
12  md51bc303ec2e30c20fab671d92b41a9e67.BaseActivityFlowFragment_1.n_onAttach(BaseActivityFlowFragment_1.java:-2)
13  md51bc303ec2e30c20fab671d92b41a9e67.BaseActivityFlowFragment_1.onAttach(BaseActivityFlowFragment_1.java:29)
14  android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1404)
15  android.support.v4.app.FragmentManagerImpl.moveFragmentToExpectedState(FragmentManager.java:1784)
16  android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1852)
17  android.support.v4.app.FragmentManagerImpl.dispatchStateChange(FragmentManager.java:3269)
18  android.support.v4.app.FragmentManagerImpl.dispatchCreate(FragmentManager.java:3223)
19  android.support.v4.app.FragmentController.dispatchCreate(FragmentController.java:190)
20  android.support.v4.app.FragmentActivity.onCreate(FragmentActivity.java:369)
21  android.support.v7.app.AppCompatActivity.onCreate(AppCompatActivity.java:85)
22  md51bc303ec2e30c20fab671d92b41a9e67.ActivityFlowHostView.n_onCreate(ActivityFlowHostView.java:-2)
23  md51bc303ec2e30c20fab671d92b41a9e67.ActivityFlowHostView.onCreate(ActivityFlowHostView.java:32)
24  android.app.Activity.performCreate(Activity.java:7174)
25  android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1220)
26  android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2910)
27  android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3032)
28  android.app.ActivityThread.-wrap11
29  android.app.ActivityThread$H.handleMessage(ActivityThread.java:1696)
30  android.os.Handler.dispatchMessage(Handler.java:105)
31  android.os.Looper.loop(Looper.java:164)
32  android.app.ActivityThread.main(ActivityThread.java:6944)
33  java.lang.reflect.Method.invoke(Method.java:-2)
34  com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:327)
35  com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1374)
```

### :new: What is the new behavior (if this is a feature change)?
Prevent Null Reference Exception

### :boom: Does this PR introduce a breaking change?
Uhm, no

### :bug: Recommendations for testing
Have no idea how to repro this

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
