### PR TITLE
Fix crash when App gets rehydrated

### DIFF
--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -37,6 +37,9 @@ namespace MvvmCross.Platforms.Android.Core
             ArgumentNullException.ThrowIfNull(activity.Application);
 
             PlatformInitialize(activity.Application);
+
+            // this is needed for when App is rehydrated from being killed by Android in the background
+            _currentTopActivity?.OnActivityCreated(activity, null);
         }
 
         public void PlatformInitialize(Application application)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
If you kill the App when it is in the background. I.e. through developer options using Running Services. Opening it back crashes due to Android starting from the Activity that was the top of the stack (not Splash) and Current Top Activity not having been set yet.

### :new: What is the new behavior (if this is a feature change)?
Set Top Activity as early as possible.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
