### PR TITLE
Add ability to Add fragment instead of always replacing it

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -27,7 +27,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             bool isCacheableFragment = false,
             string tag = null,
             string popBackStackImmediateName = "",
-            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive
+            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
+            bool addFragment = false
         )
         {
             ActivityHostViewModelType = activityHostViewModelType;
@@ -43,6 +44,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             Tag = tag;
             PopBackStackImmediateName = popBackStackImmediateName;
             PopBackStackImmediateFlag = popBackStackImmediateFlag;
+            AddFragment = addFragment;
         }
 
         public MvxFragmentPresentationAttribute(
@@ -58,7 +60,8 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             bool isCacheableFragment = false,
             string tag = null,
             string popBackStackImmediateName = "",
-            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive
+            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
+            bool addFragment = false
         )
         {
             var context = Mvx.IoCProvider.Resolve<IMvxAndroidGlobals>().ApplicationContext;
@@ -76,6 +79,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
             Tag = tag;
             PopBackStackImmediateName = popBackStackImmediateName;
             PopBackStackImmediateFlag = popBackStackImmediateFlag;
+            AddFragment = addFragment;
         }
 
         /// <summary>
@@ -124,6 +128,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
         public int TransitionStyle { get; set; } = DefaultTransitionStyle;
 
         public static bool DefaultIsCacheableFragment = false;
+
         /// <summary>
         /// Indicates if the fragment can be cached. False by default.
         /// </summary>
@@ -135,6 +140,7 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
         public string Tag { get; set; }
 
         public static string DefaultPopBackStackImmediateName = "";
+
         /// <summary>
         /// The name to be passed into PopBackStackImmediate.
         /// Assigning an empty string will default to using the FragmentJavaName
@@ -143,9 +149,15 @@ namespace MvvmCross.Platforms.Android.Presenters.Attributes
         public string PopBackStackImmediateName { get; set; } = DefaultPopBackStackImmediateName;
 
         public static MvxPopBackStack DefaultPopBackStackImmediateFlag = MvxPopBackStack.Inclusive;
+
         /// <summary>
         /// Flag to be used with PopBackStackImmediate. 
         /// </summary>
         public MvxPopBackStack PopBackStackImmediateFlag { get; set; } = DefaultPopBackStackImmediateFlag;
+
+        /// <summary>
+        /// Setting this to true, will use Add instead of Replace on the Fragment transaction
+        /// </summary>
+        public bool AddFragment { get; set; }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
We _always_ replace fragments.

### :new: What is the new behavior (if this is a feature change)?
This PR allows fragments to be added on top of eachother. If a Fragment is marked as IsCachableFragment, and it is navigated to while already being in the stack. We simply call Show on it, instead of Adding again.

### :boom: Does this PR introduce a breaking change?
Nope.

### :bug: Recommendations for testing
Try use the `addFragment` argument in `MvxFragmentPresentationAttribute`.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
