### PR TITLE
Fix navigate with TParameter and TResult resulting in crash

### DIFF
--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -388,7 +388,14 @@ namespace MvvmCross.Navigation
 
             OnDidNavigate(this, args);
 
-            return (TResult?)await tcs.Task.ConfigureAwait(false);
+            try
+            {
+                return (TResult?)await tcs.Task.ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return default;
+            }
         }
 
         public virtual async Task<bool> Navigate(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Exception can be thrown when navigating backwards expecting a result from the task completion source.

### :new: What is the new behavior (if this is a feature change)?
Returns default return value if this happens

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4226

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
