### PR TITLE
Fix docs about Template Selectors

### DIFF
--- a/docs/_documentation/platform/android/android-recyclerview.md
+++ b/docs/_documentation/platform/android/android-recyclerview.md
@@ -23,7 +23,7 @@ Then adding your first `MvxRecyclerView` is fairly simple. You add the widget in
 <mvvmcross.droid.support.v7.recyclerview.MvxRecyclerView
     ...
     local:MvxItemTemplate="@layout/item_template"
-    local:MvxItemTemplateSelector="Fully.Qualified.Name,Assembly.Name"
+    local:MvxTemplateSelector="Fully.Qualified.Name,Assembly.Name"
     local:MvxBind="ItemsSource Items; ItemClick ItemClickCommand; ItemLongClick ItemLongClickCommand"
     />
 ```
@@ -90,7 +90,7 @@ So let us say are trying to keep track of animals in a zoo and you want a differ
 
 Assuming you have a ViewModel type for each of these group like: MammalViewModel, ReptileViewModel or some other way you could uniquely identify which View to present for the ViewModel, you could create a `ItemTemplateSelector` which could help you achieve this.
 
-To create your own `ItemTemplateSelector` you must create a class implementing the `IMvxItemTemplate` interface, which has two very important methods. `GetItemViewType(object forItemObject)` is used for the RecyclerView to determine how to recycle the Views. If you return `0` it will assume there is only one View type. Usually you would just return the layout id here. `GetItemLayoutId(int fromViewType)` this method is used to provide the actual id of the layout you want to use for the View type.
+To create your own `ItemTemplateSelector` you must create a class implementing the `IMvxTemplateSelector` interface, which has two very important methods. `GetItemViewType(object forItemObject)` is used for the RecyclerView to determine how to recycle the Views. If you return `0` it will assume there is only one View type. Usually you would just return the layout id here. `GetItemLayoutId(int fromViewType)` this method is used to provide the actual id of the layout you want to use for the View type.
 
 > Ensure you are returning something else than `0` from `GetItemViewType(object)` if you use multiple views in your `ItemTemplateSelector`.
 
@@ -130,7 +130,7 @@ namespace Zoo.App
 }
 ```
 
-To use this `ItemTemplateSelctor` you will need to provide it in the `MvxTemplateSelector` attribute on the `MvxRecyclerView`. It must be of the format: `Fully.Qualified.ClassName,Assembly.Name`. Hence, for the example above. Let us say the assembly will be `Zoo.App.Droid` and as you see the namespace is `Zoo.App` then the string will be: `Zoo.App.AnimalTemplateSelector,Zoo.App.Droid`.
+To use this `ItemTemplateSelector` you will need to provide it in the `MvxTemplateSelector` attribute on the `MvxRecyclerView`. It must be of the format: `Fully.Qualified.ClassName,Assembly.Name`. Hence, for the example above. Let us say the assembly will be `Zoo.App.Droid` and as you see the namespace is `Zoo.App` then the string will be: `Zoo.App.AnimalTemplateSelector,Zoo.App.Droid`.
 
 ```xml
 <mvvmcross.droid.support.v7.recyclerview.MvxRecyclerView


### PR DESCRIPTION
 `Template Selectors` section in docs for MvxRecyclerView contains several errors and typos which makes impossible copy-pasting from it.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
docs update

### :arrow_heading_down: What is the current behavior?
Docs for Android's MvxRecyclerView Item Template Selectors are not up to date

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
