### PR TITLE
Fix MvxAppCompatAutoCompleteTextView ItemClick being subscribed to twice

### DIFF
--- a/MvvmCross/Platforms/Android/Binding/Views/MvxAppCompatAutoCompleteTextView.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxAppCompatAutoCompleteTextView.cs
@@ -20,18 +20,20 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         public MvxAppCompatAutoCompleteTextView(Context context, IAttributeSet attrs)
             : this(context, attrs, new MvxFilteringAdapter(context))
         {
-            // note - we shouldn't realy need both of these... but we do
-            ItemClick += OnItemClick;
-            ItemSelected += OnItemSelected;
         }
 
         public MvxAppCompatAutoCompleteTextView(Context context, IAttributeSet attrs,
             MvxFilteringAdapter adapter) : base(context, attrs)
         {
             var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
-            adapter.ItemTemplateId = itemTemplateId;
+            if (itemTemplateId > 0)
+                adapter.ItemTemplateId = itemTemplateId;
+
             Adapter = adapter;
+
+            // note - we shouldn't realy need both of these... but we do
             ItemClick += OnItemClick;
+            ItemSelected += OnItemSelected;
         }
 
         protected MvxAppCompatAutoCompleteTextView(IntPtr javaReference, JniHandleOwnership transfer)


### PR DESCRIPTION
Fix MvxAppCompatAutoCompleteTextView ItemClick event being subscribed to twice

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for #4507 

### :arrow_heading_down: What is the current behavior?
/

### :new: What is the new behavior (if this is a feature change)?
/

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Add a new class which inherits from `MvxAppCompatAutoCompleteTextView` and override OnItemClick(int position) and add some custom logic and see if it is now fired once instead of twice.

### :memo: Links to relevant issues/docs
#4507

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
