### PR TITLE
Feature/gh3711 visibility plugin build targetting

### DIFF
--- a/Directory.build.targets
+++ b/Directory.build.targets
@@ -2,7 +2,7 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
     <DefineConstants>$(DefineConstants);NETSTANDARD;PORTABLE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netcoreapp3'))">
     <DefineConstants>$(DefineConstants);NET;WPF;XAML</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -36,7 +36,7 @@ This package contains the 'Visibility' plugin for MvvmCross</Description>
     <Compile Include="Platforms\Console\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) And '$(OS)' == 'Windows_NT' ">
+  <ItemGroup Condition=" ($(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netcoreapp3'))) And '$(OS)' == 'Windows_NT' ">
     <Compile Include="Platforms\Net\**\*.cs" />
     <Compile Include="Platforms\Wpf\**\*.cs" />
     <Reference Include="PresentationCore" />

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid90;monoandroid10.0;tizen40;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid90;monoandroid10.0;tizen40;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Visibility plugin cannot be used in WPF running on top of .NET Core 3.0/3.1

### :new: What is the new behavior (if this is a feature change)?
Visibility plugin can be used in WPF running on top of .NET Core 3.0/3.1

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
Fixes #3711 (hopefully)

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
