### PR TITLE
fix for adjusting scrollview insets twice

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
@@ -159,6 +159,9 @@ namespace MvvmCross.Platforms.Ios.Views
             UIView.CommitAnimations();
         }
 
+        private CGRect _lastKeyboardFrame = CGRect.Empty;
+        [Weak] private UIView _lastActiveView;
+
         /// <summary>
         /// Override this method to apply custom logic when the keyboard is shown/hidden
         /// </summary>
@@ -173,21 +176,36 @@ namespace MvvmCross.Platforms.Ios.Views
             var activeView = ViewToCenterOnKeyboardShown ?? KeyboardGetActiveView();
             if (activeView == null)
             {
+                _lastKeyboardFrame = CGRect.Empty;
+                _lastActiveView = null;
                 return;
             }
 
             var scrollView = ScrollToCenterOnKeyboardShown ?? activeView.FindTopSuperviewOfType(View, typeof(UIScrollView)) as UIScrollView;
             if (scrollView == null)
             {
+                _lastKeyboardFrame = CGRect.Empty;
+                _lastActiveView = null;
                 return;
             }
 
             if (!visible)
             {
+                _lastKeyboardFrame = CGRect.Empty;
+                _lastActiveView = null;
                 scrollView.RestoreScrollPosition();
             }
             else
             {
+                //avoid recalculation if the activeView is the same.
+                if (_lastKeyboardFrame == keyboardFrame &&
+                    _lastActiveView?.Equals(activeView) == true)
+                {
+                    return;
+                }
+
+                _lastKeyboardFrame = keyboardFrame;
+                _lastActiveView = activeView;
                 if (_iosVersion11Checker.IsVersionOrHigher)
                     keyboardFrame.Height -= scrollView.SafeAreaInsets.Bottom;
                 scrollView.CenterView(activeView, keyboardFrame);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
If you tap a UITextField two times, the scroll inset gets adjusted twice causing a keyboard sized gap to appear above the keyboard.

### :new: What is the new behavior (if this is a feature change)?
Checks if the inset was adjusted for the same view and keyboard size. If the view or keyboard size did not change, the inset adjustment is ignored as it has already been updated.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
