### PR TITLE
gh-4532 fix invalidoperationexception in MvxIntentService and MvxFragment

### DIFF
--- a/MvvmCross/Platforms/Android/Services/MvxIntentService.cs
+++ b/MvvmCross/Platforms/Android/Services/MvxIntentService.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.App;
-using Android.Content;
 using Android.Runtime;
-using MvvmCross.Core;
 using MvvmCross.Platforms.Android.Core;
 
 namespace MvvmCross.Platforms.Android.Services
@@ -22,8 +18,13 @@ namespace MvvmCross.Platforms.Android.Services
         {
         }
 
-        protected override void OnHandleIntent(Intent intent)
+        public override void OnCreate()
         {
+            base.OnCreate();
+
+            if (ApplicationContext == null)
+                return;
+
             var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);
             setup.EnsureInitialized();
         }

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
@@ -30,8 +30,6 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
 
         protected override void HandleCreateCalled(object sender, MvxValueEventArgs<Bundle> bundleArgs)
         {
-            FragmentView.EnsureSetupInitialized();
-
             // Create is called after Fragment is attached to Activity
             // it's safe to assume that Fragment has activity
 

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxFragment.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxFragment.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.OS;
 using Android.Runtime;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Views.Fragments.EventSource;

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
-using MvvmCross.Platforms.Android.Core;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 using Fragment = AndroidX.Fragment.App.Fragment;
@@ -65,11 +64,9 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
                     new MvxSimpleLayoutInflaterHolder(inflater),
                     fragment.DataContext);
             }
-            else
+            else if (fragment.BindingContext is IMvxAndroidBindingContext androidContext)
             {
-                var androidContext = fragment.BindingContext as IMvxAndroidBindingContext;
-                if (androidContext != null)
-                    androidContext.LayoutInflaterHolder = new MvxSimpleLayoutInflaterHolder(inflater);
+                androidContext.LayoutInflaterHolder = new MvxSimpleLayoutInflaterHolder(inflater);
             }
         }
 
@@ -86,14 +83,11 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
                         actualFragment.Activity.LayoutInflater),
                     fragment.DataContext);
             }
-            else
+            else if (fragment.BindingContext is IMvxAndroidBindingContext androidContext)
             {
-                var androidContext = fragment.BindingContext as IMvxAndroidBindingContext;
-                if (androidContext != null)
-                    androidContext.LayoutInflaterHolder = new MvxSimpleLayoutInflaterHolder(actualFragment.Activity.LayoutInflater);
+                androidContext.LayoutInflaterHolder = new MvxSimpleLayoutInflaterHolder(actualFragment.Activity.LayoutInflater);
             }
         }
-
 
         public static TFragment FindFragmentById<TFragment>(this MvxActivity activity, int resourceId)
             where TFragment : Fragment
@@ -102,7 +96,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             if (fragment == null)
             {
                 MvxLogHost.Default?.Log(LogLevel.Warning,
-                    "Failed to find fragment id {resourceId} in {activityTypeName}", resourceId, activity.GetType().Name);
+                    "Failed to find fragment id {ResourceId} in {ActivityTypeName}", resourceId, activity.GetType().Name);
                 return default(TFragment);
             }
 
@@ -116,7 +110,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             if (fragment == null)
             {
                 MvxLogHost.Default?.Log(LogLevel.Warning,
-                    "Failed to find fragment tag {tag} in {activityTypeName}", tag, activity.GetType().Name);
+                    "Failed to find fragment tag {Tag} in {ActivityTypeName}", tag, activity.GetType().Name);
                 return default(TFragment);
             }
 
@@ -128,7 +122,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             if (!(fragment is TFragment))
             {
                 MvxLogHost.Default?.Log(LogLevel.Warning,
-                    "Fragment type mismatch got {fragmentType} but expected {expectedType}",
+                    "Fragment type mismatch got {FragmentType} but expected {ExpectedType}",
                     fragment.GetType().FullName, typeof(TFragment).FullName);
                 return default(TFragment);
             }
@@ -142,7 +136,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             var viewModel = loader.LoadViewModel(request, savedState);
             if (viewModel == null)
             {
-                MvxLogHost.Default?.Log(LogLevel.Warning, "ViewModel not loaded for {viewModelType}", request.ViewModelType.FullName);
+                MvxLogHost.Default?.Log(LogLevel.Warning, "ViewModel not loaded for {ViewModelType}", request.ViewModelType.FullName);
                 return;
             }
 

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxFragmentExtensions.cs
@@ -94,15 +94,6 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             }
         }
 
-        public static void EnsureSetupInitialized(this IMvxFragmentView fragmentView)
-        {
-            var fragment = fragmentView.ToFragment();
-            if (fragment == null)
-                throw new MvxException($"{nameof(EnsureSetupInitialized)} called on an {nameof(IMvxFragmentView)} which is not an Android Fragment: {fragmentView}");
-
-            var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(fragment.Activity.ApplicationContext);
-            setup.EnsureInitialized();
-        }
 
         public static TFragment FindFragmentById<TFragment>(this MvxActivity activity, int resourceId)
             where TFragment : Fragment


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MvxIntentService and MvxFragment throw InvalidOperationException, because they are trying to ensure MvvmCross has been initialized.

Fragments cannot live without a MvxActivity, so doesn't make sense to do there.

For MvxIntentService, I've moved the check into OnCreate which is more appropriate than checking every time you want to handle an Intent.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4532

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
