### PR TITLE
Fix NoSuchMethodError exception when calling IsDestroyed

### DIFF
--- a/MvvmCross/Platforms/Android/MvxJavaObjectExtensions.cs
+++ b/MvvmCross/Platforms/Android/MvxJavaObjectExtensions.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using Android.App;
+using Android.OS;
 using Object = Java.Lang.Object;
 
 namespace MvvmCross.Platforms.Android
@@ -29,7 +30,7 @@ namespace MvvmCross.Platforms.Android
             if (activity.IsFinishing)
                 return true;
 
-            if (activity.IsDestroyed)
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1 && activity.IsDestroyed)
                 return true;
 
             return false;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When running an App on API level 16 or lower, the destruction of an Activity crashes the App, because lifecycle checks whether Activity is destroyed. IsDestroyed prop was added in API 17.

### :new: What is the new behavior (if this is a feature change)?
Check API level before calling IsDestroyed

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Test on API level 16 and lower

### :memo: Links to relevant issues/docs
Fixes #3727 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
