### PR TITLE
Fix for closing and re-opening non-fullscreen modals on iOS fast not working correctly

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/IMvxIosViewPresenter.cs
@@ -14,9 +14,6 @@ namespace MvvmCross.Platforms.Ios.Presenters
     public interface IMvxIosViewPresenter : IMvxViewPresenter, IMvxCanCreateIosView
     {
         public void ClosedPopoverViewController();
-
-        public ConfiguredTaskAwaitable<bool> ClosedModalViewController(UIViewController viewController,
-            MvxModalPresentationAttribute attribute);
     }
 #nullable restore
 }

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -445,7 +445,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             if (viewController.PresentationController != null)
             {
                 viewController.PresentationController.Delegate =
-                    new CustomModalPresentationControllerDelegate(this, viewController, attribute);
+                    new MvxModalPresentationControllerDelegate(this, viewController, attribute);
             }
 
             // Check if there is a modal already presented first. Otherwise use the window root

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -410,27 +410,6 @@ namespace MvvmCross.Platforms.Ios.Presenters
         {
             ValidateArguments(viewController, attribute);
 
-            // Check if the requested viewmodel is already presented AND ignore this request
-            var lastModal = ModalViewControllers.LastOrDefault();
-            if (lastModal != null)
-            {
-                var lastViewController = lastModal;
-                if (lastViewController is UINavigationController navCtrl && navCtrl.TopViewController != null)
-                {
-                    lastViewController = navCtrl.TopViewController;
-                }
-
-                if (lastViewController.GetType() == viewController.GetType())
-                {
-                    if (viewController is IDisposable disposable)
-                    {
-                        disposable.Dispose();
-                    }
-
-                    return Task.FromResult(false);
-                }
-            }
-
             // setup modal based on attribute
             if (attribute.WrapInNavigationController)
             {

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -442,7 +442,7 @@ namespace MvvmCross.Platforms.Ios.Presenters
             if (attribute.PreferredContentSize != default(CGSize))
                 viewController.PreferredContentSize = attribute.PreferredContentSize;
 
-            if (viewController.PresentationController != null)
+            if (_iosVersion13Checker.IsVersionOrHigher && viewController.PresentationController != null)
             {
                 viewController.PresentationController.Delegate =
                     new MvxModalPresentationControllerDelegate(this, viewController, attribute);

--- a/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
@@ -20,9 +20,9 @@ namespace MvvmCross.Platforms.Ios.Presenters
             _attribute = attribute;
         }
 
-        public override void DidDismiss(UIPresentationController presentationController)
+        public override void WillDismiss(UIPresentationController presentationController)
         {
-            _presenter.ClosedModalViewController(_viewController, _attribute);
+            _presenter.CloseModalViewController(_viewController, _attribute);
         }
     }
 }

--- a/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
@@ -9,11 +9,11 @@ namespace MvvmCross.Platforms.Ios.Presenters
 {
     public class MvxModalPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
     {
-        private readonly IMvxIosViewPresenter _presenter;
+        private readonly MvxIosViewPresenter _presenter;
         private readonly UIViewController _viewController;
         private readonly MvxModalPresentationAttribute _attribute;
 
-        public MvxModalPresentationControllerDelegate(IMvxIosViewPresenter presenter, UIViewController viewController, MvxModalPresentationAttribute attribute)
+        public MvxModalPresentationControllerDelegate(MvxIosViewPresenter presenter, UIViewController viewController, MvxModalPresentationAttribute attribute)
         {
             _presenter = presenter;
             _viewController = viewController;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This is a new bug fix for #3546 since #4040 didn't completely fix this. When showing a non-fullscreen modal, swipe to close, re-open it fast, repeat if needed for x amount of times, the following error is thrown in the application output:

> [Presentation] Attempt to present <MvvmCross_Platforms_Ios_Views_MvxNavigationController: 0x7fdae1b74a00> on <MvvmCross_Platforms_Ios_Views_MvxNavigationController: 0x7fdae69c8c00> (from <MvvmCross_Platforms_Ios_Views_MvxNavigationController: 0x7fdae69c8c00>) whose view is not in the window hierarchy.

### :arrow_heading_down: What is the current behavior?
Error from #3546 still sometimes occurs when closing and re-opening non-fullscreen modals on iOS fast.

### :new: What is the new behavior (if this is a feature change)?
Closing and re-opening non-fullscreen modals on iOS fast should work correctly now.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Show a non-fullscreen modal, swipe to close, re-open it fast, repeat if needed for x amount of times.

### :memo: Links to relevant issues/docs
#3546 
#4040 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop