### PR TITLE
Fix issue where Android App would not start after exiting with back button

### DIFF
--- a/Projects/Playground/Playground.Droid/Fragments/BaseSplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BaseSplitDetailView.cs
@@ -11,6 +11,7 @@ using MvvmCross.Platforms.Android.Views.AppCompat;
 using MvvmCross.Platforms.Android.Views.Fragments;
 using MvvmCross.ViewModels;
 using Playground.Droid.Activities;
+using Toolbar = AndroidX.AppCompat.Widget.Toolbar;
 
 namespace Playground.Droid.Fragments
 {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix/Regression fix

### :arrow_heading_down: What is the current behavior?
If you exit a MvvmCross app using the back button, AppStart ResetStart call is not being called and you cannot launch the App again unless you kill it from recents or through a task manager.

### :new: What is the new behavior (if this is a feature change)?
Fixes app restart

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Start playground app, press android software or hardware back button. Try launch again from drawer or recents

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
