### PR TITLE
Switch from IntPtr to NativeHandle

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxActionBasedTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxActionBasedTableViewSource.cs
@@ -8,6 +8,7 @@ using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings;
 using MvvmCross.Logging;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -20,11 +21,11 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             Initialize();
         }
 
-        public MvxActionBasedTableViewSource(IntPtr handle)
+        public MvxActionBasedTableViewSource(NativeHandle handle)
             : base(handle)
         {
             MvxLogHost.GetLog<MvxActionBasedTableViewSource>()?.Log(
-                LogLevel.Warning, "MvxActionBasedTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+                LogLevel.Warning, "MvxActionBasedTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
             Initialize();
         }
 

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxBaseTableViewSource.cs
@@ -8,6 +8,7 @@ using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Logging;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -23,11 +24,11 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             _tableView = new WeakReference<UITableView>(tableView);
         }
 
-        protected MvxBaseTableViewSource(IntPtr handle)
+        protected MvxBaseTableViewSource(NativeHandle handle)
             : base(handle)
         {
             MvxLogHost.GetLog<MvxBaseTableViewSource>()?.Log(LogLevel.Warning,
-                "MvxBaseTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+                "MvxBaseTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         protected UITableView TableView

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionReusableView.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionReusableView.cs
@@ -8,6 +8,7 @@ using CoreGraphics;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -44,18 +45,18 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             this.CreateBindingContext(bindingDescriptions);
         }
 
-        public MvxCollectionReusableView(IntPtr handle)
+        public MvxCollectionReusableView(NativeHandle handle)
             : this(string.Empty, handle)
         {
         }
 
-        public MvxCollectionReusableView(string bindingText, IntPtr handle)
+        public MvxCollectionReusableView(string bindingText, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingText);
         }
 
-        public MvxCollectionReusableView(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+        public MvxCollectionReusableView(IEnumerable<MvxBindingDescription> bindingDescriptions, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingDescriptions);

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewCell.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewCell.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using CoreGraphics;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -43,18 +44,18 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             this.CreateBindingContext(bindingDescriptions);
         }
 
-        public MvxCollectionViewCell(IntPtr handle)
+        public MvxCollectionViewCell(NativeHandle handle)
             : this(string.Empty, handle)
         {
         }
 
-        public MvxCollectionViewCell(string bindingText, IntPtr handle)
+        public MvxCollectionViewCell(string bindingText, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingText);
         }
 
-        public MvxCollectionViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+        public MvxCollectionViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingDescriptions);

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxSimpleTableViewSource.cs
@@ -6,6 +6,7 @@ using System;
 using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -17,10 +18,10 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
 
         protected virtual NSString CellIdentifier => _cellIdentifier;
 
-        public MvxSimpleTableViewSource(IntPtr handle)
+        public MvxSimpleTableViewSource(NativeHandle handle)
             : base(handle)
         {
-            MvxLogHost.Default?.LogWarning("MvxSimpleTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+            MvxLogHost.Default?.LogWarning("MvxSimpleTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         public MvxSimpleTableViewSource(UITableView tableView, string nibName, string cellIdentifier = null,

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxStandardTableViewCell.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxStandardTableViewCell.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.Bindings;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -14,17 +15,17 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
     public class MvxStandardTableViewCell
         : MvxTableViewCell
     {
-        public MvxStandardTableViewCell(IntPtr handle)
+        public MvxStandardTableViewCell(NativeHandle handle)
             : this("TitleText" /* default binding is ToString() on the passed in item */, handle)
         {
         }
 
-        public MvxStandardTableViewCell(string bindingText, IntPtr handle)
+        public MvxStandardTableViewCell(string bindingText, NativeHandle handle)
             : base(bindingText, handle)
         {
         }
 
-        public MvxStandardTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+        public MvxStandardTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, NativeHandle handle)
             : base(bindingDescriptions, handle)
         {
         }

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxStandardTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxStandardTableViewSource.cs
@@ -10,6 +10,7 @@ using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.Bindings;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Logging;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -52,10 +53,10 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
         {
         }
 
-        public MvxStandardTableViewSource(IntPtr handle)
+        public MvxStandardTableViewSource(NativeHandle handle)
             : base(handle)
         {
-            MvxLogHost.Default?.LogWarning("MvxStandardTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+            MvxLogHost.Default?.LogWarning("MvxStandardTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         public MvxStandardTableViewSource(

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewCell.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewCell.cs
@@ -8,6 +8,7 @@ using CoreGraphics;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -44,18 +45,18 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             this.CreateBindingContext(bindingDescriptions);
         }
 
-        public MvxTableViewCell(IntPtr handle)
+        public MvxTableViewCell(NativeHandle handle)
             : this(string.Empty, handle)
         {
         }
 
-        public MvxTableViewCell(string bindingText, IntPtr handle)
+        public MvxTableViewCell(string bindingText, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingText);
         }
 
-        public MvxTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+        public MvxTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingDescriptions);

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewHeaderFooterView.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewHeaderFooterView.cs
@@ -8,6 +8,7 @@ using CoreGraphics;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
@@ -44,18 +45,18 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             this.CreateBindingContext(bindingDescriptions);
         }
 
-        public MvxTableViewHeaderFooterView(IntPtr handle)
+        public MvxTableViewHeaderFooterView(NativeHandle handle)
             : this(string.Empty, handle)
         {
         }
 
-        public MvxTableViewHeaderFooterView(string bindingText, IntPtr handle)
+        public MvxTableViewHeaderFooterView(string bindingText, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingText);
         }
 
-        public MvxTableViewHeaderFooterView(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+        public MvxTableViewHeaderFooterView(IEnumerable<MvxBindingDescription> bindingDescriptions, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingDescriptions);

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxTableViewSource.cs
@@ -2,17 +2,14 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Specialized;
-using System.Linq;
-using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.Extensions;
 using MvvmCross.Logging;
 using MvvmCross.WeakSubscription;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
 {
@@ -26,10 +23,10 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
         {
         }
 
-        protected MvxTableViewSource(IntPtr handle)
+        protected MvxTableViewSource(NativeHandle handle)
             : base(handle)
         {
-            MvxLogHost.Default?.LogWarning("TableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+            MvxLogHost.Default?.LogWarning("TableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         [MvxSetToNullAfterBinding]

--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxView.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxView.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using CoreGraphics;
-using Foundation;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Ios.Binding.Views
 {
@@ -22,7 +19,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
         // interface builder (or Xamarin iOS designer). More documentation can be found:
         // - here: https://developer.xamarin.com/guides/ios/user_interface/designer/ios_designable_controls_overview/
         // - and here: https://developer.xamarin.com/guides/ios/under_the_hood/api_design/#Types_and_Interface_Builder
-        public MvxView(IntPtr handle) : base(handle) { }
+        public MvxView(NativeHandle handle) : base(handle) { }
 
         public MvxView()
         {

--- a/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceCollectionViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceCollectionViewController.cs
@@ -5,6 +5,7 @@
 using System;
 using Foundation;
 using MvvmCross.Base;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views.Base
@@ -24,7 +25,7 @@ namespace MvvmCross.Platforms.Ios.Views.Base
         {
         }
 
-        protected internal MvxEventSourceCollectionViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceCollectionViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourcePageViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourcePageViewController.cs
@@ -5,6 +5,7 @@
 using System;
 using Foundation;
 using MvvmCross.Base;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views.Base
@@ -35,7 +36,7 @@ namespace MvvmCross.Platforms.Ios.Views.Base
         {
         }
 
-        protected internal MvxEventSourcePageViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourcePageViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceSplitViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceSplitViewController.cs
@@ -6,6 +6,7 @@ using System;
 using Foundation;
 using MvvmCross.Base;
 using MvvmCross.Platforms.Ios.Views.Base;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views.Base
@@ -24,7 +25,7 @@ namespace MvvmCross.Platforms.Ios.Views.Base
         {
         }
 
-        protected internal MvxEventSourceSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceSplitViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceTabBarController.cs
+++ b/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceTabBarController.cs
@@ -5,6 +5,7 @@
 using System;
 using Foundation;
 using MvvmCross.Base;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views.Base
@@ -24,7 +25,7 @@ namespace MvvmCross.Platforms.Ios.Views.Base
         {
         }
 
-        protected internal MvxEventSourceTabBarController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceTabBarController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceTableViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceTableViewController.cs
@@ -5,6 +5,7 @@
 using System;
 using Foundation;
 using MvvmCross.Base;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views.Base
@@ -24,7 +25,7 @@ namespace MvvmCross.Platforms.Ios.Views.Base
         {
         }
 
-        protected internal MvxEventSourceTableViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceTableViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/Base/MvxEventSourceViewController.cs
@@ -5,6 +5,7 @@
 using System;
 using Foundation;
 using MvvmCross.Base;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views.Base
@@ -24,7 +25,7 @@ namespace MvvmCross.Platforms.Ios.Views.Base
         {
         }
 
-        protected internal MvxEventSourceViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxBasePageViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBasePageViewController.cs
@@ -7,6 +7,7 @@ using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -38,7 +39,7 @@ namespace MvvmCross.Platforms.Ios.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxBasePageViewController(IntPtr handle) : base(handle)
+        protected internal MvxBasePageViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -153,7 +154,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxBasePageViewController(IntPtr handle) : base(handle)
+        protected internal MvxBasePageViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxBaseSplitViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseSplitViewController.cs
@@ -7,6 +7,7 @@ using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -28,7 +29,7 @@ namespace MvvmCross.Platforms.Ios.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxBaseSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxBaseSplitViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -122,7 +123,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxBaseSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxBaseSplitViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxBaseTabBarViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseTabBarViewController.cs
@@ -7,6 +7,7 @@ using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -28,7 +29,7 @@ namespace MvvmCross.Platforms.Ios.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxBaseTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxBaseTabBarViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -124,7 +125,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxBaseTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxBaseTabBarViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxBaseViewController.cs
@@ -6,6 +6,7 @@ using System;
 using CoreGraphics;
 using Foundation;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -27,7 +28,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected MvxBaseViewController(IntPtr handle) : base(handle)
+        protected MvxBaseViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxCollectionViewController.cs
@@ -7,6 +7,7 @@ using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -29,7 +30,7 @@ namespace MvvmCross.Platforms.Ios.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxCollectionViewController(IntPtr handle) : base(handle)
+        protected internal MvxCollectionViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -127,7 +128,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxCollectionViewController(IntPtr handle) : base(handle)
+        protected internal MvxCollectionViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxNavigationController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxNavigationController.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Foundation;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -34,7 +35,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxNavigationController(IntPtr handle) : base(handle)
+        protected internal MvxNavigationController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxPageViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxPageViewController.cs
@@ -9,6 +9,7 @@ using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -35,7 +36,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxPageViewController(IntPtr handle) : base(handle)
+        protected internal MvxPageViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -131,7 +132,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxPageViewController(IntPtr handle) : base(handle)
+        protected internal MvxPageViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxSplitViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxSplitViewController.cs
@@ -9,6 +9,7 @@ using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -27,7 +28,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxSplitViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -106,7 +107,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxSplitViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxTabBarViewController.cs
@@ -10,6 +10,7 @@ using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Presenters;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -34,7 +35,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxTabBarViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -250,7 +251,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxTabBarViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxTableViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxTableViewController.cs
@@ -7,6 +7,7 @@ using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -29,7 +30,7 @@ namespace MvvmCross.Platforms.Ios.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxTableViewController(IntPtr handle) : base(handle)
+        protected internal MvxTableViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -143,7 +144,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxTableViewController(IntPtr handle) : base(handle)
+        protected internal MvxTableViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Ios/Views/MvxViewController.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxViewController.cs
@@ -7,6 +7,7 @@ using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Views
@@ -29,7 +30,7 @@ namespace MvvmCross.Platforms.Ios.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxViewController(IntPtr handle) : base(handle)
+        protected internal MvxViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -118,7 +119,7 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        protected internal MvxViewController(IntPtr handle) : base(handle)
+        protected internal MvxViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/ChildView.cs
+++ b/Projects/Playground/Playground.iOS/Views/ChildView.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -10,7 +11,7 @@ namespace Playground.iOS.Views
     [MvxChildPresentation]
     public partial class ChildView : MvxViewController<ChildViewModel>
     {
-        public ChildView(IntPtr handle) : base(handle)
+        public ChildView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/ModalView.cs
+++ b/Projects/Playground/Playground.iOS/Views/ModalView.cs
@@ -2,6 +2,7 @@ using System;
 using CoreGraphics;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -11,7 +12,7 @@ namespace Playground.iOS.Views
     [MvxModalPresentation(ModalPresentationStyle = UIModalPresentationStyle.OverFullScreen, ModalTransitionStyle = UIModalTransitionStyle.CrossDissolve)]
     public partial class ModalView : MvxViewController<ModalViewModel>
     {
-        public ModalView(IntPtr handle) : base(handle)
+        public ModalView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/NestedModalView.cs
+++ b/Projects/Playground/Playground.iOS/Views/NestedModalView.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -10,7 +11,7 @@ namespace Playground.iOS.Views
     [MvxModalPresentation(WrapInNavigationController = true)]
     public partial class NestedModalView : MvxViewController<NestedModalViewModel>
     {
-        public NestedModalView(IntPtr handle) : base(handle)
+        public NestedModalView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/RootView.cs
+++ b/Projects/Playground/Playground.iOS/Views/RootView.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -10,7 +11,7 @@ namespace Playground.iOS.Views
     [MvxRootPresentation(WrapInNavigationController = true)]
     public partial class RootView : MvxViewController<RootViewModel>
     {
-        public RootView(IntPtr handle) : base(handle)
+        public RootView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/Tab1View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Tab1View.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -9,7 +10,7 @@ namespace Playground.iOS.Views
     [MvxTabPresentation(WrapInNavigationController = true, TabIconName = "home", TabName = "Tab 1")]
     public partial class Tab1View : MvxViewController<Tab1ViewModel>
     {
-        public Tab1View(IntPtr handle) : base(handle)
+        public Tab1View(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/Tab2View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Tab2View.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -9,7 +10,7 @@ namespace Playground.iOS.Views
     [MvxTabPresentation]
     public partial class Tab2View : MvxViewController<Tab2ViewModel>
     {
-        public Tab2View(IntPtr handle) : base(handle)
+        public Tab2View(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/Tab3View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Tab3View.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -9,7 +10,7 @@ namespace Playground.iOS.Views
     [MvxTabPresentation(WrapInNavigationController = false)]
     public partial class Tab3View : MvxViewController<Tab3ViewModel>, IMvxTabBarItemViewController
     {
-        public Tab3View(IntPtr handle) : base(handle)
+        public Tab3View(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/TabsRootView.cs
+++ b/Projects/Playground/Playground.iOS/Views/TabsRootView.cs
@@ -2,6 +2,7 @@ using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -13,7 +14,7 @@ namespace Playground.iOS.Views
     {
         private bool _isPresentedFirstTime = true;
 
-        public TabsRootView(IntPtr handle) : base(handle)
+        public TabsRootView(NativeHandle handle) : base(handle)
         {
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
in net6.0-ios we should not use IntPtr ctors, instead we should use NativeHandle

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
Yes, signature changes of many ctors

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
