### PR TITLE
Added an MvxSplitViewController constructor with UISplitViewControllerStyle argument

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceSplitViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceSplitViewController.cs
@@ -32,6 +32,10 @@ namespace MvvmCross.Platforms.Ios.Views.Base
         {
         }
 
+        public MvxEventSourceSplitViewController(UISplitViewControllerStyle style) : base(style)
+        {
+        }
+
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);

--- a/MvvmCross/Platforms/Ios/Views/MvxBaseSplitViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseSplitViewController.cs
@@ -38,6 +38,11 @@ namespace MvvmCross.Platforms.Ios.Views
             this.AdaptForBinding();
         }
 
+        public MvxBaseSplitViewController(UISplitViewControllerStyle style) : base(style)
+        {
+            this.AdaptForBinding();
+        }
+
         public object DataContext
         {
             get { return BindingContext.DataContext; }

--- a/MvvmCross/Platforms/Ios/Views/MvxSplitViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxSplitViewController.cs
@@ -35,6 +35,10 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
+        public MvxSplitViewController(UISplitViewControllerStyle style) : base(style)
+        {
+        }
+
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Enhancement to current implementation of `MvxSplitViewController`.

### :arrow_heading_down: What is the current behavior?
`MvxSplitViewController` is missing a new iOS 14 constructor that takes `MvxSplitViewControllerStyle` argument.

### :new: What is the new behavior (if this is a feature change)?
`MvxSplitViewController` has got a new iOS 14 constructor that takes `MvxSplitViewControllerStyle` argument.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
--

### :memo: Links to relevant issues/docs
--

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
