### PR TITLE
Getting plugin types safely

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -568,7 +568,7 @@ namespace MvvmCross.Core
                 _state = value;
                 FireStateChange(value);
             }
-        }       
+        }
 
         private void FireStateChange(MvxSetupState state)
         {

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -389,7 +389,7 @@ namespace MvvmCross.Core
 
             var pluginTypes =
                 GetPluginAssemblies()
-                    .SelectMany(assembly => assembly.GetTypes())
+                    .SelectMany(assembly => assembly.ExceptionSafeGetTypes())
                     .Where(TypeContainsPluginAttribute);
 
             foreach (var pluginType in pluginTypes)
@@ -568,7 +568,7 @@ namespace MvvmCross.Core
                 _state = value;
                 FireStateChange(value);
             }
-        }
+        }       
 
         private void FireStateChange(MvxSetupState state)
         {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? 

Bug fix for #3588

### :arrow_heading_down: What is the current behavior?

When a Plugin assembly cannot be loaded from the target, the app startup crashes on `LoadPlugins` with `ReflectionTypeLoadException`.

### :new: What is the new behavior (if this is a feature change)?

Using the `ExceptionSafeGetTypes` extension method to ignore types which cannot be loaded.

### :boom: Does this PR introduce a breaking change?

No, instead of a hard crash, the app now breaks if the debugger is attached or ignores the error otherwise.

### :bug: Recommendations for testing

Test on the `Playground.Wpf` app where I noticed the problem due to `Plugin.Permissions` which is not available for WPF.

### :memo: Links to relevant issues/docs

-

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
