### PR TITLE
Fix WPF app close view model lifecycle

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -389,7 +389,7 @@ namespace MvvmCross.Core
 
             var pluginTypes =
                 GetPluginAssemblies()
-                    .SelectMany(assembly => assembly.GetTypes())
+                    .SelectMany(assembly => assembly.ExceptionSafeGetTypes())
                     .Where(TypeContainsPluginAttribute);
 
             foreach (var pluginType in pluginTypes)

--- a/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
+++ b/MvvmCross/Platforms/Wpf/Views/MvxWindow.cs
@@ -13,6 +13,7 @@ namespace MvvmCross.Platforms.Wpf.Views
     {
         private IMvxViewModel _viewModel;
         private IMvxBindingContext _bindingContext;
+        private bool _unloaded = false;
 
         public IMvxViewModel ViewModel
         {
@@ -44,7 +45,8 @@ namespace MvvmCross.Platforms.Wpf.Views
 
         public MvxWindow()
         {
-            Unloaded += MvxWindow_Unloaded;
+            Closed += MvxWindow_Closed;
+            Unloaded += MvxWindow_Unloaded;            
             Loaded += MvxWindow_Loaded;
             Initialized += MvxWindow_Initialized;
         }
@@ -57,17 +59,25 @@ namespace MvvmCross.Platforms.Wpf.Views
             }
         }
 
-        private void MvxWindow_Unloaded(object sender, RoutedEventArgs e)
-        {
-            ViewModel?.ViewDisappearing();
-            ViewModel?.ViewDisappeared();
-            ViewModel?.ViewDestroy();
-        }
+        private void MvxWindow_Closed(object sender, EventArgs e) => Unload();
+
+        private void MvxWindow_Unloaded(object sender, RoutedEventArgs e) => Unload();
 
         private void MvxWindow_Loaded(object sender, RoutedEventArgs e)
         {
             ViewModel?.ViewAppearing();
             ViewModel?.ViewAppeared();
+        }
+
+        private void Unload()
+        {
+            if (!_unloaded)
+            {
+                ViewModel?.ViewDisappearing();
+                ViewModel?.ViewDisappeared();
+                ViewModel?.ViewDestroy();
+                _unloaded = true;
+            }
         }
 
         public void Dispose()
@@ -87,6 +97,7 @@ namespace MvvmCross.Platforms.Wpf.Views
             {
                 Unloaded -= MvxWindow_Unloaded;
                 Loaded -= MvxWindow_Loaded;
+                Closed -= MvxWindow_Closed;
             }
         }
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix for #3481

### :arrow_heading_down: What is the current behavior?

App closes, but ViewModel's `ViewDisappearing`, `ViewDisappeared` and `ViewDestroy` methods are not called.

### :new: What is the new behavior (if this is a feature change)?

The ViewModel's lifecycle methods are called even when the app is closed when triggered by the `Closed` event.

### :boom: Does this PR introduce a breaking change?

Potentially if someone depended on this erroneous behavior, but the new behavior is in line with other platforms and with the expected lifecycle.

### :bug: Recommendations for testing

-

### :memo: Links to relevant issues/docs

Fixes #3481

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
