### PR TITLE
Fix NullReferenceException in MvxAndroidBindingContextHelpers

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/BindingContext/MvxAndroidBindingContextHelpers.cs
+++ b/MvvmCross/Platforms/Android/Binding/BindingContext/MvxAndroidBindingContextHelpers.cs
@@ -20,7 +20,7 @@ namespace MvvmCross.Platforms.Android.Binding.BindingContext
                 return null;
             
             if (Mvx.IoCProvider.TryResolve<IMvxBindingContextStack<T>>(out var stack))
-                return stack.Current;
+                return stack?.Current;
 
             return null;
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Potential crash when `stack` is resolved to be null

### :new: What is the new behavior (if this is a feature change)?
Check for null before accessing `stack`

### :boom: Does this PR introduce a breaking change?
No, further up the call stack we properly check for null, so we should be golden

### :bug: Recommendations for testing
Show some Android views

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
