### PR TITLE
Refactor #3649: Change MvxAndroidBindingResource to be registered and used with the IoC

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewBinder.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewBinder.cs
@@ -20,6 +20,7 @@ namespace MvvmCross.Platforms.Android.Binding.Binders
     public class MvxAndroidViewBinder : IMvxAndroidViewBinder
     {
         private readonly List<KeyValuePair<object, IMvxUpdateableBinding>> _viewBindings = new List<KeyValuePair<object, IMvxUpdateableBinding>>();
+        private readonly Lazy<IMvxAndroidBindingResource> mvxAndroidBindingResource = new Lazy<IMvxAndroidBindingResource>(() => Mvx.IoCProvider.GetSingleton<IMvxAndroidBindingResource>());
 
         private readonly object _source;
 
@@ -38,18 +39,18 @@ namespace MvvmCross.Platforms.Android.Binding.Binders
         {
             using (
                 var typedArray = context.ObtainStyledAttributes(attrs,
-                                                                MvxAndroidBindingResource.Instance.BindingStylableGroupId))
+                                                                mvxAndroidBindingResource.Value.BindingStylableGroupId))
             {
                 int numStyles = typedArray.IndexCount;
                 for (var i = 0; i < numStyles; ++i)
                 {
                     var attributeId = typedArray.GetIndex(i);
 
-                    if (attributeId == MvxAndroidBindingResource.Instance.BindingBindId)
+                    if (attributeId == mvxAndroidBindingResource.Value.BindingBindId)
                     {
                         ApplyBindingsFromAttribute(view, typedArray, attributeId);
                     }
-                    else if (attributeId == MvxAndroidBindingResource.Instance.BindingLangId)
+                    else if (attributeId == mvxAndroidBindingResource.Value.BindingLangId)
                     {
                         ApplyLanguageBindingsFromAttribute(view, typedArray, attributeId);
                     }

--- a/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.Graphics;
 using Android.Preferences;
 using Android.Views;
 using Android.Webkit;
 using Android.Widget;
-using MvvmCross.Base;
-using MvvmCross.IoC;
 using MvvmCross.Binding;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.IoC;
 using MvvmCross.Platforms.Android.Binding.Binders;
 using MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -61,7 +59,13 @@ namespace MvvmCross.Platforms.Android.Binding
 
         protected virtual void InitializeBindingResources()
         {
-            MvxAndroidBindingResource.Initialize();
+            var mvxAndroidBindingResource = CreateAndroidBindingResource();
+            Mvx.IoCProvider.RegisterSingleton(mvxAndroidBindingResource);
+        }
+
+        protected virtual IMvxAndroidBindingResource CreateAndroidBindingResource()
+        {
+            return new MvxAndroidBindingResource();
         }
 
         protected virtual void InitializeAppResourceTypeFinder()

--- a/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAndroidBindingResource.cs
+++ b/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAndroidBindingResource.cs
@@ -2,93 +2,26 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using MvvmCross.Binding;
-using MvvmCross.Exceptions;
+using Android;
 
 namespace MvvmCross.Platforms.Android.Binding.ResourceHelpers
 {
     public class MvxAndroidBindingResource : IMvxAndroidBindingResource
     {
-        public MvxAndroidBindingResource()
-        {
-            var finder = Mvx.IoCProvider.Resolve<IMvxAppResourceTypeFinder>();
-            var resourceType = finder.Find();
-            try
-            {
-                var id = resourceType.GetNestedType("Id");
-                BindingTagUnique = (int)SafeGetFieldValue(id, "MvxBindingTagUnique");
+        public int BindingTagUnique => Resource.Id.MvxBindingTagUnique;
 
-                var styleable = resourceType.GetNestedType("Styleable");
+        public int[] BindingStylableGroupId => Resource.Styleable.MvxBinding;
+        public int BindingBindId => Resource.Styleable.MvxBinding_MvxBind;
+        public int BindingLangId => Resource.Styleable.MvxBinding_MvxLang;
 
-                ControlStylableGroupId =
-                    (int[])SafeGetFieldValue(styleable, "MvxControl", new int[0]);
-                TemplateId =
-                    (int)SafeGetFieldValue(styleable, "MvxControl_MvxTemplate");
+        public int[] ControlStylableGroupId => Resource.Styleable.MvxControl;
+        public int TemplateId => Resource.Styleable.MvxControl_MvxTemplate;
 
-                BindingStylableGroupId =
-                    (int[])SafeGetFieldValue(styleable, "MvxBinding", new int[0]);
-                BindingBindId =
-                    (int)SafeGetFieldValue(styleable, "MvxBinding_MvxBind");
-                BindingLangId =
-                    (int)SafeGetFieldValue(styleable, "MvxBinding_MvxLang");
-               
-                ListViewStylableGroupId =
-                    (int[])SafeGetFieldValue(styleable, "MvxListView");
-                ListItemTemplateId =
-                    (int)
-                    styleable
-                        .GetField("MvxListView_MvxItemTemplate")
-                        .GetValue(null);
-                DropDownListItemTemplateId =
-                    (int)
-                    styleable
-                        .GetField("MvxListView_MvxDropDownItemTemplate")
-                        .GetValue(null);
+        public int[] ListViewStylableGroupId => Resource.Styleable.MvxListView;
+        public int ListItemTemplateId => Resource.Styleable.MvxListView_MvxItemTemplate;
+        public int DropDownListItemTemplateId => Resource.Styleable.MvxListView_MvxDropDownItemTemplate;
 
-                ExpandableListViewStylableGroupId =
-                    (int[])SafeGetFieldValue(styleable, "MvxExpandableListView", new int[0]);
-                GroupItemTemplateId =
-                    (int)SafeGetFieldValue(styleable, "MvxExpandableListView_MvxGroupItemTemplate");
-            }
-            catch (Exception exception)
-            {
-                throw exception.MvxWrap(
-                    "Error finding resource ids for MvxBinding - please make sure ResourcesToCopy are linked into the executable");
-            }
-        }
-
-        private static object SafeGetFieldValue(Type styleable, string fieldName)
-        {
-            return SafeGetFieldValue(styleable, fieldName, 0);
-        }
-
-        private static object SafeGetFieldValue(Type styleable, string fieldName, object defaultValue)
-        {
-            var field = styleable.GetField(fieldName);
-            if (field == null)
-            {
-                MvxBindingLog.Error( "Missing stylable field {0}", fieldName);
-                return defaultValue;
-            }
-
-            return field.GetValue(null);
-        }
-
-        public int BindingTagUnique { get; }
-
-        public int[] BindingStylableGroupId { get; }
-        public int BindingBindId { get; }
-        public int BindingLangId { get; }
-
-        public int[] ControlStylableGroupId { get; }
-        public int TemplateId { get; }
-        
-        public int[] ListViewStylableGroupId { get; }
-        public int ListItemTemplateId { get; }
-        public int DropDownListItemTemplateId { get; }
-
-        public int[] ExpandableListViewStylableGroupId { get; }
-        public int GroupItemTemplateId { get; }
+        public int[] ExpandableListViewStylableGroupId => Resource.Styleable.MvxExpandableListView;
+        public int GroupItemTemplateId => Resource.Styleable.MvxExpandableListView_MvxGroupItemTemplate;
     }
 }

--- a/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAndroidBindingResource.cs
+++ b/MvvmCross/Platforms/Android/Binding/ResourceHelpers/MvxAndroidBindingResource.cs
@@ -3,25 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using MvvmCross.Base;
-using MvvmCross.Exceptions;
 using MvvmCross.Binding;
+using MvvmCross.Exceptions;
 
 namespace MvvmCross.Platforms.Android.Binding.ResourceHelpers
-{ 
-    public class MvxAndroidBindingResource
-        : MvxSingleton<IMvxAndroidBindingResource>
-        , IMvxAndroidBindingResource
+{
+    public class MvxAndroidBindingResource : IMvxAndroidBindingResource
     {
-        public static void Initialize()
-        {
-            if (Instance != null)
-                return;
-
-            var androidBindingResource = new MvxAndroidBindingResource();
-        }
-
-        private MvxAndroidBindingResource()
+        public MvxAndroidBindingResource()
         {
             var finder = Mvx.IoCProvider.Resolve<IMvxAppResourceTypeFinder>();
             var resourceType = finder.Find();

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxAttributeHelpers.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxAttributeHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Android.Content;
 using Android.Util;
 using MvvmCross.Platforms.Android.Binding.ResourceHelpers;
@@ -10,32 +11,34 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 {
     public static class MvxAttributeHelpers
     {
+        private static readonly Lazy<IMvxAndroidBindingResource> mvxAndroidBindingResource = new Lazy<IMvxAndroidBindingResource>(() => Mvx.IoCProvider.GetSingleton<IMvxAndroidBindingResource>());
+
         public static int ReadDropDownListItemTemplateId(Context context, IAttributeSet attrs)
         {
             return ReadAttributeValue(context, attrs,
-                                      MvxAndroidBindingResource.Instance.ListViewStylableGroupId,
-                                      MvxAndroidBindingResource.Instance.DropDownListItemTemplateId);
+                                      mvxAndroidBindingResource.Value.ListViewStylableGroupId,
+                                      mvxAndroidBindingResource.Value.DropDownListItemTemplateId);
         }
 
         public static int ReadListItemTemplateId(Context context, IAttributeSet attrs)
         {
             return ReadAttributeValue(context, attrs,
-                                      MvxAndroidBindingResource.Instance.ListViewStylableGroupId,
-                                      MvxAndroidBindingResource.Instance.ListItemTemplateId);
+                                      mvxAndroidBindingResource.Value.ListViewStylableGroupId,
+                                      mvxAndroidBindingResource.Value.ListItemTemplateId);
         }
 
         public static int ReadTemplateId(Context context, IAttributeSet attrs)
         {
             return ReadAttributeValue(context, attrs,
-                                      MvxAndroidBindingResource.Instance.ControlStylableGroupId,
-                                      MvxAndroidBindingResource.Instance.TemplateId);
+                                      mvxAndroidBindingResource.Value.ControlStylableGroupId,
+                                      mvxAndroidBindingResource.Value.TemplateId);
         }
 
         public static int ReadGroupItemTemplateId(Context context, IAttributeSet attrs)
         {
             return ReadAttributeValue(context, attrs,
-                                      MvxAndroidBindingResource.Instance.ExpandableListViewStylableGroupId,
-                                      MvxAndroidBindingResource.Instance.GroupItemTemplateId);
+                                      mvxAndroidBindingResource.Value.ExpandableListViewStylableGroupId,
+                                      mvxAndroidBindingResource.Value.GroupItemTemplateId);
         }
 
         public static int ReadAttributeValue(Context context, IAttributeSet attrs, int[] groupId,


### PR DESCRIPTION
Changed `MvxAndroidBindingResource` from being a singleton to be registered as one in the IoC so that then it can be resolved wherever it needs to be used. Therefore there can be a custom implementation of `IMvxAndroidBindingResource` which one can create to improve performance on the startup.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Enhancement

### :arrow_heading_down: What is the current behavior?
Currently, the `MvxAndroidBindingResource` cannot be changed with a different implementation

### :new: What is the new behavior (if this is a feature change)?
Now a custom `IMvxAndroidBindingResource` can be created and registered to change how the resources are gotten

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
```c#
    public class Setup : MvxAppCompatSetup<App>
    {
        protected override MvxBindingBuilder CreateBindingBuilder()
        {
            return new CustomMvxAndroidBindingBuilder();
        }
    }
    
    public class CustomMvxAndroidBindingBuilder : MvxAndroidBindingBuilder
    {
        protected override IMvxAndroidBindingResource CreateAndroidBindingResource()
        {
            return new CustomMvxAndroidBindingResource();
        }
    }

    public class CustomMvxAndroidBindingResource : IMvxAndroidBindingResource
    {
        public int BindingTagUnique => Resource.Id.MvxBindingTagUnique;

        public int[] BindingStylableGroupId => Resource.Styleable.MvxBinding;
        public int BindingBindId => Resource.Styleable.MvxBinding_MvxBind;
        public int BindingLangId => Resource.Styleable.MvxBinding_MvxLang;

        public int[] ControlStylableGroupId => Resource.Styleable.MvxControl;
        public int TemplateId => Resource.Styleable.MvxControl_MvxTemplate;

        public int[] ListViewStylableGroupId => Resource.Styleable.MvxListView;
        public int ListItemTemplateId => Resource.Styleable.MvxListView_MvxItemTemplate;
        public int DropDownListItemTemplateId => Resource.Styleable.MvxListView_MvxDropDownItemTemplate;

        public int[] ExpandableListViewStylableGroupId => Resource.Styleable.MvxExpandableListView;
        public int GroupItemTemplateId => Resource.Styleable.MvxExpandableListView_MvxGroupItemTemplate;
    }
```

### :memo: Links to relevant issues/docs
Fixes #3649 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
