### PR TITLE
Fix iOS Modal ViewController closing issue

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -549,10 +549,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
             MasterNavigationController = null;
         }
 
-        public virtual Task<bool> CloseModalViewController(UIViewController viewController, MvxModalPresentationAttribute attribute)
+        public virtual async Task<bool> CloseModalViewController(UIViewController viewController, MvxModalPresentationAttribute attribute)
         {
             if (viewController == null)
-                return Task.FromResult(true);
+                return true;
 
             if (viewController is UINavigationController modalNavController)
             {
@@ -560,9 +560,9 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     item.DidMoveToParentViewController(null);
             }
 
-            viewController.DismissViewController(attribute.Animated, null);
+            await viewController.DismissViewControllerAsync(attribute.Animated);
             ModalViewControllers.Remove(viewController);
-            return Task.FromResult(true);
+            return true;
         }
 
         public virtual async Task<bool> CloseModalViewControllers()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
iOS fails to close all modal view controllers 

### :new: What is the new behavior (if this is a feature change)?
iOS should close all modal view controllers

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Create iOS app and open 5 plus modal views. Then close them all with call to CloseModalViewControllers in a customer presenter.

### :memo: Links to relevant issues/docs
Fixes #3826

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
