### PR TITLE
Fix header by changing whitespace

### DIFF
--- a/docs/_documentation/samples/samples.md
+++ b/docs/_documentation/samples/samples.md
@@ -8,7 +8,7 @@ category: Samples
 
 We have a [dedicated repository](https://github.com/MvvmCross/MvvmCross-Samples) full of samples at your disposal. Don't hesitate to open an issue (or even better - a PR)  if you see anything wrong!
 
-#### StarWars Sample
+#### StarWars Sample
 
 Inside the samples repository you will find the [StarWars Sample](https://github.com/MvvmCross/MvvmCross-Samples/tree/master/StarWarsSample) app, which is fairly comprehensive app that showcases many MvvmCross features. It's available for iOS and Android at the moment.
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixing formatting.

### :arrow_heading_down: What is the current behavior?
The "StarWars Sample" header does not render as a header on GitHub or the documentation website.

### :new: What is the new behavior (if this is a feature change)?
By replacing the non-breaking space character  (Unicode codepoint 0xA0) that is currently seperating the hash marks and the header name with a regular space, it is properly rendered.

### :boom: Does this PR introduce a breaking change?
Nope.

### :bug: Recommendations for testing
The improvement in rendering is visible by viewing the document in the GitHub markdown viewer.

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

I'm just changing the white space, so I'm crossing my fingers that it was not a load-bearing whitespace and skipped everything in the checklist.

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
