### PR TITLE
Initialize logging as early as possible

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -85,6 +85,8 @@ namespace MvvmCross.Core
             State = MvxSetupState.InitializingPrimary;
             _iocProvider = InitializeIoC();
 
+            InitializeLoggingServices(_iocProvider);
+
             // Register the default setup dependencies before
             // invoking the static call back.
             // Developers can either extend the MvxSetup and override
@@ -92,7 +94,6 @@ namespace MvvmCross.Core
             // callback method by setting the RegisterSetupDependencies method
             RegisterDefaultSetupDependencies(_iocProvider);
             RegisterSetupDependencies?.Invoke(_iocProvider);
-            InitializeLoggingServices(_iocProvider);
             SetupLog?.Log(LogLevel.Trace, "Setup: Primary start");
             SetupLog?.Log(LogLevel.Trace, "Setup: FirstChance start");
             InitializeFirstChance(_iocProvider);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix/feature

### :arrow_heading_down: What is the current behavior?

We register a bunch of things before we initialize logging services. We can do this much earlier.

### :new: What is the new behavior (if this is a feature change)?

We not initialize logging _right_ after IoC container is created

### :boom: Does this PR introduce a breaking change?

This shouldn't break anything, unless someone is using anything from the IoC container when creating their logging services.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Fixes #3845 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
