### PR TITLE
Change Slack links to Discord links in the docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/e-question.md
+++ b/.github/ISSUE_TEMPLATE/e-question.md
@@ -9,5 +9,5 @@ about: If you have questions, please use this for support
 For questions or help we recommend checking:
 
 - The [MvvmCross tag in Stack Overflow](https://stackoverflow.com/questions/tagged/mvvmcross)
-- The [MvvmCross slack channel in the Xamarin Slack](https://xamarinchat.herokuapp.com/)
+- The [MvvmCross channel in the DotNetEvolution Discord](https://aka.ms/dotnet-discord)
 - Ask your question in the [Xamarin Forums](https://forums.xamarin.com/)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Note that code submissions will be reviewed and tested. Only code that meets qua
 
 * [StackOverflow](https://stackoverflow.com/questions/tagged/mvvmcross)
 * [Xamarin forums](https://forums.xamarin.com)
-* [Slack](https://xamarinchat.herokuapp.com/) join the #mvvmcross channel after you are in
+* [Discord](https://aka.ms/dotnet-discord) #mvvmcross channel
 
 ### Licensing
 

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -36,7 +36,7 @@
                 <ul role="menu" aria-hidden="true" aria-label="Connect link">
                     <li role="listitem" aria-label="Connect link item"><a href="{{ site.github.repository_url }}" target="_blank" role="link" aria-label="GitHub">GitHub</a></li>
                     <li role="listitem" aria-label="Connect link item"><a href="{{ site.github.issues_url }}" target="_blank" role="link" aria-label="GitHub Issues">GitHub Issues</a></li>
-                    <li role="listitem" aria-label="Connect link item"><a href="https://xamarinchat.herokuapp.com/" target="_blank" role="link" aria-label="Slack">Slack</a></li>
+                    <li role="listitem" aria-label="Connect link item"><a href="https://aka.ms/dotnet-discord" target="_blank" role="link" aria-label="Discord">Discord</a></li>
                     <li role="listitem" aria-label="Connect link item"><a href="https://stackoverflow.com/questions/tagged/mvvmcross" target="_blank" role="link" aria-label="Stack Overflow">Stack Overflow</a></li>
                     <li role="listitem" aria-label="Connect link item"><a href="https://forums.xamarin.com" target="_blank" role="link" aria-label="Xamarin Forums">Xamarin Forums</a></li>
                     <li role="listitem" aria-label="Connect link item"><a href="https://www.linkedin.com/groups/8456977" target="_blank" role="link" aria-label="Linkedin">Linkedin</a></li>
@@ -49,7 +49,7 @@
         <ul role="menu" aria-hidden="true" aria-label="Social link">
             <li role="listitem" aria-label="Social link item"><a href="{{ site.github.repository_url }}" target="_blank" role="link" aria-label="GitHub"><i class="fa fa-github" aria-hidden="true"></i></a></li>
             <li role="listitem" aria-label="Social link item"><a href="https://twitter.com/{{ site.twitter.username }}" target="_blank" role="link" aria-label="Twitter"><i class="fa fa-twitter" aria-hidden="true"></i></a></li>
-            <li role="listitem" aria-label="Social link item"><a href="https://xamarinchat.herokuapp.com/" target="_blank" role="link" aria-label="Slack"><i class="fa fa-slack" aria-hidden="true"></i></a></li>
+            <li role="listitem" aria-label="Social link item"><a href="https://aka.ms/dotnet-discord" target="_blank" role="link" aria-label="Discord"><i class="fa fa-discord" aria-hidden="true"></i></a></li>
             <li role="listitem" aria-label="Social link item"><a href="https://stackoverflow.com/questions/tagged/mvvmcross" target="_blank" role="link" aria-label="Stack Overflow"><i class="fa fa-stack-overflow" aria-hidden="true"></i></a></li>
             <li role="listitem" aria-label="Social link item"><a href="https://www.linkedin.com/groups/8456977" target="_blank" role="link" aria-label="Linkedin"><i class="fa fa-linkedin-square" aria-hidden="true"></i></a></li>
             <li role="listitem" aria-label="Social link item"><a href="{{ '/feed.xml' | relative_url }}" role="link" aria-label="RSS"><i class="fa fa-rss-square" aria-hidden="true"></i></a></li>

--- a/docs/support.md
+++ b/docs/support.md
@@ -10,19 +10,19 @@ Got stuck? Need help? Get in touch with us on these different platforms. We do o
 
 Use StackOverflow to find already asked questions, and post new questions with details about your problem. Do add tags to at least MvvmCross and Xamarin so we are able to find it.
 
-**[Slack][slack] - join the #mvvmcross channel**
+**[Discord][discord] - #mvvmcross channel**
 
-Use Slack to get in touch with us directly, and ask quick questions. After joining the Xamarin Chat, join the MvvmCross channel to find all other MvvmCross users.
+Use Discord to get in touch with us directly, and ask quick questions. After joining the DotNetEvolution Discord, go to the MvvmCross channel to find all other MvvmCross users.
 
 **[Xamarin forums][xf]**
 
-Use the Xamarin Forums for specific questions where neither StackOverflow or Slack works for you.
+Use the Xamarin Forums for specific questions where neither StackOverflow or Discord works for you.
 
 **[GitHub issues][gi]**
 
 Use only GitHub issues for actual bugs with the framework. We try to keep GitHub issues only for bugs, feature requests, roadmaps and the like.
 
 [so]: https://stackoverflow.com/questions/tagged/mvvmcross "StackOverflow questions tagged MvvmCross"
-[slack]: https://xamarinchat.herokuapp.com/ "Invite yourself to the Xamarin Chat Slack"
+[discord]: https://aka.ms/dotnet-discord "Invite yourself to the DotNetEvolution Discord"
 [xf]: https://forums.xamarin.com "Xamarin Forums"
 [gi]: https://github.com/mvvmcross/mvvmcross "GitHub issues for MvvmCross"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Edits in readme, docs, the site's front page

### :arrow_heading_down: What is the current behavior?

New users keep coming to the #mvvmcross channel in Xamarin Chat Slack

### :new: What is the new behavior (if this is a feature change)?

New users will be directed to the DotNetEvolution Discord instead

### :thinking: Checklist before submitting

- [+] All projects build
- [+] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [+] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [+] Rebased onto current develop
