### PR TITLE
OnCreateViewHolder should receive the view type

### DIFF
--- a/MvvmCross.Android.Support/V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Android.Support/V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -123,26 +123,27 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         public override int GetItemViewType(int position)
         {
             var itemAtPosition = GetItem(position);
-            var viewTypeIndex = ItemTemplateSelector.GetItemViewType(itemAtPosition);
-            var viewType = ItemTemplateSelector.GetItemLayoutId(viewTypeIndex);
+            var viewType = ItemTemplateSelector.GetItemViewType(itemAtPosition);
+            
             return viewType;
         }
 
         public override Android.Support.V7.Widget.RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
         {
+            var viewLayoutId = ItemTemplateSelector.GetItemLayoutId(viewType);
             var itemBindingContext = new MvxAndroidBindingContext(parent.Context, BindingContext.LayoutInflaterHolder);
 
-            var viewHolder = new MvxRecyclerViewHolder(InflateViewForHolder(parent, viewType, itemBindingContext), itemBindingContext)
+            var viewHolder = new MvxRecyclerViewHolder(InflateViewForHolder(parent, viewLayoutId, itemBindingContext), itemBindingContext)
             {
-                Id = viewType
+                Id = viewLayoutId
             };
 
             return viewHolder;
         }
 
-        protected virtual View InflateViewForHolder(ViewGroup parent, int viewType, IMvxAndroidBindingContext bindingContext)
+        protected virtual View InflateViewForHolder(ViewGroup parent, int viewLayoutId, IMvxAndroidBindingContext bindingContext)
         {
-            return bindingContext.BindingInflate(viewType, parent, false);
+            return bindingContext.BindingInflate(viewLayoutId, parent, false);
         }
 
         public override void OnBindViewHolder(Android.Support.V7.Widget.RecyclerView.ViewHolder holder, int position)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
OnCreateViewHolder should receive the view type, not the LayoutId. This is confusing when extending the MvxRecyclerAdapter.
### :new: What is the new behavior (if this is a feature change)?
OnCreateViewHolder will be called with the viewType.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
[OnCreateViewHolder docs](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter#oncreateviewholder)

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
