### PR TITLE
Sticky Messages

### DIFF
--- a/MvvmCross.Plugins/Messenger/IMvxMessenger.cs
+++ b/MvvmCross.Plugins/Messenger/IMvxMessenger.cs
@@ -17,8 +17,9 @@ namespace MvvmCross.Plugin.Messenger
         /// <param name="deliveryAction">Action to invoke when message is delivered</param>
         /// <param name="reference">Use a strong or weak reference to the deliveryAction</param>
         /// <param name="tag">An optional tag to include with this subscription</param>
+        /// <param name="isSticky">If true, immediately invokes the deliveryAction if a cached message exists</param>
         /// <returns>MessageSubscription used to unsubscribing</returns>
-        MvxSubscriptionToken Subscribe<TMessage>(Action<TMessage> deliveryAction, MvxReference reference = MvxReference.Weak, string? tag = null)
+        MvxSubscriptionToken Subscribe<TMessage>(Action<TMessage> deliveryAction, MvxReference reference = MvxReference.Weak, string? tag = null, bool isSticky = false)
             where TMessage : MvxMessage;
 
         /// <summary>
@@ -30,7 +31,7 @@ namespace MvvmCross.Plugin.Messenger
         /// <param name="reference">Use a strong or weak reference to the deliveryAction</param>
         /// <param name="tag">An optional tag to include with this subscription</param>
         /// <returns>MessageSubscription used to unsubscribing</returns>
-        MvxSubscriptionToken SubscribeOnMainThread<TMessage>(Action<TMessage> deliveryAction, MvxReference reference = MvxReference.Weak, string? tag = null)
+        MvxSubscriptionToken SubscribeOnMainThread<TMessage>(Action<TMessage> deliveryAction, MvxReference reference = MvxReference.Weak, string? tag = null, bool isSticky = false)
              where TMessage : MvxMessage;
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace MvvmCross.Plugin.Messenger
         /// <param name="reference">Use a strong or weak reference to the deliveryAction</param>
         /// <param name="tag">An optional tag to include with this subscription</param>
         /// <returns>MessageSubscription used to unsubscribing</returns>
-        MvxSubscriptionToken SubscribeOnThreadPoolThread<TMessage>(Action<TMessage> deliveryAction, MvxReference reference = MvxReference.Weak, string? tag = null)
+        MvxSubscriptionToken SubscribeOnThreadPoolThread<TMessage>(Action<TMessage> deliveryAction, MvxReference reference = MvxReference.Weak, string? tag = null, bool isSticky = false)
              where TMessage : MvxMessage;
 
         /// <summary>
@@ -100,21 +101,24 @@ namespace MvvmCross.Plugin.Messenger
         /// </summary>
         /// <typeparam name="TMessage">Type of message</typeparam>
         /// <param name="message">Message to deliver</param>
-        void Publish<TMessage>(TMessage message) where TMessage : MvxMessage;
+        /// <param name="isSticky">If true, caches the message for sticky subscribers</param>
+        void Publish<TMessage>(TMessage message, bool isSticky = false) where TMessage : MvxMessage;
 
         /// <summary>
         /// Publish a message to any subscribers
         /// - GetType() will be used to determine the message type
         /// </summary>
         /// <param name="message">Message to deliver</param>
-        void Publish(MvxMessage message);
+        /// <param name="isSticky">If true, caches the message for sticky subscribers</param>
+        void Publish(MvxMessage message, bool isSticky = false);
 
         /// <summary>
         /// Publish a message to any subscribers
         /// </summary>
         /// <param name="message">Message to deliver</param>
         /// <param name="messageType">The type of the message to use for delivery - message should be of that class or a of a subclass</param>
-        void Publish(MvxMessage message, Type messageType);
+        /// <param name="isSticky">If true, caches the message for sticky subscribers</param>
+        void Publish(MvxMessage message, Type messageType, bool isSticky = false);
 
         /// <summary>
         /// Schedules a check on all subscribers for the specified messageType. If any are not alive, they will be removed
@@ -126,6 +130,12 @@ namespace MvvmCross.Plugin.Messenger
         /// Schedules a check on all subscribers for all messageType. If any are not alive, they will be removed
         /// </summary>
         void RequestPurgeAll();
+
+        /// <summary>
+        /// Removes the message type from the sticky cache.
+        /// </summary>
+        /// <typeparam name="TMessageType">The type of the message to remove</typeparam>
+        void RemoveSticky<TMessageType>() where TMessageType : MvxMessage;
     }
 #nullable restore
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

Sticky message subscriptions allow for previously sent messages to be delivered upon a subscription.

### :arrow_heading_down: What is the current behavior?

When subscribing to a message type there is no way to receive previously sent messages.
When publishing a message there is no way to mark it as sticky.

### :new: What is the new behavior (if this is a feature change)?

When subscribing to a message type, you can specify if the subscription is sticky or not.
When publishing a message, you can now indicate that it should be sticky.
You can also call `RemoveSticky` to remove the sticky messages of a given type.

### :boom: Does this PR introduce a breaking change?

No. While the `isSticky` parameter was added, it defaults to `false`. This should prevent breaking changes.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4232
Discussion #4204

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
