### PR TITLE
Android can call RegisterSetupType twice, add guard

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -23,6 +23,7 @@ namespace MvvmCross.Core
     {
         public event EventHandler<MvxSetupStateEventArgs>? StateChanged;
 
+        private static readonly object _lock = new object();
         private MvxSetupState _state;
         private IMvxIoCProvider? _iocProvider;
 
@@ -46,24 +47,33 @@ namespace MvvmCross.Core
 
         public static void RegisterSetupType<TMvxSetup>(params Assembly[] assemblies) where TMvxSetup : MvxSetup, new()
         {
-            if (SetupCreator != null)
+            // We are using double-checked locking here to avoid overhead of locking if the
+            // SetupCreator is already created
+            if (SetupCreator is null)
             {
-                MvxLogHost.Default.LogInformation("Setup: RegisterSetupType already called");
-                return;
+                lock (_lock)
+                {
+                    if (SetupCreator is null)
+                    {
+                        ViewAssemblies.AddRange(assemblies);
+                        if (ViewAssemblies.Count == 0)
+                        {
+                            // fall back to all assemblies. Assembly.GetEntryAssembly() always returns
+                            // null on Xamarin platforms do not use it!
+                            ViewAssemblies.AddRange(AppDomain.CurrentDomain.GetAssemblies());
+                        }
+
+                        // Avoid creating the instance of Setup right now, instead
+                        // take a reference to the type in a way that we can avoid
+                        // using reflection to create the instance.
+                        SetupCreator = () => new TMvxSetup();
+
+                        return;
+                    }
+                }
             }
 
-            ViewAssemblies.AddRange(assemblies);
-            if (ViewAssemblies.Count == 0)
-            {
-                // fall back to all assemblies. Assembly.GetEntryAssembly() always returns
-                // null on Xamarin platforms do not use it!
-                ViewAssemblies.AddRange(AppDomain.CurrentDomain.GetAssemblies());
-            }
-
-            // Avoid creating the instance of Setup right now, instead
-            // take a reference to the type in a way that we can avoid
-            // using reflection to create the instance.
-            SetupCreator = () => new TMvxSetup();
+            MvxLogHost.Default.LogInformation("Setup: RegisterSetupType already called");
         }
 
         public static IMvxSetup Instance()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Android can call RegisterSetupType twice, once through MvxAndroidApplication and once again through MvxSplashActivity, which can add duplicates to ViewAssemblies in MvxSetup. This can aparently lead to crashes according to linked issue.

### :new: What is the new behavior (if this is a feature change)?
This PR adds a guard, to prevent further calls to RegisterSetupType changing anything.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4295

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
