### PR TITLE
Fix potential null ref in MvxColorValueConverter

### DIFF
--- a/MvvmCross.Plugins/Color/BasePlugin.cs
+++ b/MvvmCross.Plugins/Color/BasePlugin.cs
@@ -15,12 +15,14 @@ namespace MvvmCross.Plugin.Color
 
         private void RegisterValueConverters()
         {
-            var registry = Mvx.IoCProvider.Resolve<IMvxValueConverterRegistry>();
-            registry.AddOrOverwrite("ARGB", new MvxARGBValueConverter());
-            registry.AddOrOverwrite("NativeColor", new MvxNativeColorValueConverter());
-            registry.AddOrOverwrite("RGBA", new MvxRGBAValueConverter());
-            registry.AddOrOverwrite("RGB", new MvxRGBValueConverter());
-            registry.AddOrOverwrite("RGBIntColor", new MvxRGBIntColorValueConverter());
+            if (Mvx.IoCProvider.TryResolve<IMvxValueConverterRegistry>(out var registry))
+            {
+                registry.AddOrOverwrite("ARGB", new MvxARGBValueConverter());
+                registry.AddOrOverwrite("NativeColor", new MvxNativeColorValueConverter());
+                registry.AddOrOverwrite("RGBA", new MvxRGBAValueConverter());
+                registry.AddOrOverwrite("RGB", new MvxRGBValueConverter());
+                registry.AddOrOverwrite("RGBIntColor", new MvxRGBIntColorValueConverter());
+            }
         }
     }
 }

--- a/MvvmCross.Plugins/Color/MvxColorValueConverter.cs
+++ b/MvvmCross.Plugins/Color/MvxColorValueConverter.cs
@@ -9,24 +9,28 @@ using MvvmCross.UI;
 
 namespace MvvmCross.Plugin.Color
 {
+#nullable enable
     public abstract class MvxColorValueConverter : MvxValueConverter
     {
-        private IMvxNativeColor _nativeColor;
+        private readonly IMvxNativeColor? _nativeColor;
 
-        private IMvxNativeColor NativeColor => _nativeColor ?? (_nativeColor = Mvx.IoCProvider.Resolve<IMvxNativeColor>());
-
-        protected abstract System.Drawing.Color Convert(object value, object parameter, CultureInfo culture);
-
-        public sealed override object Convert(object value, Type targetType, object parameter,
-                                       CultureInfo culture)
+        protected MvxColorValueConverter()
         {
-            return NativeColor.ToNative(Convert(value, parameter, culture));
+            Mvx.IoCProvider?.TryResolve<IMvxNativeColor>(out _nativeColor);
+        }
+
+        protected abstract System.Drawing.Color Convert(object value, object? parameter, CultureInfo? culture);
+
+        public sealed override object Convert(object value, Type? targetType, object? parameter,
+                                       CultureInfo? culture)
+        {
+            return _nativeColor?.ToNative(Convert(value, parameter, culture)) ?? MvxBindingConstant.UnsetValue;
         }
     }
 
     public abstract class MvxColorValueConverter<T> : MvxColorValueConverter
     {
-        protected sealed override System.Drawing.Color Convert(object value, object parameter, CultureInfo culture)
+        protected sealed override System.Drawing.Color Convert(object value, object? parameter, CultureInfo? culture)
         {
             if (value is T t)
                 return Convert(t, parameter, culture);
@@ -34,6 +38,7 @@ namespace MvvmCross.Plugin.Color
             return default;
         }
 
-        protected abstract System.Drawing.Color Convert(T value, object parameter, CultureInfo culture);
+        protected abstract System.Drawing.Color Convert(T value, object? parameter, CultureInfo? culture);
     }
+#nullable restore
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Design time throws null ref because IoC isn't initialized. The color converter relies on types in the IoC provider.

### :new: What is the new behavior (if this is a feature change)?
Added some protection for this.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4144 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
