### PR TITLE
Fix nullable references in Android Presenter

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -46,7 +46,7 @@ namespace MvvmCross.Platforms.Android.Presenters
 
         private readonly Lazy<IMvxNavigationSerializer> _navigationSerializer =
             new Lazy<IMvxNavigationSerializer>(() => Mvx.IoCProvider.Resolve<IMvxNavigationSerializer>());
-        
+
         private readonly Lazy<IMvxLog> _logger =
             new Lazy<IMvxLog>(() => Mvx.IoCProvider.Resolve<IMvxLog>());
 

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -328,8 +328,8 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             var bundle = Bundle.Empty!;
 
-            if (CurrentActivity.IsActivityAlive() && 
-                CurrentActivity is IMvxAndroidSharedElements sharedElementsActivity && 
+            if (CurrentActivity.IsActivityAlive() &&
+                CurrentActivity is IMvxAndroidSharedElements sharedElementsActivity &&
                 Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
             {
                 var (elements, transitionElementPairs) =
@@ -340,7 +340,7 @@ namespace MvvmCross.Platforms.Android.Presenters
                     _logger.Value?.Warn("No transition elements are provided");
                     return bundle;
                 }
-                
+
                 var transitionElementsBundle = CreateTransitionElementsBundle(intent, transitionElementPairs, elements);
                 if (transitionElementsBundle != null)
                     return transitionElementsBundle;
@@ -360,7 +360,7 @@ namespace MvvmCross.Platforms.Android.Presenters
                 CurrentActivity, transitionElementPairs.ToArray());
             if (activityOptions == null)
                 return null;
-            
+
             intent.PutExtra(SharedElementsBundleKey, string.Join("|", elements));
             var activityOptionsBundle = activityOptions.ToBundle();
             return activityOptionsBundle;
@@ -1149,7 +1149,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             if (attribute == null)
                 throw new ArgumentNullException(nameof(attribute));
         }
-        
+
         private static void ValidateArguments(MvxViewModelRequest? request)
         {
             if (request == null)

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -835,7 +835,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             }
 
             // Close fragment. If it isn't successful, then close the current Activity
-            if (TryPerformCloseFragmentTransaction(CurrentFragmentManager, attribute))
+            if (CurrentFragmentManager != null && TryPerformCloseFragmentTransaction(CurrentFragmentManager, attribute))
             {
                 return Task.FromResult(true);
             }

--- a/MvvmCross/Platforms/Android/Views/IMvxAndroidSharedElements.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxAndroidSharedElements.cs
@@ -9,6 +9,7 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Android.Views
 {
+#nullable enable
     /// <summary>
     /// Used by Android presenters to check if they need to include shared element animations on navigation
     /// </summary>
@@ -22,4 +23,5 @@ namespace MvvmCross.Platforms.Android.Views
         /// <returns>An <see cref="IDictionary{key, value}"/> containing the identifier key and view to animate with assigned transition name.</returns>
         IDictionary<string, View> FetchSharedElementsToAnimate(MvxBasePresentationAttribute attribute, MvxViewModelRequest request);
     }
+#nullable restore
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently, a lot of the Presentation Attribute arguments in the Android presenter are marked as if they are allowed to be null. However, this should not be the case and we should explode in such cases.

### :new: What is the new behavior (if this is a feature change)?
Remove the ?-marks to not allow nullables for attributes and other arguments in the presenter.
Refactored some methods a bit to improve cognitive complexity
Also getting log from IoC lasily

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing
Run playground and see that stuff still works

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
