### PR TITLE
Fix MvxCollectionViewCell when working with Auto Layout

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewCell.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxCollectionViewCell.cs
@@ -61,19 +61,6 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
             this.CreateBindingContext(bindingDescriptions);
         }
 
-        /// <summary>
-        /// Should fix choppy scrolling on ios8+ by preventing a layout pass when autolayout is already computed
-        /// 
-        /// iOS 8 provides a new self-sizing API for CollectionView and CollectionViewCells. It lets cells determine their own height, based on the content that they're about to load.
-        /// preferredLayoutAttributesFittingAttributes: (on the cell)
-        /// shouldLayoutAttributesFittingAttributes: (on the layout)
-        /// invalidationContextForPreferredLayoutAttributes:withOriginalAttributes: (on the layout)
-        /// </summary>
-        public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(UICollectionViewLayoutAttributes layoutAttributes)
-        {
-            return layoutAttributes;
-        }
-
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxCollectionViewCell.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxCollectionViewCell.cs
@@ -51,19 +51,6 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             this.CreateBindingContext(bindingDescriptions);
         }
 
-        /// <summary>
-        /// Should fix choppy scrolling on ios8+ by preventing a layout pass when autolayout is already computed
-        /// 
-        /// tvOS 8 provides a new self-sizing API for CollectionView and CollectionViewCells. It lets cells determine their own height, based on the content that they're about to load.
-        /// preferredLayoutAttributesFittingAttributes: (on the cell)
-        /// shouldLayoutAttributesFittingAttributes: (on the layout)
-        /// invalidationContextForPreferredLayoutAttributes:withOriginalAttributes: (on the layout)
-        /// </summary>
-        public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(UICollectionViewLayoutAttributes layoutAttributes)
-        {
-            return layoutAttributes;
-        }
-
         protected override void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This is a bug fix for #3714

### :arrow_heading_down: What is the current behavior?
The current implementation breaks Auto Layout with MvxCollectionViewCell as it doesn't call the base implementation.

### :new: What is the new behavior (if this is a feature change)?
The override is removed since developers should override `PreferredLayoutAttributesFittingAttributes` and provide their own implementation if needed.

For example, if I set `EstimatedItemSize = new CGSize(1, 47)` on my instance of `UICollectionViewFlowLayout` which I pass on in the ctor of `UICollectionView` to have a fixed height but dynamic width, I could provide the following implementation of `PreferredLayoutAttributesFittingAttributes` in my own `MvxCollectionViewCell`:

```
public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(UICollectionViewLayoutAttributes layoutAttributes)
{
    var layoutAttrs = base.PreferredLayoutAttributesFittingAttributes(layoutAttributes);

    var frame = layoutAttrs.Frame;
    frame.Size = new CGSize(layoutAttrs.Frame.Width, layoutAttributes.Frame.Size.Height);

    layoutAttrs.Frame = frame;

    return layoutAttrs;
} 
```
If you want both dynamic height and width, you shouldn't override PreferredLayoutAttributesFittingAttributes for that case and just provide `EstimatedItemSize = UICollectionViewFlowLayout.AutomaticSize` (or any size since it doesn't really matter I think) 
In the current implementation of `MvxCollectionViewCell,` `var layoutAttrs = base.PreferredLayoutAttributesFittingAttributes(layoutAttributes);` would not work right now since `MvxCollectionViewCell` overrides it and doesn't call the base implementation.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Set up a basic `UICollectionView` with a `MvxCollectionViewCell` which uses Auto Layout.

### :memo: Links to relevant issues/docs
#3714

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
