### PR TITLE
Support embedding NavigationPage inside of TabbedPage

### DIFF
--- a/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms/Presenters/MvxFormsPagePresenter.cs
@@ -586,6 +586,7 @@ namespace MvvmCross.Forms.Presenters
             }
             else
             {
+                var tabPage = page;
                 var tabHost = GetPageOfType<TabbedPage>();
                 if (tabHost == null)
                 {
@@ -594,7 +595,17 @@ namespace MvvmCross.Forms.Presenters
                     await PushOrReplacePage(FormsApplication.MainPage, tabHost, attribute);
                 }
 
-                tabHost.Children.Add(page);
+                if (attribute.WrapInNavigationPage)
+                {
+                    var navigationPage = CreateNavigationPage(page).Build(tp =>
+                    {
+                        tp.Title = page.Title;
+                        tp.IconImageSource = page.IconImageSource;
+                    });
+                    tabPage = navigationPage;
+                }
+
+                tabHost.Children.Add(tabPage);
             }
             return true;
         }
@@ -806,6 +817,19 @@ namespace MvvmCross.Forms.Presenters
                 {
                     var navMasterPage = TopNavigationPage(masterDetailsPage.Flyout);
                     if (navMasterPage != null) return navMasterPage;
+                }
+            }
+            
+            // The page isn't a MasterDetailPage, so check
+            // to see if it's a TabbedPage, and if so, check
+            // the current page for a navigation page.
+            if (rootPage is TabbedPage tabbedPage)
+            {
+                if (tabbedPage.CurrentPage != null)
+                {
+                    // Check if there's a nested navigation
+                    var navPage = TopNavigationPage(tabbedPage.CurrentPage);
+                    if (navPage != null) return navPage;
                 }
             }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

If you mark a non root `MvxTabbedPagePresentation` with `WrapInNavigationPage = true` the attribute is ignored.

### :new: What is the new behavior (if this is a feature change)?

The page is wrapped in a NavigationPage allowing for navigation within a tab.
This is opposed to wrapping the TabHost in a NavigationPage.

### :boom: Does this PR introduce a breaking change?

Possibly.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#3514
#2502
#4135

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
