### PR TITLE
Add missing inheritance for Split and TabBar view controllers

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/MvxSplitViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxSplitViewController.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using Foundation;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
@@ -82,8 +83,8 @@ namespace MvvmCross.Platforms.Ios.Views
         }
     }
 
-    public class MvxSplitViewController<TViewModel> : MvxSplitViewController
-        where TViewModel : IMvxViewModel
+    public class MvxSplitViewController<TViewModel> : MvxSplitViewController, IMvxIosView<TViewModel>
+        where TViewModel : class, IMvxViewModel
     {
         public MvxSplitViewController()
         {
@@ -109,6 +110,11 @@ namespace MvvmCross.Platforms.Ios.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
+        }
+
+        public MvxFluentBindingDescriptionSet<IMvxIosView<TViewModel>, TViewModel> CreateBindingSet()
+        {
+            return this.CreateBindingSet<IMvxIosView<TViewModel>, TViewModel>();
         }
     }
 }

--- a/MvvmCross/Platforms/Ios/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxTabBarViewController.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Foundation;
+using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Presenters;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.ViewModels;
@@ -230,8 +231,8 @@ namespace MvvmCross.Platforms.Ios.Views
         }
     }
 
-    public class MvxTabBarViewController<TViewModel> : MvxTabBarViewController
-        where TViewModel : IMvxViewModel
+    public class MvxTabBarViewController<TViewModel> : MvxTabBarViewController, IMvxIosView<TViewModel>
+        where TViewModel : class, IMvxViewModel
     {
         public MvxTabBarViewController()
         {
@@ -257,6 +258,11 @@ namespace MvvmCross.Platforms.Ios.Views
         {
             get { return (TViewModel)base.ViewModel; }
             set { base.ViewModel = value; }
+        }
+
+        public MvxFluentBindingDescriptionSet<IMvxIosView<TViewModel>, TViewModel> CreateBindingSet()
+        {
+            return this.CreateBindingSet<IMvxIosView<TViewModel>, TViewModel>();
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Makes `MvxSplitViewController` and `MvxTabBarViewController` inherit from `IMvxIosView<TViewModel>` and implement `CreateBindingSet` method.

### :arrow_heading_down: What is the current behavior?

`MvxSplitViewController` and `MvxTabBarViewController` do not inherit from `IMvxIosView<TViewModel>`.

### :new: What is the new behavior (if this is a feature change)?

`MvxSplitViewController` and `MvxTabBarViewController` are now `IMvxIosView<TViewModel>`s and are implementing `CreateBindingSet` method.

### :boom: Does this PR introduce a breaking change?

Yes. If anyone used these view controllers with their own interfaces inherited from `IMvxViewModel`, but not classes (which I doubt 😃), they must use a class now.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
