### PR TITLE
Added support for floating point values in Android Margin bindings

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
@@ -19,7 +19,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             _whichMargin = whichMargin;
         }
 
-        public override Type TargetType => typeof(int);
+        public override Type TargetType => typeof(float);
         public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;
 
         protected override void SetValueImpl(object target, object value)
@@ -30,7 +30,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             var layoutParameters = view.LayoutParameters as ViewGroup.MarginLayoutParams;
             if (layoutParameters == null) return;
 
-            var dpMargin = (int)value;
+            var dpMargin = (float)value;
             var pxMargin = DpToPx(dpMargin);
 
             switch (_whichMargin)
@@ -59,7 +59,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             }
         }
 
-        private int DpToPx(int dp)
+        private int DpToPx(float dp)
             => (int)(dp * Resources.System.DisplayMetrics.Density);
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Enhancement to current implementation of Android Margin bindings.

### :arrow_heading_down: What is the current behavior?
Margin bindings use integer values.

### :new: What is the new behavior (if this is a feature change)?
Margin bindings use floating point values.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Yes.

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
