### PR TITLE
Prevent null reference exception in MvxPickerViewModel when using a null entry in your list

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Views/MvxPickerViewModel.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Views/MvxPickerViewModel.cs
@@ -105,7 +105,7 @@ namespace MvvmCross.Platforms.Ios.Binding.Views
 
         protected virtual string RowTitle(nint row, object item)
         {
-            return item.ToString();
+            return item?.ToString();
         }
 
         public override void Selected(UIPickerView picker, nint row, nint component)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This fix prevents a null reference exception when using a `null` entry in your list with `MvxPickerViewModel`.

### :arrow_heading_down: What is the current behavior?
Crash when having a `null` entry in your list with `MvxPickerViewModel`.

### :new: What is the new behavior (if this is a feature change)?
Doesn't crash and picker shows an empty entry.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
/

### :memo: Links to relevant issues/docs
/

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
