### PR TITLE
Use string key in dictionary instead on not uniquie hash code

### DIFF
--- a/MvvmCross/Binding/Parse/PropertyPath/MvxSourcePropertyPathParser.cs
+++ b/MvvmCross/Binding/Parse/PropertyPath/MvxSourcePropertyPathParser.cs
@@ -13,21 +13,19 @@ namespace MvvmCross.Binding.Parse.PropertyPath
     /// </summary>
     public class MvxSourcePropertyPathParser : IMvxSourcePropertyPathParser
     {
-        private static readonly ConcurrentDictionary<int, IList<MvxPropertyToken>> ParseCache = 
-            new ConcurrentDictionary<int, IList<MvxPropertyToken>>();
+        private static readonly ConcurrentDictionary<string, IList<MvxPropertyToken>> ParseCache =
+            new ConcurrentDictionary<string, IList<MvxPropertyToken>>();
 
         public IList<MvxPropertyToken> Parse(string textToParse)
         {
             textToParse = MvxPropertyPathParser.MakeSafe(textToParse);
-            var hash = textToParse.GetHashCode();
-            IList<MvxPropertyToken> list;
-            if (ParseCache.TryGetValue(hash, out list))
-                return list;
+            if (ParseCache.TryGetValue(textToParse, out var cachedItem))
+                return cachedItem;
 
             var parser = new MvxPropertyPathParser();
             var currentTokens = parser.Parse(textToParse);
 
-            ParseCache.TryAdd(hash, currentTokens);
+            ParseCache.TryAdd(textToParse, currentTokens);
             return currentTokens;
         }
     }

--- a/UnitTests/MvvmCross.UnitTest/Binding/Parse/PropertyPath/MvxSourcePropertyPathParserTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Parse/PropertyPath/MvxSourcePropertyPathParserTest.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using MvvmCross.Binding.Parse.PropertyPath;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Parse.PropertyPath
 {
-    
     public class MvxSourcePropertyPathParserTest
     {
         [Fact]
@@ -190,6 +191,33 @@ namespace MvvmCross.UnitTest.Binding.Parse.PropertyPath
         {
             var tokeniser = new MvxSourcePropertyPathParser();
             return tokeniser.Parse(text);
+        }
+
+        [Fact]
+        public void TestTokeniser_ReturnsParsedValueSimilarToOriginalValueForSimpleExpressions()
+        {
+            var random = new Random(123);
+            for (int i = 0; i < 100_000; i++)
+            {
+                var originalExpression = CreateRandomExpression(random);
+                var mvxPropertyTokens = Tokenise(originalExpression);
+
+                var actual = string.Join<string>(".",
+                    mvxPropertyTokens.Cast<MvxPropertyNamePropertyToken>().Select(t => t.PropertyName));
+
+                Assert.Equal(originalExpression, actual);
+            }
+        }
+
+        private static string CreateRandomExpression(Random random)
+        {
+            return string.Join<string>(".",
+                Enumerable.Repeat(0, random.Next() % 6 + 3).Select(_ =>
+                {
+                    var length = random.Next() % 6 + 3;
+                    return new string(Enumerable.Repeat("qwertyuiopasdfghjklzxcvbnm", length)
+                        .Select(s => s[random.Next(s.Length)]).ToArray());
+                }));
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Resolves incorrect behavior of cache. 

### :arrow_heading_down: What is the current behavior?

Cache uses not unique hash codes of strings as keys in dictionary. 
Random cached value can be returned from this service

### :new: What is the new behavior (if this is a feature change)?

Cache uses strings as keys in dictionary.
Random cached value can **NOT** be returned from this service

### :boom: Does this PR introduce a breaking change?

I have checked performance for about 1 000 000 expressions. It is the same in my case. 

```
| Method |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|------- |--------:|---------:|---------:|------------:|-----------:|----------:|
|   Slow | 3.129 s | 0.0618 s | 0.1368 s | 242000.0000 | 61000.0000 |      1 GB | - After change
|   Fast | 3.063 s | 0.0613 s | 0.1559 s | 242000.0000 | 61000.0000 |      1 GB | - Before change
```

About 2000 different expressions are used in real scenario in our current project

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

Fixes #4339

https://docs.microsoft.com/en-us/dotnet/api/system.object.gethashcode?view=net-6.0#remarks

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop

