### PR TITLE
Change ViewModel Parameters and Result constraints from class to notnull

### DIFF
--- a/MvvmCross/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Navigation/IMvxNavigationService.cs
@@ -65,7 +65,8 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class;
+        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull;
 
         /// <summary>
         /// Navigates to an instance of a ViewModel and returns TResult
@@ -75,7 +76,8 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
+        Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull;
 
         /// <summary>
         /// Navigates to an instance of a ViewModel passes TParameter and returns TResult
@@ -87,7 +89,9 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
+        Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
+            where TResult : notnull;
 
         /// <summary>
         /// Navigates to a ViewModel Type
@@ -107,7 +111,8 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class;
+        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull;
 
         /// <summary>
         /// Navigates to a ViewModel Type passes and returns TResult
@@ -117,7 +122,8 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
+        Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull;
 
         /// <summary>
         /// Navigates to a ViewModel Type passes TParameter and returns TResult
@@ -129,7 +135,9 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
+        Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
+            where TResult : notnull;
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -149,7 +157,8 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class;
+        Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull;
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -159,7 +168,8 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
+        Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull;
 
         /// <summary>
         /// Translates the provided Uri to a ViewModel request and dispatches it.
@@ -171,19 +181,25 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class;
+        Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
+            where TResult : notnull;
 
         Task<bool> Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
             where TViewModel : IMvxViewModel;
 
         Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModel<TParameter> where TParameter : class;
+            where TViewModel : IMvxViewModel<TParameter>
+            where TParameter : notnull;
 
         Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModelResult<TResult> where TResult : class;
+            where TViewModel : IMvxViewModelResult<TResult>
+            where TResult : notnull;
 
         Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
-            where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class;
+            where TViewModel : IMvxViewModel<TParameter, TResult>
+            where TParameter : notnull
+            where TResult : notnull;
 
         /// <summary>
         /// Verifies if the provided Uri can be routed to a ViewModel request.
@@ -196,7 +212,8 @@ namespace MvvmCross.Navigation
         /// Verifies if the provided viewmodel is available
         /// </summary>
         /// <returns>True if the ViewModel is available</returns>
-        Task<bool> CanNavigate<TViewModel>() where TViewModel : IMvxViewModel;
+        Task<bool> CanNavigate<TViewModel>()
+            where TViewModel : IMvxViewModel;
 
         /// <summary>
         /// Verifies if the provided viewmodel is available
@@ -221,7 +238,8 @@ namespace MvvmCross.Navigation
         /// <param name="result"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
+        Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull;
 
         /// <summary>
         /// Dispatches a ChangePresentation with Hint

--- a/MvvmCross/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Navigation/MvxNavigationExtensions.cs
@@ -35,17 +35,21 @@ namespace MvvmCross.Navigation
             return navigationService.Navigate(path.ToString(), presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
+        public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
         {
             return navigationService.Navigate<TParameter>(path.ToString(), param, presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
+        public static Task Navigate<TResult>(this IMvxNavigationService navigationService, Uri path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull
         {
             return navigationService.Navigate<TResult>(path.ToString(), presentationBundle, cancellationToken);
         }
 
-        public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
+        public static Task Navigate<TParameter, TResult>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
+            where TResult : notnull
         {
             return navigationService.Navigate<TParameter, TResult>(path.ToString(), param, presentationBundle, cancellationToken);
         }

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -204,7 +204,8 @@ namespace MvvmCross.Navigation
             return request;
         }
 
-        protected async Task<MvxViewModelInstanceRequest> NavigationRouteRequest<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null) where TParameter : class
+        protected async Task<MvxViewModelInstanceRequest> NavigationRouteRequest<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null)
+            where TParameter : notnull
         {
             KeyValuePair<Regex, Type> entry;
 
@@ -265,7 +266,8 @@ namespace MvvmCross.Navigation
             return Task.FromResult(TryGetRoute(path, out var entry));
         }
 
-        public virtual Task<bool> CanNavigate<TViewModel>() where TViewModel : IMvxViewModel
+        public virtual Task<bool> CanNavigate<TViewModel>()
+            where TViewModel : IMvxViewModel
         {
             return Task.FromResult(ViewsContainer.GetViewType(typeof(TViewModel)) != null);
         }
@@ -296,7 +298,8 @@ namespace MvvmCross.Navigation
             return true;
         }
 
-        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
+        protected virtual async Task<TResult> Navigate<TResult>(MvxViewModelRequest request, IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull
         {
             var hasNavigated = false;
             var tcs = new TaskCompletionSource<object>();
@@ -339,7 +342,9 @@ namespace MvvmCross.Navigation
             }
         }
 
-        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken), IMvxNavigateEventArgs args = null) where TParameter : class where TResult : class
+        protected virtual async Task<TResult> Navigate<TParameter, TResult>(MvxViewModelRequest request, IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken), IMvxNavigateEventArgs args = null)
+            where TParameter : notnull
+            where TResult : notnull
         {
             var hasNavigated = false;
             if (cancellationToken != default(CancellationToken))
@@ -387,19 +392,23 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
+        public virtual async Task<bool> Navigate<TParameter>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
         {
             var request = await NavigationRouteRequest(path, param, presentationBundle).ConfigureAwait(false);
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
+        public virtual async Task<TResult> Navigate<TResult>(string path, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull
         {
             var request = await NavigationRouteRequest(path, presentationBundle).ConfigureAwait(false);
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(string path, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
+            where TResult : notnull
         {
             var request = await NavigationRouteRequest(path, param, presentationBundle).ConfigureAwait(false);
             return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken).ConfigureAwait(false);
@@ -415,7 +424,8 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
+        public virtual async Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
@@ -425,7 +435,8 @@ namespace MvvmCross.Navigation
             return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
+        public virtual async Task<TResult> Navigate<TResult>(Type viewModelType, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull
         {
             var request = new MvxViewModelInstanceRequest(viewModelType)
             {
@@ -435,7 +446,9 @@ namespace MvvmCross.Navigation
             return await Navigate<TResult>(request, (IMvxViewModelResult<TResult>)request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(Type viewModelType, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
+            where TResult : notnull
         {
             var args = new MvxNavigateEventArgs(NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModelType)
@@ -447,22 +460,30 @@ namespace MvvmCross.Navigation
             return await Navigate<TParameter, TResult>(request, (IMvxViewModel<TParameter, TResult>)request.ViewModelInstance, param, presentationBundle, cancellationToken, args).ConfigureAwait(false);
         }
 
-        public virtual Task<bool> Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel
+        public virtual Task<bool> Navigate<TViewModel>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TViewModel : IMvxViewModel
         {
             return Navigate(typeof(TViewModel), presentationBundle, cancellationToken);
         }
 
-        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter> where TParameter : class
+        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TViewModel : IMvxViewModel<TParameter>
+            where TParameter : notnull
         {
             return Navigate(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
 
-        public virtual Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModelResult<TResult> where TResult : class
+        public virtual Task<TResult> Navigate<TViewModel, TResult>(IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TViewModel : IMvxViewModelResult<TResult>
+            where TResult : notnull
         {
             return Navigate<TResult>(typeof(TViewModel), presentationBundle, cancellationToken);
         }
 
-        public virtual Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TViewModel : IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class
+        public virtual Task<TResult> Navigate<TViewModel, TParameter, TResult>(TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TViewModel : IMvxViewModel<TParameter, TResult>
+            where TParameter : notnull
+            where TResult : notnull
         {
             return Navigate<TParameter, TResult>(typeof(TViewModel), param, presentationBundle, cancellationToken);
         }
@@ -474,21 +495,25 @@ namespace MvvmCross.Navigation
             return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class
+        public virtual async Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
             return await Navigate(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
+        public virtual async Task<TResult> Navigate<TResult>(IMvxViewModelResult<TResult> viewModel, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull
         {
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
             ViewModelLoader.ReloadViewModel(viewModel, request, null);
             return await Navigate<TResult>(request, viewModel, presentationBundle, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken)) where TParameter : class where TResult : class
+        public virtual async Task<TResult> Navigate<TParameter, TResult>(IMvxViewModel<TParameter, TResult> viewModel, TParameter param, IMvxBundle presentationBundle = null, CancellationToken cancellationToken = default(CancellationToken))
+            where TParameter : notnull
+            where TResult : notnull
         {
             var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
             var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
@@ -527,7 +552,8 @@ namespace MvvmCross.Navigation
             return close;
         }
 
-        public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken)) where TResult : class
+        public virtual async Task<bool> Close<TResult>(IMvxViewModelResult<TResult> viewModel, TResult result, CancellationToken cancellationToken = default(CancellationToken))
+            where TResult : notnull
         {
             _tcsResults.TryGetValue(viewModel, out var _tcs);
 

--- a/MvvmCross/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxViewModel.cs
@@ -37,22 +37,22 @@ namespace MvvmCross.ViewModels
     }
 
     public interface IMvxViewModel<TParameter>
-        : IMvxViewModel where TParameter : class
+        : IMvxViewModel where TParameter : notnull
     {
-        void Prepare(TParameter? parameter);
+        void Prepare(TParameter parameter);
     }
 
     public interface IMvxViewModelResult<TResult>
         : IMvxViewModel
-        where TResult : class
+        where TResult : notnull
     {
         TaskCompletionSource<object>? CloseCompletionSource { get; set; }
     }
 
     public interface IMvxViewModel<TParameter, TResult>
         : IMvxViewModel<TParameter>, IMvxViewModelResult<TResult>
-        where TParameter : class
-        where TResult : class
+        where TParameter : notnull
+        where TResult : notnull
     {
     }
 #nullable restore

--- a/MvvmCross/ViewModels/IMvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLoader.cs
@@ -10,10 +10,12 @@ namespace MvvmCross.ViewModels
     {
         IMvxViewModel LoadViewModel(MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class;
+        IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null)
+            where TParameter : notnull;
 
         IMvxViewModel ReloadViewModel(IMvxViewModel viewModel, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null);
 
-        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null) where TParameter : class;
+        IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs = null)
+            where TParameter : notnull;
     }
 }

--- a/MvvmCross/ViewModels/IMvxViewModelLocator.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLocator.cs
@@ -39,11 +39,11 @@ namespace MvvmCross.ViewModels
         /// <returns>Returns a ViewModel</returns>
         IMvxViewModel<TParameter> Load<TParameter>(
             Type viewModelType,
-            TParameter? param,
+            TParameter param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
             IMvxNavigateEventArgs? navigationArgs = null)
-            where TParameter : class;
+            where TParameter : notnull;
 
         /// <summary>
         /// Reload ViewModel, runs start lifecycle in ViewModel.
@@ -71,11 +71,11 @@ namespace MvvmCross.ViewModels
         /// <returns>Returns reloaded ViewModel</returns>
         IMvxViewModel<TParameter> Reload<TParameter>(
             IMvxViewModel<TParameter> viewModel,
-            TParameter? param,
+            TParameter param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
             IMvxNavigateEventArgs? navigationArgs = null)
-            where TParameter : class;
+            where TParameter : notnull;
     }
 #nullable restore
 }

--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -85,7 +85,9 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public class MvxAppStart<TViewModel, TParameter> : MvxAppStart<TViewModel> where TViewModel : IMvxViewModel<TParameter> where TParameter : class
+    public class MvxAppStart<TViewModel, TParameter> : MvxAppStart<TViewModel>
+        where TViewModel : IMvxViewModel<TParameter>
+        where TParameter : notnull
     {
         public MvxAppStart(IMvxApplication application, IMvxNavigationService navigationService) : base(application, navigationService)
         {

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -39,10 +39,11 @@ namespace MvvmCross.ViewModels
 
         public virtual IMvxViewModel<TParameter> Load<TParameter>(
             Type viewModelType,
-            TParameter? param,
+            TParameter param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
-            IMvxNavigateEventArgs? navigationArgs) where TParameter : class
+            IMvxNavigateEventArgs? navigationArgs)
+            where TParameter : notnull
         {
             if (viewModelType == null)
                 throw new ArgumentNullException(nameof(viewModelType));
@@ -75,10 +76,11 @@ namespace MvvmCross.ViewModels
 
         public virtual IMvxViewModel<TParameter> Reload<TParameter>(
             IMvxViewModel<TParameter> viewModel,
-            TParameter? param,
+            TParameter param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
-            IMvxNavigateEventArgs? navigationArgs) where TParameter : class
+            IMvxNavigateEventArgs? navigationArgs)
+            where TParameter : notnull
         {
             RunViewModelLifecycle(viewModel, param, parameterValues, savedState, navigationArgs);
 
@@ -133,10 +135,11 @@ namespace MvvmCross.ViewModels
 
         protected void RunViewModelLifecycle<TParameter>(
             IMvxViewModel<TParameter> viewModel,
-            TParameter? param,
+            TParameter param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
-            IMvxNavigateEventArgs? navigationArgs) where TParameter : class
+            IMvxNavigateEventArgs? navigationArgs)
+            where TParameter : notnull
         {
             if (viewModel == null)
                 throw new ArgumentNullException(nameof(viewModel));

--- a/MvvmCross/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/ViewModels/MvxViewModel.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using MvvmCross.Logging;
-using MvvmCross.Navigation;
 
 namespace MvvmCross.ViewModels
 {
@@ -87,13 +85,15 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxViewModel<TParameter> : MvxViewModel, IMvxViewModel<TParameter> where TParameter : class
+    public abstract class MvxViewModel<TParameter> : MvxViewModel, IMvxViewModel<TParameter>
+        where TParameter : notnull
     {
         public abstract void Prepare(TParameter parameter);
     }
 
     //TODO: Not possible to name MvxViewModel, name is MvxViewModelResult for now
-    public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult> where TResult : class
+    public abstract class MvxViewModelResult<TResult> : MvxViewModel, IMvxViewModelResult<TResult>
+        where TResult : notnull
     {
         public TaskCompletionSource<object> CloseCompletionSource { get; set; }
 
@@ -106,7 +106,9 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult> where TParameter : class where TResult : class
+    public abstract class MvxViewModel<TParameter, TResult> : MvxViewModelResult<TResult>, IMvxViewModel<TParameter, TResult>
+        where TParameter : notnull
+        where TResult : notnull
     {
         public abstract void Prepare(TParameter parameter);
     }

--- a/MvvmCross/ViewModels/MvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/MvxViewModelLoader.cs
@@ -38,7 +38,8 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class
+        public IMvxViewModel ReloadViewModel<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, MvxViewModelRequest request, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
+            where TParameter : notnull
         {
             var viewModelLocator = FindViewModelLocator(request);
 
@@ -81,7 +82,8 @@ namespace MvvmCross.ViewModels
             return viewModel;
         }
 
-        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs) where TParameter : class
+        public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle savedState, IMvxNavigateEventArgs navigationArgs)
+            where TParameter : notnull
         {
             if (request.ViewModelType == typeof(MvxNullViewModel))
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
We added constraints to Parameter and Result on ViewModels which was a breaking change. This had to be done to enable nullable references. What I didn't know was the existence of `notnull` which covers both reference types and value types. As where `class` can only be used for reference types.

### :new: What is the new behavior (if this is a feature change)?
Change the constraints from `where TParameter : class` to `where TParameter : notnull` which still allows value types.

### :boom: Does this PR introduce a breaking change?
Fixes regression

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#3934 

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
