### PR TITLE
UAP ViewModel ViewCreated isn't being called

### DIFF
--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -101,7 +101,7 @@ namespace MvvmCross.Platforms.Uap.Views
             {
                 var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxWindowsViewModelLoader>();
                 ViewModel = viewModelLoader.Load(e.Parameter.ToString(), LoadStateBundle(e));
-                ViewModel.ViewCreated();
+                ViewModel?.ViewCreated();
             }
             _reqData = (string)e.Parameter;
 

--- a/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
+++ b/MvvmCross/Platforms/Uap/Views/MvxWindowsPage.cs
@@ -101,6 +101,7 @@ namespace MvvmCross.Platforms.Uap.Views
             {
                 var viewModelLoader = Mvx.IoCProvider.Resolve<IMvxWindowsViewModelLoader>();
                 ViewModel = viewModelLoader.Load(e.Parameter.ToString(), LoadStateBundle(e));
+                ViewModel.ViewCreated();
             }
             _reqData = (string)e.Parameter;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
A bug fix.

### :arrow_heading_down: What is the current behavior?
ViewModel?.ViewCreated() is never called as ViewModel is not set.

### :new: What is the new behavior (if this is a feature change)?
When ViewModel is set, ViewModel.ViewCreated() is called.

### :boom: Does this PR introduce a breaking change?
Unsure

### :bug: Recommendations for testing
Usual regression.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
