### PR TITLE
Correct ios freezing when take photo.

### DIFF
--- a/MvvmCross.Plugins/PictureChooser/Platforms/Ios/MvxImagePickerTask.cs
+++ b/MvvmCross.Plugins/PictureChooser/Platforms/Ios/MvxImagePickerTask.cs
@@ -27,14 +27,6 @@ namespace MvvmCross.Plugin.PictureChooser.Platforms.Ios
         private Action<Stream, string> _pictureAvailable;
         private Action _assumeCancelled;
 
-        #region Event subscriptions
-
-        private IDisposable _mediaSubscription;
-        private IDisposable _imageSubscription;
-        private IDisposable _cancelledSubscription;
-
-        #endregion
-        
         private UIImagePickerController EnsurePickerController()
         {
             if (_picker != null)
@@ -52,23 +44,16 @@ namespace MvvmCross.Plugin.PictureChooser.Platforms.Ios
 
         private void SubscribeEvents()
         {
-            _mediaSubscription = _picker.WeakSubscribe<UIImagePickerController, UIImagePickerMediaPickedEventArgs>(
-                nameof(_picker.FinishedPickingMedia), Picker_FinishedPickingMedia);
-            
-            _imageSubscription = _picker.WeakSubscribe<UIImagePickerController, UIImagePickerImagePickedEventArgs>(
-                nameof(_picker.FinishedPickingImage), Picker_FinishedPickingImage);
-            
-            _cancelledSubscription = _picker.WeakSubscribe(nameof(_picker.Canceled), Picker_Canceled);
+            _picker.FinishedPickingMedia += Picker_FinishedPickingMedia;
+            _picker.FinishedPickingImage += Picker_FinishedPickingImage;
+            _picker.Canceled += Picker_Canceled;
         }
 
         private void UnsubscribeEvents()
         {
-            _mediaSubscription?.Dispose();
-            _mediaSubscription = null;
-            _imageSubscription?.Dispose();
-            _imageSubscription = null;
-            _cancelledSubscription?.Dispose();
-            _cancelledSubscription = null;
+            _picker.FinishedPickingMedia -= Picker_FinishedPickingMedia;
+            _picker.FinishedPickingImage -= Picker_FinishedPickingImage;
+            _picker.Canceled -= Picker_Canceled;
         }
         
         public void ChoosePictureFromLibrary(int maxPixelDimension, int percentQuality, Action<Stream, string> pictureAvailable,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Correct ios freezing when take photo.

### :arrow_heading_down: What is the current behavior?
It was caused by garbage collection. Sometimes or often (depending iphone model) events was never thrown
Remplacing WeakSubsribe by strong subscribe. It prevents the garbage collection


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Take photo and choose picture on ios many times
On a ipod 6, before correction, frozen appeared
Doesn't appear now
Here is the application that I used to test the modification: https://github.com/PierreYvesBl/testpicturechooser

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/3517

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
