### PR TITLE
Replace deprecated Fragment.Instantiate by FragmentFactory.Instantiate

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxTabsFragmentActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxTabsFragmentActivity.cs
@@ -150,7 +150,7 @@ namespace MvvmCross.Platforms.Android.Views
                 var ft = activity.SupportFragmentManager.BeginTransaction();
                 ft.Detach(tabInfo.CachedFragment);
                 ft.Commit();
-                activity.FragmentManager.ExecutePendingTransactions();
+                activity.SupportFragmentManager.ExecutePendingTransactions();
             }
 
             tabHost.AddTab(tabSpec);
@@ -171,9 +171,12 @@ namespace MvvmCross.Platforms.Android.Views
                 {
                     if (newTab.CachedFragment == null)
                     {
-                        newTab.CachedFragment = Fragment.Instantiate(this,
-                                                                     FragmentJavaName(newTab.FragmentType),
-                                                                     newTab.Bundle);
+                        var fragmentClass = Class.FromType(newTab.FragmentType);
+                        newTab.CachedFragment = SupportFragmentManager.FragmentFactory.Instantiate(
+                            fragmentClass.ClassLoader,
+                            fragmentClass.Name
+                        );
+
                         FixupDataContext(newTab);
                         ft.Add(_tabContentId, newTab.CachedFragment, newTab.Tag);
                     }
@@ -186,7 +189,7 @@ namespace MvvmCross.Platforms.Android.Views
 
                 _currentTab = newTab;
                 ft.Commit();
-                FragmentManager.ExecutePendingTransactions();
+                SupportFragmentManager.ExecutePendingTransactions();
             }
         }
 

--- a/MvvmCross/Platforms/Android/Views/ViewPager/MvxCachingFragmentPagerAdapter.cs
+++ b/MvvmCross/Platforms/Android/Views/ViewPager/MvxCachingFragmentPagerAdapter.cs
@@ -28,6 +28,8 @@ namespace MvvmCross.Platforms.Android.Views.ViewPager
         private List<string> _savedFragmentTags = new List<string>();
         private readonly List<Fragment.SavedState> _savedState = new List<Fragment.SavedState>();
 
+        protected FragmentFactory FragmentFactory => _fragmentManager.FragmentFactory;
+
         protected MvxCachingFragmentPagerAdapter(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
         {

--- a/MvvmCross/Platforms/Android/Views/ViewPager/MvxCachingFragmentStatePagerAdapter.cs
+++ b/MvvmCross/Platforms/Android/Views/ViewPager/MvxCachingFragmentStatePagerAdapter.cs
@@ -44,8 +44,12 @@ namespace MvvmCross.Platforms.Android.Views.ViewPager
 
         public override Fragment GetItem(int position, Fragment.SavedState fragmentSavedState = null)
         {
-            var fragmentInfo = FragmentsInfo.ElementAt(position);
-            var fragment = Fragment.Instantiate(_context, fragmentInfo.FragmentType.FragmentJavaName());
+            var fragmentInfo = FragmentsInfo[position];
+            var fragmentClass = Class.FromType(fragmentInfo.FragmentType);
+            var fragment = FragmentFactory.Instantiate(
+                fragmentClass.ClassLoader,
+                fragmentClass.Name
+            );
 
             if (!(fragment is IMvxFragmentView mvxFragment))
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
We use deprecated `Fragment.Instantiate` method to create `Fragment`

### :new: What is the new behavior (if this is a feature change)?
Uses `FragmentFactory.Instantiate` method to create `Fragment`

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Please check tabbed pages of Android Playground app.

### :memo: Links to relevant issues/docs
Fixes #3949

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
