### PR TITLE
Fix: MvxCurrentTopActivity.Activity returns last seen activity if no activity exists

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxCurrentTopActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxCurrentTopActivity.cs
@@ -2,66 +2,63 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.App;
-using Android.OS;
 using Android.Runtime;
 
-namespace MvvmCross.Platforms.Android.Views
-{
+namespace MvvmCross.Platforms.Android.Views;
+
 #nullable enable
-    [Register("mvvmcross.platforms.android.MvxCurrentTopActivity")]
-    public class MvxCurrentTopActivity
-        : Java.Lang.Object, Application.IActivityLifecycleCallbacks, IMvxAndroidCurrentTopActivity
+[Register("mvvmcross.platforms.android.MvxCurrentTopActivity")]
+public class MvxCurrentTopActivity
+    : Java.Lang.Object, Application.IActivityLifecycleCallbacks, IMvxAndroidCurrentTopActivity
+{
+    private readonly WeakReference<Activity?> _lastSeenActivity = new(null);
+
+    public Activity? Activity
     {
-        private readonly WeakReference<Activity?> _lastSeenActivity = new WeakReference<Activity?>(null);
-
-        public Activity? Activity
+        get
         {
-            get
-            {
-                if (_lastSeenActivity?.TryGetTarget(out var activity) ?? false)
-                    return activity;
-                return null;
-            }
-        }
-
-        public static bool Initialized { get; set; }
-
-        public void OnActivityCreated(Activity activity, Bundle? savedInstanceState)
-        {
-            _lastSeenActivity.SetTarget(activity);
-        }
-
-        public void OnActivityPaused(Activity activity)
-        {
-            _lastSeenActivity.SetTarget(activity);
-        }
-
-        public void OnActivityResumed(Activity activity)
-        {
-            _lastSeenActivity.SetTarget(activity);
-        }
-
-        public void OnActivityDestroyed(Activity activity)
-        {
-            // not interested in this
-        }
-
-        public void OnActivitySaveInstanceState(Activity activity, Bundle outState)
-        {
-            // not interested in this
-        }
-
-        public void OnActivityStarted(Activity activity)
-        {
-            // not interested in this
-        }
-
-        public void OnActivityStopped(Activity activity)
-        {
-            // not interested in this
+            if (_lastSeenActivity?.TryGetTarget(out var activity) ?? false)
+                return activity;
+            return null;
         }
     }
-#nullable restore
+
+    public static bool Initialized { get; set; }
+
+    public void OnActivityCreated(Activity activity, Bundle? savedInstanceState)
+    {
+        _lastSeenActivity.SetTarget(activity);
+    }
+
+    public void OnActivityPaused(Activity activity)
+    {
+        _lastSeenActivity.SetTarget(activity);
+    }
+
+    public void OnActivityResumed(Activity activity)
+    {
+        _lastSeenActivity.SetTarget(activity);
+    }
+
+    public void OnActivityDestroyed(Activity activity)
+    {
+        if (Activity == activity)
+            _lastSeenActivity.SetTarget(default);
+    }
+
+    public void OnActivitySaveInstanceState(Activity activity, Bundle outState)
+    {
+        // not interested in this
+    }
+
+    public void OnActivityStarted(Activity activity)
+    {
+        // not interested in this
+    }
+
+    public void OnActivityStopped(Activity activity)
+    {
+        // not interested in this
+    }
 }
+#nullable restore


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MvxCurrentTopActivity.Activity is never null. Even if no activity exists.

### :new: What is the new behavior (if this is a feature change)?
MvxCurrentTopActivity.Activity is null when no activity exists

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
[#4505](https://github.com/MvvmCross/MvvmCross/issues/4505)

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
