### PR TITLE
Switch base type of TargetType property of generic MvxAndroidTargetBinding

### DIFF
--- a/MvvmCross.Forms/Bindings/Target/MvxBindablePropertyTargetBinding.cs
+++ b/MvvmCross.Forms/Bindings/Target/MvxBindablePropertyTargetBinding.cs
@@ -36,7 +36,7 @@ namespace MvvmCross.Forms.Bindings.Target
             _propertyChangedSubscription = bindableObject.WeakSubscribe(OnBindableObjectPropertyChanged);
         }
 
-        public override Type TargetType => _actualPropertyType;
+        public override Type TargetValueType => _actualPropertyType;
 
         private MvxBindingMode _defaultBindingMode = MvxBindingMode.TwoWay;
         public override MvxBindingMode DefaultMode => _defaultBindingMode;

--- a/MvvmCross.Plugins/Color/Platforms/Android/BindingTargets/MvxViewColorBinding.cs
+++ b/MvvmCross.Plugins/Color/Platforms/Android/BindingTargets/MvxViewColorBinding.cs
@@ -22,6 +22,6 @@ namespace MvvmCross.Plugin.Color.Platforms.Android.BindingTargets
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(global::Android.Graphics.Color);
+        public override Type TargetValueType => typeof(global::Android.Graphics.Color);
     }
 }

--- a/MvvmCross/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Binding/Bindings/MvxFullBinding.cs
@@ -83,7 +83,7 @@ namespace MvvmCross.Binding.Bindings
             // does the right thing.
             _dataContext = source;
             _sourceStep = SourceStepFactory.Create(_bindingDescription.Source);
-            _sourceStep.TargetType = _targetBinding.TargetType;
+            _sourceStep.TargetType = _targetBinding.TargetValueType;
             _sourceStep.DataContext = source;
 
             if (NeedToObserveSourceChanges)
@@ -158,7 +158,7 @@ namespace MvvmCross.Binding.Bindings
                 _targetBinding.ValueChanged += _targetBindingOnValueChanged;
             }
 
-            _defaultTargetValue = _targetBinding.TargetType.CreateDefault();
+            _defaultTargetValue = _targetBinding.TargetValueType.CreateDefault();
         }
 
         private async void UpdateTargetFromSource(object value, CancellationToken cancel)

--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxCombinerSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxCombinerSourceStep.cs
@@ -43,7 +43,7 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
             base.OnFirstChangeListenerAdded();
         }
 
-        public override Type TargetType
+        public override Type TargetValueType
         {
             get
             {

--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxCombinerSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxCombinerSourceStep.cs
@@ -43,7 +43,7 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
             base.OnFirstChangeListenerAdded();
         }
 
-        public override Type TargetValueType
+        public override Type TargetType
         {
             get
             {

--- a/MvvmCross/Binding/Bindings/Target/IMvxTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/IMvxTargetBinding.cs
@@ -8,7 +8,7 @@ namespace MvvmCross.Binding.Bindings.Target
 {
     public interface IMvxTargetBinding : IMvxBinding
     {
-        Type TargetType { get; }
+        Type TargetValueType { get; }
         MvxBindingMode DefaultMode { get; }
 
         void SetValue(object value);

--- a/MvvmCross/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
@@ -78,7 +78,7 @@ namespace MvvmCross.Binding.Bindings.Target
 
         protected virtual object MakeSafeValue(object value)
         {
-            var safeValue = TargetType.MakeSafeValue(value);
+            var safeValue = TargetValueType.MakeSafeValue(value);
             return safeValue;
         }
 
@@ -166,7 +166,7 @@ namespace MvvmCross.Binding.Bindings.Target
 
         protected virtual TValue MakeSafeValue(TValue value)
         {
-            var safeValue = (TValue)TargetType.MakeSafeValue(value);
+            var safeValue = (TValue)TargetValueType.MakeSafeValue(value);
             return safeValue;
         }
 

--- a/MvvmCross/Binding/Bindings/Target/MvxEventHandlerEventInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventHandlerEventInfoTargetBinding.cs
@@ -32,7 +32,7 @@ namespace MvvmCross.Binding.Bindings.Target
             addMethod.Invoke(target, new[] { _eventHandler });
         }
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 

--- a/MvvmCross/Binding/Bindings/Target/MvxEventInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventInfoTargetBinding.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.Binding.Bindings.Target
             addMethod.Invoke(target, new object[] { new EventHandler<T>(HandleEvent) });
         }
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 

--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.Binding.Bindings.Target
             _eventSubscription = target.WeakSubscribe(targetEventName, HandleEvent);
         }
 
-        public override Type TargetType { get; } = typeof(ICommand);
+        public override Type TargetValueType { get; } = typeof(ICommand);
 
         public override MvxBindingMode DefaultMode { get; } = MvxBindingMode.OneWay;
 

--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.Binding.Bindings.Target
             _eventSubscription = target.WeakSubscribe<TTarget, TEventArgs>(targetEventName, HandleEvent);
         }
 
-        public override Type TargetType { get; } = typeof(ICommand);
+        public override Type TargetValueType { get; } = typeof(ICommand);
 
         public override MvxBindingMode DefaultMode { get; } = MvxBindingMode.OneWay;
 

--- a/MvvmCross/Binding/Bindings/Target/MvxNullTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxNullTargetBinding.cs
@@ -15,7 +15,7 @@ namespace MvvmCross.Binding.Bindings.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneTime;
 
-        public override Type TargetType => typeof(object);
+        public override Type TargetValueType => typeof(object);
 
         public override void SetValue(object value)
         {

--- a/MvvmCross/Binding/Bindings/Target/MvxPropertyInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxPropertyInfoTargetBinding.cs
@@ -34,7 +34,7 @@ namespace MvvmCross.Binding.Bindings.Target
             base.Dispose(isDisposing);
         }
 
-        public override Type TargetType => TargetPropertyInfo.PropertyType;
+        public override Type TargetValueType => TargetPropertyInfo.PropertyType;
 
         protected PropertyInfo TargetPropertyInfo => _targetPropertyInfo;
 

--- a/MvvmCross/Binding/Bindings/Target/MvxTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxTargetBinding.cs
@@ -67,7 +67,7 @@ namespace MvvmCross.Binding.Bindings.Target
 
         public abstract MvxBindingMode DefaultMode { get; }
 
-        public Type TargetType => typeof(TTarget);
+        public Type TargetType => typeof(TValue);
 
         public event EventHandler<MvxTargetChangedEventArgs> ValueChanged;
 

--- a/MvvmCross/Binding/Bindings/Target/MvxTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxTargetBinding.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.Binding.Bindings.Target
             ValueChanged?.Invoke(this, new MvxTargetChangedEventArgs(newValue));
         }
 
-        public abstract Type TargetType { get; }
+        public abstract Type TargetValueType { get; }
 
         public abstract void SetValue(object value);
 
@@ -67,7 +67,7 @@ namespace MvvmCross.Binding.Bindings.Target
 
         public abstract MvxBindingMode DefaultMode { get; }
 
-        public Type TargetType => typeof(TValue);
+        public Type TargetValueType => typeof(TValue);
 
         public event EventHandler<MvxTargetChangedEventArgs> ValueChanged;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAdapterViewSelectedItemPositionTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAdapterViewSelectedItemPositionTargetBinding.cs
@@ -44,7 +44,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
                 nameof(adapterView.ItemSelected), AdapterViewOnItemSelected);
         }
 
-        public override Type TargetType => typeof(int);
+        public override Type TargetValueType => typeof(int);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatRadioGroupSelectedItemBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatRadioGroupSelectedItemBinding.cs
@@ -109,7 +109,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 
-        public override Type TargetType => typeof(object);
+        public override Type TargetValueType => typeof(object);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatSearchViewQueryTextTargetBinding.cs
@@ -19,7 +19,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatSpinnerSelectedItemBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatSpinnerSelectedItemBinding.cs
@@ -86,7 +86,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
                 SpinnerItemSelected);
         }
 
-        public override Type TargetType => typeof(object);
+        public override Type TargetValueType => typeof(object);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxBaseViewVisibleBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxBaseViewVisibleBinding.cs
@@ -17,6 +17,6 @@ namespace MvvmCross.Platforms.Android.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(bool);
+        public override Type TargetValueType => typeof(bool);
     }
 }

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
@@ -29,7 +29,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         protected MvxExpandableListView ListView => (MvxExpandableListView)Target;
 
-        public override Type TargetType => typeof(object);
+        public override Type TargetValueType => typeof(object);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewBitmapTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewBitmapTargetBinding.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(Bitmap);
+        public override Type TargetValueType => typeof(Bitmap);
 
         protected override bool GetBitmap(object value, out Bitmap bitmap)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableNameTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableNameTargetBinding.cs
@@ -18,7 +18,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableTargetBinding.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(int);
+        public override Type TargetValueType => typeof(int);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewImageDrawableTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewImageDrawableTargetBinding.cs
@@ -16,7 +16,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(ImageView);
+        public override Type TargetValueType => typeof(ImageView);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewImageTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewImageTargetBinding.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override Stream GetStream(object value)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxListViewSelectedItemTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxListViewSelectedItemTargetBinding.cs
@@ -66,7 +66,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             _subscription = listView.WeakSubscribe<ListView, AdapterView.ItemClickEventArgs>(nameof(listView.ItemClick), OnItemClick);
         }
 
-        public override Type TargetType => typeof(object);
+        public override Type TargetValueType => typeof(object);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxPreferenceClickTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxPreferenceClickTargetBinding.cs
@@ -65,7 +65,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxPreferenceValueTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxPreferenceValueTargetBinding.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public Preference Preference => Target as Preference;
 
-        public override Type TargetType => typeof(Preference);
+        public override Type TargetValueType => typeof(Preference);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxRadioGroupSelectedItemBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxRadioGroupSelectedItemBinding.cs
@@ -108,7 +108,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 
-        public override Type TargetType => typeof(object);
+        public override Type TargetValueType => typeof(object);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxRatingBarRatingTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxRatingBarRatingTargetBinding.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             ratingBar.Rating = (float)value;
         }
 
-        public override Type TargetType => typeof(float);
+        public override Type TargetValueType => typeof(float);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxSearchViewQueryTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxSearchViewQueryTextTargetBinding.cs
@@ -19,7 +19,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         private IDisposable _subscription;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxSpinnerSelectedItemBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxSpinnerSelectedItemBinding.cs
@@ -86,7 +86,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
                 SpinnerItemSelected);
         }
 
-        public override Type TargetType => typeof(object);
+        public override Type TargetValueType => typeof(object);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxTextViewFocusTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxTextViewFocusTargetBinding.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         protected EditText TextField => Target as EditText;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxTextViewTextFormattedTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxTextViewTextFormattedTargetBinding.cs
@@ -31,7 +31,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             _isEditTextBinding = target is EditText;
         }
 
-        public override Type TargetType => typeof(ISpanned);
+        public override Type TargetValueType => typeof(ISpanned);
 
         protected override bool ShouldSkipSetValueForViewSpecificReasons(object target, object value)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxTextViewTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxTextViewTextTargetBinding.cs
@@ -33,7 +33,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             _isEditTextBinding = target is EditText;
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override bool ShouldSkipSetValueForViewSpecificReasons(object target, object value)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxToolbarSubtitleBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxToolbarSubtitleBinding.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
         protected override void SetValueImpl(object target, object value)

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxVideoViewUriTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxVideoViewUriTargetBinding.cs
@@ -9,7 +9,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
     {
         public MvxVideoViewUriTargetBinding(object target) : base(target) { }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxViewClickBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxViewClickBinding.cs
@@ -71,7 +71,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxViewFocusChangedTargetbinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxViewFocusChangedTargetbinding.cs
@@ -30,7 +30,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             _command.Execute(e.HasFocus);
         }
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxViewLongClickBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxViewLongClickBinding.cs
@@ -42,7 +42,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
@@ -19,7 +19,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             _whichMargin = whichMargin;
         }
 
-        public override Type TargetType => typeof(float);
+        public override Type TargetValueType => typeof(float);
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
         protected override void SetValueImpl(object target, object value)

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxWebViewHtmlTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxWebViewHtmlTargetBinding.cs
@@ -9,7 +9,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
     {
         public MvxWebViewHtmlTargetBinding(object target) : base(target) { }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
         protected override void SetValueImpl(object target, object value)

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxWebViewUriTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxWebViewUriTargetBinding.cs
@@ -9,7 +9,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
     {
         public MvxWebViewUriTargetBinding(object target) : base(target) { }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
         protected override void SetValueImpl(object target, object value)

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxBaseUIViewVisibleTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxBaseUIViewVisibleTargetBinding.cs
@@ -20,6 +20,6 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(bool);
+        public override Type TargetValueType => typeof(bool);
     }
 }

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIActivityIndicatorViewHiddenTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIActivityIndicatorViewHiddenTargetBinding.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(bool);
+        public override Type TargetValueType => typeof(bool);
 
         protected UIActivityIndicatorView View => Target as UIActivityIndicatorView;
 

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIBarButtonItemTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIBarButtonItemTargetBinding.cs
@@ -34,7 +34,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
             _canExecuteEventHandler = OnCanExecuteChanged;
         }
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIButtonTitleTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIButtonTitleTargetBinding.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlTargetBinding.cs
@@ -50,7 +50,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIDatePickerCountdownDurationTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIDatePickerCountdownDurationTargetBinding.cs
@@ -20,6 +20,6 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
             return view.CountDownDuration;
         }
 
-        public override Type TargetType => typeof(double);
+        public override Type TargetValueType => typeof(double);
     }
 }

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIDatePickerTimeTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIDatePickerTimeTargetBinding.cs
@@ -24,7 +24,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
             return valueLocal.TimeOfDay;
         }
 
-        //public override Type TargetType => typeof(TimeSpan);
+        //public override Type TargetValueType => typeof(TimeSpan);
 
         protected override object MakeSafeValue(object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUILabelTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUILabelTextTargetBinding.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextFieldShouldReturnTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextFieldShouldReturnTargetBinding.cs
@@ -44,7 +44,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
             _command = command;
         }
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextFieldTextFocusTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextFieldTextFocusTargetBinding.cs
@@ -16,7 +16,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         protected UITextField TextField => Target as UITextField;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextFieldTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextFieldTextTargetBinding.cs
@@ -47,7 +47,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
             _subscriptionEndEditing = target.WeakSubscribe(nameof(target.EditingDidEnd), HandleEditTextValueChanged);
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override bool ShouldSkipSetValueForViewSpecificReasons(object target, object value)
             => this.ShouldSkipSetValueAsHaveNearlyIdenticalNumericText(target, value);

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextViewTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUITextViewTextTargetBinding.cs
@@ -53,7 +53,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
             _subscription = textStorage.WeakSubscribe<NSTextStorage, NSTextStorageEventArgs>(nameof(textStorage.DidProcessEditing), EditTextOnChanged);
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIViewLayerBorderWidthTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIViewLayerBorderWidthTargetBinding.cs
@@ -15,7 +15,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(float);
+        public override Type TargetValueType => typeof(float);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIViewTapTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIViewTapTargetBinding.cs
@@ -23,7 +23,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIViewVisibilityTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIViewVisibilityTargetBinding.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(MvxVisibility);
+        public override Type TargetValueType => typeof(MvxVisibility);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSButtonTitleTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSButtonTitleTargetBinding.cs
@@ -29,7 +29,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             get { return MvxBindingMode.OneWay; }
         }
 
-        public override Type TargetType
+        public override Type TargetValueType
         {
             get { return typeof(string); }
         }

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSDatePickerDateTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSDatePickerDateTargetBinding.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             datePicker.DateValue = (NSDate)((DateTime)value);
         }
 
-        public override Type TargetType
+        public override Type TargetValueType
         {
             get { return typeof(DateTime); }
         }

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSDatePickerTimeTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSDatePickerTimeTargetBinding.cs
@@ -43,7 +43,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             //            return new TimeSpan((int)components.Hour, (int)components.Minute, (int)components.Second);
         }
 
-        public override Type TargetType
+        public override Type TargetValueType
         {
             get { return typeof(TimeSpan); }
         }

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSViewVisibilityTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSViewVisibilityTargetBinding.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             get { return MvxBindingMode.OneWay; }
         }
 
-        public override Type TargetType
+        public override Type TargetValueType
         {
             get { return typeof(MvxVisibility); }
         }

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSViewVisibleTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSViewVisibleTargetBinding.cs
@@ -25,7 +25,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             get { return MvxBindingMode.OneWay; }
         }
 
-        public override Type TargetType
+        public override Type TargetValueType
         {
             get { return typeof(bool); }
         }

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxBaseUIViewVisibleTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxBaseUIViewVisibleTargetBinding.cs
@@ -20,6 +20,6 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(bool);
+        public override Type TargetValueType => typeof(bool);
     }
 }

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIActivityIndicatorViewHiddenTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIActivityIndicatorViewHiddenTargetBinding.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(bool);
+        public override Type TargetValueType => typeof(bool);
 
         protected UIActivityIndicatorView View => Target as UIActivityIndicatorView;
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIButtonTitleTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIButtonTitleTargetBinding.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlTouchUpInsideTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlTouchUpInsideTargetBinding.cs
@@ -47,7 +47,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlValueChangedTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlValueChangedTargetBinding.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
         }
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUILabelTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUILabelTextTargetBinding.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldShouldReturnTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldShouldReturnTargetBinding.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             _command = command;
         }
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldTextFocusTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldTextFocusTargetBinding.cs
@@ -15,7 +15,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         protected UITextField TextField => Target as UITextField;
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldTextTargetBinding.cs
@@ -47,7 +47,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             _subscribed = true;
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override bool ShouldSkipSetValueForViewSpecificReasons(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextViewTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextViewTextTargetBinding.cs
@@ -45,7 +45,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             _subscribed = true;
         }
 
-        public override Type TargetType => typeof(string);
+        public override Type TargetValueType => typeof(string);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewLayerBorderWidthTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewLayerBorderWidthTargetBinding.cs
@@ -16,7 +16,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
         {
         }
 
-        public override Type TargetType => typeof(float);
+        public override Type TargetValueType => typeof(float);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewTapTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewTapTargetBinding.cs
@@ -23,7 +23,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(ICommand);
+        public override Type TargetValueType => typeof(ICommand);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewVisibilityTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewVisibilityTargetBinding.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(MvxVisibility);
+        public override Type TargetValueType => typeof(MvxVisibility);
 
         protected override void SetValueImpl(object target, object value)
         {

--- a/MvvmCross/Platforms/Uap/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
+++ b/MvvmCross/Platforms/Uap/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
@@ -55,7 +55,7 @@ namespace MvvmCross.Platforms.Uap.Binding.MvxBinding.Target
             frameworkElement.SetBinding(attachedProperty, listenerBinding);
         }
 
-        public override Type TargetType => _actualPropertyType;
+        public override Type TargetValueType => _actualPropertyType;
 
         public override MvxBindingMode DefaultMode { get; } = MvxBindingMode.TwoWay;
 

--- a/MvvmCross/Platforms/Uap/Binding/MvxBinding/Target/MvxVisibleTargetBinding.cs
+++ b/MvvmCross/Platforms/Uap/Binding/MvxBinding/Target/MvxVisibleTargetBinding.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Platforms.Uap.Binding.MvxBinding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(bool);
+        public override Type TargetValueType => typeof(bool);
 
         public override void SetValue(object value)
         {

--- a/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
@@ -53,7 +53,7 @@ namespace MvvmCross.Platforms.Wpf.Binding.MvxBinding.Target
             frameworkElement.SetBinding(attachedProperty, listenerBinding);
         }
 
-        public override Type TargetType => _actualPropertyType;
+        public override Type TargetValueType => _actualPropertyType;
 
         private MvxBindingMode _defaultBindingMode = MvxBindingMode.TwoWay;
         public override MvxBindingMode DefaultMode => _defaultBindingMode;

--- a/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxVisibleTargetBinding.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxVisibleTargetBinding.cs
@@ -17,7 +17,7 @@ namespace MvvmCross.Platforms.Wpf.Binding.MvxBinding.Target
 
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
-        public override Type TargetType => typeof(bool);
+        public override Type TargetValueType => typeof(bool);
 
         public override void SetValue(object value)
         {

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingValueConversionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingValueConversionTest.cs
@@ -458,7 +458,7 @@ namespace MvvmCross.UnitTest.Binding.Bindings
         }
 
         private MvxFullBinding TestSetupCommon(IMvxValueConverter valueConverter, object converterParameter, object fallbackValue,
-            Type targetType, out MockSourceBinding mockSource, out MockTargetBinding mockTarget)
+            Type targetValueType, out MockSourceBinding mockSource, out MockTargetBinding mockTarget)
         {
             _fixture.ClearAll();
             _fixture.Ioc.RegisterSingleton<IMvxMainThreadAsyncDispatcher>(new InlineMockMainThreadDispatcher());
@@ -491,7 +491,7 @@ namespace MvvmCross.UnitTest.Binding.Bindings
             };
 
             mockSource = new MockSourceBinding();
-            mockTarget = new MockTargetBinding() { TargetType = targetType };
+            mockTarget = new MockTargetBinding() { TargetValueType = targetValueType };
             mockTarget.DefaultMode = MvxBindingMode.TwoWay;
 
             var localSource = mockSource;

--- a/UnitTests/MvvmCross.UnitTest/Binding/Mocks/MockTargetBinding.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Mocks/MockTargetBinding.cs
@@ -13,7 +13,7 @@ namespace MvvmCross.UnitTest.Binding.Mocks
     {
         public MockTargetBinding()
         {
-            TargetType = typeof(object);
+            TargetValueType = typeof(object);
         }
 
         public int DisposeCalled { get; set; }
@@ -30,7 +30,7 @@ namespace MvvmCross.UnitTest.Binding.Mocks
             SubscribeToEventsCalled++;
         }
 
-        public Type TargetType { get; set; }
+        public Type TargetValueType { get; set; }
         public MvxBindingMode DefaultMode { get; set; }
 
         public List<object> Values { get; } = new List<object>();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This pull request fixes base `TargetType` of base generic MvxTargetBinding class. I think, this is bug

### :arrow_heading_down: What is the current behavior?

MvxFullBinding tryes to set instance of `TTarget` type into target property of `TValue` type

### :new: What is the new behavior (if this is a feature change)?

MvxFullBinding sets instance of `TValue` into property of `TValue` type

### :boom: Does this PR introduce a breaking change?

Yes, derived types will be affected.

### :bug: Recommendations for testing

You can try to write new class (like following) and check, how it works. In my case it throws exception when fallback value is not presented and source returns "unset value".

```c#
    public sealed class BackgroundColorBinding : MvxAndroidTargetBinding<View, Color>
    {
        private readonly View _view;

        public BackgroundColorBinding(View view)
            : base(view)
        {
        }

        protected override void SetValueImpl(View target, Color value)
        {
            target.SetBackgroundColor(value.ToAndroidColor());
        }
    }
```

### :memo: Links to relevant issues/docs

#4385

fixes #4389

### :thinking: Checklist before submitting

- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] All projects build
- [x] Rebased onto current develop
