### PR TITLE
PresentationStyle for MvxModalPresentationAttribute for iOS devices on Xamarin Forms

### DIFF
--- a/MvvmCross.Forms/Extensions/PageExtensions.cs
+++ b/MvvmCross.Forms/Extensions/PageExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using MvvmCross.Forms.Presenters.Attributes;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;

--- a/MvvmCross.Forms/Extensions/PageExtensions.cs
+++ b/MvvmCross.Forms/Extensions/PageExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using MvvmCross.Forms.Presenters.Attributes;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using XFPage = Xamarin.Forms.Page;
+
+namespace MvvmCross.Forms.Presenters
+{
+    public static class PageExtensions
+    {
+        public static void SetModalPagePresentationStyle(this XFPage page, ModalPresentationStyle presentationStyle)
+        {
+            if (page == null)
+            {
+                throw new ArgumentNullException(nameof(page));
+            }
+
+            page.On<iOS>().SetModalPresentationStyle((UIModalPresentationStyle)presentationStyle);
+        }
+    }
+}

--- a/MvvmCross.Forms/Extensions/PageExtensions.cs
+++ b/MvvmCross.Forms/Extensions/PageExtensions.cs
@@ -8,7 +8,7 @@ namespace MvvmCross.Forms.Presenters
 {
     public static class PageExtensions
     {
-        public static void SetModalPagePresentationStyle(this XFPage page, ModalPresentationStyle presentationStyle)
+        public static void SetModalPagePresentationStyle(this XFPage page, MvxFormsModalPresentationStyle presentationStyle)
         {
             if (page == null)
             {

--- a/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
+++ b/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
@@ -11,6 +11,18 @@ namespace MvvmCross.Forms.Presenters.Attributes
     {
         public MvxModalPresentationAttribute()
         {
+
         }
+
+        public ModalPresentationStyle PresentationStyle { get; set; }
+    }
+
+    public enum ModalPresentationStyle
+    {
+        FullScreen = 0,
+        FormSheet = 1,
+        Automatic = 2,
+        OverFullScreen = 3,
+        PageSheet = 4
     }
 }

--- a/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
+++ b/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
@@ -14,15 +14,37 @@ namespace MvvmCross.Forms.Presenters.Attributes
 
         }
 
+        /// <summary>
+        /// set the modal presentation style of the modal. This is used for iOS devices for setting different types of modals.
+        /// </summary>
         public ModalPresentationStyle PresentationStyle { get; set; }
     }
 
     public enum ModalPresentationStyle
     {
+        /// <summary>
+        /// A presentation style in which the presented view covers the screen.
+        /// </summary>
         FullScreen = 0,
+
+        /// <summary>
+        /// A presentation style that displays the content centered in the screen.
+        /// </summary>
         FormSheet = 1,
+
+        /// <summary>
+        /// The default presentation style chosen by the system.
+        /// </summary>
         Automatic = 2,
+
+        /// <summary>
+        /// A view presentation style in which the presented view covers the screen.
+        /// </summary>
         OverFullScreen = 3,
+
+        /// <summary>
+        /// A presentation style that partially covers the underlying content.
+        /// </summary>
         PageSheet = 4
     }
 }

--- a/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
+++ b/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
@@ -16,10 +16,10 @@ namespace MvvmCross.Forms.Presenters.Attributes
         /// <summary>
         /// set the modal presentation style of the modal. This is used for iOS devices for setting different types of modals.
         /// </summary>
-        public ModalPresentationStyle PresentationStyle { get; set; }
+        public MvxFormsModalPresentationStyle PresentationStyle { get; set; }
     }
 
-    public enum ModalPresentationStyle
+    public enum MvxFormsModalPresentationStyle
     {
         /// <summary>
         /// A presentation style in which the presented view covers the screen.

--- a/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
+++ b/MvvmCross.Forms/Presenters/Attributes/MvxModalPresentationAttribute.cs
@@ -11,7 +11,6 @@ namespace MvvmCross.Forms.Presenters.Attributes
     {
         public MvxModalPresentationAttribute()
         {
-
         }
 
         /// <summary>

--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -502,6 +502,7 @@ namespace MvvmCross.Forms.Presenters
             MvxViewModelRequest request)
         {
             var page = await CloseAndCreatePage(view, request, attribute, closeModal: false);
+            page.SetModalPagePresentationStyle(attribute.PresentationStyle);
 
             if (FormsApplication.MainPage == null)
                 FormsApplication.MainPage = CreateNavigationPage(CreateContentPage().Build(cp => cp.Title = nameof(ContentPage)));

--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -502,7 +502,6 @@ namespace MvvmCross.Forms.Presenters
             MvxViewModelRequest request)
         {
             var page = await CloseAndCreatePage(view, request, attribute, closeModal: false);
-            page.SetModalPagePresentationStyle(attribute.PresentationStyle);
 
             if (FormsApplication.MainPage == null)
                 FormsApplication.MainPage = CreateNavigationPage(CreateContentPage().Build(cp => cp.Title = nameof(ContentPage)));
@@ -519,11 +518,16 @@ namespace MvvmCross.Forms.Presenters
                 {
                     // Either last isn't a nav page, or there is no last page
                     // So, wrap the current page in a nav page and push onto stack
-                    await FormsApplication.MainPage.Navigation.PushModalAsync(CreateNavigationPage(page));
+                    var navigationPage = CreateNavigationPage(page);
+                    navigationPage.SetModalPagePresentationStyle(attribute.PresentationStyle);
+
+                    await FormsApplication.MainPage.Navigation.PushModalAsync(navigationPage);
                 }
             }
             else
             {
+                page.SetModalPagePresentationStyle(attribute.PresentationStyle);
+
                 // No navigation page required, so just push onto modal stack
                 await FormsApplication.MainPage.Navigation.PushModalAsync(page, attribute.Animated);
             }

--- a/docs/_documentation/platform/xamarin.forms/xamarin-forms-view-presenter.md
+++ b/docs/_documentation/platform/xamarin.forms/xamarin-forms-view-presenter.md
@@ -56,6 +56,10 @@ This is the standard Page attribute.
 
 Will show the Page as a Modal.
 
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| PresentationStyle | `ModalPresentationStyle` | Use this to set the modal presentation style of the modal. This is used for iOS devices for setting different types of modals. |
+
 ### MvxNavigationPagePresentationAttribute
 
 Used to indicate that this is a NavigationPage.

--- a/docs/_documentation/platform/xamarin.forms/xamarin-forms-view-presenter.md
+++ b/docs/_documentation/platform/xamarin.forms/xamarin-forms-view-presenter.md
@@ -58,7 +58,7 @@ Will show the Page as a Modal.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| PresentationStyle | `ModalPresentationStyle` | Use this to set the modal presentation style of the modal. This is used for iOS devices for setting different types of modals. |
+| PresentationStyle | `MvxFormsModalPresentationStyle` | Use this to set the modal presentation style of the modal. This is used for iOS devices for setting different types of modals. |
 
 ### MvxNavigationPagePresentationAttribute
 


### PR DESCRIPTION
This PR makes it possible to set the ModalPresentationStyle for iOS devices. [See documentation here](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/platform/ios/page-presentation-style).
`MvcFormsPagePresenter` uses this to set the iOS specific property ModalPresentationStyle.

**Note:** this is done in a new class called `PageExtensions`. Why? Because of a name collision between `Xamarin.Forms.Page` and `Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page`. Including this in `MvcFormsPagePresenter` is impossible without aliasing or full referencing `Xamarin.Forms.Page` everywhere.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- Ability to set ModalPresentationStyle so that iOS devices with large screen can have different Modal styles.

### :arrow_heading_down: What is the current behavior?

All modals open as a fullscreen page. This is not configurable.

### :new: What is the new behavior (if this is a feature change)?

All modals still open as a fullscreen page. However, you can set a different style now using the `PresentationStyle`-property on `MvxModalPresentationAttribute`

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Use an iPad 😋

### :memo: Links to relevant issues/docs

- [Modal Page Presentation Style on iOS](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop