### PR TITLE
Centralize NuGet package versions + bump AndroidX packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -44,4 +44,24 @@
   </PropertyGroup>
 
   <Import Project="XamarinForms.targets" Condition="'$(IsXamarinForms)' == 'true'"/>
+
+  <ItemGroup>
+    <PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.1.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.Leanback" Version="1.0.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.0.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.CardView" Version="1.0.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.1.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.Fragment" Version="1.2.4.2" />
+    <PackageReference Update="Xamarin.AndroidX.Preference" Version="1.1.1.2" />
+    <PackageReference Update="Xamarin.AndroidX.ViewPager" Version="1.0.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.ExifInterface" Version="1.1.0.2" />
+    <PackageReference Update="Xamarin.Google.Android.Material" Version="1.0.0.1" />
+    <PackageReference Update="Xamarin.GooglePlayServices.Location" Version="71.1600.4" />
+
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="3.7.0" />
+
+    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+
+    <PackageReference Update="SidebarNavigation" Version="2.1.0" />
+  </ItemGroup>
 </Project>

--- a/MvvmCross.Analyzers/CodeAnalysis/MvvmCross.CodeAnalysis.csproj
+++ b/MvvmCross.Analyzers/CodeAnalysis/MvvmCross.CodeAnalysis.csproj
@@ -9,7 +9,7 @@ This package contains the 'Code Analysis' analyzers and code fixes for MvvmCross
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
+++ b/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
@@ -16,8 +16,8 @@ This package contains AndroidX Leanback support for MvvmCross.</Description>
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Leanback" Version="1.0.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Leanback" />
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
+++ b/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
@@ -16,7 +16,8 @@ This package contains Support v7 Design support for MvvmCross.</Description>
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" />
+    <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
+++ b/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
@@ -16,7 +16,7 @@ This package contains AndroidX RecyclerView support for MvvmCross.</Description>
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
+++ b/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
@@ -16,7 +16,7 @@ This package contains Support Core UI support for MvvmCross.</Description>
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MvvmCross.Forms/MvvmCross.Forms.csproj
+++ b/MvvmCross.Forms/MvvmCross.Forms.csproj
@@ -80,8 +80,8 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('monoandroid')) ">
     <Compile Include="Platforms\Android\**\*.cs" />
     <Compile Include="Platforms\Xamarin\**\*.cs" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" />
+    <PackageReference Include="Xamarin.AndroidX.CardView" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">

--- a/MvvmCross.Plugins/Json/MvvmCross.Plugin.Json.csproj
+++ b/MvvmCross.Plugins/Json/MvvmCross.Plugin.Json.csproj
@@ -10,7 +10,7 @@ This package contains the 'Json' plugin for MvvmCross</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MvvmCross.Plugins/Location.Fused/MvvmCross.Plugin.Location.Fused.csproj
+++ b/MvvmCross.Plugins/Location.Fused/MvvmCross.Plugin.Location.Fused.csproj
@@ -10,7 +10,7 @@ This package contains the implementation of FusedLocationApi as 'Location' plugi
   </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('monoandroid')) ">
-    <PackageReference Include="Xamarin.GooglePlayServices.Location" Version="71.1600.4" />
+    <PackageReference Include="Xamarin.GooglePlayServices.Location" />
     <None Include="Resources\*.cs" />
     <Compile Remove="Resources\*.cs" />
     <ProjectReference Include="..\..\MvvmCross\MvvmCross.csproj" />

--- a/MvvmCross.Plugins/PictureChooser/MvvmCross.Plugin.PictureChooser.csproj
+++ b/MvvmCross.Plugins/PictureChooser/MvvmCross.Plugin.PictureChooser.csproj
@@ -81,7 +81,7 @@ This package contains the 'PictureChooser' plugin for MvvmCross</Description>
     <Compile Include="Platforms\Android\**\*.cs" />
     <Compile Include="Platforms\Xamarin\**\*.cs" />
     <AndroidResource Include="Resources\**\*.xml" SubType="Designer" Generator="MSBuild:UpdateAndroidResources" />
-    <PackageReference Include="Xamarin.AndroidX.ExifInterface" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.ExifInterface" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">

--- a/MvvmCross.Plugins/Sidebar/MvvmCross.Plugin.Sidebar.csproj
+++ b/MvvmCross.Plugins/Sidebar/MvvmCross.Plugin.Sidebar.csproj
@@ -10,7 +10,7 @@ This package contains the 'Sidebar' plugin for MvvmCross</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SidebarNavigation" Version="2.1.0" />
+    <PackageReference Include="SidebarNavigation" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -85,11 +85,11 @@ This package contains the 'Core' libraries for MvvmCross</Description>
     <Compile Include="Platforms\Xamarin\**\*.cs" />
     <AndroidResource Include="Resources\**\*.xml" SubType="Designer" Generator="MSBuild:UpdateAndroidResources" />
   
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.2.4.1" />
-    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.1.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.ViewPager" Version="1.0.0.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" />
+    <PackageReference Include="Xamarin.AndroidX.Fragment" />
+    <PackageReference Include="Xamarin.AndroidX.Preference" />
+    <PackageReference Include="Xamarin.AndroidX.ViewPager" />
+    <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature-ish

### :arrow_heading_down: What is the current behavior?
Package versions spread all over projects
"old" AndroidX packages used

### :new: What is the new behavior (if this is a feature change)?
Centralized package versions in Directory.Build.targets file
Bumped AndroidX packages
- Kept Xamarin.AndroidX.AppCompat at 1.1.0.2 as the newer package is broken and missing `AppCompatDialogFragment`

### :boom: Does this PR introduce a breaking change?
Not really

### :bug: Recommendations for testing
Does it build?

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
