### PR TITLE
Fix memory leak in MvxMacViewPresenter

### DIFF
--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -15,6 +15,7 @@ using MvvmCross.ViewModels;
 using MvvmCross.Presenters;
 using MvvmCross.Presenters.Attributes;
 using System.Threading.Tasks;
+using Foundation;
 
 namespace MvvmCross.Platforms.Mac.Presenters
 {
@@ -60,13 +61,14 @@ namespace MvvmCross.Platforms.Mac.Presenters
 
         protected virtual INSApplicationDelegate ApplicationDelegate => _applicationDelegate;
 
-        protected virtual List<NSWindow> Windows => NSApplication.SharedApplication.DangerousWindows.ToList();
+        protected virtual List<NSWindow> Windows { get; } = new List<NSWindow>();
 
         protected virtual NSWindow MainWindow => NSApplication.SharedApplication.MainWindow;
 
         public MvxMacViewPresenter(INSApplicationDelegate applicationDelegate)
         {
             _applicationDelegate = applicationDelegate;
+            NSWindow.Notifications.ObserveWillClose(OnWindowWillCloseNotification);
         }
 
         public override void RegisterAttributeTypes()
@@ -142,6 +144,9 @@ namespace MvvmCross.Platforms.Mac.Presenters
                 UpdateWindow(attribute, window);
             }
 
+            if (!Windows.Contains(window))
+                Windows.Add(window);
+
             window.Identifier = attribute.Identifier ?? viewController.GetType().Name;
 
             if (!string.IsNullOrEmpty(viewController.Title))
@@ -206,6 +211,11 @@ namespace MvvmCross.Platforms.Mac.Presenters
             return windowController;
         }
 
+        protected virtual MvxWindowController CreateWindowController(NSWindow window)
+        {
+            return new MvxWindowController(window);
+        }
+
         protected virtual Task<bool> ShowContentViewController(
             NSViewController viewController,
             MvxContentPresentationAttribute attribute,
@@ -252,7 +262,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
 
             var tabViewController = window.ContentViewController as IMvxTabViewController;
             if (tabViewController == null)
-                throw new MvxException($"Trying to display a tab but there is no TabViewController! View type: {viewController.GetType()}");
+                throw new MvxException($"Trying to display a tab but there is no TabViewController to host it! View type: {viewController.GetType()}");
 
             tabViewController.ShowTabView(viewController, attribute.TabTitle);
             return Task.FromResult(true);
@@ -271,16 +281,15 @@ namespace MvvmCross.Platforms.Mac.Presenters
             if (window == null)
                 throw new MvxException($"Could not find a window with identifier '{identifier}' to display view '{viewController.GetType()}'");
 
-            return window ?? (MainWindow ?? Windows.Last());
+            return window;
         }
 
         public override Task<bool> Close(IMvxViewModel viewModel)
         {
-            var currentWindows = Windows;
-            for (int i = currentWindows.Count - 1; i >= 0; i--)
+            for (int i = Windows.Count - 1; i >= 0; i--)
             {
-                var window = currentWindows[i];
-
+                var window = Windows[i];
+                
                 // closing controller is a tab
                 var tabViewController = window.ContentViewController as IMvxTabViewController;
                 if (tabViewController != null && tabViewController.CloseTabView(viewModel))
@@ -290,26 +299,31 @@ namespace MvvmCross.Platforms.Mac.Presenters
 
                 var controller = window.ContentViewController as MvxViewController;
 
-                // if controller is a sheet or modal, it must have a presenting parent
-                if (controller.PresentingViewController is MvxViewController parent)
+                // if closing controller is a sheet or modal, it must have a presenting parent
+                var presentedController = controller.PresentedViewControllers?.FirstOrDefault(c => ((MvxViewController)c).ViewModel == viewModel);
+                if (presentedController != null)
                 {
-                    parent.DismissViewController(controller);
+                    controller.DismissViewController(presentedController);
                     return Task.FromResult(true);
                 }
 
-                // closing controller is a content
+                // closing controller is content in a regular window
                 if (controller != null && controller.ViewModel == viewModel)
                 {
+                    Windows.Remove(window);
                     window.Close();
                     return Task.FromResult(true);
                 }
             }
-            return Task.FromResult(true);
+
+            throw new MvxException($"Could not find and close a view for '{viewModel.GetType()}'");
         }
 
-        protected virtual MvxWindowController CreateWindowController(NSWindow window)
+        protected void OnWindowWillCloseNotification(object sender, NSNotificationEventArgs e)
         {
-            return new MvxWindowController(window);
+            var window = e.Notification.Object as NSWindow;
+            if (Windows.Contains(window))
+                Windows.Remove(window);
         }
     }
 }

--- a/Projects/Playground/Playground.Mac/RootView.cs
+++ b/Projects/Playground/Playground.Mac/RootView.cs
@@ -16,6 +16,9 @@ namespace Playground.Mac
     [MvxWindowPresentation(PositionX = 300)]
     public partial class RootView : MvxViewController<RootViewModel>, IMvxOverridePresentationAttribute
     {
+        // prevents presentation in a new window when navigating back to root from a child
+        private static bool WasPresentedInWindow = false;
+
         public bool MyValue { get; set; } = true;
 
         public RootView(IntPtr handle) : base(handle)
@@ -48,8 +51,11 @@ namespace Playground.Mac
 
         public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
         {
-            if (!NSApplication.SharedApplication.DangerousWindows.Any())
+            if (!WasPresentedInWindow)
+            {
+                WasPresentedInWindow = true;
                 return null;
+            }
 
             return new MvxContentPresentationAttribute
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

`MvxMacViewPresenter` makes calls to `NSApplication.SharedApplication.DangerousWindows` but it prevents windows from being released after closing, see #3963

### :new: What is the new behavior (if this is a feature change)?

All calls to `DangerousWindows` were removed, instead `MvxMacViewPresenter` keeps a list of references to the regular windows it creates. It tracks windows closed with the X button or cmd+W by observing `NSWindow.WillCloseNotification`.

Windows for presented sheets and modals are harder to manage "manually" because macOS creates them on its own after calling `window.ContentViewController.PresentViewControllerAs…()`. But since there must be a presenting regular window created by `MvxMacViewPresenter`, sheets and modals always can be reached through its `PresentedViewControllers` property.

(I also experimented with tracking view controllers instead but that got out of hand really quickly.)

In Playground.Mac `RootView` now relies on a static `bool` instead of window count to provide the correct attribute via `IMvxOverridePresentationAttribute`.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Mac Playground should work for all 5 window modes

### :memo: Links to relevant issues/docs

Fixes #3579 and #3963 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
