### PR TITLE
Fix crash when trying to close plain iOS popover

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -640,7 +640,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             // check for plain popover
             if (PopoverViewController is IMvxIosView iosView && iosView.ViewModel == viewModel)
             {
-                return ClosePopoverViewController(viewModel, attribute);
+                return ClosePopoverViewController(PopoverViewController, attribute);
             }
 
             // check for popover navigation stack


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Attempting to close a plain popover (no UINavigationController) triggers and endless loop in the iOS view presenter.

### :new: What is the new behavior (if this is a feature change)?

Attempting to close a plain popover (no UINavigationController) closes the plain popover.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Show a plain popover (no UINavigationController) and try to dismiss it.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
