### PR TITLE
Use CreateNavigationPage in MvxFormsPagePresenter.ShowModal

### DIFF
--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -518,7 +518,7 @@ namespace MvvmCross.Forms.Presenters
                 {
                     // Either last isn't a nav page, or there is no last page
                     // So, wrap the current page in a nav page and push onto stack
-                    await FormsApplication.MainPage.Navigation.PushModalAsync(new NavigationPage(page));
+                    await FormsApplication.MainPage.Navigation.PushModalAsync(CreateNavigationPage(page));
                 }
             }
             else


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Uses the implementation of MvxFormsPagePresenter.CreateNavigationPage when a modal has _WrapInNavigationPage = true_ instead of using _new NavigationPage()_ - as proposed in #3315 

### :arrow_heading_down: What is the current behavior?
When a modal page needs to be wrapped in a NavigationPage, _new NavigationPage()_ is used, meaning a custom implementation of _CreateNavigationPage()_ is ignored in this case.

### :new: What is the new behavior (if this is a feature change)?
_CreateNavigationPage()_ is called, when a modal needs to be wrapped in a NavigationPage; unless there is a custom implementation of _CreateNavigationPage()_ the result will be the same.


### :boom: Does this PR introduce a breaking change?
If a custom implementation of CreateNavigationPage is currently used, this may also be used when wrapping a ModalPage. Probably rare, and probably not breaking.

### :bug: Recommendations for testing
Create a custom implementation of MvxFormsPagePresenter.CreateNavigationPage, and and call ShowModal with attribute _WrapInNavigationPage = true_ from a main page not wrapped in a NavigationPage.

### :memo: Links to relevant issues/docs
Proposed in: #3315 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop
