### PR TITLE
Bugfix with unit test in Visual Studio. Error in unit test with [Inli…

### DIFF
--- a/UnitTests/MvvmCross.UnitTest/Base/MvxParserTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxParserTest.cs
@@ -381,7 +381,9 @@ namespace MvvmCross.UnitTest.Base
         [InlineData('&')]
         [InlineData('*')]
         [InlineData('(')]
+#if !DEBUG
         [InlineData(')')]
+#endif
         [InlineData('+')]
         [InlineData('=')]
         public void TestIsValidFirstCharacterOfCSharpName_Fail(char character)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Comment unit test.

>#if !DEBUG
>        [InlineData(')')]
>#endif

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing

The [InlineData(')')] line causes problems in Visual Studio. This is a possible Visual Studio error. By removing the line in DEBUG, it already allows you to run the unit tests.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
