### PR TITLE
Don't try to sign packages for Pull Requests

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -186,6 +186,8 @@ Task("SignPackages")
     .WithCriteria(() => IsRepository(repoName))
     .WithCriteria(() => !string.IsNullOrEmpty(signingSecret))
     .WithCriteria(() => !string.IsNullOrEmpty(signingUser))
+    .WithCriteria(() => isRunningOnPipelines)
+    .WithCriteria(() => !TFBuild.Environment.PullRequest.IsPullRequest)
     .IsDependentOn("Build")
     .IsDependentOn("CopyPackages")
     .Does(() => 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Ci

### :arrow_heading_down: What is the current behavior?
We try to sign packages for PR's. That is not necessary

### :new: What is the new behavior (if this is a feature change)?
Don't sign them, they are not published anyways

### :boom: Does this PR introduce a breaking change?
nope

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
