### PR TITLE
Ensure UICollectionView animations are on main thread

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewSourceAnimated.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewSourceAnimated.cs
@@ -46,7 +46,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
         {
             if (!NSThread.IsMain)
             {
-                InvokeOnMainThread(() => CollectionChangedOnCollectionChanged(sender, args));
+                BeginInvokeOnMainThread(() => CollectionChangedOnCollectionChanged(sender, args));
                 return;
             }
             

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewSourceAnimated.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewSourceAnimated.cs
@@ -44,6 +44,12 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
 
         protected override void CollectionChangedOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
+            if (!NSThread.IsMain)
+            {
+                InvokeOnMainThread(() => CollectionChangedOnCollectionChanged(sender, args));
+                return;
+            }
+            
             var itemsSource = (ItemsSource as IEnumerable<object>)?.ToList();
             if (itemsSource == null)
                 throw new ArgumentException("ItemsSource must be convertible to IEnumerable<object>, as this code needs to take a snapshot of the list in order to be thread safe for the ios animations");


### PR DESCRIPTION
This was the cause of a lot of headache for me. It looks like the TableViewSource implements a check for main thread but the CollectionViewSource does not. Adding this ensures that collection view animations occur on the main thread.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

If the ObservableCollection notifies changes on something other than the main thread, the collection view does not reload data.

### :new: What is the new behavior (if this is a feature change)?

When receiving a Collection changed notification, ensures that animations are run on the main thread.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

I was binding to DynamicData's ReadOnlyObservableCollection instead of the MvxObservableCollection

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
