### PR TITLE
Add back preferences related bindings and helpers

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/MvxPreferencePropertyBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxPreferencePropertyBinding.cs
@@ -1,0 +1,11 @@
+﻿namespace MvvmCross.Platforms.Android.Binding
+{
+    internal static class MvxPreferencePropertyBinding
+    {
+        public const string Preference_Value = "Value";
+        public const string EditTextPreference_Text = "Text";
+        public const string ListPreference_Value = "Value";
+        public const string TwoStatePreference_Checked = "Checked";
+        public const string Preference_Click = "PreferenceClick";
+    }
+}

--- a/MvvmCross/Platforms/Android/Binding/MvxPreferencePropertyBindingExtensions.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxPreferencePropertyBindingExtensions.cs
@@ -1,0 +1,22 @@
+﻿using AndroidX.Preference;
+
+namespace MvvmCross.Platforms.Android.Binding
+{
+    public static class MvxPreferencePropertyBindingExtensions
+    {
+        public static string BindValue(this AndroidX.Preference.Preference preference)
+            => MvxPreferencePropertyBinding.Preference_Value;
+
+        public static string BindValue(this ListPreference listPreference)
+            => MvxPreferencePropertyBinding.ListPreference_Value;
+
+        public static string BindText(this EditTextPreference editTextPreference)
+            => MvxPreferencePropertyBinding.EditTextPreference_Text;
+
+        public static string BindChecked(this TwoStatePreference twoStatePreference)
+            => MvxPreferencePropertyBinding.TwoStatePreference_Checked;
+
+        public static string BindClick(this AndroidX.Preference.Preference preference)
+            => MvxPreferencePropertyBinding.Preference_Click;
+    }
+}

--- a/MvvmCross/Platforms/Android/Binding/MvxPreferenceSetupHelper.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxPreferenceSetupHelper.cs
@@ -1,0 +1,32 @@
+﻿using AndroidX.Preference;
+using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Platforms.Android.Binding.Target;
+
+namespace MvvmCross.Platforms.Android.Binding
+{
+    public static class MvxPreferenceSetupHelper
+    {
+        public static void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+        {
+            registry.RegisterCustomBindingFactory<Preference>(
+                MvxPreferencePropertyBinding.Preference_Value,
+                preference => new MvxPreferenceValueTargetBinding(preference));
+
+            registry.RegisterCustomBindingFactory<EditTextPreference>(
+                MvxPreferencePropertyBinding.EditTextPreference_Text,
+                preference => new MvxEditTextPreferenceTextTargetBinding(preference));
+
+            registry.RegisterCustomBindingFactory<ListPreference>(
+                MvxPreferencePropertyBinding.ListPreference_Value,
+                preference => new MvxListPreferenceTargetBinding(preference));
+
+            registry.RegisterCustomBindingFactory<TwoStatePreference>(
+                MvxPreferencePropertyBinding.TwoStatePreference_Checked,
+                preference => new MvxTwoStatePreferenceCheckedTargetBinding(preference));
+
+            registry.RegisterCustomBindingFactory<Preference>(
+                MvxPreferencePropertyBinding.Preference_Click,
+                preference => new MvxPreferenceClickTargetBinding(preference));
+        }
+    }
+}

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxPreferenceClickTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxPreferenceClickTargetBinding.cs
@@ -1,0 +1,83 @@
+﻿using AndroidX.Preference;
+using MvvmCross.Binding;
+using MvvmCross.Platforms.Android.WeakSubscription;
+using System;
+using System.Windows.Input;
+
+namespace MvvmCross.Platforms.Android.Binding.Target
+{
+    public class MvxPreferenceClickTargetBinding : MvxAndroidTargetBinding
+    {
+        private ICommand _command;
+        private IDisposable _clickSubscription;
+        private IDisposable _canExecuteSubscription;
+        private readonly EventHandler<EventArgs> _canExecuteEventHandler;
+
+        protected Preference Preference => (Preference)Target;
+
+        public MvxPreferenceClickTargetBinding(Preference view)
+            : base(view)
+        {
+            _canExecuteEventHandler = OnCanExecuteChanged;
+
+            _clickSubscription = Preference.WeakSubscribe<Preference, Preference.PreferenceClickEventArgs>(
+                nameof(Preference.PreferenceClick),
+                ViewOnPreferenceClick);
+        }
+
+        private void ViewOnPreferenceClick(object sender, Preference.PreferenceClickEventArgs args)
+        {
+            if (_command == null)
+                return;
+
+            if (!_command.CanExecute(null))
+                return;
+
+            _command.Execute(null);
+        }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            _canExecuteSubscription?.Dispose();
+            _canExecuteSubscription = null;
+
+            _command = value as ICommand;
+            if (_command != null)
+            {
+                _canExecuteSubscription = MvvmCross.WeakSubscription.MvxWeakSubscriptionExtensions.WeakSubscribe(_command, _canExecuteEventHandler);
+            }
+            RefreshEnabledState();
+        }
+
+        private void RefreshEnabledState()
+        {
+            var view = Preference;
+            if (view == null)
+                return;
+
+            view.Enabled = _command?.CanExecute(null) ?? false;
+        }
+
+        private void OnCanExecuteChanged(object sender, EventArgs e)
+        {
+            RefreshEnabledState();
+        }
+
+        public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
+
+        public override Type TargetType => typeof(ICommand);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                _clickSubscription?.Dispose();
+                _clickSubscription = null;
+
+                _canExecuteSubscription?.Dispose();
+                _canExecuteSubscription = null;
+            }
+            base.Dispose(isDisposing);
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When I migrated to AndroidX, I accidentally missed migrating some Preferences classes and forgot to include them.

### :new: What is the new behavior (if this is a feature change)?
This PR adds these back

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4094

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
