### PR TITLE
Big fix - ColorConverter null value

### DIFF
--- a/MvvmCross.Plugins/Color/MvxColorValueConverter.cs
+++ b/MvvmCross.Plugins/Color/MvxColorValueConverter.cs
@@ -28,7 +28,10 @@ namespace MvvmCross.Plugin.Color
     {
         protected sealed override System.Drawing.Color Convert(object value, object parameter, CultureInfo culture)
         {
-            return Convert((T)value, parameter, culture);
+            if (value is T t)
+                return Convert(t, parameter, culture);
+
+            return default;
         }
 
         protected abstract System.Drawing.Color Convert(T value, object parameter, CultureInfo culture);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
When you have object for example ColorHolder which has BackgroundColor and this color is null. App throws handled exception.

For example: `local:MvxBind="BackgroundColor NativeColor(ColorHolder.BackgroundColor);"`

### :new: What is the new behavior (if this is a feature change)?
When value in ColorConverter is null so it return `default(System.Drawing.Color);`

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
It's not necessary.

### :memo: Links to relevant issues/docs
Fixes: https://github.com/MvvmCross/MvvmCross/issues/3632

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
