### PR TITLE
Fix documentation bottom padding/margin not working.

### DIFF
--- a/docs/_sass/layouts/_documentation.scss
+++ b/docs/_sass/layouts/_documentation.scss
@@ -47,7 +47,7 @@
 
   > .documentation {
     margin-top: $documentation-margin / 2;
-    margin-bottom: $documentation-margin;
+    padding-bottom: $documentation-margin / 2 + 40px + 30px;
 
     h1 {
       font-weight: $base-font-weight;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

The margin at the bottom of the documentation was not working. This made the documentation harder to read.

### :arrow_heading_down: What is the current behavior?

Look at any of the docs, the bottom margin is 0px.

### :new: What is the new behavior (if this is a feature change)?

Bottom margin is $documentation-margin / 2 + 40px + 30px.
The 40px is for the height of the "back-to-top" element, and the 30 px is to account for its margin.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
