### PR TITLE
Fix exception disposing weakevent on disposed source

### DIFF
--- a/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
@@ -98,10 +98,18 @@ namespace MvvmCross.WeakSubscription
             if (!_subscribed)
                 return;
 
-            TSource source;
-            if (_sourceReference.TryGetTarget(out source))
+            try
             {
-                _sourceEventInfo.GetRemoveMethod().Invoke(source, new object[] { _ourEventHandler });
+                TSource source;
+                if (_sourceReference.TryGetTarget(out source))
+                {
+                    _sourceEventInfo.GetRemoveMethod().Invoke(source, new object[] { _ourEventHandler });
+                    _subscribed = false;
+                }
+            }
+            catch (TargetInvocationException tie) when (tie.InnerException is ObjectDisposedException)
+            {
+                // we don't care if source has already been disposed
                 _subscribed = false;
             }
         }
@@ -210,10 +218,18 @@ namespace MvvmCross.WeakSubscription
             if (!_subscribed)
                 return;
 
-            TSource source;
-            if (_sourceReference.TryGetTarget(out source))
+            try
             {
-                _sourceEventInfo.GetRemoveMethod().Invoke(source, new object[] { _ourEventHandler });
+                TSource source;
+                if (_sourceReference.TryGetTarget(out source))
+                {
+                    _sourceEventInfo.GetRemoveMethod().Invoke(source, new object[] { _ourEventHandler });
+                    _subscribed = false;
+                }
+            }
+            catch (TargetInvocationException tie) when (tie.InnerException is ObjectDisposedException)
+            {
+                // we don't care if source has already been disposed
                 _subscribed = false;
             }
         }

--- a/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
@@ -8,6 +8,7 @@ using MvvmCross.Exceptions;
 
 namespace MvvmCross.WeakSubscription
 {
+#nullable enable
     public class MvxWeakEventSubscription<TSource, TEventArgs> : IDisposable
         where TSource : class
     {
@@ -38,7 +39,7 @@ namespace MvvmCross.WeakSubscription
             EventHandler<TEventArgs> targetEventHandler)
         {
             if (source == null)
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(source), "missing source in MvxWeakEventSubscription");
 
             if (sourceEventInfo == null)
                 throw new ArgumentNullException(nameof(sourceEventInfo),
@@ -117,7 +118,7 @@ namespace MvvmCross.WeakSubscription
         private void AddEventHandler()
         {
             if (_subscribed)
-                throw new MvxException("Should not call _subscribed twice");
+                throw new MvxException("Should not call AddEventHandler twice");
 
             TSource source;
             if (_sourceReference.TryGetTarget(out source))
@@ -158,7 +159,7 @@ namespace MvvmCross.WeakSubscription
             EventHandler targetEventHandler)
         {
             if (source == null)
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(source), "missing source in MvxWeakEventSubscription");
 
             if (sourceEventInfo == null)
                 throw new ArgumentNullException(nameof(sourceEventInfo),
@@ -237,7 +238,7 @@ namespace MvvmCross.WeakSubscription
         private void AddEventHandler()
         {
             if (_subscribed)
-                throw new MvxException("Should not call _subscribed twice");
+                throw new MvxException("Should not call AddEventHandler() twice");
 
             TSource source;
             if (_sourceReference.TryGetTarget(out source))
@@ -247,4 +248,5 @@ namespace MvvmCross.WeakSubscription
             }
         }
     }
+#nullable restore
 }

--- a/Projects/Playground/Playground.Droid/Adapter/SelectedItemRecyclerAdapter.cs
+++ b/Projects/Playground/Playground.Droid/Adapter/SelectedItemRecyclerAdapter.cs
@@ -4,8 +4,8 @@
 
 using System;
 using Android.Runtime;
-using Android.Support.V4.View;
 using Android.Widget;
+using AndroidX.Core.View;
 using AndroidX.RecyclerView.Widget;
 using MvvmCross.DroidX.RecyclerView;
 using MvvmCross.Platforms.Android.Binding.BindingContext;

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxWeakEventSubscriptionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxWeakEventSubscriptionTest.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using MvvmCross.WeakSubscription;
+using Xunit;
+
+namespace MvvmCross.UnitTest.Base
+{
+    public class MvxWeakEventSubscriptionTest
+    {
+        private sealed class DisposableClass : IDisposable
+        {
+            private bool _isDisposed;
+            private EventHandler _testEvent;
+
+            public event EventHandler TestEvent
+            {
+                add
+                {
+                    if (_isDisposed)
+                        throw new ObjectDisposedException(nameof(DisposableClass));
+
+                    _testEvent += value;
+                }
+                remove
+                {
+                    if (_isDisposed)
+                        throw new ObjectDisposedException(nameof(DisposableClass));
+
+                    _testEvent -= value;
+                }
+            }
+
+            public void Dispose()
+            {
+                _isDisposed = true;
+            }
+        }
+
+        [Fact]
+        public void DisposeWeakEventSubscription_OnDisposedObject_DoesNotThrow()
+        {
+            var disposableClass = new DisposableClass();
+
+            var subscription = new MvxWeakEventSubscription<DisposableClass>(disposableClass, "TestEvent", (s, e) =>
+            {
+            });
+
+            disposableClass.Dispose();
+            subscription.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug

### :arrow_heading_down: What is the current behavior?
If you try to dispose a MvxWeakEventSubscription which has weak subscribed on a class that is disposed. In some cases (especially on Android) it can throw an Exception attempting to remove eventhandlers when disposing.

### :new: What is the new behavior (if this is a feature change)?
Since source is already disposed and doesn't like us to do more on it, I simply catch the ObjectDisposedException when attempting to remove event handlers.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4071

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
