### PR TITLE
Fix MvxLayoutInflater nullref

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -363,12 +363,49 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             return view;
         }
 
-        protected IMvxAndroidViewFactory AndroidViewFactory => 
-            _androidViewFactory = _androidViewFactory ?? Mvx.IoCProvider.Resolve<IMvxAndroidViewFactory>();
+        protected IMvxAndroidViewFactory AndroidViewFactory 
+        {
+            get
+            {
+                if (_androidViewFactory != null)
+                    return _androidViewFactory;
 
-        protected IMvxLayoutInflaterHolderFactoryFactory FactoryFactory => 
-            _layoutInflaterHolderFactoryFactory = _layoutInflaterHolderFactoryFactory ??
-                Mvx.IoCProvider.Resolve<IMvxLayoutInflaterHolderFactoryFactory>();
+                if (Mvx.IoCProvider == null)
+                {
+                    MvxLog.Instance.Error("{Tag} - ... AndroidViewFactory IoCProvider is null!", Tag);
+                    return null;
+                }
+                
+                if (Mvx.IoCProvider.TryResolve(out IMvxAndroidViewFactory viewFactory))
+                {
+                    _androidViewFactory = viewFactory;
+                }
+
+                return _androidViewFactory;
+            }
+        }
+
+        protected IMvxLayoutInflaterHolderFactoryFactory FactoryFactory
+        {
+            get
+            {
+                if (_layoutInflaterHolderFactoryFactory != null)
+                    return _layoutInflaterHolderFactoryFactory;
+
+                if (Mvx.IoCProvider == null)
+                {
+                    MvxLog.Instance.Error("{Tag} - ... FactoryFactory IoCProvider is null!", Tag);
+                    return null;
+                }
+                
+                if (Mvx.IoCProvider.TryResolve(out IMvxLayoutInflaterHolderFactoryFactory factoryFactory))
+                {
+                    _layoutInflaterHolderFactoryFactory = factoryFactory;
+                }
+
+                return _layoutInflaterHolderFactoryFactory;
+            }
+        }
 
         private class DelegateFactory2 : IMvxLayoutInflaterFactory
         {

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -363,10 +363,12 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             return view;
         }
 
-        protected IMvxAndroidViewFactory AndroidViewFactory => _androidViewFactory ?? (_androidViewFactory = Mvx.IoCProvider.Resolve<IMvxAndroidViewFactory>());
+        protected IMvxAndroidViewFactory AndroidViewFactory => 
+            _androidViewFactory = _androidViewFactory ?? Mvx.IoCProvider.Resolve<IMvxAndroidViewFactory>();
 
-        protected IMvxLayoutInflaterHolderFactoryFactory FactoryFactory => _layoutInflaterHolderFactoryFactory ??
-                                                                           (_layoutInflaterHolderFactoryFactory = Mvx.IoCProvider.Resolve<IMvxLayoutInflaterHolderFactoryFactory>());
+        protected IMvxLayoutInflaterHolderFactoryFactory FactoryFactory => 
+            _layoutInflaterHolderFactoryFactory = _layoutInflaterHolderFactoryFactory ??
+                Mvx.IoCProvider.Resolve<IMvxLayoutInflaterHolderFactoryFactory>();
 
         private class DelegateFactory2 : IMvxLayoutInflaterFactory
         {

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -255,6 +255,8 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                 {
                     MvxLayoutInflaterCompat.SetFactory(this, new DelegateFactory2(Factory2, _bindingVisitor));
                 }
+
+                return; // we shouldn't set Factory if Factory2 is being set...
             }
 
             // Check for FactoryWrapper may be too loose

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -158,7 +158,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         protected override View OnCreateView(View parent, string name, IAttributeSet attrs)
         {
             if (Debug)
-                MvxLog.Instance.Trace(Tag, "... OnCreateView 3 ... {0}", name);
+                MvxLog.Instance.Trace("{Tag} - ... OnCreateView 3 ... {name}", Tag, name);
 
             return _bindingVisitor.OnViewCreated(
                 base.OnCreateView(parent, name, attrs),
@@ -169,7 +169,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         protected override View OnCreateView(string name, IAttributeSet attrs)
         {
             if (Debug)
-                MvxLog.Instance.Trace(Tag, "... OnCreateView 2 ... {0}", name);
+                MvxLog.Instance.Trace("{Tag} - ... OnCreateView 2 ... {name}", Tag, name);
 
             View view = AndroidViewFactory.CreateView(null, name, Context, attrs) ??
                         PhoneLayoutInflaterOnCreateView(name, attrs) ??
@@ -182,7 +182,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         public override View OnCreateView(Context viewContext, View parent, string name, IAttributeSet attrs)
         {
             if (Debug)
-                MvxLog.Instance.Trace(Tag, "... OnCreateView 4 ... {0}", name);
+                MvxLog.Instance.Trace("{Tag} - ... OnCreateView 4 ... {name}", Tag, name);
 
             return _bindingVisitor.OnViewCreated(
                 base.OnCreateView(viewContext, parent, name, attrs),
@@ -195,7 +195,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         private View PhoneLayoutInflaterOnCreateView(string name, IAttributeSet attrs)
         {
             if (Debug)
-                MvxLog.Instance.Trace(Tag, "... PhoneLayoutInflaterOnCreateView ... {0}", name);
+                MvxLog.Instance.Trace("{Tag} - ... PhoneLayoutInflaterOnCreateView ... {name}", Tag, name);
 
             foreach (var prefix in ClassPrefixList)
             {
@@ -301,7 +301,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             IAttributeSet attrs)
         {
             if (Debug)
-                MvxLog.Instance.Trace(Tag, "... CreateCustomViewInternal ... {0}", name);
+                MvxLog.Instance.Trace("{Tag} - ... CreateCustomViewInternal ... {name}", Tag, name);
 
             if (view == null && name.IndexOf('.') > -1)
             {
@@ -382,7 +382,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             public View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
             {
                 if (Debug)
-                    MvxLog.Instance.Trace(Tag, "... OnCreateView ... {0}", name);
+                    MvxLog.Instance.Trace("{Tag} - ... OnCreateView ... {name}", Tag, name);
 
                 return _factoryPlaceholder.OnViewCreated(
                     _factory.OnCreateView(parent, name, context, attrs),
@@ -406,7 +406,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             public View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
             {
                 if (Debug)
-                    MvxLog.Instance.Trace(Tag, "... OnCreateView ... {0}", name);
+                    MvxLog.Instance.Trace("{Tag} - ... OnCreateView ... {name}", Tag, name);
 
                 return _factoryPlaceholder.OnViewCreated(
                     _factory.OnCreateView(name, context, attrs),
@@ -438,7 +438,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             public View OnCreateView(string name, Context context, IAttributeSet attrs)
             {
                 if (Debug)
-                    MvxLog.Instance.Trace(Tag, "... OnCreateView 2 ... {0}", name);
+                    MvxLog.Instance.Trace("{Tag} - ... OnCreateView 2 ... {name}", Tag, name);
 
                 return _bindingVisitor.OnViewCreated(
                     // The activity's OnCreateView
@@ -449,7 +449,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             public View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
             {
                 if (Debug)
-                    MvxLog.Instance.Trace(Tag, "... OnCreateView 3 ... {0}", name);
+                    MvxLog.Instance.Trace("{Tag} - ... OnCreateView 3 ... {name}", Tag, name);
 
                 return _bindingVisitor.OnViewCreated(
                     _inflater.CreateCustomViewInternal(

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -130,7 +130,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                 var currentBindingContext = MvxAndroidBindingContextHelpers.Current();
                 if (currentBindingContext != null)
                 {
-                    factory = FactoryFactory.Create(currentBindingContext.DataContext);
+                    factory = FactoryFactory?.Create(currentBindingContext.DataContext);
 
                     // Set the current factory used to generate bindings
                     if (factory != null)
@@ -171,7 +171,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             if (Debug)
                 MvxLog.Instance.Trace("{Tag} - ... OnCreateView 2 ... {name}", Tag, name);
 
-            View view = AndroidViewFactory.CreateView(null, name, Context, attrs) ??
+            View view = AndroidViewFactory?.CreateView(null, name, Context, attrs) ??
                         PhoneLayoutInflaterOnCreateView(name, attrs) ??
                         base.OnCreateView(name, attrs);
 
@@ -311,7 +311,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                 // since we don't resolve those.
                 if (!name.StartsWith("com.android.internal."))
                 {
-                    view = AndroidViewFactory.CreateView(parent, name, viewContext, attrs);
+                    view = AndroidViewFactory?.CreateView(parent, name, viewContext, attrs);
                 }
 
                 if (view == null)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug

### :arrow_heading_down: What is the current behavior?
Sometimes, mostly when an Activity is tearing down, for some odd reason something in the getter of `AndroidViewFactory` can become `null` and crash the App hard with a null reference in the `MvxLayoutInflater`.

We have a lot of crashes in AppCenter with vague stack traces looking like this:

```
System.NullReferenceException: Object reference not set to an instance of an object
  at MvvmCross.Platforms.Android.Binding.Views.MvxLayoutInflater.get_AndroidViewFactory () [0x00010] in <3096bcb9506441939cd5fa3cb69bc3f5>:0
  at MvvmCross.Platforms.Android.Binding.Views.MvxLayoutInflater.OnCreateView (System.String name, Android.Util.IAttributeSet attrs) [0x00028] in <3096bcb9506441939cd5fa3cb69bc3f5>:0
  at Android.Views.LayoutInflater.n_OnCreateView_Ljava_lang_String_Landroid_util_AttributeSet_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_name, System.IntPtr native_attrs) [0x00019] in <53ed8d3916fc4ddaad05f54afb17f2f5>:0
  at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.41(intptr,intptr,intptr,intptr)
```

### :new: What is the new behavior (if this is a feature change)?
- Fix debug output, it was only printing Tag before
- Prevent null reference from both Mvx.IoCProvider and the resolved instance

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
I have no real case to trigger this issue

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
