### PR TITLE
Fix CreateViewsContainer getting Application Context from Top Activity

### DIFF
--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -123,7 +123,7 @@ namespace MvvmCross.Platforms.Android.Core
             return new MvxSavedStateConverter();
         }
 
-        protected sealed override IMvxViewsContainer CreateViewsContainer(IMvxIoCProvider iocProvider)
+        protected override IMvxViewsContainer CreateViewsContainer(IMvxIoCProvider iocProvider)
         {
             ValidateArguments(iocProvider);
 

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
+#nullable enable
 using System.Reflection;
 using Android.Content;
 using Android.Views;
@@ -22,289 +22,286 @@ using MvvmCross.Presenters;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 
-namespace MvvmCross.Platforms.Android.Core
+namespace MvvmCross.Platforms.Android.Core;
+
+public abstract class MvxAndroidSetup
+    : MvxSetup, IMvxAndroidGlobals, IMvxAndroidSetup
 {
-#nullable enable
-    public abstract class MvxAndroidSetup
-        : MvxSetup, IMvxAndroidGlobals, IMvxAndroidSetup
+    private MvxCurrentTopActivity? _currentTopActivity;
+    private IMvxAndroidViewPresenter? _presenter;
+
+    public void PlatformInitialize(Activity activity)
     {
-        private MvxCurrentTopActivity? _currentTopActivity;
-        private IMvxAndroidViewPresenter? _presenter;
+        ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(activity.Application);
 
-        public void PlatformInitialize(Activity activity)
+        PlatformInitialize(activity.Application);
+
+        // this is needed for when App is rehydrated from being killed by Android in the background
+        _currentTopActivity?.OnActivityCreated(activity, null);
+    }
+
+    public void PlatformInitialize(Application application)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+
+        if (_currentTopActivity != null)
+            return;
+
+        _currentTopActivity = new MvxCurrentTopActivity();
+        application.RegisterActivityLifecycleCallbacks(_currentTopActivity);
+    }
+
+    public virtual Assembly ExecutableAssembly => ViewAssemblies.FirstOrDefault() ?? GetType().Assembly;
+
+    public virtual Context? ApplicationContext => Application.Context;
+
+    protected override void InitializeFirstChance(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        InitializeLifetimeMonitor(iocProvider);
+        InitializeAndroidCurrentTopActivity(iocProvider);
+        RegisterPresenter(iocProvider);
+
+        iocProvider.RegisterSingleton<IMvxAndroidGlobals>(this);
+
+        var intentResultRouter = new MvxIntentResultSink();
+        iocProvider.RegisterSingleton<IMvxIntentResultSink>(intentResultRouter);
+        iocProvider.RegisterSingleton<IMvxIntentResultSource>(intentResultRouter);
+
+        var viewModelTemporaryCache = new MvxSingleViewModelCache();
+        iocProvider.RegisterSingleton<IMvxSingleViewModelCache>(viewModelTemporaryCache);
+
+        var viewModelMultiTemporaryCache = new MvxMultipleViewModelCache();
+        iocProvider.RegisterSingleton<IMvxMultipleViewModelCache>(viewModelMultiTemporaryCache);
+        base.InitializeFirstChance(iocProvider);
+    }
+
+    protected virtual void InitializeAndroidCurrentTopActivity(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        var currentTopActivity = CreateAndroidCurrentTopActivity();
+        iocProvider.RegisterSingleton(currentTopActivity);
+    }
+
+    protected virtual IMvxAndroidCurrentTopActivity CreateAndroidCurrentTopActivity()
+    {
+        if (_currentTopActivity == null)
+            throw new InvalidOperationException($"Please call {nameof(PlatformInitialize)} first");
+
+        return _currentTopActivity;
+    }
+
+    protected virtual void InitializeLifetimeMonitor(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        var lifetimeMonitor = CreateLifetimeMonitor();
+
+        iocProvider.RegisterSingleton<IMvxAndroidActivityLifetimeListener>(lifetimeMonitor);
+        iocProvider.RegisterSingleton<IMvxLifetime>(lifetimeMonitor);
+    }
+
+    protected virtual MvxAndroidLifetimeMonitor CreateLifetimeMonitor()
+    {
+        return new MvxAndroidLifetimeMonitor();
+    }
+
+    protected virtual void InitializeSavedStateConverter(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        var converter = CreateSavedStateConverter();
+        iocProvider.RegisterSingleton(converter);
+    }
+
+    protected virtual IMvxSavedStateConverter CreateSavedStateConverter()
+    {
+        return new MvxSavedStateConverter();
+    }
+
+    protected override IMvxViewsContainer CreateViewsContainer(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        if (ApplicationContext == null)
+            throw new InvalidOperationException("Cannot create Views Container without ApplicationContext");
+
+        var container = CreateViewsContainer(ApplicationContext);
+        iocProvider.RegisterSingleton<IMvxAndroidViewModelRequestTranslator>(container);
+        iocProvider.RegisterSingleton<IMvxAndroidViewModelLoader>(container);
+        if (container is not MvxViewsContainer viewsContainer)
+            throw new MvxException("CreateViewsContainer must return an MvxViewsContainer");
+        return viewsContainer;
+    }
+
+    protected virtual IMvxAndroidViewsContainer CreateViewsContainer(Context applicationContext)
+    {
+        return new MvxAndroidViewsContainer(applicationContext);
+    }
+
+    protected IMvxAndroidViewPresenter Presenter
+    {
+        get
         {
-            ArgumentNullException.ThrowIfNull(activity);
-            ArgumentNullException.ThrowIfNull(activity.Application);
-
-            PlatformInitialize(activity.Application);
-
-            // this is needed for when App is rehydrated from being killed by Android in the background
-            _currentTopActivity?.OnActivityCreated(activity, null);
-        }
-
-        public void PlatformInitialize(Application application)
-        {
-            ArgumentNullException.ThrowIfNull(application);
-
-            if (_currentTopActivity != null)
-                return;
-
-            _currentTopActivity = new MvxCurrentTopActivity();
-            application.RegisterActivityLifecycleCallbacks(_currentTopActivity);
-        }
-
-        public virtual Assembly ExecutableAssembly => ViewAssemblies.FirstOrDefault() ?? GetType().Assembly;
-
-        public virtual Context? ApplicationContext => Application.Context;
-
-        protected override void InitializeFirstChance(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            InitializeLifetimeMonitor(iocProvider);
-            InitializeAndroidCurrentTopActivity(iocProvider);
-            RegisterPresenter(iocProvider);
-
-            iocProvider.RegisterSingleton<IMvxAndroidGlobals>(this);
-
-            var intentResultRouter = new MvxIntentResultSink();
-            iocProvider.RegisterSingleton<IMvxIntentResultSink>(intentResultRouter);
-            iocProvider.RegisterSingleton<IMvxIntentResultSource>(intentResultRouter);
-
-            var viewModelTemporaryCache = new MvxSingleViewModelCache();
-            iocProvider.RegisterSingleton<IMvxSingleViewModelCache>(viewModelTemporaryCache);
-
-            var viewModelMultiTemporaryCache = new MvxMultipleViewModelCache();
-            iocProvider.RegisterSingleton<IMvxMultipleViewModelCache>(viewModelMultiTemporaryCache);
-            base.InitializeFirstChance(iocProvider);
-        }
-
-        protected virtual void InitializeAndroidCurrentTopActivity(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            var currentTopActivity = CreateAndroidCurrentTopActivity();
-            iocProvider.RegisterSingleton(currentTopActivity);
-        }
-
-        protected virtual IMvxAndroidCurrentTopActivity CreateAndroidCurrentTopActivity()
-        {
-            if (_currentTopActivity == null)
-                throw new InvalidOperationException($"Please call {nameof(PlatformInitialize)} first");
-
-            return _currentTopActivity;
-        }
-
-        protected virtual void InitializeLifetimeMonitor(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            var lifetimeMonitor = CreateLifetimeMonitor();
-
-            iocProvider.RegisterSingleton<IMvxAndroidActivityLifetimeListener>(lifetimeMonitor);
-            iocProvider.RegisterSingleton<IMvxLifetime>(lifetimeMonitor);
-        }
-
-        protected virtual MvxAndroidLifetimeMonitor CreateLifetimeMonitor()
-        {
-            return new MvxAndroidLifetimeMonitor();
-        }
-
-        protected virtual void InitializeSavedStateConverter(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            var converter = CreateSavedStateConverter();
-            iocProvider.RegisterSingleton(converter);
-        }
-
-        protected virtual IMvxSavedStateConverter CreateSavedStateConverter()
-        {
-            return new MvxSavedStateConverter();
-        }
-
-        protected override IMvxViewsContainer CreateViewsContainer(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            if (ApplicationContext == null)
-                throw new InvalidOperationException("Cannot create Views Container without ApplicationContext");
-
-            var container = CreateViewsContainer(ApplicationContext);
-            iocProvider.RegisterSingleton<IMvxAndroidViewModelRequestTranslator>(container);
-            iocProvider.RegisterSingleton<IMvxAndroidViewModelLoader>(container);
-            if (container is not MvxViewsContainer viewsContainer)
-                throw new MvxException("CreateViewsContainer must return an MvxViewsContainer");
-            return viewsContainer;
-        }
-
-        protected virtual IMvxAndroidViewsContainer CreateViewsContainer(Context applicationContext)
-        {
-            return new MvxAndroidViewsContainer(applicationContext);
-        }
-
-        protected IMvxAndroidViewPresenter Presenter
-        {
-            get
-            {
-                _presenter ??= CreateViewPresenter();
-                return _presenter;
-            }
-        }
-
-        protected virtual IMvxAndroidViewPresenter CreateViewPresenter()
-        {
-            return new MvxAndroidViewPresenter(AndroidViewAssemblies);
-        }
-
-        protected override IMvxViewDispatcher CreateViewDispatcher()
-        {
-            return new MvxAndroidViewDispatcher(Presenter);
-        }
-
-        protected virtual void RegisterPresenter(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            var presenter = Presenter;
-            iocProvider.RegisterSingleton(presenter);
-            iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
-        }
-
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            InitializeSavedStateConverter(iocProvider);
-
-            InitializeBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            var bindingBuilder = CreateBindingBuilder();
-            RegisterBindingBuilderCallbacks(iocProvider);
-            bindingBuilder.DoRegistration(iocProvider);
-        }
-
-        protected virtual void RegisterBindingBuilderCallbacks(IMvxIoCProvider iocProvider)
-        {
-            ValidateArguments(iocProvider);
-
-            iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
-            iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
-            iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
-            iocProvider.CallbackWhenRegistered<IMvxTypeCache<View>>(FillViewTypes);
-            iocProvider.CallbackWhenRegistered<IMvxAxmlNameViewTypeResolver>(FillAxmlViewTypeResolver);
-            iocProvider.CallbackWhenRegistered<IMvxNamespaceListViewTypeResolver>(FillNamespaceListViewTypeResolver);
-        }
-
-        protected virtual MvxBindingBuilder CreateBindingBuilder()
-        {
-            return new MvxAndroidBindingBuilder();
-        }
-
-        protected virtual void FillViewTypes(IMvxTypeCache<View> cache)
-        {
-            ArgumentNullException.ThrowIfNull(cache);
-
-            foreach (var assembly in AndroidViewAssemblies)
-            {
-                cache.AddAssembly(assembly);
-            }
-        }
-
-        protected virtual void FillBindingNames(IMvxBindingNameRegistry registry)
-        {
-            // this base class does nothing
-        }
-
-        protected virtual void FillAxmlViewTypeResolver(IMvxAxmlNameViewTypeResolver viewTypeResolver)
-        {
-            ArgumentNullException.ThrowIfNull(viewTypeResolver);
-
-            foreach (var kvp in ViewNamespaceAbbreviations)
-            {
-                viewTypeResolver.ViewNamespaceAbbreviations[kvp.Key] = kvp.Value;
-            }
-        }
-
-        protected virtual void FillNamespaceListViewTypeResolver(IMvxNamespaceListViewTypeResolver viewTypeResolver)
-        {
-            ArgumentNullException.ThrowIfNull(viewTypeResolver);
-
-            foreach (var viewNamespace in ViewNamespaces)
-            {
-                viewTypeResolver.Add(viewNamespace);
-            }
-        }
-
-        protected virtual void FillValueConverters(IMvxValueConverterRegistry registry)
-        {
-            ArgumentNullException.ThrowIfNull(registry);
-
-            registry.Fill(ValueConverterAssemblies);
-            registry.Fill(ValueConverterHolders);
-        }
-
-        protected virtual IEnumerable<Type> ValueConverterHolders => new List<Type>();
-
-        protected virtual IEnumerable<Assembly> ValueConverterAssemblies
-        {
-            get
-            {
-                var toReturn = new List<Assembly>();
-                toReturn.AddRange(GetViewModelAssemblies());
-                toReturn.AddRange(GetViewAssemblies());
-                return toReturn;
-            }
-        }
-
-        protected virtual IDictionary<string, string> ViewNamespaceAbbreviations => new Dictionary<string, string>
-        {
-            { "Mvx", "mvvmcross.platforms.android.binding.views" }
-        };
-
-        protected virtual IEnumerable<string> ViewNamespaces => new List<string>
-        {
-            "Android.Views",
-            "Android.Widget",
-            "Android.Webkit",
-            "MvvmCross.Platforms.Android.Views",
-            "MvvmCross.Platforms.Android.Binding.Views"
-        };
-
-        protected virtual IEnumerable<Assembly> AndroidViewAssemblies => new List<Assembly>()
-        {
-            typeof(View).Assembly,
-            typeof(MvxDatePicker).Assembly,
-            GetType().Assembly,
-        };
-
-        protected virtual void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
-        {
-            // nothing to do in this base class
-        }
-
-        protected override IMvxNameMapping CreateViewToViewModelNaming()
-        {
-            return new MvxPostfixAwareViewToViewModelNameMapping("View", "Activity", "Fragment");
+            _presenter ??= CreateViewPresenter();
+            return _presenter;
         }
     }
 
-    public abstract class MvxAndroidSetup<TApplication> : MvxAndroidSetup
-        where TApplication : class, IMvxApplication, new()
+    protected virtual IMvxAndroidViewPresenter CreateViewPresenter()
     {
-        protected override IMvxApplication CreateApp(IMvxIoCProvider iocProvider) =>
-            iocProvider.IoCConstruct<TApplication>();
+        return new MvxAndroidViewPresenter(AndroidViewAssemblies);
+    }
 
-        public override IEnumerable<Assembly> GetViewModelAssemblies()
+    protected override IMvxViewDispatcher CreateViewDispatcher()
+    {
+        return new MvxAndroidViewDispatcher(Presenter);
+    }
+
+    protected virtual void RegisterPresenter(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        var presenter = Presenter;
+        iocProvider.RegisterSingleton(presenter);
+        iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
+    }
+
+    protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        InitializeSavedStateConverter(iocProvider);
+
+        InitializeBindingBuilder(iocProvider);
+        base.InitializeLastChance(iocProvider);
+    }
+
+    protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        var bindingBuilder = CreateBindingBuilder();
+        RegisterBindingBuilderCallbacks(iocProvider);
+        bindingBuilder.DoRegistration(iocProvider);
+    }
+
+    protected virtual void RegisterBindingBuilderCallbacks(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+        iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
+        iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
+        iocProvider.CallbackWhenRegistered<IMvxTypeCache<View>>(FillViewTypes);
+        iocProvider.CallbackWhenRegistered<IMvxAxmlNameViewTypeResolver>(FillAxmlViewTypeResolver);
+        iocProvider.CallbackWhenRegistered<IMvxNamespaceListViewTypeResolver>(FillNamespaceListViewTypeResolver);
+    }
+
+    protected virtual MvxBindingBuilder CreateBindingBuilder()
+    {
+        return new MvxAndroidBindingBuilder();
+    }
+
+    protected virtual void FillViewTypes(IMvxTypeCache<View> cache)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+
+        foreach (var assembly in AndroidViewAssemblies)
         {
-            return new[] { typeof(TApplication).GetTypeInfo().Assembly };
+            cache.AddAssembly(assembly);
         }
     }
-#nullable restore
+
+    protected virtual void FillBindingNames(IMvxBindingNameRegistry registry)
+    {
+        // this base class does nothing
+    }
+
+    protected virtual void FillAxmlViewTypeResolver(IMvxAxmlNameViewTypeResolver viewTypeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(viewTypeResolver);
+
+        foreach (var kvp in ViewNamespaceAbbreviations)
+        {
+            viewTypeResolver.ViewNamespaceAbbreviations[kvp.Key] = kvp.Value;
+        }
+    }
+
+    protected virtual void FillNamespaceListViewTypeResolver(IMvxNamespaceListViewTypeResolver viewTypeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(viewTypeResolver);
+
+        foreach (var viewNamespace in ViewNamespaces)
+        {
+            viewTypeResolver.Add(viewNamespace);
+        }
+    }
+
+    protected virtual void FillValueConverters(IMvxValueConverterRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        registry.Fill(ValueConverterAssemblies);
+        registry.Fill(ValueConverterHolders);
+    }
+
+    protected virtual IEnumerable<Type> ValueConverterHolders => new List<Type>();
+
+    protected virtual IEnumerable<Assembly> ValueConverterAssemblies
+    {
+        get
+        {
+            var toReturn = new List<Assembly>();
+            toReturn.AddRange(GetViewModelAssemblies());
+            toReturn.AddRange(GetViewAssemblies());
+            return toReturn;
+        }
+    }
+
+    protected virtual IDictionary<string, string> ViewNamespaceAbbreviations => new Dictionary<string, string>
+    {
+        { "Mvx", "mvvmcross.platforms.android.binding.views" }
+    };
+
+    protected virtual IEnumerable<string> ViewNamespaces => new List<string>
+    {
+        "Android.Views",
+        "Android.Widget",
+        "Android.Webkit",
+        "MvvmCross.Platforms.Android.Views",
+        "MvvmCross.Platforms.Android.Binding.Views"
+    };
+
+    protected virtual IEnumerable<Assembly> AndroidViewAssemblies => new List<Assembly>()
+    {
+        typeof(View).Assembly,
+        typeof(MvxDatePicker).Assembly,
+        GetType().Assembly,
+    };
+
+    protected virtual void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+    {
+        // nothing to do in this base class
+    }
+
+    protected override IMvxNameMapping CreateViewToViewModelNaming()
+    {
+        return new MvxPostfixAwareViewToViewModelNameMapping("View", "Activity", "Fragment");
+    }
+}
+
+public abstract class MvxAndroidSetup<TApplication> : MvxAndroidSetup
+    where TApplication : class, IMvxApplication, new()
+{
+    protected override IMvxApplication CreateApp(IMvxIoCProvider iocProvider) =>
+        iocProvider.IoCConstruct<TApplication>();
+
+    public override IEnumerable<Assembly> GetViewModelAssemblies()
+    {
+        return new[] { typeof(TApplication).GetTypeInfo().Assembly };
+    }
 }

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -55,7 +55,7 @@ namespace MvvmCross.Platforms.Android.Core
 
         public virtual Assembly ExecutableAssembly => ViewAssemblies.FirstOrDefault() ?? GetType().Assembly;
 
-        public Context? ApplicationContext => _currentTopActivity?.Activity?.ApplicationContext;
+        public Context? ApplicationContext => Application.Context;
 
         protected override void InitializeFirstChance(IMvxIoCProvider iocProvider)
         {

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -55,7 +55,7 @@ namespace MvvmCross.Platforms.Android.Core
 
         public virtual Assembly ExecutableAssembly => ViewAssemblies.FirstOrDefault() ?? GetType().Assembly;
 
-        public Context? ApplicationContext => Application.Context;
+        public virtual Context? ApplicationContext => Application.Context;
 
         protected override void InitializeFirstChance(IMvxIoCProvider iocProvider)
         {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
MvxAndroidSetup uses `_currentTopActivity.Activity.Context` as `ApplicationContext`. This doesn't work if an App doesn't have any Activities.

### :new: What is the new behavior (if this is a feature change)?
Now using Application.Context instead.

Also removed `sealed` keyword on CreateViewsContainer preventing someone from overriding the behavior

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4555

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
