### PR TITLE
NullReferenceException when initializing fragment in ViewPager

### DIFF
--- a/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
+++ b/MvvmCross.Android.Support/Fragment/MvxCachingFragmentStatePagerAdapter.cs
@@ -61,7 +61,7 @@ namespace MvvmCross.Droid.Support.V4
 
             mvxFragment.ViewModel = GetViewModel(fragmentInfo);
 
-            fragmentInfo.CachedFragment.Arguments = GetArguments(fragmentInfo);
+            fragment.Arguments = GetArguments(fragmentInfo);
 
             return fragment;
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes NRE when initializing fragment in ViewPager.

### :arrow_heading_down: What is the current behavior?
App crashes on view pager initialization.

### :new: What is the new behavior (if this is a feature change)?
No crashes anymore

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Playground.Android project and click through the tabs.

### :memo: Links to relevant issues/docs
#3535

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
