### PR TITLE
Fix TemplateSelector for Collection View sample in Playground.Droid

### DIFF
--- a/Projects/Playground/Playground.Droid/TemplateSelectors/AnimalTemplateSelector.cs
+++ b/Projects/Playground/Playground.Droid/TemplateSelectors/AnimalTemplateSelector.cs
@@ -1,38 +1,29 @@
-﻿using MvvmCross.DroidX.RecyclerView.ItemTemplates;
+﻿using System;
+using System.Collections.Generic;
+using MvvmCross.DroidX.RecyclerView.ItemTemplates;
 using static Playground.Core.ViewModels.CollectionViewModel;
 
 namespace Playground.Droid.TemplateSelectors
 {
-    public class AnimalTemplateSelector : MvxTemplateSelector<AnimalViewModel>
+    public class AnimalTemplateSelector : IMvxTemplateSelector
     {
-        public override int GetItemLayoutId(int fromViewType)
+        private readonly Dictionary<Type, int> _itemsTypeDictionary = new Dictionary<Type, int>
         {
-            switch(fromViewType)
-            {
-                case 0:
-                    return Resource.Layout.itemtemplate_cat;
-                case 1:
-                    return Resource.Layout.itemtemplate_dog;
-                case 2:
-                    return Resource.Layout.itemtemplate_monkey;
-            }
+            [typeof(CatViewModel)] = Resource.Layout.itemtemplate_cat,
+            [typeof(DogViewModel)] = Resource.Layout.itemtemplate_dog,
+            [typeof(MonkeyViewModel)] = Resource.Layout.itemtemplate_monkey,
+        };
 
-            return -1;
+        public int ItemTemplateId { get; set; }
+
+        public int GetItemLayoutId(int fromViewType)
+        {
+            return fromViewType;
         }
 
-        protected override int SelectItemViewType(AnimalViewModel forItemObject)
+        public int GetItemViewType(object forItemObject)
         {
-            switch(forItemObject)
-            {
-                case CatViewModel _:
-                    return 0;
-                case DogViewModel _:
-                    return 1;
-                case MonkeyViewModel _:
-                    return 2;
-            }
-
-            return -1;
+            return _itemsTypeDictionary[forItemObject.GetType()];
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Sample crashes if you press collection view sample in Playground.Droid

### :new: What is the new behavior (if this is a feature change)?
Fixes the ItemTemplate which was returning wrong value, leading to wrong view ID being inflated

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Run Playground.Droid and try the sample

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
