### PR TITLE
Bugfix - iOS - Crash on Custom Modal's

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -422,7 +422,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
 
             viewController.ModalPresentationStyle = attribute.ModalPresentationStyle;
             viewController.ModalTransitionStyle = attribute.ModalTransitionStyle;
-            if (_iosVersion13Checker.IsVersionOrHigher)
+            if (_iosVersion13Checker.IsVersionOrHigher && viewController.PresentationController != null)
             {
                 viewController.PresentationController.Delegate =
                     new MvxModalPresentationControllerDelegate(this, viewController, attribute);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

### :arrow_heading_down: What is the current behavior?
When utilizing the Modal Presentation Style of UIModalPresentationStyle.Custom, the viewcontroller's PresentationController is null, which is causing an application crash.

### :new: What is the new behavior (if this is a feature change)?
No new behavior, just bypassing the Delegate code when this scenario occurs.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the Custom presentation style on a modal viewcontroller and navigate to it.
`[MvxModalPresentation(ModalPresentationStyle = UIModalPresentationStyle.Custom)]`

### :memo: Links to relevant issues/docs
Fixes #4294

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
