### PR TITLE
fix iOS closing non fullscreen modals not closing view model

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
 using MvvmCross.Presenters;
+using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Presenters
 {
@@ -11,6 +14,9 @@ namespace MvvmCross.Platforms.Ios.Presenters
     public interface IMvxIosViewPresenter : IMvxViewPresenter, IMvxCanCreateIosView
     {
         public void ClosedPopoverViewController();
+
+        public ConfiguredTaskAwaitable<bool> ClosedModalViewController(UIViewController viewController,
+            MvxModalPresentationAttribute attribute);
     }
 #nullable restore
 }

--- a/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using MvvmCross.Platforms.Ios.Presenters.Attributes;
+using UIKit;
+
+namespace MvvmCross.Platforms.Ios.Presenters
+{
+    public class MvxModalPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
+    {
+        private readonly IMvxIosViewPresenter _presenter;
+        private readonly UIViewController _viewController;
+        private readonly MvxModalPresentationAttribute _attribute;
+
+        public MvxModalPresentationControllerDelegate(IMvxIosViewPresenter presenter, UIViewController viewController, MvxModalPresentationAttribute attribute)
+        {
+            _presenter = presenter;
+            _viewController = viewController;
+            _attribute = attribute;
+        }
+
+        public override void DidDismiss(UIPresentationController presentationController)
+        {
+            _presenter.ClosedModalViewController(_viewController, _attribute);
+        }
+    }
+}

--- a/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationControllerDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxPopoverPresentationControllerDelegate.cs
@@ -7,11 +7,11 @@ using UIKit;
 namespace MvvmCross.Platforms.Ios.Presenters
 {
 #nullable enable
-    public class MvxPopoverDelegate : UIPopoverPresentationControllerDelegate
+    public class MvxPopoverPresentationControllerDelegate : UIPopoverPresentationControllerDelegate
     {
         private readonly IMvxIosViewPresenter _presenter;
 
-        public MvxPopoverDelegate(IMvxIosViewPresenter presenter)
+        public MvxPopoverPresentationControllerDelegate(IMvxIosViewPresenter presenter)
         {
             _presenter = presenter;
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

If you dismiss a non fullscreen modal, the viewPresenter will fail to present another modal view.

### :new: What is the new behavior (if this is a feature change)?

If you dismiss a non fullscreen modal, the viewPresenter will catch it.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

https://github.com/MvvmCross/MvvmCross/issues/3546

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
