### PR TITLE
Revert change to InflateViewForHolder in #3802

### DIFF
--- a/MvvmCross.DroidX/RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.DroidX/RecyclerView/MvxRecyclerAdapter.cs
@@ -142,8 +142,7 @@ namespace MvvmCross.DroidX.RecyclerView
 
         protected virtual View InflateViewForHolder(ViewGroup parent, int viewType, IMvxAndroidBindingContext bindingContext)
         {
-            var layoutId = ItemTemplateSelector.GetItemLayoutId (viewType);
-            return bindingContext.BindingInflate(layoutId, parent, false);
+            return bindingContext.BindingInflate(viewType, parent, false);
         }
 
         public override void OnBindViewHolder(AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder holder, int position)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
#3802 introduced a regression into how TemplateSelectors work with MvxRecyclerView

This was wrong change. The TemplateSelectors were working as expected prior to the change.
This introduced a breaking change to how they behave. viewType passed into `InflateViewForHolder` will be the id of the View if the TemplateSelector is implemented correctly.

### :new: What is the new behavior (if this is a feature change)?
Revert the change

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#3802 

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
