### PR TITLE
Add missing constructor to MvxActivity<T>

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxActivity.cs
@@ -156,6 +156,14 @@ namespace MvvmCross.Platforms.Android.Views
             set { base.ViewModel = value; }
         }
 
+        protected MvxActivity() : base()
+        {
+        }
+
+        protected MvxActivity(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+        }
+
         public MvxFluentBindingDescriptionSet<IMvxAndroidView<TViewModel>, TViewModel> CreateBindingSet()
         {
             return this.CreateBindingSet<IMvxAndroidView<TViewModel>, TViewModel>();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
There is no `(IntPtr ptr, JniHandleOwnership ownership)` ctor in `MvxActivity<T>`.

### :new: What is the new behavior (if this is a feature change)?
Adds missed ctor.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
None.

### :memo: Links to relevant issues/docs
None.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
