### PR TITLE
Fix binding context not set on Android Activities

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxActivity.cs
@@ -33,6 +33,7 @@ namespace MvvmCross.Platforms.Android.Views
         protected MvxActivity()
         {
             BindingContext = new MvxAndroidBindingContext(this, this);
+            this.AddEventListeners();
         }
 
         public object DataContext

--- a/MvvmCross/Platforms/Android/Views/MvxActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxActivity.cs
@@ -61,7 +61,7 @@ namespace MvvmCross.Platforms.Android.Views
 
         public override void SetContentView(int layoutResID)
         {
-            if (BaseContext is MvxContextWrapper)
+            if (BaseContextToAttach(this) is MvxContextWrapper)
             {
                 _view = this.BindingInflate(layoutResID, null);
                 SetContentView(_view);

--- a/MvvmCross/Platforms/Android/Views/MvxActivityViewExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxActivityViewExtensions.cs
@@ -12,11 +12,29 @@ using MvvmCross.ViewModels;
 using MvvmCross.Views;
 using MvvmCross.Core;
 using Microsoft.Extensions.Logging;
+using MvvmCross.Platforms.Android.Views.Base;
+using MvvmCross.Binding.BindingContext;
 
 namespace MvvmCross.Platforms.Android.Views
 {
     public static class MvxActivityViewExtensions
     {
+        public static void AddEventListeners(this IMvxEventSourceActivity activity)
+        {
+            if (activity is IMvxAndroidView)
+            {
+                var adapter = new MvxActivityAdapter(activity);
+            }
+            if (activity is IMvxBindingContextOwner)
+            {
+                var bindingAdapter = new MvxBindingActivityAdapter(activity);
+            }
+            if (activity is IMvxChildViewModelOwner)
+            {
+                var childOwnerAdapter = new MvxChildViewModelOwnerAdapter(activity);
+            }
+        }
+
         public static void OnViewCreate(this IMvxAndroidView androidView, Bundle bundle)
         {
             androidView.EnsureSetupInitialized();

--- a/Projects/Playground/Playground.Droid/LinkerPleaseInclude.cs
+++ b/Projects/Playground/Playground.Droid/LinkerPleaseInclude.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using Android.App;
 using Android.Views;
 using Android.Widget;
+using MvvmCross;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Navigation;
 using MvvmCross.ViewModels;
@@ -111,7 +112,7 @@ namespace Playground.Droid
 
         public void Include(MvxNavigationService service, IMvxViewModelLoader loader, IMvxViewDispatcher viewDispatcher)
         {
-            service = new MvxNavigationService(null, viewDispatcher);
+            service = new MvxNavigationService(null, viewDispatcher, Mvx.IoCProvider);
         }
 
         public void Include(ConsoleColor color)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Regression

### :arrow_heading_down: What is the current behavior?

I managed to mess up setting of BindingContext on Android Activities by cleaning up a bit too much code.

I removed AddEventListeners in the MvxActivityAdapter, because it looked like the instances were not used, but they are indeed needed for bindings to work.

### :new: What is the new behavior (if this is a feature change)?

Added back the listeners

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
