### PR TITLE
Respect Tag in attribute when set

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -536,7 +536,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             if (fragmentManager == null)
                 throw new ArgumentNullException(nameof(fragmentManager));
 
-            var fragmentName = attribute.ViewType.FragmentJavaName();
+            var fragmentName = attribute.Tag ?? attribute.ViewType.FragmentJavaName();
 
             IMvxFragmentView? fragmentView = null;
             if (attribute.IsCacheableFragment)
@@ -677,7 +677,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             if (attribute.ViewType == null)
                 throw new InvalidOperationException($"{nameof(MvxDialogFragmentPresentationAttribute)}.ViewType is null");
 
-            var fragmentName = attribute.ViewType.FragmentJavaName();
+            var fragmentName = attribute.Tag ?? attribute.ViewType.FragmentJavaName();
             IMvxFragmentView mvxFragmentView = CreateFragment(CurrentActivity.SupportFragmentManager, attribute, attribute.ViewType);
             var dialog = (DialogFragment)mvxFragmentView;
 
@@ -851,7 +851,7 @@ namespace MvvmCross.Platforms.Android.Presenters
         {
             ValidateArguments(attribute);
 
-            string tag = attribute.ViewType.FragmentJavaName();
+            string tag = attribute.Tag ?? attribute.ViewType.FragmentJavaName();
             var toClose = CurrentFragmentManager?.FindFragmentByTag(tag);
             if (toClose is DialogFragment dialog)
             {
@@ -916,7 +916,7 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             try
             {
-                var fragmentName = fragmentAttribute.ViewType.FragmentJavaName();
+                var fragmentName = fragmentAttribute.Tag ?? fragmentAttribute.ViewType.FragmentJavaName();
                 if (fragmentManager.BackStackEntryCount > 0)
                 {
                     PopOnBackstackEntries(fragmentName, fragmentManager, fragmentAttribute);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
In most cases we ignore the Tag property in the MvxFragmentPresentationAttribute.

### :new: What is the new behavior (if this is a feature change)?
This should be fixed, and fragments will be registered using the Tag property if set, otherwise falls back to the fragment name.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #3999

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
