### PR TITLE
Enable Nullable References on MvxDefaultViewModelLocator

### DIFF
--- a/MvvmCross/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Navigation/IMvxNavigationService.cs
@@ -65,7 +65,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new();
+        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class;
 
         /// <summary>
         /// Navigates to an instance of a ViewModel and returns TResult
@@ -75,7 +75,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
+        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
 
         /// <summary>
         /// Navigates to an instance of a ViewModel passes TParameter and returns TResult
@@ -87,7 +87,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new();
+        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
 
         /// <summary>
         /// Navigates to a ViewModel Type
@@ -107,7 +107,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new();
+        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class;
 
         /// <summary>
         /// Navigates to a ViewModel Type passes and returns TResult
@@ -117,7 +117,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
+        Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
 
         /// <summary>
         /// Navigates to a ViewModel Type passes TParameter and returns TResult
@@ -129,7 +129,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new();
+        Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -149,7 +149,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new();
+        Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class;
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -159,7 +159,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
+        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -171,19 +171,19 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new();
+        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
 
         Task<bool> Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModel;
 
         Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new();
+            where TViewModel : IMvxViewModel<TParameter> where TParameter : class;
 
         Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModelResult<TResult> where TResult : class, new();
+            where TViewModel : IMvxViewModelResult<TResult> where TResult : class;
 
         Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new();
+            where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class;
 
         /// <summary>
         /// Verifies if the provided Uri can be routed to a ViewModel request.
@@ -221,7 +221,7 @@ namespace MvvmCross.Navigation
         /// <param name="result"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
+        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
 
         /// <summary>
         /// Dispatches a ChangePresentation with Hint

--- a/MvvmCross/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Navigation/IMvxNavigationService.cs
@@ -65,7 +65,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new();
 
         /// <summary>
         /// Navigates to an instance of a ViewModel and returns TResult
@@ -75,7 +75,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
 
         /// <summary>
         /// Navigates to an instance of a ViewModel passes TParameter and returns TResult
@@ -87,7 +87,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new();
 
         /// <summary>
         /// Navigates to a ViewModel Type
@@ -107,7 +107,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new();
 
         /// <summary>
         /// Navigates to a ViewModel Type passes and returns TResult
@@ -117,7 +117,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
 
         /// <summary>
         /// Navigates to a ViewModel Type passes TParameter and returns TResult
@@ -129,7 +129,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new();
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -149,7 +149,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new();
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -159,7 +159,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -171,19 +171,19 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new();
 
         Task<bool> Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModel;
 
         Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModel<TParameter>;
+            where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new();
 
         Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModelResult<TResult>;
+            where TViewModel : IMvxViewModelResult<TResult> where TResult : class, new();
 
         Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModel<TParameter, TResult>;
+            where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new();
 
         /// <summary>
         /// Verifies if the provided Uri can be routed to a ViewModel request.
@@ -221,7 +221,7 @@ namespace MvvmCross.Navigation
         /// <param name="result"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken));
+        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new();
 
         /// <summary>
         /// Dispatches a ChangePresentation with Hint

--- a/MvvmCross/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Navigation/MvxNavigationExtensions.cs
@@ -35,17 +35,17 @@ namespace MvvmCross.Navigation
             return navigationService.Navigate(path.ToString(), presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
+        public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
         {
             return navigationService.Navigate<TParameter>(path.ToString(), param, presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
+        public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             return navigationService.Navigate<TResult>(path.ToString(), presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
+        public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
         {
             return navigationService.Navigate<TParameter, TResult>(path.ToString(), param, presentationBundle, cancellationToken);
         }

--- a/MvvmCross/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Navigation/MvxNavigationExtensions.cs
@@ -35,17 +35,17 @@ namespace MvvmCross.Navigation
             return navigationService.Navigate(path.ToString(), presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
         {
             return navigationService.Navigate<TParameter>(path.ToString(), param, presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
         {
             return navigationService.Navigate<TResult>(path.ToString(), presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
         {
             return navigationService.Navigate<TParameter, TResult>(path.ToString(), param, presentationBundle, cancellationToken);
         }

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -21,9 +21,10 @@ using MvvmCross.Views;
 
 namespace MvvmCross.Navigation
 {
+    /// <inheritdoc cref="IMvxNavigationService"/>
     public class MvxNavigationService : IMvxNavigationService
     {
-        protected readonly IMvxLog Log = Mvx.IoCProvider.Resolve<IMvxLogProvider>().GetLogFor<MvxNavigationService>();
+        private readonly IMvxLog _log = Mvx.IoCProvider.Resolve<IMvxLogProvider>().GetLogFor<MvxNavigationService>();
 
         private IMvxViewDispatcher _viewDispatcher;
 
@@ -94,7 +95,7 @@ namespace MvvmCross.Navigation
                 {
                     case 0:
                         entry = default(KeyValuePair<Regex, Type>);
-                        Log.Trace("Unable to find routing for {0}", url);
+                        _log.Trace("Unable to find routing for {0}", url);
                         return false;
 
                     case 1:
@@ -110,7 +111,7 @@ namespace MvvmCross.Navigation
                     return true;
                 }
 
-                Log.Warn("The following regular expressions match the provided url ({0}), each RegEx must be unique (otherwise try using IMvxRoutingFacade): {1}",
+                _log.Warn("The following regular expressions match the provided url ({0}), each RegEx must be unique (otherwise try using IMvxRoutingFacade): {1}",
                     matches.Count - 1,
                     string.Join(", ", matches.Select(t => t.Key.ToString())));
 
@@ -120,7 +121,7 @@ namespace MvvmCross.Navigation
             }
             catch (Exception ex)
             {
-                Log.Error("MvxNavigationService", "Unable to determine routability: {0}", ex);
+                _log.Error("MvxNavigationService", "Unable to determine routability: {0}", ex);
                 entry = default(KeyValuePair<Regex, Type>);
                 return false;
             }
@@ -203,7 +204,7 @@ namespace MvvmCross.Navigation
             return request;
         }
 
-        protected async Task<MvxViewModelInstanceRequest> NavigationRouteRequest<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null)
+        protected async Task<MvxViewModelInstanceRequest> NavigationRouteRequest<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class, new()
         {
             KeyValuePair<Regex, Type> entry;
 
@@ -295,7 +296,7 @@ namespace MvvmCross.Navigation
             return true;
         }
 
-        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
         {
             var hasNavigated = false;
             var tcs = new TaskCompletionSource<object>();
@@ -338,7 +339,7 @@ namespace MvvmCross.Navigation
             }
         }
 
-        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken), IMvxNavigateEventArgs args = null)
+        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken), IMvxNavigateEventArgs args = null) where TParameter : class, new() where TResult : class, new()
         {
             var hasNavigated = false;
             if (cancellationToken != default(CancellationToken))
@@ -386,19 +387,19 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
         {
             var request = await NavigationRouteRequest(path, param, presentationBundle).ConfigureAwait(false);
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
         {
             var request = await NavigationRouteRequest(path, param, presentationBundle).ConfigureAwait(false);
             return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
@@ -414,7 +415,7 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
@@ -424,7 +425,7 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
@@ -434,7 +435,7 @@ namespace MvvmCross.Navigation
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
         {
             var args = new MvxNavigateEventArgs(NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModelType)
@@ -451,17 +452,17 @@ namespace MvvmCross.Navigation
             return Navigate(typeof(TViewModel), presentationBundle, cancellationToken);
         }
 
-        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter>
+        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new()
         {
             return Navigate(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
 
-        public virtual Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult>
+        public virtual Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult> where TResult : class, new()
         {
             return Navigate<TResult>(typeof(TViewModel), presentationBundle, cancellationToken);
         }
 
-        public virtual Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult>
+        public virtual Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new()
         {
             return Navigate<TParameter, TResult>(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
@@ -473,21 +474,21 @@ namespace MvvmCross.Navigation
             return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
             return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
             return await Navigate<TResult>(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
         {
             var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
@@ -526,7 +527,7 @@ namespace MvvmCross.Navigation
             return close;
         }
 
-        public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
         {
             _tcsResults.TryGetValue(viewModel, out var _tcs);
 

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -204,7 +204,7 @@ namespace MvvmCross.Navigation
             return request;
         }
 
-        protected async Task<MvxViewModelInstanceRequest> NavigationRouteRequest<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class, new()
+        protected async Task<MvxViewModelInstanceRequest> NavigationRouteRequest<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class
         {
             KeyValuePair<Regex, Type> entry;
 
@@ -296,7 +296,7 @@ namespace MvvmCross.Navigation
             return true;
         }
 
-        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
+        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             var hasNavigated = false;
             var tcs = new TaskCompletionSource<object>();
@@ -339,7 +339,7 @@ namespace MvvmCross.Navigation
             }
         }
 
-        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken), IMvxNavigateEventArgs args = null) where TParameter : class, new() where TResult : class, new()
+        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken), IMvxNavigateEventArgs args = null) where TParameter : class where TResult : class
         {
             var hasNavigated = false;
             if (cancellationToken != default(CancellationToken))
@@ -387,19 +387,19 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
+        public virtual async Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
         {
             var request = await NavigationRouteRequest(path, param, presentationBundle).ConfigureAwait(false);
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
+        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
         {
             var request = await NavigationRouteRequest(path, param, presentationBundle).ConfigureAwait(false);
             return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
@@ -415,7 +415,7 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
+        public virtual async Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
@@ -425,7 +425,7 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
+        public virtual async Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
@@ -435,7 +435,7 @@ namespace MvvmCross.Navigation
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
         {
             var args = new MvxNavigateEventArgs(NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModelType)
@@ -452,17 +452,17 @@ namespace MvvmCross.Navigation
             return Navigate(typeof(TViewModel), presentationBundle, cancellationToken);
         }
 
-        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new()
+        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter> where TParameter : class
         {
             return Navigate(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
 
-        public virtual Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult> where TResult : class, new()
+        public virtual Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult> where TResult : class
         {
             return Navigate<TResult>(typeof(TViewModel), presentationBundle, cancellationToken);
         }
 
-        public virtual Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new()
+        public virtual Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class
         {
             return Navigate<TParameter, TResult>(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
@@ -474,21 +474,21 @@ namespace MvvmCross.Navigation
             return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new()
+        public virtual async Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
             return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
+        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
             return await Navigate<TResult>(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class, new() where TResult : class, new()
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
         {
             var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
@@ -527,7 +527,7 @@ namespace MvvmCross.Navigation
             return close;
         }
 
-        public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class, new()
+        public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
         {
             _tcsResults.TryGetValue(viewModel, out var _tcs);
 

--- a/MvvmCross/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxViewModel.cs
@@ -37,22 +37,22 @@ namespace MvvmCross.ViewModels
     }
 
     public interface IMvxViewModel<TParameter>
-        : IMvxViewModel where TParameter : class, new()
+        : IMvxViewModel where TParameter : class
     {
         void Prepare(TParameter? parameter);
     }
 
     public interface IMvxViewModelResult<TResult>
         : IMvxViewModel
-        where TResult : class, new()
+        where TResult : class
     {
         TaskCompletionSource<object>? CloseCompletionSource { get; set; }
     }
 
     public interface IMvxViewModel<TParameter, TResult>
         : IMvxViewModel<TParameter>, IMvxViewModelResult<TResult>
-        where TParameter : class, new()
-        where TResult : class, new()
+        where TParameter : class
+        where TResult : class
     {
     }
 #nullable restore

--- a/MvvmCross/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxViewModel.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using MvvmCross.Navigation;
 
 namespace MvvmCross.ViewModels
 {
+#nullable enable
     public interface IMvxViewModel
     {
         void ViewCreated();
@@ -36,18 +36,24 @@ namespace MvvmCross.ViewModels
         MvxNotifyTask InitializeTask { get; set; }
     }
 
-    public interface IMvxViewModel<TParameter> : IMvxViewModel
+    public interface IMvxViewModel<TParameter>
+        : IMvxViewModel where TParameter : class, new()
     {
-        void Prepare(TParameter parameter);
+        void Prepare(TParameter? parameter);
     }
 
-    //TODO: Can we keep the IMvxViewModel syntax here? Compiler complains
-    public interface IMvxViewModelResult<TResult> : IMvxViewModel
+    public interface IMvxViewModelResult<TResult>
+        : IMvxViewModel
+        where TResult : class, new()
     {
-        TaskCompletionSource<object> CloseCompletionSource { get; set; }
+        TaskCompletionSource<object>? CloseCompletionSource { get; set; }
     }
 
-    public interface IMvxViewModel<TParameter, TResult> : IMvxViewModel<TParameter>, IMvxViewModelResult<TResult>
+    public interface IMvxViewModel<TParameter, TResult>
+        : IMvxViewModel<TParameter>, IMvxViewModelResult<TResult>
+        where TParameter : class, new()
+        where TResult : class, new()
     {
     }
+#nullable restore
 }

--- a/MvvmCross/ViewModels/IMvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLoader.cs
@@ -10,10 +10,10 @@ namespace MvvmCross.ViewModels
     {
         IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class, new();
+        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class;
 
         IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class, new();
+        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class;
     }
 }

--- a/MvvmCross/ViewModels/IMvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLoader.cs
@@ -10,10 +10,10 @@ namespace MvvmCross.ViewModels
     {
         IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
+        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class, new();
 
         IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
+        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class, new();
     }
 }

--- a/MvvmCross/ViewModels/IMvxViewModelLocator.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLocator.cs
@@ -43,7 +43,7 @@ namespace MvvmCross.ViewModels
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
             IMvxNavigateEventArgs? navigationArgs = null)
-            where TParameter : class, new();
+            where TParameter : class;
 
         /// <summary>
         /// Reload ViewModel, runs start lifecycle in ViewModel.
@@ -75,7 +75,7 @@ namespace MvvmCross.ViewModels
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
             IMvxNavigateEventArgs? navigationArgs = null)
-            where TParameter : class, new();
+            where TParameter : class;
     }
 #nullable restore
 }

--- a/MvvmCross/ViewModels/IMvxViewModelLocator.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLocator.cs
@@ -7,14 +7,75 @@ using MvvmCross.Navigation.EventArguments;
 
 namespace MvvmCross.ViewModels
 {
+#nullable enable
+    /// <summary>
+    /// ViewModelLocator helps locating and running start lifecycle of a ViewModel
+    /// </summary>
     public interface IMvxViewModelLocator
     {
-        IMvxViewModel Load(Type viewModelType, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
+        /// <summary>
+        /// Load ViewModel
+        /// </summary>
+        /// <param name="viewModelType"><see cref="Type"/> of ViewModel to load</param>
+        /// <param name="parameterValues">Parameter values to pass into Init methods of ViewModel</param>
+        /// <param name="savedState">Saved state to pass into RestoreState methods of ViewModel</param>
+        /// <param name="navigationArgs">(Optional) Extra navigation arguments</param>
+        /// <returns>Returns a ViewModel</returns>
+        IMvxViewModel Load(
+            Type viewModelType,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs = null);
 
-        IMvxViewModel<TParameter> Load<TParameter>(Type viewModelType, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
+        /// <summary>
+        /// Load ViewModel with parameters
+        /// </summary>
+        /// <typeparam name="TParameter">Type of parameter to pass into <see cref="IMvxViewModel{TParameter}.Prepare(TParameter)"/> method</typeparam>
+        /// <param name="viewModelType"><see cref="Type"/> of ViewModel to load</param>
+        /// <param name="param">Parameters to pass into <see cref="IMvxViewModel{TParameter}.Prepare(TParameter)"/> method</param>
+        /// <param name="parameterValues">Parameter values to pass into Init methods of ViewModel</param>
+        /// <param name="savedState">Saved state to pass into RestoreState methods of ViewModel</param>
+        /// <param name="navigationArgs">(Optional) Extra navigation arguments</param>
+        /// <returns>Returns a ViewModel</returns>
+        IMvxViewModel<TParameter> Load<TParameter>(
+            Type viewModelType,
+            TParameter? param,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs = null)
+            where TParameter : class, new();
 
-        IMvxViewModel Reload(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
+        /// <summary>
+        /// Reload ViewModel, runs start lifecycle in ViewModel.
+        /// </summary>
+        /// <param name="viewModel"><see cref="IMvxViewModel"/> to reload</param>
+        /// <param name="parameterValues">Parameter values to pass into Init methods of ViewModel</param>
+        /// <param name="savedState">Saved state to pass into RestoreState methods of ViewModel</param>
+        /// <param name="navigationArgs">(Optional) Extra navigation arguments</param>
+        /// <returns>Returns reloaded ViewModel</returns>
+        IMvxViewModel Reload(
+            IMvxViewModel viewModel,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs = null);
 
-        IMvxViewModel<TParameter> Reload<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
+        /// <summary>
+        /// Reload ViewModel, runs start lifecycle in ViewModel.
+        /// </summary>
+        /// <typeparam name="TParameter">Type of parameter to pass into <see cref="IMvxViewModel{TParameter}.Prepare(TParameter)"/> method</typeparam>
+        /// <param name="viewModel"><see cref="IMvxViewModel"/> to reload</param>
+        /// <param name="param">Parameters to pass into <see cref="IMvxViewModel{TParameter}.Prepare(TParameter)"/> method</param>
+        /// <param name="parameterValues">Parameter values to pass into Init methods of ViewModel</param>
+        /// <param name="savedState">Saved state to pass into RestoreState methods of ViewModel</param>
+        /// <param name="navigationArgs">(Optional) Extra navigation arguments</param>
+        /// <returns>Returns reloaded ViewModel</returns>
+        IMvxViewModel<TParameter> Reload<TParameter>(
+            IMvxViewModel<TParameter> viewModel,
+            TParameter? param,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs = null)
+            where TParameter : class, new();
     }
+#nullable restore
 }

--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -85,7 +85,7 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public class MvxAppStart<TViewModel, TParameter> : MvxAppStart<TViewModel> where TViewModel : IMvxViewModel<TParameter>
+    public class MvxAppStart<TViewModel, TParameter> : MvxAppStart<TViewModel> where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new()
     {
         public MvxAppStart(IMvxApplication application, IMvxNavigationService navigationService) : base(application, navigationService)
         {

--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -85,7 +85,7 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public class MvxAppStart<TViewModel, TParameter> : MvxAppStart<TViewModel> where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new()
+    public class MvxAppStart<TViewModel, TParameter> : MvxAppStart<TViewModel> where TViewModel : IMvxViewModel<TParameter> where TParameter : class
     {
         public MvxAppStart(IMvxApplication application, IMvxNavigationService navigationService) : base(application, navigationService)
         {

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -85,7 +85,7 @@ namespace MvvmCross.ViewModels
         }
 
         protected virtual void RegisterAppStart<TViewModel, TParameter>()
-          where TViewModel : IMvxViewModel<TParameter>
+          where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new()
         {
             Mvx.IoCProvider.ConstructAndRegisterSingleton<IMvxAppStart, MvxAppStart<TViewModel, TParameter>>();
         }

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -85,7 +85,7 @@ namespace MvvmCross.ViewModels
         }
 
         protected virtual void RegisterAppStart<TViewModel, TParameter>()
-          where TViewModel : IMvxViewModel<TParameter> where TParameter : class, new()
+          where TViewModel : IMvxViewModel<TParameter> where TParameter : class
         {
             Mvx.IoCProvider.ConstructAndRegisterSingleton<IMvxAppStart, MvxAppStart<TViewModel, TParameter>>();
         }

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -42,7 +42,7 @@ namespace MvvmCross.ViewModels
             TParameter? param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
-            IMvxNavigateEventArgs? navigationArgs) where TParameter : class, new()
+            IMvxNavigateEventArgs? navigationArgs) where TParameter : class
         {
             if (viewModelType == null)
                 throw new ArgumentNullException(nameof(viewModelType));
@@ -78,7 +78,7 @@ namespace MvvmCross.ViewModels
             TParameter? param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
-            IMvxNavigateEventArgs? navigationArgs) where TParameter : class, new()
+            IMvxNavigateEventArgs? navigationArgs) where TParameter : class
         {
             RunViewModelLifecycle(viewModel, param, parameterValues, savedState, navigationArgs);
 
@@ -136,7 +136,7 @@ namespace MvvmCross.ViewModels
             TParameter? param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
-            IMvxNavigateEventArgs? navigationArgs) where TParameter : class, new()
+            IMvxNavigateEventArgs? navigationArgs) where TParameter : class
         {
             if (viewModel == null)
                 throw new ArgumentNullException(nameof(viewModel));

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -4,52 +4,24 @@
 
 using System;
 using MvvmCross.Exceptions;
-using MvvmCross.Logging;
-using MvvmCross.Navigation;
 using MvvmCross.Navigation.EventArguments;
 
 namespace MvvmCross.ViewModels
 {
+#nullable enable
+    /// <inheritdoc cref="IMvxViewModelLocator"/>
     public class MvxDefaultViewModelLocator
         : IMvxViewModelLocator
     {
-        private IMvxNavigationService _navigationService;
-        protected IMvxNavigationService NavigationService => _navigationService ?? (_navigationService = Mvx.IoCProvider.Resolve<IMvxNavigationService>());
-
-        private IMvxLogProvider _logProvider;
-        protected IMvxLogProvider LogProvider => _logProvider ?? (_logProvider = Mvx.IoCProvider.Resolve<IMvxLogProvider>());
-
-        public MvxDefaultViewModelLocator() : this(null) { }
-
-        public MvxDefaultViewModelLocator(IMvxNavigationService navigationService)
+        public virtual IMvxViewModel Load(
+            Type viewModelType,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs)
         {
-            if (navigationService != null)
-                _navigationService = navigationService;
-        }
+            if (viewModelType == null)
+                throw new ArgumentNullException(nameof(viewModelType));
 
-        public virtual IMvxViewModel Reload(IMvxViewModel viewModel,
-                                            IMvxBundle parameterValues,
-                                            IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
-        {
-            RunViewModelLifecycle(viewModel, parameterValues, savedState, navigationArgs);
-
-            return viewModel;
-        }
-
-        public virtual IMvxViewModel<TParameter> Reload<TParameter>(IMvxViewModel<TParameter> viewModel,
-                                                                    TParameter param,
-                                                                    IMvxBundle parameterValues,
-                                                                    IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
-        {
-            RunViewModelLifecycle(viewModel, param, parameterValues, savedState, navigationArgs);
-
-            return viewModel;
-        }
-
-        public virtual IMvxViewModel Load(Type viewModelType,
-                                          IMvxBundle parameterValues,
-                                          IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
-        {
             IMvxViewModel viewModel;
             try
             {
@@ -65,11 +37,16 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public virtual IMvxViewModel<TParameter> Load<TParameter>(Type viewModelType,
-                                                                  TParameter param,
-                                                                  IMvxBundle parameterValues,
-                                                                  IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
+        public virtual IMvxViewModel<TParameter> Load<TParameter>(
+            Type viewModelType,
+            TParameter? param,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs) where TParameter : class, new()
         {
+            if (viewModelType == null)
+                throw new ArgumentNullException(nameof(viewModelType));
+
             IMvxViewModel<TParameter> viewModel;
             try
             {
@@ -85,18 +62,48 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        protected virtual void CallCustomInitMethods(IMvxViewModel viewModel, IMvxBundle parameterValues)
+        public virtual IMvxViewModel Reload(
+            IMvxViewModel viewModel,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs)
+        {
+            RunViewModelLifecycle(viewModel, parameterValues, savedState, navigationArgs);
+
+            return viewModel;
+        }
+
+        public virtual IMvxViewModel<TParameter> Reload<TParameter>(
+            IMvxViewModel<TParameter> viewModel,
+            TParameter? param,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs) where TParameter : class, new()
+        {
+            RunViewModelLifecycle(viewModel, param, parameterValues, savedState, navigationArgs);
+
+            return viewModel;
+        }
+
+        protected virtual void CallCustomInitMethods(IMvxViewModel viewModel, IMvxBundle? parameterValues)
         {
             viewModel.CallBundleMethods("Init", parameterValues);
         }
 
-        protected virtual void CallReloadStateMethods(IMvxViewModel viewModel, IMvxBundle savedState)
+        protected virtual void CallReloadStateMethods(IMvxViewModel viewModel, IMvxBundle? savedState)
         {
             viewModel.CallBundleMethods("ReloadState", savedState);
         }
 
-        protected void RunViewModelLifecycle(IMvxViewModel viewModel, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
+        protected void RunViewModelLifecycle(
+            IMvxViewModel viewModel,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs)
         {
+            if (viewModel == null)
+                throw new ArgumentNullException(nameof(viewModel));
+
             try
             {
                 CallCustomInitMethods(viewModel, parameterValues);
@@ -124,8 +131,16 @@ namespace MvvmCross.ViewModels
             }
         }
 
-        protected void RunViewModelLifecycle<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle parameterValues, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
+        protected void RunViewModelLifecycle<TParameter>(
+            IMvxViewModel<TParameter> viewModel,
+            TParameter? param,
+            IMvxBundle? parameterValues,
+            IMvxBundle? savedState,
+            IMvxNavigateEventArgs? navigationArgs) where TParameter : class, new()
         {
+            if (viewModel == null)
+                throw new ArgumentNullException(nameof(viewModel));
+
             try
             {
                 CallCustomInitMethods(viewModel, parameterValues);
@@ -157,4 +172,5 @@ namespace MvvmCross.ViewModels
             }
         }
     }
+#nullable restore
 }

--- a/MvvmCross/ViewModels/MvxNavigationViewModel.cs
+++ b/MvvmCross/ViewModels/MvxNavigationViewModel.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.ViewModels
         protected virtual IMvxLog Log => _log ?? (_log = LogProvider.GetLogFor(GetType()));
     }
 
-    public abstract class MvxNavigationViewModel<TParameter> : MvxNavigationViewModel, IMvxViewModel<TParameter>
+    public abstract class MvxNavigationViewModel<TParameter> : MvxNavigationViewModel, IMvxViewModel<TParameter> where TParameter : class, new()
     {
         protected MvxNavigationViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {
@@ -36,7 +36,7 @@ namespace MvvmCross.ViewModels
     }
 
     //TODO: Not possible to name MvxViewModel, name is MvxViewModelResult for now
-    public abstract class MvxNavigationViewModelResult<TResult> : MvxNavigationViewModel, IMvxViewModelResult<TResult>
+    public abstract class MvxNavigationViewModelResult<TResult> : MvxNavigationViewModel, IMvxViewModelResult<TResult> where TResult : class, new()
     {
         protected MvxNavigationViewModelResult(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {
@@ -53,7 +53,7 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxNavigationViewModel<TParameter, TResult> : MvxNavigationViewModelResult<TResult>, IMvxViewModel<TParameter, TResult>
+    public abstract class MvxNavigationViewModel<TParameter, TResult> : MvxNavigationViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new()
     {
         protected MvxNavigationViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {

--- a/MvvmCross/ViewModels/MvxNavigationViewModel.cs
+++ b/MvvmCross/ViewModels/MvxNavigationViewModel.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.ViewModels
         protected virtual IMvxLog Log => _log ?? (_log = LogProvider.GetLogFor(GetType()));
     }
 
-    public abstract class MvxNavigationViewModel<TParameter> : MvxNavigationViewModel, IMvxViewModel<TParameter> where TParameter : class, new()
+    public abstract class MvxNavigationViewModel<TParameter> : MvxNavigationViewModel, IMvxViewModel<TParameter> where TParameter : class
     {
         protected MvxNavigationViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {
@@ -36,7 +36,7 @@ namespace MvvmCross.ViewModels
     }
 
     //TODO: Not possible to name MvxViewModel, name is MvxViewModelResult for now
-    public abstract class MvxNavigationViewModelResult<TResult> : MvxNavigationViewModel, IMvxViewModelResult<TResult> where TResult : class, new()
+    public abstract class MvxNavigationViewModelResult<TResult> : MvxNavigationViewModel, IMvxViewModelResult<TResult> where TResult : class
     {
         protected MvxNavigationViewModelResult(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {
@@ -53,7 +53,7 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxNavigationViewModel<TParameter, TResult> : MvxNavigationViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new()
+    public abstract class MvxNavigationViewModel<TParameter, TResult> : MvxNavigationViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class
     {
         protected MvxNavigationViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService) : base(logProvider, navigationService)
         {

--- a/MvvmCross/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/ViewModels/MvxViewModel.cs
@@ -87,13 +87,13 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxViewModel<TParameter> : MvxViewModel, IMvxViewModel<TParameter> where TParameter : class, new()
+    public abstract class MvxViewModel<TParameter> : MvxViewModel, IMvxViewModel<TParameter> where TParameter : class
     {
         public abstract void Prepare(TParameter parameter);
     }
 
     //TODO: Not possible to name MvxViewModel, name is MvxViewModelResult for now
-    public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult> where TResult : class, new()
+    public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult> where TResult : class
     {
         public TaskCompletionSource<object> CloseCompletionSource { get; set; }
 
@@ -106,7 +106,7 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new()
+    public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class
     {
         public abstract void Prepare(TParameter parameter);
     }

--- a/MvvmCross/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/ViewModels/MvxViewModel.cs
@@ -87,13 +87,13 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxViewModel<TParameter> : MvxViewModel, IMvxViewModel<TParameter>
+    public abstract class MvxViewModel<TParameter> : MvxViewModel, IMvxViewModel<TParameter> where TParameter : class, new()
     {
         public abstract void Prepare(TParameter parameter);
     }
 
     //TODO: Not possible to name MvxViewModel, name is MvxViewModelResult for now
-    public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult>
+    public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult> where TResult : class, new()
     {
         public TaskCompletionSource<object> CloseCompletionSource { get; set; }
 
@@ -106,7 +106,7 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult>
+    public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class, new() where TResult : class, new()
     {
         public abstract void Prepare(TParameter parameter);
     }

--- a/MvvmCross/ViewModels/MvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/MvxViewModelLoader.cs
@@ -38,7 +38,7 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
+        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class, new()
         {
             var viewModelLocator = FindViewModelLocator(request);
 
@@ -81,7 +81,7 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
+        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class, new()
         {
             if (request.ViewModelType == typeof(MvxNullViewModel))
             {

--- a/MvvmCross/ViewModels/MvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/MvxViewModelLoader.cs
@@ -38,7 +38,7 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class, new()
+        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class
         {
             var viewModelLocator = FindViewModelLocator(request);
 
@@ -81,7 +81,7 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class, new()
+        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class
         {
             if (request.ViewModelType == typeof(MvxNullViewModel))
             {

--- a/UnitTests/MvvmCross.UnitTest/Mocks/ViewModels/SimpleParameterTestViewModel.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/ViewModels/SimpleParameterTestViewModel.cs
@@ -6,7 +6,12 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.UnitTest.Mocks.ViewModels
 {
-    public class SimpleParameterTestViewModel : MvxViewModel<string>
+    public class SimpleParameter
+    {
+        public string Hello { get; set; }
+    }
+
+    public class SimpleParameterTestViewModel : MvxViewModel<SimpleParameter>
     {
         public string Parameter { get; set; }
 
@@ -14,9 +19,9 @@ namespace MvvmCross.UnitTest.Mocks.ViewModels
         {
         }
 
-        public override void Prepare(string parameter)
+        public override void Prepare(SimpleParameter parameter)
         {
-            Parameter = parameter;
+            Parameter = parameter.Hello;
         }
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Mocks/ViewModels/SimpleResultTestViewModel.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/ViewModels/SimpleResultTestViewModel.cs
@@ -7,7 +7,12 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.UnitTest.Mocks.ViewModels
 {
-    public class SimpleResultTestViewModel : MvxViewModelResult<bool>
+    public class SimpleResult
+    {
+        public bool Result { get; set; }
+    }
+
+    public class SimpleResultTestViewModel : MvxViewModelResult<SimpleResult>
     {
         public SimpleResultTestViewModel()
         {
@@ -18,7 +23,7 @@ namespace MvvmCross.UnitTest.Mocks.ViewModels
             await base.Initialize();
 
             await Task.Delay(2000);
-            CloseCompletionSource.SetResult(true);
+            CloseCompletionSource.SetResult(new SimpleResult { Result = true });
         }
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/MvxTestCollection.cs
+++ b/UnitTests/MvvmCross.UnitTest/MvxTestCollection.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.UnitTest
         {
             var navigationServiceMock = new Mock<IMvxNavigationService>();
             Ioc.RegisterSingleton(navigationServiceMock.Object);
-            Ioc.RegisterSingleton(new MvxDefaultViewModelLocator(navigationServiceMock.Object));
+            Ioc.RegisterSingleton(new MvxDefaultViewModelLocator());
         }
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Navigation/NavigationServiceTests.cs
+++ b/UnitTests/MvvmCross.UnitTest/Navigation/NavigationServiceTests.cs
@@ -56,12 +56,12 @@ namespace MvvmCross.UnitTest.Navigation
                            return vm;
                        });
             MockLoader.Setup(
-                l => l.LoadViewModel<string>(It.IsAny<MvxViewModelRequest>(), It.IsAny<string>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
+                l => l.LoadViewModel<SimpleParameter>(It.IsAny<MvxViewModelRequest>(), It.IsAny<SimpleParameter>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                       .Returns(() =>
                       {
                           var vm = new SimpleParameterTestViewModel();
                           vm.Prepare();
-                          vm.Prepare("");
+                          vm.Prepare(new SimpleParameter { Hello = "" });
                           vm.InitializeTask = MvxNotifyTask.Create(() => vm.Initialize());
                           return vm;
                       });
@@ -75,12 +75,12 @@ namespace MvvmCross.UnitTest.Navigation
                           return vm;
                       });
             MockLoader.Setup(
-                l => l.ReloadViewModel<string>(It.IsAny<IMvxViewModel<string>>(), It.IsAny<string>(), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
+                l => l.ReloadViewModel<SimpleParameter>(It.IsAny<IMvxViewModel<SimpleParameter>>(), It.IsAny<SimpleParameter>(), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
                       .Returns(() =>
                       {
                           var vm = new SimpleParameterTestViewModel();
                           vm.Prepare();
-                          vm.Prepare("");
+                          vm.Prepare(new SimpleParameter { Hello = "" });
                           vm.InitializeTask = MvxNotifyTask.Create(() => vm.Initialize());
                           return vm;
                       });
@@ -150,9 +150,9 @@ namespace MvvmCross.UnitTest.Navigation
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
 
             var parameter = "hello";
-            await navigationService.Navigate<SimpleParameterTestViewModel, string>(parameter);
+            await navigationService.Navigate<SimpleParameterTestViewModel, SimpleParameter>(new SimpleParameter { Hello = parameter });
 
-            MockLoader.Verify(loader => loader.LoadViewModel<string>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<string>(val => val == parameter), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
+            MockLoader.Verify(loader => loader.LoadViewModel<SimpleParameter>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<SimpleParameter>(val => val.Hello == parameter), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -169,10 +169,10 @@ namespace MvvmCross.UnitTest.Navigation
 
             var mockVm = new Mock<SimpleParameterTestViewModel>();
 
-            var parameter = "hello";
-            await navigationService.Navigate<string>(mockVm.Object, parameter);
+            var parameter = new SimpleParameter { Hello = "hello" };
+            await navigationService.Navigate<SimpleParameter>(mockVm.Object, parameter);
 
-            MockLoader.Verify(loader => loader.ReloadViewModel<string>(It.Is<SimpleParameterTestViewModel>(val => mockVm.Object == val), It.Is<string>(val => val == parameter), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
+            MockLoader.Verify(loader => loader.ReloadViewModel<SimpleParameter>(It.Is<SimpleParameterTestViewModel>(val => mockVm.Object == val), It.Is<SimpleParameter>(val => val.Hello == parameter.Hello), It.IsAny<MvxViewModelRequest>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -216,10 +216,10 @@ namespace MvvmCross.UnitTest.Navigation
         {
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
 
-            var parameter = "hello";
-            await navigationService.Navigate<string>(typeof(SimpleParameterTestViewModel), parameter);
+            var parameter = new SimpleParameter { Hello = "hello" };
+            await navigationService.Navigate<SimpleParameter>(typeof(SimpleParameterTestViewModel), parameter);
 
-            MockLoader.Verify(loader => loader.LoadViewModel<string>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<string>(val => val == parameter), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
+            MockLoader.Verify(loader => loader.LoadViewModel<SimpleParameter>(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleParameterTestViewModel)), It.Is<SimpleParameter>(val => val.Hello == parameter.Hello), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
 
             MockDispatcher.Verify(
@@ -234,7 +234,7 @@ namespace MvvmCross.UnitTest.Navigation
         {
             var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
 
-            var result = await navigationService.Navigate<SimpleResultTestViewModel, bool>();
+            var result = await navigationService.Navigate<SimpleResultTestViewModel, SimpleResult>();
 
             MockLoader.Verify(loader => loader.LoadViewModel(It.Is<MvxViewModelRequest>(t => t.ViewModelType == typeof(SimpleResultTestViewModel)), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()),
                               Times.Once);
@@ -244,7 +244,7 @@ namespace MvvmCross.UnitTest.Navigation
                 Times.Once);
 
             Assert.NotEmpty(MockDispatcher.Object.Requests);
-            Assert.True(result);
+            Assert.True(result.Result);
         }
 
         [Fact]
@@ -261,10 +261,10 @@ namespace MvvmCross.UnitTest.Navigation
             {
                 navigationService.Navigate<SimpleTestViewModel>(),
                 navigationService.Navigate<SimpleTestViewModel>(new MvxBundle()),
-                navigationService.Navigate<SimpleResultTestViewModel, bool>(),
-                navigationService.Navigate<SimpleResultTestViewModel, bool>(new MvxBundle()),
-                navigationService.Navigate<SimpleParameterTestViewModel, string>("hello"),
-                navigationService.Navigate<SimpleParameterTestViewModel, string>("hello", new MvxBundle())
+                navigationService.Navigate<SimpleResultTestViewModel, SimpleResult>(),
+                navigationService.Navigate<SimpleResultTestViewModel, SimpleResult>(new MvxBundle()),
+                navigationService.Navigate<SimpleParameterTestViewModel, SimpleParameter>(new SimpleParameter { Hello = "hello" }),
+                navigationService.Navigate<SimpleParameterTestViewModel, SimpleParameter>(new SimpleParameter { Hello = "hello" }, new MvxBundle())
             };
             await Task.WhenAll(tasks);
             await Task.Delay(200);
@@ -286,7 +286,7 @@ namespace MvvmCross.UnitTest.Navigation
             var tasks = new Task[]
             {
                 navigationService.Close(new SimpleTestViewModel()),
-                navigationService.Close<bool>(new SimpleResultTestViewModel(), false)
+                navigationService.Close<SimpleResult>(new SimpleResultTestViewModel(), new SimpleResult { Result = false })
             };
             await Task.WhenAll(tasks);
 

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxDefaultViewModelLocatorTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxDefaultViewModelLocatorTest.cs
@@ -48,8 +48,7 @@ namespace MvvmCross.UnitTest.ViewModels
             var bundle = new MvxBundle();
             bundle.Write(testObject);
 
-            var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
-            var toTest = new MvxDefaultViewModelLocator(navigationService);
+            var toTest = new MvxDefaultViewModelLocator();
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
 
             IMvxViewModel viewModel = toTest.Load(typeof(Test1ViewModel), bundle, null, args);
@@ -108,8 +107,7 @@ namespace MvvmCross.UnitTest.ViewModels
             var reloadBundle = new MvxBundle();
             reloadBundle.Write(reloadBundleObject);
 
-            var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
-            var toTest = new MvxDefaultViewModelLocator(navigationService);
+            var toTest = new MvxDefaultViewModelLocator();
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
             IMvxViewModel viewModel = toTest.Load(typeof(Test1ViewModel), initBundle, reloadBundle, args);
 
@@ -136,8 +134,7 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var bundle = new MvxBundle();
 
-            var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
-            var toTest = new MvxDefaultViewModelLocator(navigationService);
+            var toTest = new MvxDefaultViewModelLocator();
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
             Assert.Throws<MvxException>(() =>
             {
@@ -154,8 +151,7 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var bundle = new MvxBundle();
 
-            var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
-            var toTest = new MvxDefaultViewModelLocator(navigationService);
+            var toTest = new MvxDefaultViewModelLocator();
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
 
             Assert.Throws<MvxException>(() =>
@@ -174,8 +170,7 @@ namespace MvvmCross.UnitTest.ViewModels
 
             var bundle = new MvxBundle();
 
-            var navigationService = _fixture.Ioc.Resolve<IMvxNavigationService>();
-            var toTest = new MvxDefaultViewModelLocator(navigationService);
+            var toTest = new MvxDefaultViewModelLocator();
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
             Assert.Throws<MvxException>(() =>
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Clean up MvxDefaultViewModelLocator

### :arrow_heading_down: What is the current behavior?
Random NavigationService + Logger that is not used anywhere.
We don't restrict what TParameter and TResult can be on MvxViewModel.
Potential null references in MvxDefaultViewModelLocator

### :new: What is the new behavior (if this is a feature change)?
Also added some XML docs.
Also restricted what TResult and TParameter can be.
Cleaned up unused NavigationService and LogProvider in MvxDefaultViewModelLocator.
Enabled Nullable References and now throwing ArgumentNullException if `Type` or `IMvxViewModel` in Load/Reload are null.

### :boom: Does this PR introduce a breaking change?
Yes

### :bug: Recommendations for testing
Run any app

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
