### PR TITLE
Fixed never re laying out the view when Margin bound value changes on Android

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxViewMarginTargetBinding.cs
@@ -57,6 +57,8 @@ namespace MvvmCross.Platforms.Android.Binding.Target
                     layoutParameters.MarginStart = pxMargin;
                     break;
             }
+
+            view.LayoutParameters = layoutParameters;
         }
 
         private int DpToPx(int dp)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes a bug when Android Margin bindings value gets changed but the layout remain the same

### :arrow_heading_down: What is the current behavior?
Any change on Margin doesn't update the layout.  
Look at the space between 2 messages with "hi": https://i.imgur.com/6on0cZg.png
MarginBottom changed from 15 to 7.5.

### :new: What is the new behavior (if this is a feature change)?
Any change on Margin does update the layout.
No more space between 2 messages with "hi": https://i.imgur.com/wbaDbOx.png
MarginBottom changed from 15 to 7.5.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Yes.

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
