### PR TITLE
add wpf core support for certain plugins

### DIFF
--- a/MvvmCross.Plugins/Network/MvvmCross.Plugin.Network.csproj
+++ b/MvvmCross.Plugins/Network/MvvmCross.Plugin.Network.csproj
@@ -34,6 +34,7 @@ This package contains the 'Network' plugin for MvvmCross</Description>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
     <Compile Include="Platforms\Net\**\*.cs" />
     <Compile Include="Platforms\Console\**\*.cs" />
+    <Compile Include="Platforms\Wpf\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) and '$(OS)' == 'Windows_NT' ">
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -34,6 +34,9 @@ This package contains the 'ResourceLoader' plugin for MvvmCross</Description>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
     <Compile Include="Platforms\Net\**\*.cs" />
     <Compile Include="Platforms\Console\**\*.cs" />
+    <Compile Include="Platforms\Wpf\**\*.cs" />
+    <Reference Include="c:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\PresentationFramework.dll" />
+    <Reference Include="c:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\WindowsBase.dll" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) And '$(OS)' == 'Windows_NT' ">

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetsToBuild)' != 'All' ">
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Android' ">netstandard2.0;monoandroid10.0;</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Uap' ">netstandard2.0;uap10.0.16299</TargetFrameworks>
@@ -35,8 +39,6 @@ This package contains the 'ResourceLoader' plugin for MvvmCross</Description>
     <Compile Include="Platforms\Net\**\*.cs" />
     <Compile Include="Platforms\Console\**\*.cs" />
     <Compile Include="Platforms\Wpf\**\*.cs" />
-    <Reference Include="c:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\PresentationFramework.dll" />
-    <Reference Include="c:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\WindowsBase.dll" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) And '$(OS)' == 'Windows_NT' ">

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -3,7 +3,11 @@
     <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
-
+ 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  
   <PropertyGroup Condition=" '$(TargetsToBuild)' != 'All' ">
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Android' ">netstandard2.0;monoandroid10.0;</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Uap' ">netstandard2.0;uap10.0.16299</TargetFrameworks>
@@ -35,7 +39,6 @@ This package contains the 'Visibility' plugin for MvvmCross</Description>
     <Compile Include="Platforms\Net\**\*.cs" />
     <Compile Include="Platforms\Console\**\*.cs" />
     <Compile Include="Platforms\Wpf\**\*.cs" />
-    <Reference Include="c:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\PresentationCore.dll" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) And '$(OS)' == 'Windows_NT' ">

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
  
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) and '$(OS)' == 'Windows_NT' ">
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -34,6 +34,8 @@ This package contains the 'Visibility' plugin for MvvmCross</Description>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
     <Compile Include="Platforms\Net\**\*.cs" />
     <Compile Include="Platforms\Console\**\*.cs" />
+    <Compile Include="Platforms\Wpf\**\*.cs" />
+    <Reference Include="c:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\PresentationCore.dll" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) And '$(OS)' == 'Windows_NT' ">


### PR DESCRIPTION
Network, ResourceLocalization and Visibility plugins can support WPF on .NET Core platform. The only change was to include WPF source codes in .netcore3.1 build. 

**Caveat**: I'm not sure, how to correctly reference WPF core libraries like `PresentationFramework` or `WindowsBase`