### PR TITLE
Fix MvxPopoverPresentationAttribute

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
@@ -47,7 +47,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             if (SourceView != null)
             {
                 popoverPresentationController.SourceView = SourceView;
-                popoverPresentationController.SourceRect = SourceView.Frame;
+                popoverPresentationController.SourceRect = SourceView.Bounds;
             }
             else
             {

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationSourceProvider.cs
@@ -9,31 +9,27 @@ namespace MvvmCross.Platforms.Ios.Presenters
 {
     public class MvxPopoverPresentationSourceProvider : IMvxPopoverPresentationSourceProvider
     {
-        private UIView _sourceView;
-        private UIBarButtonItem _sourceBarButtonItem;
+        [Weak] private UIView _sourceView;
+        [Weak] private UIBarButtonItem _sourceBarButtonItem;
 
         public UIView SourceView
         {
-            get
+            get => _sourceView;
+            set
             {
-                var sourceView = _sourceView;
-                _sourceView = null;
                 _sourceBarButtonItem = null;
-                return sourceView;
+                _sourceView = value;
             }
-            set => _sourceView = value;
         }
 
         public UIBarButtonItem SourceBarButtonItem
         {
-            get
+            get => _sourceBarButtonItem;
+            set
             {
-                var sourceBarButtonItem = _sourceBarButtonItem;
-                _sourceBarButtonItem = null;
                 _sourceView = null;
-                return sourceBarButtonItem;
+                _sourceBarButtonItem = value;
             }
-            set => _sourceBarButtonItem = value;
         }
 
         public void SetSource(UIPopoverPresentationController popoverPresentationController)
@@ -48,10 +44,12 @@ namespace MvvmCross.Platforms.Ios.Presenters
             {
                 popoverPresentationController.SourceView = SourceView;
                 popoverPresentationController.SourceRect = SourceView.Bounds;
+                SourceView = null;
             }
             else
             {
                 popoverPresentationController.BarButtonItem = SourceBarButtonItem;
+                SourceBarButtonItem = null;
             }
         }
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fixes

### :arrow_heading_down: What is the current behavior?
Doesn't work. 
Thinks the sourceView or sourceBarButtonItem is always null.
Also is using frame instead of bounds for SourceView

### :new: What is the new behavior (if this is a feature change)?
Works as expected

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
