### PR TITLE
Only warn about lollipop Shared element transition if using Interface

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -341,8 +341,18 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             var bundle = Bundle.Empty!;
 
-            if (CurrentActivity.IsActivityAlive() &&
-                CurrentActivity is IMvxAndroidSharedElements sharedElementsActivity)
+            if (!(CurrentActivity is IMvxAndroidSharedElements sharedElementsActivity))
+            {
+                return bundle;
+            }
+
+            if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
+            {
+                _logger.Value?.Log(LogLevel.Warning, "Shared element transition requires Android v21+.");
+                return bundle;
+            }
+
+            if (CurrentActivity.IsActivityAlive())
             {
                 var (elements, transitionElementPairs) =
                     GetTransitionElements(attribute, request, sharedElementsActivity);
@@ -356,10 +366,6 @@ namespace MvvmCross.Platforms.Android.Presenters
                 var transitionElementsBundle = CreateTransitionElementsBundle(intent, transitionElementPairs, elements);
                 if (transitionElementsBundle != null)
                     return transitionElementsBundle;
-            }
-            else
-            {
-                _logger.Value?.Log(LogLevel.Warning, "Shared element transition requires Android v21+.");
             }
 
             return bundle;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
We are always showing Shared Transition Element warning in log even if not using the interface and even if not on lower than API21 (Lollipop)

### :new: What is the new behavior (if this is a feature change)?
This PR fixes this behavior. The warning now only appears in the log if:

- Activity implements `IMvxAndroidSharedElements` interface
- Android version is lower than API 21

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Start any activity and not see the warning anymore

### :memo: Links to relevant issues/docs
Fixes #4260

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
