### PR TITLE
Fix: Typo: Event name PropertyChanged

### DIFF
--- a/docs/_documentation/advanced/custom-data-binding.md
+++ b/docs/_documentation/advanced/custom-data-binding.md
@@ -127,7 +127,7 @@ This class is a subclass of [`MvxConvertingTargetBinding`](#mvxconvertingtargetb
 
 #### MvxWithEventPropertyInfoTargetBinding
 
-This class is a subclass of [`MvxPropertyInfoTargetBinding`](#mvxpropertyinfotargetbinding), which is a shortcut to adding `TwoWay` bindings based on a specific event. Similarly to `MvxPropertyInfoTargetBinding` it uses the `PropertyInfo` to implement the `SetValue()` method. Additionally it implements the `SubscribeToEvents()` method, based on the assumption that there is an event which is called the same as the name of the property, postfixed with `Changed`. So if your property is called `MyProperty` it assumes that the corresponding event is called `MyPropertChanged`.
+This class is a subclass of [`MvxPropertyInfoTargetBinding`](#mvxpropertyinfotargetbinding), which is a shortcut to adding `TwoWay` bindings based on a specific event. Similarly to `MvxPropertyInfoTargetBinding` it uses the `PropertyInfo` to implement the `SetValue()` method. Additionally it implements the `SubscribeToEvents()` method, based on the assumption that there is an event which is called the same as the name of the property, postfixed with `Changed`. So if your property is called `MyProperty` it assumes that the corresponding event is called `MyPropertyChanged`.
 
 #### MvxEventNameTargetBinding
 


### PR DESCRIPTION
An event whose name should be MyPropertyChanged had MyPropertChanged as the name instead.

### :sparkles: What kind of change does this PR introduce?
Docs update

### :boom: Does this PR introduce a breaking change?
No

### :memo: Links to relevant issues/docs
https://www.mvvmcross.com/documentation/advanced/custom-data-binding?scroll=432#mvxwitheventpropertyinfotargetbinding

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
