### PR TITLE
Fix presentation hint for non-forms views in forms presenter

### DIFF
--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -181,7 +181,7 @@ namespace MvvmCross.Forms.Presenters
             try
             {
 #endif
-                var navigation = GetPageOfType<NavigationPage>().Navigation;
+                var navigation = GetPageOfType<NavigationPage>()?.Navigation;
                 if (hint is MvxPopToRootPresentationHint popToRootHint)
                 {
                     // Make sure all modals are closed


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix

### :arrow_heading_down: What is the current behavior?
App crash on close presentation hint if present non-forms view and forms NavigationPage is missing (forms views was not already shown)

### :new: What is the new behavior (if this is a feature change)?
You can close native view with forms presenter

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
