### PR TITLE
Fix CurrentTopActivity returning null when App in background

### DIFF
--- a/MvvmCross/Platforms/Android/MvxJavaObjectExtensions.cs
+++ b/MvvmCross/Platforms/Android/MvxJavaObjectExtensions.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Android.App;
+using Object = Java.Lang.Object;
+
+namespace MvvmCross.Platforms.Android
+{
+    public static class MvxJavaObjectExtensions
+    {
+        public static bool IsNull(this Object @object)
+        {
+            if (@object == null)
+                return true;
+
+            if (@object.Handle == IntPtr.Zero)
+                return true;
+
+            return false;
+        }
+
+        public static bool IsActivityDead(this Activity activity)
+        {
+            if (activity.IsNull())
+                return true;
+
+            if (activity.IsFinishing)
+                return true;
+
+            if (activity.IsDestroyed)
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxApplicationCallbacksCurrentTopActivity.cs
@@ -8,11 +8,14 @@ using Android.OS;
 
 namespace MvvmCross.Platforms.Android.Views
 {
-    public class MvxApplicationCallbacksCurrentTopActivity : Java.Lang.Object, Application.IActivityLifecycleCallbacks, IMvxAndroidCurrentTopActivity
+    public class MvxApplicationCallbacksCurrentTopActivity 
+        : Java.Lang.Object, Application.IActivityLifecycleCallbacks, IMvxAndroidCurrentTopActivity
     {
-        protected ConcurrentDictionary<string, ActivityInfo> Activities { get; private set; } = new ConcurrentDictionary<string, ActivityInfo>();
-        
+        protected ConcurrentDictionary<string, ActivityInfo> Activities { get; }
+            = new ConcurrentDictionary<string, ActivityInfo>();
+
         public Activity Activity => GetCurrentActivity();
+        private Activity _lastKnownActivity;
 
         public void OnActivityCreated(Activity activity, Bundle savedInstanceState)
         {
@@ -22,7 +25,7 @@ namespace MvvmCross.Platforms.Android.Views
         public void OnActivityDestroyed(Activity activity)
         {
             var activityName = GetActivityName(activity);
-            Activities.TryRemove(activityName, out ActivityInfo removed);
+            Activities.TryRemove(activityName, out var removed);
         }
 
         public void OnActivityPaused(Activity activity)
@@ -33,6 +36,8 @@ namespace MvvmCross.Platforms.Android.Views
         public void OnActivityResumed(Activity activity)
         {
             UpdateActivityListItem(activity, true);
+
+            _lastKnownActivity = activity;
         }
 
         public void OnActivitySaveInstanceState(Activity activity, Bundle outState)
@@ -42,6 +47,8 @@ namespace MvvmCross.Platforms.Android.Views
         public void OnActivityStarted(Activity activity)
         {
             UpdateActivityListItem(activity, true);
+
+            _lastKnownActivity = activity;
         }
 
         public void OnActivityStopped(Activity activity)
@@ -65,21 +72,37 @@ namespace MvvmCross.Platforms.Android.Views
         {
             if (Activities.Count > 0)
             {
-                var e = Activities.GetEnumerator();
-                while (e.MoveNext())
+                Activity currentActivity = null;
+
+                using (var e = Activities.GetEnumerator())
                 {
-                    var current = e.Current;
-                    if (current.Value.IsCurrent)
+                    while (e.MoveNext())
                     {
-                        return current.Value.Activity;
+                        var (_, value) = e.Current;
+                        if (value.IsCurrent)
+                        {
+                            currentActivity = value.Activity;
+                            break;
+                        }
                     }
                 }
+
+                if (currentActivity == null)
+                {
+                    if (!_lastKnownActivity.IsActivityDead() && 
+                        _lastKnownActivity.GetType() != typeof(MvxSplashScreenActivity) &&
+                        _lastKnownActivity.GetType() != typeof(MvxSplashScreenActivity<,>))
+                        return _lastKnownActivity;
+                }
+
+                return currentActivity;
             }
 
             return null;
         }
 
-        protected virtual string GetActivityName(Activity activity) => $"{activity.Class.SimpleName}_{activity.Handle.ToString()}";
+        protected virtual string GetActivityName(Activity activity) => 
+            $"{activity.Class.SimpleName}_{activity.Handle.ToString()}";
 
         /// <summary>
         /// Used to store additional info along with an activity.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When you background the app. CurrentTopActivity will _always_ return `null`. This isn't really correct behavior.

### :new: What is the new behavior (if this is a feature change)?
Always return the last top Activity

### :boom: Does this PR introduce a breaking change?
No this fixes a lot of issues, if you accidentally try to navigate while the App is in background etc.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #3455 

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
