### PR TITLE
Feature/visual studio build improvement

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,5 +29,16 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageVersion Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageVersion Include="System.Console" Version="4.3.1" />
+    <PackageVersion Include="Plugin.Permissions" Version="6.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.MediaRouter" Version="1.2.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.AppCompat.Resources" Version="1.1.0.1" />
+    <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="12.0.3"/>
+    <PackageVersion Include="Serilog" Version="2.10.0"/>
+    <PackageVersion Include="Serilog.Sinks.Xamarin" Version="0.2.0.64"/>
+    <PackageVersion Include="Xamarin.GooglePlayServices.Basement" Version="117.5.0" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
+    <PackageVersion Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
+    <PackageVersion Include="Xamarin.FFImageLoading" Version="2.4.11.982" />
   </ItemGroup>
 </Project>

--- a/Projects/Directory.Build.props
+++ b/Projects/Directory.Build.props
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="..\Directory.Build.props" />
+
   <PropertyGroup>
     <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
     <Authors>.NET Foundation and Contributors</Authors>

--- a/Projects/Directory.Build.targets
+++ b/Projects/Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="..\Directory.Build.targets" />
+
   <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
     <DefineConstants>$(DefineConstants);NETSTANDARD;PORTABLE</DefineConstants>
   </PropertyGroup>

--- a/Projects/Directory.Packages.props
+++ b/Projects/Directory.Packages.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <Import Project="..\Directory.Packages.props" />
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.11" />
+  </ItemGroup>
+</Project>

--- a/Projects/Playground/Playground.Core/Playground.Core.csproj
+++ b/Projects/Playground/Playground.Core/Playground.Core.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
+    <PackageReference Include="Plugin.Permissions" />
   </ItemGroup>
 
 </Project>

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -198,19 +198,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
-    </PackageReference>
-    <PackageReference Include="Serilog.Sinks.Xamarin">
-      <Version>0.2.0.64</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.FFImageLoading">
-      <Version>2.4.11.982</Version>
-    </PackageReference>
-    <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
-    <PackageReference Include="Xamarin.GooglePlayServices.Basement" Version="117.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Xamarin" />
+    <PackageReference Include="Xamarin.FFImageLoading" />
+    <PackageReference Include="Plugin.Permissions" />
+    <PackageReference Include="Xamarin.GooglePlayServices.Basement" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable-hdpi\mvvmcross_logo.png" />

--- a/Projects/Playground/Playground.Forms.Droid/LinkerPleaseInclude.cs
+++ b/Projects/Playground/Playground.Forms.Droid/LinkerPleaseInclude.cs
@@ -7,6 +7,7 @@ using Android.Widget;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Navigation;
 using MvvmCross.ViewModels;
+using MvvmCross.Views;
 
 namespace Playground.Forms.Droid
 {
@@ -107,9 +108,9 @@ namespace Playground.Forms.Droid
             context2.Dispose();
         }
 
-        public void Include(MvxNavigationService service, IMvxViewModelLoader loader)
+        public void Include(MvxNavigationService service, IMvxViewDispatcher dispatcher, IMvxViewModelLoader loader)
         {
-            service = new MvxNavigationService(null, loader);
+            service = new MvxNavigationService(null, dispatcher);
         }
 
         public void Include(ConsoleColor color)

--- a/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/Projects/Playground/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -124,18 +124,12 @@
     <AndroidResource Include="Resources\mipmap-xxxhdpi\hamburger.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
-    </PackageReference>
-    <PackageReference Include="Serilog.Sinks.Xamarin">
-      <Version>0.2.0.64</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat.Resources" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
+    <PackageReference Include="Newtonsoft.Json"/>
+    <PackageReference Include="Serilog"/>
+    <PackageReference Include="Serilog.Sinks.Xamarin"/>
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat.Resources" />
+    <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\MvvmCross.DroidX\Material\MvvmCross.DroidX.Material.csproj">
@@ -183,6 +177,5 @@
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
-  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.Mac/Playground.Forms.Mac.csproj
+++ b/Projects/Playground/Playground.Forms.Mac/Playground.Forms.Mac.csproj
@@ -121,8 +121,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
+    <PackageReference Include="Plugin.Permissions"/>
   </ItemGroup>
-  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
+++ b/Projects/Playground/Playground.Forms.UI/Playground.Forms.UI.csproj
@@ -15,5 +15,4 @@
     <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
   </ItemGroup>
   
-  <Import Project="..\..\..\XamarinForms.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
+++ b/Projects/Playground/Playground.Forms.Uwp/Playground.Forms.Uwp.csproj
@@ -168,9 +168,8 @@
       <Project>{9a317670-f2d9-4155-9ea7-f8cfd3cfe79f}</Project>
       <Name>Playground.Forms.UI</Name>
     </ProjectReference>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.11" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
   </ItemGroup>
-  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
+++ b/Projects/Playground/Playground.Forms.Wpf/Playground.Forms.Wpf.csproj
@@ -133,7 +133,6 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="..\..\..\XamarinFormsWpf.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Forms.iOS/LinkerPleaseInclude.cs
+++ b/Projects/Playground/Playground.Forms.iOS/LinkerPleaseInclude.cs
@@ -118,9 +118,9 @@ namespace Playground.Forms.iOS
             changed.PropertyChanged += (sender, e) => { var test = e.PropertyName; };
         }
 
-        public void Include(MvxNavigationService service, IMvxViewModelLoader loader)
+        public void Include(MvxNavigationService service, IMvxViewModelLoader loader, MvvmCross.Views.IMvxViewDispatcher dispatcher)
         {
-            service = new MvxNavigationService(null, loader);
+            service = new MvxNavigationService(null, dispatcher);
         }
 
         public void Include(ConsoleColor color)

--- a/Projects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
+++ b/Projects/Playground/Playground.Forms.iOS/Playground.Forms.iOS.csproj
@@ -135,7 +135,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
+    <PackageReference Include="Plugin.Permissions"/>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" />
@@ -160,6 +160,5 @@
     <BundleResource Include="Resources\MvvmCross%402x.png" />
     <BundleResource Include="Resources\MvvmCross%403x.png" />
   </ItemGroup>
-  <Import Project="..\..\..\XamarinForms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.Mac/Playground.Mac.csproj
+++ b/Projects/Playground/Playground.Mac/Playground.Mac.csproj
@@ -143,7 +143,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
+    <PackageReference Include="Plugin.Permissions" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/Projects/Playground/Playground.TvOS/LinkerPleaseInclude.cs
+++ b/Projects/Playground/Playground.TvOS/LinkerPleaseInclude.cs
@@ -86,9 +86,9 @@ namespace Playground.TvOS
             changed.PropertyChanged += (sender, e) => { var test = e.PropertyName; };
         }
 
-        public void Include(MvxNavigationService service, IMvxViewModelLoader loader)
+        public void Include(MvxNavigationService service, MvvmCross.Views.IMvxViewDispatcher dispatcher, IMvxViewModelLoader loader)
         {
-            service = new MvxNavigationService(null, loader);
+            service = new MvxNavigationService(null, dispatcher);
         }
 
         public void Include(ConsoleColor color)

--- a/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
+++ b/Projects/Playground/Playground.Uwp/Playground.Uwp.csproj
@@ -194,7 +194,7 @@
       <Project>{fe374d1a-1a19-49bc-8e93-d52399a9c3f3}</Project>
       <Name>Playground.Core</Name>
     </ProjectReference>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.11" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Projects/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/Projects/Playground/Playground.iOS/Playground.iOS.csproj
@@ -127,7 +127,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
+    <PackageReference Include="Plugin.Permissions" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Build fix for for visual studio build due to centrally packages
https://github.com/MvvmCross/MvvmCross/issues/4043

### :arrow_heading_down: What is the current behavior?

Visual Studio 2019 16.8.3 is unable to restore the nuget packages and therefore fails

### :new: What is the new behavior (if this is a feature change)?

Build does work.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Checkout and build with visual studio 2019

### :memo: Links to relevant issues/docs

https://github.com/MvvmCross/MvvmCross/issues/4043

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
