### PR TITLE
Fix for Forms Modal Back Navigation #3914

### DIFF
--- a/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
+++ b/MvvmCross.Forms/Platforms/Android/Views/MvxFormsAppCompatActivity.cs
@@ -175,38 +175,6 @@ namespace MvvmCross.Forms.Platforms.Android.Views
             ViewModel?.ViewDisappeared();
         }
 
-        public override async void OnBackPressed()
-        {
-            var presenter = Mvx.IoCProvider.Resolve<IMvxFormsPagePresenter>();
-            var pages = presenter.CurrentPageTree;
-
-            for (var i = pages.Length - 1; i >= 0; i--)
-            {
-                var pg = pages[i];
-                if (pg is Xamarin.Forms.NavigationPage navPage)
-                {
-                    if (pg.Navigation.ModalStack.Count > 0)
-                    {
-                        await pg.Navigation.PopModalAsync();
-                        return;
-                    }
-
-                    if (pg.Navigation.NavigationStack.Count > 1)
-                    {
-                        var handled = pg.SendBackButtonPressed();
-                        if (handled) return;
-                    }
-                }
-                else
-                {
-                    var handled = pg.SendBackButtonPressed();
-                    if (handled) return;
-                }
-            }
-
-            MoveTaskToBack(true);
-        }
-
         protected virtual void RegisterSetup()
         {
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix for issue #3914 🥳🥳🥳

It's a bit strange to have something fixed by just removing a bunch of code. I May have missed something, but it is not clear why this code is here in the first place. It's added about 3 years ago, but didn't find a PR or issue explaining why.

I hope that maybe the original committer @martijn00 (legend!) can say something about it. However, may be to long ago 🙂

### :arrow_heading_down: What is the current behavior?
Using the hardware back button on Android always pops the active modal (if any), even if you have navigated within the modal to another page.

### :new: What is the new behavior (if this is a feature change)?
Using the hardware back button results in expected behavior within a modal.

### :boom: Does this PR introduce a breaking change?
Not that I know. Tested with Playground.

### :bug: Recommendations for testing
Use Playground app on **Android**.
1. On the main page, select _'SHOW MODAL NAVIGATION'_
2. On the modal, select _'SHOW NESTEDMODAL'_
3. Go back, using the hardware back button (or gestures).

Before: You are back on the first main page.
Now: You are back on the second screen (first of the modal)

Also use other navigations. Everything seems to work!

### :memo: Links to relevant issues/docs
Fixes #3914 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
