### PR TITLE
Fix Mac playground and MvxMacViewPresenter

### DIFF
--- a/ContentFiles/macOS/AppDelegate.cs.pp
+++ b/ContentFiles/macOS/AppDelegate.cs.pp
@@ -8,7 +8,7 @@ namespace $rootnamespace$
     {
 		public override void DidFinishLaunching(NSNotification notification)
 		{
-			MvxMacSetupSingleton.EnsureSingletonAvailable(this, MainWindow).EnsureInitialized();
+			MvxMacSetupSingleton.EnsureSingletonAvailable(this).EnsureInitialized();
 			RunAppStart();
 		}
 	}

--- a/MvvmCross/Platforms/Mac/Core/IMvxMacSetup.cs
+++ b/MvvmCross/Platforms/Mac/Core/IMvxMacSetup.cs
@@ -10,8 +10,7 @@ namespace MvvmCross.Platforms.Mac.Core
 {
     public interface IMvxMacSetup : IMvxSetup
     {
-        void PlatformInitialize(IMvxApplicationDelegate applicationDelegate);        
-        void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, NSWindow window);
+        void PlatformInitialize(IMvxApplicationDelegate applicationDelegate);
         void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, IMvxMacViewPresenter presenter);
     }
 }

--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -11,21 +11,6 @@ namespace MvvmCross.Platforms.Mac.Core
 {
     public abstract class MvxApplicationDelegate : NSApplicationDelegate, IMvxApplicationDelegate
     {
-        private NSWindow window;
-        public virtual NSWindow MainWindow
-        {
-            get {
-                if (window == null)
-                {
-                    var style = NSWindowStyle.Closable | NSWindowStyle.Resizable | NSWindowStyle.Titled;
-                    var rect = new CoreGraphics.CGRect(200, 1000, 1024, 768);
-                    window = new NSWindow(rect, style, NSBackingStore.Buffered, false);
-                }
-                return window;
-            }
-            set { window = value; }
-        }
-
         public MvxApplicationDelegate() : base()
         {
             RegisterSetup();
@@ -33,7 +18,7 @@ namespace MvvmCross.Platforms.Mac.Core
 
         public override void DidFinishLaunching(Foundation.NSNotification notification)
         {
-            MvxMacSetupSingleton.EnsureSingletonAvailable(this, MainWindow).EnsureInitialized();
+            MvxMacSetupSingleton.EnsureSingletonAvailable(this).EnsureInitialized();
             RunAppStart(notification);
 
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
@@ -80,8 +65,8 @@ namespace MvvmCross.Platforms.Mac.Core
     }
 
     public class MvxApplicationDelegate<TMvxMacSetup, TApplication> : MvxApplicationDelegate
-   where TMvxMacSetup : MvxMacSetup<TApplication>, new()
-   where TApplication : class, IMvxApplication, new()
+        where TMvxMacSetup : MvxMacSetup<TApplication>, new()
+        where TApplication : class, IMvxApplication, new()
     {
         protected override void RegisterSetup()
         {

--- a/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
@@ -26,7 +26,6 @@ namespace MvvmCross.Platforms.Mac.Core
         : MvxSetup, IMvxMacSetup
     {
         private IMvxApplicationDelegate _applicationDelegate;
-        private NSWindow _window;
 
         private IMvxMacViewPresenter _presenter;
 
@@ -35,21 +34,10 @@ namespace MvvmCross.Platforms.Mac.Core
             _applicationDelegate = applicationDelegate;
         }
 
-        public void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, NSWindow window)
-        {
-            PlatformInitialize(applicationDelegate);
-            _window = window;
-        }
-
         public void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, IMvxMacViewPresenter presenter)
         {
             PlatformInitialize(applicationDelegate);
             _presenter = presenter;
-        }
-
-        protected NSWindow Window
-        {
-            get { return _window; }
         }
 
         protected IMvxApplicationDelegate ApplicationDelegate

--- a/MvvmCross/Platforms/Mac/Core/MvxMacSetupSingleton.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxMacSetupSingleton.cs
@@ -18,13 +18,6 @@ namespace MvvmCross.Platforms.Mac.Core
             return instance;
         }
 
-        public static MvxMacSetupSingleton EnsureSingletonAvailable(IMvxApplicationDelegate applicationDelegate, NSWindow window)
-        {
-            var instance = EnsureSingletonAvailable<MvxMacSetupSingleton>();
-            instance.PlatformSetup<MvxMacSetup>()?.PlatformInitialize(applicationDelegate, window);
-            return instance;
-        }
-
         public static MvxMacSetupSingleton EnsureSingletonAvailable(IMvxApplicationDelegate applicationDelegate, IMvxMacViewPresenter presenter)
         {
             var instance = EnsureSingletonAvailable<MvxMacSetupSingleton>();

--- a/MvvmCross/readme.txt
+++ b/MvvmCross/readme.txt
@@ -60,7 +60,7 @@ Note: If you wish to use the AppCompat versions of Android classes, you can foll
 - macOS projects (ignore if not building for macOS) -
 1. Inside AppDelegate.cs, change the AppDelegate class to inherit from MvxApplicationDelegate<MvxMacSetup<Core.App>, Core.App> instead of ApplicationDelegate (See macOS/AppDelegate.cs.pp in sample files).
 2. Still inside AppDelegate.cs replace the contents of the DidFinishLaunching method with the following:
-   MvxMacSetupSingleton.EnsureSingletonAvailable(this, MainWindow).EnsureInitialized();
+   MvxMacSetupSingleton.EnsureSingletonAvailable(this).EnsureInitialized();
    RunAppStart();
 3. Still inside AppDelegate, delete all the other pre-populated methods.
 4. Add a Views folder and add at least one View file to this folder to correspond to the ViewModel in the Core project (See macOS/HomeView.cs.pp in sample files).

--- a/Projects/Playground/Playground.Mac/RootView.cs
+++ b/Projects/Playground/Playground.Mac/RootView.cs
@@ -48,7 +48,7 @@ namespace Playground.Mac
 
         public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
-            if (!NSApplication.SharedApplication.Windows.Any())
+            if (!NSApplication.SharedApplication.DangerousWindows.Any())
                 return null;
 
             return new MvxContentPresentationAttribute

--- a/docs/_documentation/platform/macos/mac-view-presenter.md
+++ b/docs/_documentation/platform/macos/mac-view-presenter.md
@@ -30,7 +30,7 @@ You can customize how the window will look through the following properties:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| Identifier | `string` | Window identifier, used to identify the window for other attributes. If an identifier is not provided by the developer, it will be set to the name of the view class. |
+| Identifier | `string` | Window identifier, used to identify the window for other attributes. If an identifier is not provided by the developer, it will be set to the name of the view class. In apps with multiple identical windows you should [generate unique window identifier at runtime](#override-a-presentation-attribute-at-runtime). |
 | WindowStyle | `NSWindowStyle?` | Used to set the NSWindowStyle. Default value is `NSWindowStyle.Closable | NSWindowStyle.Resizable | NSWindowStyle.Titled`. |
 | BufferingType | `NSBackingStore?` | Used to set the NSBackingStore. Default value is `NSBackingStore.Buffered`. |
 | PositionX | `float` | Default value is 200. |
@@ -52,15 +52,15 @@ will set the CustomWindow Width to 800.
 ### MvxContentPresentationAttribute
 
 Used to set a view as content of a _Window_. Please notice that changing the content of a window does not automatically generate a navigation stack as it would be on iOS. Changing the content of a window dismisses the old content.
-You can choose in which window should this view be displayed by using the `WindowIdentifier` property of the attribute. If the identifier is not provided, the view will be displayed in the last opened window.
+You can choose in which window should this view be displayed by using the `WindowIdentifier` property of the attribute. If the identifier is not provided, the view will be displayed in the [main window](https://developer.apple.com/documentation/appkit/nsapplication/1428723-mainwindow), and if no windows are focused it will be displayed in the last opened window.
 
 ### MvxModalPresentationAttribute
 
-Used to display a view as _Modal_. Same as with content, you can choose through the `WindowIdentifier` property from which window should the modal be opened. If the identifier is not provided, the view will be displayed in the last opened window.
+Used to display a view as _Modal_. Same as with content, you can choose through the `WindowIdentifier` property from which window should the modal be opened. If the identifier is not provided, the view will be displayed in the [main window](https://developer.apple.com/documentation/appkit/nsapplication/1428723-mainwindow), and if no windows are focused it will be displayed in the last opened window.
 
 ### MvxSheetPresentationAttribute
 
-MacOS uses the concept of _sheets_ to prompt the user with messages or small forms. If you use this attribute over a view class, it will be displayed as a sheet. You can choose from which window should it be opened through the `WindowIdentifier` property. If the identifier is not provided, the view will be displayed in the last opened window.
+MacOS uses the concept of _sheets_ to prompt the user with messages or small forms. If you use this attribute over a view class, it will be displayed as a sheet. You can choose from which window should it be opened through the `WindowIdentifier` property. If the identifier is not provided, the view will be displayed in the [main window](https://developer.apple.com/documentation/appkit/nsapplication/1428723-mainwindow), and if no windows are focused it will be displayed in the last opened window.
 
 ### MvxTabPresentationAttribute
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bugfixes in the Mac's presenter, along with one public API change. All was done in the process of repairing the Playground:

- "Show Child" does not crash anymore and returns back to the root
- "Show Modal" and "Show Sheet" show their views correctly on the second and following navigations
- "Show Window" works and opens a new window on each click
- "Show Tabs" works and its tabs can be switched

### :arrow_heading_down: What is the current behavior?

Mac navigation does not work both in Playground and new projects, most presentation modes are broken. [See here](https://github.com/MvvmCross/MvvmCross/issues/3579#issuecomment-536629734) for details. 

### :new: What is the new behavior (if this is a feature change)?

#### 1. `NSWindow MainWindow` was removed from `MvxApplicationDelegate`

Initially it created an excessive "ghost" window and produced the bug [described here](https://github.com/MvvmCross/MvvmCross/issues/3579#issuecomment-540247742). But I'd like to suggest its removal.

While `NSApplication.SharedApplication` offers a property `MainWindow`, this window is not "main" in the sense of ownership but rather the one focused right now. It might return `null` when the app is inactive or hidden ([source](https://developer.apple.com/documentation/appkit/nsapplication/1428723-mainwindow)). This is further complicated by another property `KeyWindow`, which may be equal to `MainWindow` but also can be its child window that currently receives key events. Or it can be `null` when no windows are receiving keyboard events. And, at the same time, neither of these two properties are guaranteed to be the frontmost window in the Z-order.

This volatility of the "main" window in macOS can lead to confusion when combined with a separate reference to it in `MvxApplicationDelegate`. It is always possible to obtain this window from `NSApplication.SharedApplication`.

So, since almost no code in MvvmCross uses this property **and** it isn't updated along the "real" `MainWindow` of the application **and** would be overall confusing in the multi-window environment of macOS, I think it's better to get rid of it. `readme.txt` and content files were updated accordingly.


#### 2. `MvxMacViewPresenter` checks if `MainWindow` is available before going for the last opened window

As described above, this window usually exists and usually is in the focus, so the last opened window should be the last resort.


#### 3. `MvxMacViewPresenter` doesn't match windows and attributes with `null` identifiers anymore

For example, "Show Sheet" was breaking because it was creating a new window with a `null` ID on the first display and then obtaining it instead of the main window when displayed for the second time (through `w.Identifier == attribute.WindowIdentifier`). With the new conditions, the four one-liners for window search were getting too long and repetitive, so I extracted them into the `FindPresentingWindow()` method.


#### 4. The condition for closing of modal and sheet windows was fixed

The condition in `Close()` for them was dependent on the parent window's `PresentedViewControllers` but because the loop is reversed, it was getting to the modal/sheet's windows first and then quitting on the `controller.ViewModel == viewModel` condition.

Initially, I thought that this bug was producing a memory leak because the `Windows` list wasn't reducing in size after closing modals/sheets, but there's a [much larger problem](https://github.com/xamarin/xamarin-macios/issues/5350) related to `NSApplication` calls, I will create a separate issue to discuss how to fix it.


#### 5. A note in the documentation what to do in the multi-window scenario

I've spent some time trying to improve the presenter and make it work well for apps with multiple windows that use the same root view model (one of the things I tried was setting a unique window `Identifier` by default). But that didn't solve the problems completely on the Presenter's level and at the same time complicated the life for people who just need to port a single-window mobile app to Mac. So, just placing a hint into the docs instead.


### :boom: Does this PR introduce a breaking change?

Yes

### :bug: Recommendations for testing

To get Playground.Mac running, the following is necessary:

- install Plugin.Permissions package into the project
- comment out the registration of `IMvxTextProvider` in [Playground.Core's App.cs](https://github.com/MvvmCross/MvvmCross/blob/develop/Projects/Playground/Playground.Core/App.cs#L28)

### :memo: Links to relevant issues/docs

Fixes #2192, #3579, #3825, #3830 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
