### PR TITLE
Fix appcompat searchview query targetbinding not registered

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
@@ -225,19 +225,19 @@ namespace MvvmCross.Platforms.Android.Binding
                 registry.RegisterCustomBindingFactory<View>(
                     margin, view => new MvxViewMarginTargetBinding(view, margin));
             }
-            
+
             registry.RegisterCustomBindingFactory<View>(
                 MvxAndroidPropertyBinding.View_Focus,
                 view => new MvxViewFocusChangedTargetbinding(view));
-            
+
             registry.RegisterCustomBindingFactory<VideoView>(
                 MvxAndroidPropertyBinding.VideoView_Uri,
                 view => new MvxVideoViewUriTargetBinding(view));
-            
+
             registry.RegisterCustomBindingFactory<WebView>(
                 MvxAndroidPropertyBinding.WebView_Uri,
                 view => new MvxWebViewUriTargetBinding(view));
-            
+
             registry.RegisterCustomBindingFactory<WebView>(
                 MvxAndroidPropertyBinding.WebView_Html,
                 view => new MvxWebViewHtmlTargetBinding(view));
@@ -263,6 +263,10 @@ namespace MvvmCross.Platforms.Android.Binding
             registry.RegisterCustomBindingFactory<Toolbar>(
                 MvxAndroidPropertyBinding.Toolbar_Subtitle,
                 toolbar => new MvxToolbarSubtitleBinding(toolbar));
+
+            registry.RegisterCustomBindingFactory<MvxAppCompatSearchViewQueryTextTargetBinding>(
+                MvxAndroidPropertyBinding.SearchView_Query,
+                searchView => new MvxAppCompatSearchViewQueryTextTargetBinding(searchView));
         }
 
         protected override void FillDefaultBindingNames(IMvxBindingNameRegistry registry)

--- a/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
@@ -17,6 +17,7 @@ using MvvmCross.Platforms.Android.Binding.ResourceHelpers;
 using MvvmCross.Platforms.Android.Binding.Target;
 using MvvmCross.Platforms.Android.Binding.Views;
 using Toolbar = AndroidX.AppCompat.Widget.Toolbar;
+using AppCompatSearchView = AndroidX.AppCompat.Widget.SearchView;
 
 namespace MvvmCross.Platforms.Android.Binding
 {
@@ -285,6 +286,7 @@ namespace MvvmCross.Platforms.Android.Binding
             registry.AddOrOverwrite(typeof(CompoundButton), MvxAndroidPropertyBinding.CompoundButton_Checked);
             registry.AddOrOverwrite(typeof(SeekBar), MvxAndroidPropertyBinding.SeekBar_Progress);
             registry.AddOrOverwrite(typeof(SearchView), MvxAndroidPropertyBinding.SearchView_Query);
+            registry.AddOrOverwrite(typeof(AppCompatSearchView), MvxAndroidPropertyBinding.SearchView_Query);
             registry.AddOrOverwrite(typeof(NumberPicker), MvxAndroidPropertyBinding.NumberPicker_Value);
             registry.AddOrOverwrite(typeof(NumberPicker), MvxAndroidPropertyBinding.NumberPicker_DisplayedValues);
             registry.AddOrOverwrite(typeof(VideoView), MvxAndroidPropertyBinding.VideoView_Uri);

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxSearchViewQueryTextTargetBinding.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,7 +9,7 @@ using MvvmCross.Platforms.Android.WeakSubscription;
 
 namespace MvvmCross.Platforms.Android.Binding.Target
 {
-    public class MvxSearchViewQueryTextTargetBinding 
+    public class MvxSearchViewQueryTextTargetBinding
         : MvxAndroidTargetBinding
     {
         public MvxSearchViewQueryTextTargetBinding(object target)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
We don't register Search View Query Target Binding for AppCompat SearchView

### :new: What is the new behavior (if this is a feature change)?
We now do this

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #3936

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
