### PR TITLE
Enable the Visual Studio fast up-to-date check

### DIFF
--- a/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
+++ b/MvvmCross.Forms.Wpf/MvvmCross.Forms.Platforms.Wpf.csproj
@@ -8,7 +8,6 @@
 This package contains the 'MvvmCross.Forms.Platforms.Wpf' libraries for MvvmCross</Description>
     <PackageId>MvvmCross.Forms.Platforms.Wpf</PackageId>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/MvvmCross.Forms/MvvmCross.Forms.csproj
+++ b/MvvmCross.Forms/MvvmCross.Forms.csproj
@@ -21,7 +21,6 @@
       This package contains MvvmCross to use with Xamarin.Forms
     </Description>
     <PackageId>MvvmCross.Forms</PackageId>
-    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
+++ b/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
@@ -8,7 +8,6 @@
 This package contains the 'MvvmCross.Platforms.Wpf' libraries for MvvmCross</Description>
     <PackageId>MvvmCross.Platforms.Wpf</PackageId>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -19,7 +19,6 @@
 
 This package contains the 'Core' libraries for MvvmCross</Description>
     <PackageId>MvvmCross</PackageId>
-    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <GenerateLibraryLayout Condition="$(TargetFramework.StartsWith('uap'))">true</GenerateLibraryLayout>
   </PropertyGroup>
 


### PR DESCRIPTION
These four projects condition their source files by target framework.

It used to be the case that Visual Studio's fast up-to-date check would only consider the source items and references of the _first_ target framework.

This is no longer the case. It was fixed in https://github.com/dotnet/project-system/pull/6862 which shipped in VS 16.10, and all target frameworks are now correctly handled.

So longer as your developers are using VS16.10 or later (including VS2022), you no longer need to pay the inner-loop performance penalty for these projects by scheduling them for build all the time.

I am actively working on improving the fast up-to-date check in Visual Studio at the moment, and would love to hear about any issues you encounter with it.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Config change for build in VS.

### :arrow_heading_down: What is the current behavior?

Four projects build all the time and are never considered up-to-date.

### :new: What is the new behavior (if this is a feature change)?

These projects can be identified as up-to-date, meaning inner-loop builds are faster in VS.

### :boom: Does this PR introduce a breaking change?

Not that I'm aware of!

### :bug: Recommendations for testing

I have tested this, but for others to verify: I recommend enabling the up-to-date check logging via _Tools | Options | Projects | SDK-Style_, setting the verbosity to at least _Minimal_ (which is a good daily default anyway, if you care about build performance).

### :memo: Links to relevant issues/docs

https://github.com/dotnet/project-system/pull/6862

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] ~Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))~
- [ ] ~Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))~
- [x] Rebased onto current develop
