### PR TITLE
Update to Xamarin.Form 4.7.0.1142 and Framework 4.7.2

### DIFF
--- a/MvvmCross.Droid.slnf
+++ b/MvvmCross.Droid.slnf
@@ -1,0 +1,24 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.DroidX\\Leanback\\MvvmCross.DroidX.Leanback.csproj",
+      "MvvmCross.DroidX\\Material\\MvvmCross.DroidX.Material.csproj",
+      "MvvmCross.DroidX\\RecyclerView\\MvvmCross.DroidX.RecyclerView.csproj",
+      "MvvmCross.DroidX\\SwipeRefreshLayout\\MvvmCross.DroidX.SwipeRefreshLayout.csproj",
+      "MvvmCross.Plugins\\Color\\MvvmCross.Plugin.Color.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location.Fused\\MvvmCross.Plugin.Location.Fused.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Droid\\Playground.Droid.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms.Droid.slnf
+++ b/MvvmCross.Forms.Droid.slnf
@@ -1,0 +1,24 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.DroidX\\Leanback\\MvvmCross.DroidX.Leanback.csproj",
+      "MvvmCross.DroidX\\Material\\MvvmCross.DroidX.Material.csproj",
+      "MvvmCross.DroidX\\RecyclerView\\MvvmCross.DroidX.RecyclerView.csproj",
+      "MvvmCross.DroidX\\SwipeRefreshLayout\\MvvmCross.DroidX.SwipeRefreshLayout.csproj",
+      "MvvmCross.Forms\\MvvmCross.Forms.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Forms.Droid\\Playground.Forms.Droid.csproj",
+      "Projects\\Playground\\Playground.Forms.UI\\Playground.Forms.UI.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms.Mac.slnf
+++ b/MvvmCross.Forms.Mac.slnf
@@ -1,0 +1,20 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Forms\\MvvmCross.Forms.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Forms.Mac\\Playground.Forms.Mac.csproj",
+      "Projects\\Playground\\Playground.Forms.UI\\Playground.Forms.UI.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms.TvOS.slnf
+++ b/MvvmCross.Forms.TvOS.slnf
@@ -1,0 +1,20 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Forms\\MvvmCross.Forms.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Forms.Mac\\Playground.Forms.TvOS.csproj",
+      "Projects\\Playground\\Playground.Forms.UI\\Playground.Forms.UI.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms.Uwp.slnf
+++ b/MvvmCross.Forms.Uwp.slnf
@@ -1,0 +1,19 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Forms.UI\\Playground.Forms.UI.csproj",
+      "Projects\\Playground\\Playground.Forms.Uwp\\Playground.Forms.Uwp.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms.Wpf.slnf
+++ b/MvvmCross.Forms.Wpf.slnf
@@ -1,0 +1,21 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Forms\\MvvmCross.Forms.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross.Wpf\\MvvmCross.Platforms.Wpf.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Forms.UI\\Playground.Forms.UI.csproj",
+      "Projects\\Playground\\Playground.Forms.Wpf\\Playground.Forms.Wpf.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
+++ b/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>MvvmCross.Forms.Platforms.Wpf</AssemblyName>
     <RootNamespace>MvvmCross.Forms.Platforms.Wpf</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Forms.WpfCore.slnf
+++ b/MvvmCross.Forms.WpfCore.slnf
@@ -1,0 +1,22 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Forms.Wpf\\MvvmCross.Forms.Platforms.Wpf.csproj",
+      "MvvmCross.Forms\\MvvmCross.Forms.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross.Wpf\\MvvmCross.Platforms.Wpf.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Forms.UI\\Playground.Forms.UI.csproj",
+      "Projects\\Playground\\Playground.Forms.WpfCore\\Playground.Forms.WpfCore.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms.iOS.slnf
+++ b/MvvmCross.Forms.iOS.slnf
@@ -1,0 +1,20 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Forms\\MvvmCross.Forms.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Forms.UI\\Playground.Forms.UI.csproj",
+      "Projects\\Playground\\Playground.Forms.iOS\\Playground.Forms.iOS.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Forms/MvvmCross.Forms.csproj
+++ b/MvvmCross.Forms/MvvmCross.Forms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;monoandroid10.0;tizen40;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross.Mac.slnf
+++ b/MvvmCross.Mac.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.iOS\\Playground.Mac.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Plugins/File/MvvmCross.Plugin.File.csproj
+++ b/MvvmCross.Plugins/File/MvvmCross.Plugin.File.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross.Plugins/Location/MvvmCross.Plugin.Location.csproj
+++ b/MvvmCross.Plugins/Location/MvvmCross.Plugin.Location.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross.Plugins/Network/MvvmCross.Plugin.Network.csproj
+++ b/MvvmCross.Plugins/Network/MvvmCross.Plugin.Network.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross.TvOS.slnf
+++ b/MvvmCross.TvOS.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.iOS\\Playground.TvOS.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Uwp.slnf
+++ b/MvvmCross.Uwp.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Uwp\\Playground.Uwp.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Wpf.slnf
+++ b/MvvmCross.Wpf.slnf
@@ -1,0 +1,20 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Forms\\MvvmCross.Forms.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross.Wpf\\MvvmCross.Platforms.Wpf.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Wpf\\Playground.Wpf.csproj"
+    ]
+  }
+}

--- a/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
+++ b/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>MvvmCross.Platforms.Wpf</AssemblyName>
     <RootNamespace>MvvmCross.Platforms.Wpf</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.WpfCore.slnf
+++ b/MvvmCross.WpfCore.slnf
@@ -1,0 +1,19 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross.Wpf\\MvvmCross.Platforms.Wpf.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.WpfCore\\Playground.WpfCore.csproj"
+    ]
+  }
+}

--- a/MvvmCross.iOS.slnf
+++ b/MvvmCross.iOS.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "MvvmCross.sln",
+    "projects": [
+      "MvvmCross.Analyzers\\CodeAnalysis\\MvvmCross.CodeAnalysis.csproj",
+      "MvvmCross.Plugins\\File\\MvvmCross.Plugin.File.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\Location\\MvvmCross.Plugin.Location.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\Network\\MvvmCross.Plugin.Network.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.iOS\\Playground.iOS.csproj"
+    ]
+  }
+}

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
@@ -20,6 +20,7 @@ This package contains the 'Core' libraries for MvvmCross</Description>
     <PackageId>MvvmCross</PackageId>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <GenerateLibraryLayout Condition="$(TargetFramework.StartsWith('uap'))">true</GenerateLibraryLayout>
+    <UserSecretsId>6aa65537-690b-4607-8c64-f38bf18e1f07</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MvvmCross/Properties/serviceDependencies.json
+++ b/MvvmCross/Properties/serviceDependencies.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets"
+    }
+  }
+}

--- a/MvvmCross/Properties/serviceDependencies.local.json
+++ b/MvvmCross/Properties/serviceDependencies.local.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets.user"
+    }
+  }
+}

--- a/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Playground.Forms.Uwp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Projects/Playground/Playground.Forms.Wpf/App.config
+++ b/Projects/Playground/Playground.Forms.Wpf/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
+++ b/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
@@ -8,11 +8,12 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>Playground.Forms.Wpf</RootNamespace>
     <AssemblyName>Playground.Forms.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Projects/Playground/Playground.Forms.Wpf/Properties/Resources.Designer.cs
+++ b/Projects/Playground/Playground.Forms.Wpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Playground.Forms.Wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Projects/Playground/Playground.Forms.Wpf/Properties/Settings.Designer.cs
+++ b/Projects/Playground/Playground.Forms.Wpf/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Playground.Forms.Wpf.Properties
-{
-
-
+namespace Playground.Forms.Wpf.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/Projects/Playground/Playground.Forms.WpfCore/Playground.Forms.WpfCore.csproj
+++ b/Projects/Playground/Playground.Forms.WpfCore/Playground.Forms.WpfCore.csproj
@@ -4,7 +4,12 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Remove="**\*.xaml" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross.Forms.Wpf\MvvmCross.Forms.Platforms.Wpf.csproj" />

--- a/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Playground.Uwp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Projects/Playground/Playground.Wpf/App.config
+++ b/Projects/Playground/Playground.Wpf/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/Projects/Playground/Playground.Wpf/Playground.Wpf.csproj
+++ b/Projects/Playground/Playground.Wpf/Playground.Wpf.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>Playground.Wpf</RootNamespace>
     <AssemblyName>Playground.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/Projects/Playground/Playground.Wpf/Properties/Resources.Designer.cs
+++ b/Projects/Playground/Playground.Wpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Playground.Wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Projects/Playground/Playground.Wpf/Properties/Settings.Designer.cs
+++ b/Projects/Playground/Playground.Wpf/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Playground.Wpf.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Projects/Playground/Playground.WpfCore/Playground.WpfCore.csproj
+++ b/Projects/Playground/Playground.WpfCore/Playground.WpfCore.csproj
@@ -4,10 +4,15 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>
     <None Remove="Assets\MvvmCross-logo.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Remove="**\*.xaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/XamarinForms.targets
+++ b/XamarinForms.targets
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.847" />
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.1142" />
   </ItemGroup>
 
   <Import Project="XamarinBuild.targets" Condition="'$(IsXamarinForms)' == 'true' and $(TargetFramework.StartsWith('monoandroid'))"/>

--- a/XamarinFormsWpf.targets
+++ b/XamarinFormsWpf.targets
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.6.0.847" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.7.0.1142" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "3.1.301",
+    "rollForward": "latestPatch"
+  },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.54"
   }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

I need Framework 4.7.2 for use Duple and ValueTask.  To migrate to asynchronous.

WPFCore, cause warking with Xamarin.Forms 4.6. I've updated to 4.7.0.1142

UWP also produced warkning and I upgraded it to version 17763

I created  Visual Studio Solution Filter, for some platform.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
