### PR TITLE
[Mac] Correctly set view type when applying default presenter attribu…

### DIFF
--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -28,7 +28,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
         public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
         {
             MvxLogHost.Default?.Log(LogLevel.Trace, "PresentationAttribute not found for {ViewTypeName}. Assuming new window presentation", viewType.Name);
-            return new MvxWindowPresentationAttribute();
+            return new MvxWindowPresentationAttribute { ViewModelType = viewModelType, ViewType = viewType };
         }
 
         public override MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType)


### PR DESCRIPTION
…te. Fixes #4572

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
View is not created until one of the presentation attributes set explicitly.

### :new: What is the new behavior (if this is a feature change)?
If a view class in a Mac app has no presentation attribute over it, the presenter will assume a new window presentation and will create such a view without problems.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/4572

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
