### PR TITLE
Stop using dynamic

### DIFF
--- a/MvvmCross/Logging/LogProviders/Log4NetLogProvider.cs
+++ b/MvvmCross/Logging/LogProviders/Log4NetLogProvider.cs
@@ -112,7 +112,7 @@ namespace MvvmCross.Logging.LogProviders
 
         internal class Log4NetLogger
         {
-            private readonly dynamic _logger;
+            private readonly object _logger;
             private static Type s_callerStackBoundaryType;
             private static readonly object CallerStackBoundaryTypeSync = new object();
 
@@ -163,9 +163,9 @@ namespace MvvmCross.Logging.LogProviders
             }
 
             [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ILogger")]
-            internal Log4NetLogger(dynamic logger)
+            internal Log4NetLogger(object logger)
             {
-                _logger = logger.Logger;
+                _logger = logger.GetType().GetRuntimeProperty("Logger").GetValue(logger, null);
             }
 
             private static Action<object, object> GetLogDelegate(Type loggerType, Type loggingEventType, UnaryExpression instanceCast,

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -28,7 +28,6 @@ This package contains the 'Core' libraries for MvvmCross</Description>
     <None Include="Resources\*.cs" />
     <Compile Remove="Resources\*.cs" />
     <None Include="readme.txt" pack="true" PackagePath="." />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix

### :arrow_heading_down: What is the current behavior?

We have a dependency on Microsoft.CSharp because UWP doesn't like the dynamic keyword.

### :new: What is the new behavior (if this is a feature change)?

Use reflection instead to get the property.

### :boom: Does this PR introduce a breaking change?

Should not

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
