### PR TITLE
Fix null reference in MvxLayoutInflater

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Views/MvxContextWrapper.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxContextWrapper.cs
@@ -1,15 +1,17 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using Android.Content;
+using Android.Runtime;
 using Android.Views;
 using MvvmCross.Binding.BindingContext;
 using Object = Java.Lang.Object;
 
 namespace MvvmCross.Platforms.Android.Binding.Views
 {
+    [Register("mvvmcross.platforms.android.binding.views.MvxContextWrapper")]
     public class MvxContextWrapper : ContextWrapper
     {
         private LayoutInflater _inflater;
@@ -31,11 +33,10 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 
         public override Object GetSystemService(string name)
         {
-            if (name.Equals(LayoutInflaterService))
+            if (string.Equals(name, LayoutInflaterService, StringComparison.InvariantCulture))
             {
-                return _inflater ??
-                       (_inflater =
-                           new MvxLayoutInflater(LayoutInflater.From(BaseContext), this, null, false));
+                return _inflater ??=
+                    new MvxLayoutInflater(LayoutInflater.From(BaseContext), this, null, false);
             }
 
             return base.GetSystemService(name);

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -61,9 +61,9 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             }
         }
 
-        public static bool Debug = false;
+        public static bool Debug { get; set; }
 
-        private static readonly string Tag = "MvxLayoutInflater";
+        private const string Tag = "MvxLayoutInflater";
 
         internal static BuildVersionCodes Sdk = Build.VERSION.SdkInt;
 
@@ -205,7 +205,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                 {
                     return CreateView(name, prefix, attrs);
                 }
-                catch (ClassNotFoundException) 
+                catch (ClassNotFoundException)
                 {
                 }
             }
@@ -351,7 +351,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 #endif
                             view = CreateView(name, null, attrs);
                     }
-                    catch (ClassNotFoundException) 
+                    catch (ClassNotFoundException)
                     {
                     }
                     finally
@@ -367,7 +367,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             return view;
         }
 
-        protected IMvxAndroidViewFactory AndroidViewFactory 
+        protected IMvxAndroidViewFactory AndroidViewFactory
         {
             get
             {
@@ -413,7 +413,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 
         private class DelegateFactory2 : IMvxLayoutInflaterFactory
         {
-            private static readonly string Tag = "DelegateFactory2";
+            private const string Tag = "DelegateFactory2";
 
             private readonly IFactory2 _factory;
             private readonly MvxBindingVisitor _factoryPlaceholder;
@@ -437,7 +437,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 
         private class DelegateFactory1 : IMvxLayoutInflaterFactory
         {
-            private static readonly string Tag = "DelegateFactory1";
+            private const string Tag = "DelegateFactory1";
 
             private readonly IFactory _factory;
             private readonly MvxBindingVisitor _factoryPlaceholder;
@@ -461,7 +461,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
 
         private class PrivateFactoryWrapper2 : Object, IFactory2
         {
-            private static readonly string Tag = "PrivateFactoryWrapper2";
+            private const string Tag = "PrivateFactoryWrapper2";
 
             private readonly IFactory2 _factory2;
             private readonly MvxBindingVisitor _bindingVisitor;

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -98,6 +98,8 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         public MvxLayoutInflater(IntPtr handle, JniHandleOwnership transfer)
             : base(handle, transfer)
         {
+            _bindingVisitor = new MvxBindingVisitor();
+            SetupLayoutFactories(false);
         }
 
         public override LayoutInflater CloneInContext(Context newContext)

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -305,11 +305,13 @@ namespace MvvmCross.Platforms.Android.Binding.Views
             if (Debug)
                 MvxLog.Instance.Trace("{Tag} - ... CreateCustomViewInternal ... {name}", Tag, name);
 
-            if (view == null && name.IndexOf('.') > -1)
+            if (view == null &&
+                !string.IsNullOrWhiteSpace(name) &&
+                name.IndexOf('.', StringComparison.InvariantCulture) > -1)
             {
                 // Attempt to inflate with MvvmCross unless we're trying to inflate an internal views
                 // since we don't resolve those.
-                if (!name.StartsWith("com.android.internal."))
+                if (!name.StartsWith("com.android.internal.", StringComparison.InvariantCulture))
                 {
                     view = AndroidViewFactory?.CreateView(parent, name, viewContext, attrs);
                 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Null reference in some rare cases where Activity/Fragment is rehydrated from java side

### :new: What is the new behavior (if this is a feature change)?
Fix null reference by instantiating binding visitor and factories in ctor with handle

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Very hard to test

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
