### PR TITLE
Embedded fragment is not displaying on Android

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -1122,34 +1122,33 @@ namespace MvvmCross.Platforms.Android.Presenters
             return FindFragmentInChildren(fragmentName, CurrentFragmentManager);
         }
 
-        protected virtual Fragment? FindFragmentInChildren(string? fragmentName, FragmentManager? fragManager)
+        protected virtual Fragment? FindFragmentInChildren(string? fragmentName, FragmentManager? fragmentManager)
         {
             if (string.IsNullOrWhiteSpace(fragmentName))
-                return null;
-
-            if (fragManager == null)
-                return null;
-
-            if (fragManager.BackStackEntryCount == 0)
-                return null;
-
-            for (int i = 0; i < fragManager.BackStackEntryCount; i++)
             {
-                var parentFrag = fragManager.FindFragmentById(fragManager.GetBackStackEntryAt(i).Id);
+                return null;
+            }
 
-                //let's try again finding it
-                var frag = parentFrag?.ChildFragmentManager?.FindFragmentByTag(fragmentName);
+            if (fragmentManager == null)
+            {
+                return null;
+            }
 
-                if (frag == null)
+            foreach (var parentFragment in fragmentManager.Fragments)
+            {
+                // Let's try again finding it
+                var fragment = parentFragment?.ChildFragmentManager?.FindFragmentByTag(fragmentName);
+
+                if (fragment == null)
                 {
-                    //reloop for other fragments
-                    frag = FindFragmentInChildren(fragmentName, parentFrag?.ChildFragmentManager);
+                    // Re-loop for other fragments
+                    fragment = FindFragmentInChildren(fragmentName, parentFragment!.ChildFragmentManager);
                 }
 
-                //if we found the frag lets return it!
-                if (frag != null)
+                // If we found the fragment let's return it!
+                if (fragment != null)
                 {
-                    return frag;
+                    return fragment;
                 }
             }
 


### PR DESCRIPTION
Use Fragments instead of BackStackEntries of the FragmentManager to find a Fragment in children.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When displaying a nested fragment, `MvxAndroidViewPresenter` checks for the backstack entries, but not for the actual fragments in the `FragmentManager`. This way, it ignores any parent fragment if it was not added to the backstack.

### :new: What is the new behavior (if this is a feature change)?
Any `Fragment` can be used as a container.

### :boom: Does this PR introduce a breaking change?
Most likely no.

### :bug: Recommendations for testing
1. Create fragment A
2. Embed fragment B to fragment A
3. Embed fragment C to fragment B
4. Fragment C will be displayed

### :memo: Links to relevant issues/docs
#4353

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
