### PR TITLE
Add an InsertRange method to MvxObservableCollection

### DIFF
--- a/MvvmCross/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/ViewModels/MvxObservableCollection.cs
@@ -120,7 +120,7 @@ namespace MvvmCross.ViewModels
             var itemsList = items.ToList();
             using (SuppressEvents())
             {
-                foreach (var i in itemsList)
+                foreach (var item in itemsList)
                 {
                     InsertItem(currentIndex, i);
                     currentIndex++;

--- a/MvvmCross/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/ViewModels/MvxObservableCollection.cs
@@ -122,7 +122,7 @@ namespace MvvmCross.ViewModels
             {
                 foreach (var item in itemsList)
                 {
-                    InsertItem(currentIndex, i);
+                    InsertItem(currentIndex, item);
                     currentIndex++;
                 }
             }

--- a/MvvmCross/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/ViewModels/MvxObservableCollection.cs
@@ -75,7 +75,7 @@ namespace MvvmCross.ViewModels
         /// <summary>
         /// Adds the specified items collection to the current <see cref="MvxObservableCollection{T}"/> instance.
         /// </summary>
-        /// <param name="items">The collection from which the items are copied.</param>
+        /// <param name="items">The collection of items to be added.</param>
         /// <exception cref="ArgumentNullException">The items list is null.</exception>
         public virtual void AddRange(IEnumerable<T> items)
         {
@@ -96,11 +96,44 @@ namespace MvvmCross.ViewModels
 
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList, startingIndex));
         }
+        
+        /// <summary>
+        /// Inserts the specified items collection in the current <see cref="MvxObservableCollection{T}"/> instance at the specified index.
+        /// </summary>
+        /// <param name="index">The position where the collection of items should be inserted at.</param>
+        /// <param name="items">The collection of items to be inserted.</param>
+        /// <exception cref="ArgumentNullException">The items list is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Index incorrect.</exception>
+        public virtual void InsertRange(int index, IEnumerable<T> items)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+            
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(start));
+            }
+
+            int currentIndex = index;
+            var itemsList = items.ToList();
+            using (SuppressEvents())
+            {
+                foreach (var i in itemsList)
+                {
+                    InsertItem(currentIndex, i);
+                    currentIndex++;
+                }
+            }
+
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList, index));
+        }
 
         /// <summary>
         /// Replaces the current <see cref="MvxObservableCollection{T}"/> instance items with the ones specified in the items collection, raising a single <see cref="NotifyCollectionChangedAction.Reset"/> event.
         /// </summary>
-        /// <param name="items">The collection from which the items are copied.</param>
+        /// <param name="items">The collection of items that will replace the current <see cref="MvxObservableCollection{T}"/> instance items.</param>
         /// <exception cref="ArgumentNullException">The items list is null.</exception>
         public virtual void ReplaceWith(IEnumerable<T> items)
         {
@@ -212,7 +245,7 @@ namespace MvvmCross.ViewModels
         /// </summary>
         /// <param name="start">The start index.</param>
         /// <param name="count">The count of items to remove.</param>
-        /// <exception cref="ArgumentOutOfRangeException">Start index or count incorrect</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Start index or count incorrect.</exception>
         public virtual void RemoveRange(int start, int count)
         {
             if (start < 0)

--- a/MvvmCross/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/ViewModels/MvxObservableCollection.cs
@@ -113,7 +113,7 @@ namespace MvvmCross.ViewModels
             
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(start));
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             int currentIndex = index;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Add an InsertRange method to MvxObservableCollection.

### :arrow_heading_down: What is the current behavior?
Non-existent.

### :new: What is the new behavior (if this is a feature change)?
Adds an InsertRange method to MvxObservableCollection to insert a collection of items at a specified index.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
/

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
