### PR TITLE
Fix Fragments not loading ViewModel after App killed in background

### DIFF
--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
@@ -53,7 +53,7 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             (Bundle? bundle, MvxViewModelRequest? request) = GetAndroidBundleAndRequest(e);
 
             var mvxBundle = ReadAndroidBundle(bundle);
-            if (mvxBundle != null)
+            if (FragmentView?.ViewModel == null)
                 FragmentView?.OnCreate(mvxBundle, request);
         }
 
@@ -94,17 +94,17 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             return request;
         }
 
-        private static IMvxBundle? ReadAndroidBundle(Bundle? bundle)
+        private static IMvxBundle ReadAndroidBundle(Bundle? bundle)
         {
             if (Mvx.IoCProvider?.TryResolve(out IMvxSavedStateConverter converter) == true && bundle != null)
             {
-                return converter.Read(bundle);
+                return converter.Read(bundle) ?? new MvxBundle();
             }
 
             MvxLogHost.GetLog<MvxBindingFragmentAdapter>()?.Log(LogLevel.Warning,
             "Saved state converter not available - saving state will be hard");
 
-            return null;
+            return new MvxBundle();
         }
 
         protected override void HandleCreateViewCalled(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
1. Set "Don't keep activities" in Developer options to true
2. Launch the playground app
3. Click "SHOW CHILD" button
4. Navigate to a different app
5. Come back
6. ViewModel is null for the Child Fragment

This is due to MvxBindingFragmentAdapter always relying on the Android bundle having saved state, but Android could kill the App in background without going through OnDestroy and related calls.

### :new: What is the new behavior (if this is a feature change)?
Instead of checking for bundle, I am relying on whether ViewModel is null, at this point it will mean, that we didn't navigate to the Fragment using the Presenter and we should load a ViewModel for the Fragment without going to the Presenter.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See steps above

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
