### PR TITLE
Added MvxPopoverPresentationAttribute

### DIFF
--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
@@ -71,6 +71,7 @@ namespace MvvmCross.Platforms.Ios.Core
         {
             RegisterPlatformProperties();
             RegisterPresenter();
+            RegisterPopoverPresentationSourceProvider();
             RegisterLifetime();
             base.InitializeFirstChance();
         }
@@ -109,6 +110,16 @@ namespace MvvmCross.Platforms.Ios.Core
             var presenter = Presenter;
             Mvx.IoCProvider.RegisterSingleton(presenter);
             Mvx.IoCProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
+        }
+
+        protected virtual void RegisterPopoverPresentationSourceProvider()
+        {
+            Mvx.IoCProvider.RegisterSingleton<IMvxPopoverPresentationSourceProvider>(CreatePopoverPresentationSourceProvider());
+        }
+
+        protected virtual IMvxPopoverPresentationSourceProvider CreatePopoverPresentationSourceProvider()
+        {
+            return new MvxPopoverPresentationSourceProvider();
         }
 
         protected override void InitializeLastChance()

--- a/MvvmCross/Platforms/Ios/Presenters/Attributes/MvxPopoverPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/Attributes/MvxPopoverPresentationAttribute.cs
@@ -15,6 +15,5 @@ namespace MvvmCross.Platforms.Ios.Presenters.Attributes
         
         public static UIPopoverArrowDirection DefaultPermittedArrowDirections = UIPopoverArrowDirection.Any;
         public UIPopoverArrowDirection PermittedArrowDirections { get; set; } = DefaultPermittedArrowDirections;
-
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/Attributes/MvxPopoverPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/Attributes/MvxPopoverPresentationAttribute.cs
@@ -1,0 +1,20 @@
+using MvvmCross.Presenters.Attributes;
+
+namespace MvvmCross.Platforms.Ios.Presenters.Attributes
+{
+    public class MvxPopoverPresentationAttribute : MvxBasePresentationAttribute
+    {
+        public static bool DefaultWrapInNavigationController = false;
+        public bool WrapInNavigationController { get; set; } = DefaultWrapInNavigationController;
+        
+        public static CGSize DefaultPreferredContentSize = CGSize.Empty;
+        public CGSize PreferredContentSize { get; set; } = DefaultPreferredContentSize;
+
+        public static bool DefaultAnimated = true;
+        public bool Animated { get; set; } = DefaultAnimated;
+        
+        public static UIPopoverArrowDirection DefaultPermittedArrowDirections = UIPopoverArrowDirection.Any;
+        public UIPopoverArrowDirection PermittedArrowDirections { get; set; } = DefaultPermittedArrowDirections;
+
+    }
+}

--- a/MvvmCross/Platforms/Ios/Presenters/Attributes/MvxPopoverPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/Attributes/MvxPopoverPresentationAttribute.cs
@@ -1,4 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using CoreGraphics;
 using MvvmCross.Presenters.Attributes;
+using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Presenters.Attributes
 {
@@ -6,13 +12,13 @@ namespace MvvmCross.Platforms.Ios.Presenters.Attributes
     {
         public static bool DefaultWrapInNavigationController = false;
         public bool WrapInNavigationController { get; set; } = DefaultWrapInNavigationController;
-        
+
         public static CGSize DefaultPreferredContentSize = CGSize.Empty;
         public CGSize PreferredContentSize { get; set; } = DefaultPreferredContentSize;
 
         public static bool DefaultAnimated = true;
         public bool Animated { get; set; } = DefaultAnimated;
-        
+
         public static UIPopoverArrowDirection DefaultPermittedArrowDirections = UIPopoverArrowDirection.Any;
         public UIPopoverArrowDirection PermittedArrowDirections { get; set; } = DefaultPermittedArrowDirections;
     }

--- a/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
@@ -8,7 +8,7 @@ using MvvmCross.Presenters;
 namespace MvvmCross.Platforms.Ios.Presenters
 {
     public interface IMvxIosViewPresenter : IMvxViewPresenter, IMvxCanCreateIosView
-    {    
+    {
         public void ClosedPopoverViewController();
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
@@ -9,5 +9,6 @@ namespace MvvmCross.Platforms.Ios.Presenters
 {
     public interface IMvxIosViewPresenter : IMvxViewPresenter, IMvxCanCreateIosView
     {    
+        public void ClosedPopoverViewController();
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/IMvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/IMvxPopoverPresentationSourceProvider.cs
@@ -1,0 +1,11 @@
+using CoreGraphics;
+using UIKit;
+
+namespace MvvmCross.Platforms.Ios.Presenters
+{
+    public interface IMvxPopoverPresentationSourceProvider
+    {
+        CGRect PopoverSourceRect { get; }
+        UIView PopoverSourceView { get; }
+    }
+}

--- a/MvvmCross/Platforms/Ios/Presenters/IMvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/IMvxPopoverPresentationSourceProvider.cs
@@ -1,4 +1,7 @@
-using CoreGraphics;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Presenters

--- a/MvvmCross/Platforms/Ios/Presenters/IMvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/IMvxPopoverPresentationSourceProvider.cs
@@ -5,7 +5,8 @@ namespace MvvmCross.Platforms.Ios.Presenters
 {
     public interface IMvxPopoverPresentationSourceProvider
     {
-        CGRect PopoverSourceRect { get; }
-        UIView PopoverSourceView { get; }
+        UIView SourceView { get; set; }
+        UIBarButtonItem SourceBarButtonItem { get; set; }
+        public void SetSource(UIPopoverPresentationController popoverPresentationController);
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -440,8 +440,8 @@ namespace MvvmCross.Platforms.Ios.Presenters
             
             var presentationController = viewController.PopoverPresentationController;
             presentationController.PermittedArrowDirections = attribute.PermittedArrowDirections;
-            presentationController.SourceRect = PopoverSourceProvider.PopoverSourceRect;
-            presentationController.SourceView = PopoverSourceProvider.PopoverSourceView;
+            var sourceProvider = Mvx.IoCProvider.Resolve<IMvxPopoverPresentationSourceProvider>();
+            sourceProvider.SetSource(presentationController);
             presentationController.Delegate = new MvxPopoverDelegate(this);
                 
             viewHost.PresentViewController(

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -437,7 +437,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             presentationController.PermittedArrowDirections = attribute.PermittedArrowDirections;
             presentationController.SourceRect = PopoverSourceProvider.PopoverSourceRect;
             presentationController.SourceView = PopoverSourceProvider.PopoverSourceView;
-            presentationController.Delegate = new MvxPopoverDelegate();
+            presentationController.Delegate = new MvxPopoverDelegate(this);
                 
             viewHost.PresentViewController(
                 viewController,

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -27,9 +27,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
         public UINavigationController MasterNavigationController { get; protected set; }
 
         public UIViewController PopoverViewController { get; protected set; }
-        
-        public IMvxPopoverPresentationSourceProvider PopoverSourceProvider { get; set; }
-        
+
         public List<UIViewController> ModalViewControllers { get; protected set; } = new List<UIViewController>();
 
         public IMvxTabBarViewController TabBarViewController { get; protected set; }
@@ -130,9 +128,9 @@ namespace MvvmCross.Platforms.Ios.Presenters
                         return ShowModalViewController(viewController, attribute, request);
                     },
                     CloseModalViewController);
-            
+
             RegisterPopoverAttributeType();
-            
+
             AttributeTypesToActionsDictionary.Register<MvxSplitViewPresentationAttribute>(
                 (viewType, attribute, request) =>
                     {
@@ -301,7 +299,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     throw new MvxException($"Trying to show View type: {viewController.GetType().Name} as child, but there is currently a plain popover view presented!");
                 }
             }
-            
+
             if (ModalViewControllers.Any())
             {
                 if (ModalViewControllers.LastOrDefault() is UINavigationController modalNavController)
@@ -409,7 +407,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             ModalViewControllers.Add(viewController);
             return Task.FromResult(true);
         }
-        
+
         protected virtual Task<bool> ShowPopoverViewController(
             UIViewController viewController,
             MvxPopoverPresentationAttribute attribute,
@@ -417,10 +415,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
         {
             if (PopoverViewController != null)
                 throw new MvxException($"Trying to show View type: {viewController.GetType().Name} as popover, but there is already a popover present!");
-            
-            if (PopoverSourceProvider == null)
-                throw new MvxException($"Trying to show View type: {viewController.GetType().Name} as popover, but the popover host view controller is null! Did you forget to set it?");
-            
+
             // Content size should be set to a target view controller, not the navigation one
             if (attribute.PreferredContentSize != default(CGSize))
             {
@@ -432,18 +427,19 @@ namespace MvvmCross.Platforms.Ios.Presenters
             {
                 viewController = CreateNavigationController(viewController);
             }
-            
+
             // Check if there is a modal already presented first. Otherwise use the topmost view controller.
             var viewHost = ModalViewControllers.LastOrDefault() ?? _window.RootViewController;
-            
+
             viewController.ModalPresentationStyle = UIModalPresentationStyle.Popover;
-            
+
             var presentationController = viewController.PopoverPresentationController;
             presentationController.PermittedArrowDirections = attribute.PermittedArrowDirections;
+
             var sourceProvider = Mvx.IoCProvider.Resolve<IMvxPopoverPresentationSourceProvider>();
             sourceProvider.SetSource(presentationController);
             presentationController.Delegate = new MvxPopoverDelegate(this);
-                
+
             viewHost.PresentViewController(
                 viewController,
                 attribute.Animated,
@@ -697,7 +693,6 @@ namespace MvvmCross.Platforms.Ios.Presenters
 
             await viewController.DismissViewControllerAsync(attribute.Animated);
             PopoverViewController = null;
-            PopoverSourceProvider = null;
             return true;
         }
 
@@ -762,7 +757,6 @@ namespace MvvmCross.Platforms.Ios.Presenters
         public virtual void ClosedPopoverViewController()
         {
             PopoverViewController = null;
-            PopoverSourceProvider = null;
         }
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -131,14 +131,8 @@ namespace MvvmCross.Platforms.Ios.Presenters
                     },
                     CloseModalViewController);
             
-            AttributeTypesToActionsDictionary.Register<MvxPopoverPresentationAttribute>(
-                (viewType, attribute, request) =>
-                {
-                    var viewController = (UIViewController)this.CreateViewControllerFor(request);
-                    return ShowPopoverViewController(viewController, attribute, request);
-                },
-                ClosePopoverViewController);
-
+            RegisterPopoverAttributeType();
+            
             AttributeTypesToActionsDictionary.Register<MvxSplitViewPresentationAttribute>(
                 (viewType, attribute, request) =>
                     {
@@ -167,6 +161,17 @@ namespace MvvmCross.Platforms.Ios.Presenters
                                 return CloseDetailSplitViewController(viewModel, splitAttribute);
                         }
                     });
+        }
+
+        protected virtual void RegisterPopoverAttributeType()
+        {
+            AttributeTypesToActionsDictionary.Register<MvxPopoverPresentationAttribute>(
+                (viewType, attribute, request) =>
+                {
+                    var viewController = (UIViewController)this.CreateViewControllerFor(request);
+                    return ShowPopoverViewController(viewController, attribute, request);
+                },
+                ClosePopoverViewController);
         }
 
         protected virtual async Task<bool> ShowRootViewController(

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverDelegate.cs
@@ -1,5 +1,7 @@
-using MvvmCross;
-using MvvmCross.Platforms.Ios.Presenters;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Presenters
@@ -11,7 +13,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
         {
             _presenter = presenter;
         }
-        
+
         public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController)
         {
             return UIModalPresentationStyle.None;

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverDelegate.cs
@@ -6,8 +6,10 @@ namespace MvvmCross.Platforms.Ios.Presenters
 {
     public class MvxPopoverDelegate : UIPopoverPresentationControllerDelegate
     {
-        public MvxPopoverDelegate()
+        private IMvxIosViewPresenter _presenter;
+        public MvxPopoverDelegate(IMvxIosViewPresenter presenter)
         {
+            _presenter = presenter;
         }
         
         public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController)
@@ -22,10 +24,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
 
         public override void DidDismissPopover(UIPopoverPresentationController popoverPresentationController)
         {
-            if (Mvx.IoCProvider.Resolve<IMvxIosViewPresenter>() is MvxIosViewPresenter presenter)
-            {
-                presenter.ClosedPopoverViewController();
-            }
+            _presenter.ClosedPopoverViewController();
         }
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverDelegate.cs
@@ -1,0 +1,31 @@
+using MvvmCross;
+using MvvmCross.Platforms.Ios.Presenters;
+using UIKit;
+
+namespace MvvmCross.Platforms.Ios.Presenters
+{
+    public class MvxPopoverDelegate : UIPopoverPresentationControllerDelegate
+    {
+        public MvxPopoverDelegate()
+        {
+        }
+        
+        public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController)
+        {
+            return UIModalPresentationStyle.None;
+        }
+
+        public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController controller, UITraitCollection traitCollection)
+        {
+            return UIModalPresentationStyle.None;
+        }
+
+        public override void DidDismissPopover(UIPopoverPresentationController popoverPresentationController)
+        {
+            if (Mvx.IoCProvider.Resolve<IMvxIosViewPresenter>() is MvxIosViewPresenter presenter)
+            {
+                presenter.ClosedPopoverViewController();
+            }
+        }
+    }
+}

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
@@ -18,6 +18,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             {
                 var sourceView = _sourceView;
                 _sourceView = null;
+                _sourceBarButtonItem = null;
                 return sourceView;
             }
             set => _sourceView = value;
@@ -29,6 +30,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             {
                 var sourceBarButtonItem = _sourceBarButtonItem;
                 _sourceBarButtonItem = null;
+                _sourceView = null;
                 return sourceBarButtonItem;
             }
             set => _sourceBarButtonItem = value;

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
@@ -1,5 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
-using CoreGraphics;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Presenters

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using CoreGraphics;
 using UIKit;
 
@@ -5,17 +6,45 @@ namespace MvvmCross.Platforms.Ios.Presenters
 {
     public class MvxPopoverPresentationSourceProvider : IMvxPopoverPresentationSourceProvider
     {
-        public CGRect PopoverSourceRect { get; }
-        public UIView PopoverSourceView { get; }
-
-        public MvxPopoverPresentationSourceProvider()
+        private UIView _sourceView;
+        private UIBarButtonItem _sourceBarButtonItem;
+        public UIView SourceView
         {
+            get
+            {
+                var sourceView = _sourceView;
+                _sourceView = null;
+                return sourceView;
+            }
+            set => _sourceView = value;
         }
-
-        public MvxPopoverPresentationSourceProvider(CGRect popoverSourceRect, UIView popoverSourceView)
+        public UIBarButtonItem SourceBarButtonItem
         {
-            PopoverSourceRect = popoverSourceRect;
-            PopoverSourceView = popoverSourceView;
+            get
+            {
+                var sourceBarButtonItem = _sourceBarButtonItem;
+                _sourceBarButtonItem = null;
+                return sourceBarButtonItem;
+            }
+            set => _sourceBarButtonItem = value;
+        }
+        public void SetSource(UIPopoverPresentationController popoverPresentationController)
+        {
+            if (SourceView == null && SourceBarButtonItem == null)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(IMvxPopoverPresentationSourceProvider)} should contain a source for popover."
+                );
+            }
+            if (SourceView != null)
+            {
+                popoverPresentationController.SourceView = SourceView;
+                popoverPresentationController.SourceRect = SourceView.Frame;
+            }
+            else
+            {
+                popoverPresentationController.BarButtonItem = SourceBarButtonItem;
+            }
         }
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
@@ -11,6 +11,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
     {
         private UIView _sourceView;
         private UIBarButtonItem _sourceBarButtonItem;
+
         public UIView SourceView
         {
             get
@@ -21,6 +22,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             }
             set => _sourceView = value;
         }
+
         public UIBarButtonItem SourceBarButtonItem
         {
             get
@@ -31,6 +33,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             }
             set => _sourceBarButtonItem = value;
         }
+
         public void SetSource(UIPopoverPresentationController popoverPresentationController)
         {
             if (SourceView == null && SourceBarButtonItem == null)

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
@@ -1,0 +1,21 @@
+using CoreGraphics;
+using UIKit;
+
+namespace MvvmCross.Platforms.Ios.Presenters
+{
+    public class MvxPopoverPresentationSourceProvider : IMvxPopoverPresentationSourceProvider
+    {
+        public CGRect PopoverSourceRect { get; }
+        public UIView PopoverSourceView { get; }
+
+        public MvxPopoverPresentationSourceProvider()
+        {
+        }
+
+        public MvxPopoverPresentationSourceProvider(CGRect popoverSourceRect, UIView popoverSourceView)
+        {
+            PopoverSourceRect = popoverSourceRect;
+            PopoverSourceView = popoverSourceView;
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Add support for iOS modal popover view controllers.

### :arrow_heading_down: What is the current behavior?

There is no support for adding a popover view using presentation attributes.

### :new: What is the new behavior (if this is a feature change)?

You can add a MvxPopoverPresentationAttribute to views to display a popover with an arrow.

### :boom: Does this PR introduce a breaking change?

I do not think so.

### :bug: Recommendations for testing

I am unable to build the project. Is this because I am on macOS?

Create a view and add the MvxPopoverPresentationAttribute (similar to the modal version).
I found it was best to set the `PreferredContentSize` in the `ViewDidLoad method`.
```
[MvxPopoverPresentation(
    WrapInNavigationController = true,
    PermittedArrowDirections = UIPopoverArrowDirection.Left)]
public class PopoverTestView : MvxViewController<PopoverTestViewModel>
{
    public override void ViewDidLoad()
    {
        base.ViewDidLoad();
        PreferredContentSize = new CGSize(200, 200);
        ...
```

It is necessary to set the viewPresenters `PopoverSourceProvider` before calling navigate each time.
I ended up binding my button this way.

```
// set.Bind(button).To(vm => vm.ShowPopupCommand);
set.Apply();
			
button.TouchUpInside += (sender, args) =>
{
    if (Mvx.IoCProvider.Resolve<IMvxIosViewPresenter>() is MvxIosViewPresenter presenter)
    {
        var sourceProvider = new MvxPopoverPresentationSourceProvider(button.Frame, button);
	presenter.PopoverSourceProvider = sourceProvider;
	ViewModel.ShowPopupCommand.Execute();
    }
};
```

Result looks like this.

<img width="584" alt="Screen Shot 2020-08-04 at 11 51 02 AM" src="https://user-images.githubusercontent.com/326668/89315399-c8054780-d648-11ea-953d-d5f8c1eb6dc7.png">

There are a couple assumptions made in this implemenation.

1) There will only be one popover. This follows Apple's Human Interface Design Guidelines.
2) You must set the PopoverSourceProvider in the iOS view just before calling navigate in the viewModel as this property is set to null when the popover is dismissed.

### :memo: Links to relevant issues/docs

Fixes #3840

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
