### PR TITLE
Fix EXC_BAD_ACCESS on MvxPathSourceStep.ClearPathSourceBinding

### DIFF
--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxPathSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxPathSourceStep.cs
@@ -12,6 +12,8 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
     public class MvxPathSourceStep : MvxSourceStep<MvxPathSourceStepDescription>
     {
         private IMvxSourceBinding _sourceBinding;
+        
+        private readonly object _sourceLocker = new object();
 
         public MvxPathSourceStep(MvxPathSourceStepDescription description)
             : base(description)
@@ -56,11 +58,14 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
 
         private void ClearPathSourceBinding()
         {
-            if (_sourceBinding != null)
+            lock (_sourceLocker)
             {
-                _sourceBinding.Changed -= SourceBindingOnChanged;
-                _sourceBinding.Dispose();
-                _sourceBinding = null;
+                if (_sourceBinding != null)
+                {
+                    _sourceBinding.Changed -= SourceBindingOnChanged;
+                    _sourceBinding.Dispose();
+                    _sourceBinding = null;
+                }
             }
         }
 


### PR DESCRIPTION
Fix EXC_BAD_ACCESS on MvxPathSourceStep.ClearPathSourceBinding

Changelog:
- Add lock on ClearPathSourceBinding()

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
FIX

### :arrow_heading_down: What is the current behavior?
Throw exception in firebase.Crashlitics

### :new: What is the new behavior (if this is a feature change)?
Lock ClearPathSourceBinding

### :boom: Does this PR introduce a breaking change?
No

### :memo: Links to relevant issues/docs
Fixes #3784

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
