### PR TITLE
Downgrade Xamarin.Build.Download to 0.4.11 as latest has a bug

### DIFF
--- a/XamarinBuild.targets
+++ b/XamarinBuild.targets
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" Version="0.7.1" />
+    <PackageReference Include="Xamarin.Build.Download" Version="0.4.11" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It creates duplicate AndroidResource folders and makes builds hang.
See https://github.com/xamarin/xamarin-android/issues/4062

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
CI Workaround

### :arrow_heading_down: What is the current behavior?
Builds fail due to other process locking R.java

### :new: What is the new behavior (if this is a feature change)?
Should hopefully work now

### :boom: Does this PR introduce a breaking change?
Nein

### :bug: Recommendations for testing
Build everything

### :memo: Links to relevant issues/docs
https://github.com/xamarin/xamarin-android/issues/4062

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
