### PR TITLE
Bugfix: MvxFragmentPresentationAttribute.FragmentContentId misses "Android.Resource.Id.Content"

### DIFF
--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -12,6 +12,7 @@
 This package contains the 'Core' libraries for MvvmCross</Description>
     <PackageId>MvvmCross</PackageId>
     <GenerateLibraryLayout Condition=" $(TargetFramework.StartsWith('net6.0-windows')) ">true</GenerateLibraryLayout>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxActivityPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxActivityPresentationAttribute.cs
@@ -2,26 +2,21 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.OS;
 using MvvmCross.Presenters.Attributes;
 
-namespace MvvmCross.Platforms.Android.Presenters.Attributes
+namespace MvvmCross.Platforms.Android.Presenters.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class MvxActivityPresentationAttribute : MvxBasePresentationAttribute
 {
-#nullable enable
-    [AttributeUsage(AttributeTargets.Class)]
-    public class MvxActivityPresentationAttribute : MvxBasePresentationAttribute
+    public MvxActivityPresentationAttribute()
     {
-        public MvxActivityPresentationAttribute()
-        {
-        }
-
-        public static Bundle? DefaultExtras { get; }
-
-        /// <summary>
-        /// Add extras to the Intent that will be started for this Activity
-        /// </summary>
-        public Bundle? Extras { get; set; } = DefaultExtras;
     }
-#nullable restore
+
+    public static Bundle? DefaultExtras { get; }
+
+    /// <summary>
+    /// Add extras to the Intent that will be started for this Activity
+    /// </summary>
+    public Bundle? Extras { get; set; } = DefaultExtras;
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxAndroidPresentationAttributeExtensions.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxAndroidPresentationAttributeExtensions.cs
@@ -2,45 +2,33 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
-using Android.App;
 using MvvmCross.Presenters;
 
-namespace MvvmCross.Platforms.Android.Presenters.Attributes
+namespace MvvmCross.Platforms.Android.Presenters.Attributes;
+
+public static class MvxAndroidPresentationAttributeExtensions
 {
-#nullable enable
-    public static class MvxAndroidPresentationAttributeExtensions
+    public static bool IsFragmentCacheable(this Type fragmentType, Type fragmentActivityParentType)
     {
-        public static bool IsFragmentCacheable(this Type fragmentType, Type fragmentActivityParentType)
-        {
-            if (!fragmentType.HasBasePresentationAttribute())
-                return false;
+        if (!fragmentType.HasBasePresentationAttribute())
+            return false;
 
-            var fragmentAttributes =
-                fragmentType.GetBasePresentationAttributes()
-                    .Select(baseAttribute => baseAttribute as MvxFragmentPresentationAttribute)
-                    .Where(fragmentAttribute => fragmentAttribute != null);
+        var fragmentAttributes =
+            fragmentType.GetBasePresentationAttributes()
+                .Select(baseAttribute => baseAttribute as MvxFragmentPresentationAttribute)
+                .Where(fragmentAttribute => fragmentAttribute != null);
 
-            var currentAttribute = fragmentAttributes.FirstOrDefault(
-                fragmentAttribute => fragmentAttribute != null &&
-                fragmentAttribute.ActivityHostViewModelType == fragmentActivityParentType);
+        var currentAttribute = fragmentAttributes.FirstOrDefault(
+            fragmentAttribute => fragmentAttribute != null &&
+            fragmentAttribute.ActivityHostViewModelType == fragmentActivityParentType);
 
-            return currentAttribute?.IsCacheableFragment == true;
-        }
-
-        public static PopBackStackFlags ToNativePopBackStackFlags(this MvxPopBackStack mvxPopBackStack)
-        {
-            switch (mvxPopBackStack)
-            {
-                case MvxPopBackStack.None:
-                    return PopBackStackFlags.None;
-                case MvxPopBackStack.Inclusive:
-                    return PopBackStackFlags.Inclusive;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(mvxPopBackStack), mvxPopBackStack, $"No matching {nameof(PopBackStackFlags)} enum is defined");
-            }
-        }
+        return currentAttribute?.IsCacheableFragment == true;
     }
-#nullable restore
+
+    public static PopBackStackFlags ToNativePopBackStackFlags(this MvxPopBackStack mvxPopBackStack) => mvxPopBackStack switch
+    {
+        MvxPopBackStack.None => PopBackStackFlags.None,
+        MvxPopBackStack.Inclusive => PopBackStackFlags.Inclusive,
+        _ => throw new ArgumentOutOfRangeException(nameof(mvxPopBackStack), mvxPopBackStack, $"No matching {nameof(PopBackStackFlags)} enum is defined"),
+    };
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxDialogFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxDialogFragmentPresentationAttribute.cs
@@ -2,74 +2,69 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+namespace MvvmCross.Platforms.Android.Presenters.Attributes;
 
-namespace MvvmCross.Platforms.Android.Presenters.Attributes
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class MvxDialogFragmentPresentationAttribute : MvxFragmentPresentationAttribute
 {
-#nullable enable
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class MvxDialogFragmentPresentationAttribute : MvxFragmentPresentationAttribute
+    public MvxDialogFragmentPresentationAttribute()
     {
-        public MvxDialogFragmentPresentationAttribute()
-        {
-        }
-
-        public MvxDialogFragmentPresentationAttribute(
-            bool cancelable = true,
-            Type? activityHostViewModelType = null,
-            bool addToBackStack = false,
-            int enterAnimation = int.MinValue,
-            int exitAnimation = int.MinValue,
-            int popEnterAnimation = int.MinValue,
-            int popExitAnimation = int.MinValue,
-            int transitionStyle = int.MinValue,
-            bool isCacheableFragment = false)
-            : base(
-                  activityHostViewModelType,
-                  int.MinValue,
-                  addToBackStack,
-                  enterAnimation,
-                  exitAnimation,
-                  popEnterAnimation,
-                  popExitAnimation,
-                  transitionStyle,
-                  null,
-                  isCacheableFragment)
-        {
-            Cancelable = cancelable;
-        }
-
-        public MvxDialogFragmentPresentationAttribute(
-            bool cancelable = true,
-            Type? activityHostViewModelType = null,
-            bool addToBackStack = false,
-            string? enterAnimation = null,
-            string? exitAnimation = null,
-            string? popEnterAnimation = null,
-            string? popExitAnimation = null,
-            string? transitionStyle = null,
-            bool isCacheableFragment = false)
-            : base(
-                  activityHostViewModelType,
-                  null,
-                  addToBackStack,
-                  enterAnimation,
-                  exitAnimation,
-                  popEnterAnimation,
-                  popExitAnimation,
-                  transitionStyle,
-                  null,
-                  isCacheableFragment)
-        {
-            Cancelable = cancelable;
-        }
-
-        public static bool DefaultCancelable { get; } = true;
-
-        /// <summary>
-        ///     Indicates if the dialog can be canceled
-        /// </summary>
-        public bool Cancelable { get; set; }
     }
-#nullable restore
+
+    public MvxDialogFragmentPresentationAttribute(
+        bool cancelable = true,
+        Type? activityHostViewModelType = null,
+        bool addToBackStack = false,
+        int enterAnimation = int.MinValue,
+        int exitAnimation = int.MinValue,
+        int popEnterAnimation = int.MinValue,
+        int popExitAnimation = int.MinValue,
+        int transitionStyle = int.MinValue,
+        bool isCacheableFragment = false)
+        : base(
+              activityHostViewModelType,
+              int.MinValue,
+              addToBackStack,
+              enterAnimation,
+              exitAnimation,
+              popEnterAnimation,
+              popExitAnimation,
+              transitionStyle,
+              null,
+              isCacheableFragment)
+    {
+        Cancelable = cancelable;
+    }
+
+    public MvxDialogFragmentPresentationAttribute(
+        bool cancelable = true,
+        Type? activityHostViewModelType = null,
+        bool addToBackStack = false,
+        string? enterAnimation = null,
+        string? exitAnimation = null,
+        string? popEnterAnimation = null,
+        string? popExitAnimation = null,
+        string? transitionStyle = null,
+        bool isCacheableFragment = false)
+        : base(
+              activityHostViewModelType,
+              null,
+              addToBackStack,
+              enterAnimation,
+              exitAnimation,
+              popEnterAnimation,
+              popExitAnimation,
+              transitionStyle,
+              null,
+              isCacheableFragment)
+    {
+        Cancelable = cancelable;
+    }
+
+    public static bool DefaultCancelable { get; } = true;
+
+    /// <summary>
+    ///     Indicates if the dialog can be canceled
+    /// </summary>
+    public bool Cancelable { get; set; }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -2,186 +2,182 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using MvvmCross.Presenters.Attributes;
 
-namespace MvvmCross.Platforms.Android.Presenters.Attributes
+namespace MvvmCross.Platforms.Android.Presenters.Attributes;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
 {
-#nullable enable
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
+    public MvxFragmentPresentationAttribute()
     {
-        public MvxFragmentPresentationAttribute()
-        {
-        }
-
-        public MvxFragmentPresentationAttribute(
-            Type? activityHostViewModelType = null,
-            int fragmentContentId = global::Android.Resource.Id.Content,
-            bool addToBackStack = false,
-            int enterAnimation = int.MinValue,
-            int exitAnimation = int.MinValue,
-            int popEnterAnimation = int.MinValue,
-            int popExitAnimation = int.MinValue,
-            int transitionStyle = int.MinValue,
-            Type? fragmentHostViewType = null,
-            bool isCacheableFragment = false,
-            string? tag = null,
-            string popBackStackImmediateName = "",
-            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
-            bool addFragment = false
-        )
-        {
-            ActivityHostViewModelType = activityHostViewModelType;
-            FragmentContentId = fragmentContentId;
-            AddToBackStack = addToBackStack;
-            EnterAnimation = enterAnimation;
-            ExitAnimation = exitAnimation;
-            PopEnterAnimation = popEnterAnimation;
-            PopExitAnimation = popExitAnimation;
-            TransitionStyle = transitionStyle;
-            FragmentHostViewType = fragmentHostViewType;
-            IsCacheableFragment = isCacheableFragment;
-            Tag = tag;
-            PopBackStackImmediateName = popBackStackImmediateName;
-            PopBackStackImmediateFlag = popBackStackImmediateFlag;
-            AddFragment = addFragment;
-        }
-
-        public MvxFragmentPresentationAttribute(
-            Type? activityHostViewModelType = null,
-            string? fragmentContentResourceName = null,
-            bool addToBackStack = false,
-            string? enterAnimation = null,
-            string? exitAnimation = null,
-            string? popEnterAnimation = null,
-            string? popExitAnimation = null,
-            string? transitionStyle = null,
-            Type? fragmentHostViewType = null,
-            bool isCacheableFragment = false,
-            string? tag = null,
-            string popBackStackImmediateName = "",
-            MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
-            bool addFragment = false
-        )
-        {
-            if (Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
-                globals.ApplicationContext.Resources != null)
-            {
-                var context = globals.ApplicationContext;
-
-                FragmentContentId = !string.IsNullOrEmpty(fragmentContentResourceName) ?
-                    context.Resources.GetIdentifier(fragmentContentResourceName, "id", context.PackageName) :
-                    global::Android.Resource.Id.Content;
-
-                EnterAnimation = !string.IsNullOrEmpty(enterAnimation) ?
-                    context.Resources.GetIdentifier(enterAnimation, "animation", context.PackageName) :
-                    int.MinValue;
-
-                ExitAnimation = !string.IsNullOrEmpty(exitAnimation) ?
-                    context.Resources.GetIdentifier(exitAnimation, "animation", context.PackageName) :
-                    int.MinValue;
-
-                PopEnterAnimation = !string.IsNullOrEmpty(popEnterAnimation) ?
-                    context.Resources.GetIdentifier(popEnterAnimation, "animation", context.PackageName) :
-                    int.MinValue;
-
-                PopExitAnimation = !string.IsNullOrEmpty(popExitAnimation) ?
-                    context.Resources.GetIdentifier(popExitAnimation, "animation", context.PackageName) :
-                    int.MinValue;
-
-                TransitionStyle = !string.IsNullOrEmpty(transitionStyle) ?
-                    context.Resources.GetIdentifier(transitionStyle, "style", context.PackageName) :
-                    int.MinValue;
-            }
-
-            ActivityHostViewModelType = activityHostViewModelType;
-            AddToBackStack = addToBackStack;
-            FragmentHostViewType = fragmentHostViewType;
-            IsCacheableFragment = isCacheableFragment;
-            Tag = tag;
-            PopBackStackImmediateName = popBackStackImmediateName;
-            PopBackStackImmediateFlag = popBackStackImmediateFlag;
-            AddFragment = addFragment;
-        }
-
-        /// <summary>
-        /// Fragment parent activity ViewModel Type. This activity is shown if the current hosting activity viewmodel is different.
-        /// </summary>
-        public Type? ActivityHostViewModelType { get; set; }
-
-        /// <summary>
-        /// Fragment parent View Type. When set ChildFragmentManager of this Fragment will be used
-        /// </summary>
-        public Type? FragmentHostViewType { get; set; }
-
-        /// <summary>
-        /// Content id - place where to show fragment.
-        /// </summary>
-        public int FragmentContentId { get; set; }
-
-        public static bool DefaultAddToBackStack { get; }
-        /// <summary>
-        /// Will add the Fragment to the FragmentManager backstack
-        /// </summary>
-        public bool AddToBackStack { get; set; }
-
-        public static int DefaultEnterAnimation { get; } = int.MinValue;
-        /// <summary>
-        /// Animation when Fragment is shown
-        /// </summary>
-        public int EnterAnimation { get; set; } = DefaultEnterAnimation;
-
-        public static int DefaultExitAnimation { get; } = int.MinValue;
-        /// <summary>
-        /// Animation when Fragment is closed
-        /// </summary>
-        public int ExitAnimation { get; set; } = DefaultExitAnimation;
-
-        public static int DefaultPopEnterAnimation { get; } = int.MinValue;
-        public int PopEnterAnimation { get; set; } = DefaultPopEnterAnimation;
-
-        public static int DefaultPopExitAnimation { get; } = int.MinValue;
-        public int PopExitAnimation { get; set; } = DefaultPopExitAnimation;
-
-        public static int DefaultTransitionStyle { get; } = int.MinValue;
-        /// <summary>
-        /// TransitionStyle for Fragment
-        /// </summary>
-        public int TransitionStyle { get; set; } = DefaultTransitionStyle;
-
-        public static bool DefaultIsCacheableFragment { get; }
-
-        /// <summary>
-        /// Indicates if the fragment can be cached. False by default.
-        /// </summary>
-        public bool IsCacheableFragment { get; set; } = DefaultIsCacheableFragment;
-
-        /// <summary>
-        /// Tag for the Fragment. Used in transactions and for finding the Fragment at a later time
-        /// </summary>
-        public string? Tag { get; set; }
-
-        public static string DefaultPopBackStackImmediateName { get; } = string.Empty;
-
-        /// <summary>
-        /// The name to be passed into PopBackStackImmediate.
-        /// Assigning an empty string will default to using the FragmentJavaName
-        /// Assigning a null will pop the top fragment
-        /// </summary>
-        public string PopBackStackImmediateName { get; set; } = DefaultPopBackStackImmediateName;
-
-        public static MvxPopBackStack DefaultPopBackStackImmediateFlag { get; } = MvxPopBackStack.Inclusive;
-
-        /// <summary>
-        /// Flag to be used with PopBackStackImmediate. 
-        /// </summary>
-        public MvxPopBackStack PopBackStackImmediateFlag { get; set; } = DefaultPopBackStackImmediateFlag;
-
-        /// <summary>
-        /// Setting this to true, will use Add instead of Replace on the Fragment transaction
-        /// </summary>
-        public bool AddFragment { get; set; }
     }
-#nullable restore
+
+    public MvxFragmentPresentationAttribute(
+        Type? activityHostViewModelType = null,
+        int fragmentContentId = global::Android.Resource.Id.Content,
+        bool addToBackStack = false,
+        int enterAnimation = int.MinValue,
+        int exitAnimation = int.MinValue,
+        int popEnterAnimation = int.MinValue,
+        int popExitAnimation = int.MinValue,
+        int transitionStyle = int.MinValue,
+        Type? fragmentHostViewType = null,
+        bool isCacheableFragment = false,
+        string? tag = null,
+        string popBackStackImmediateName = "",
+        MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
+        bool addFragment = false
+    )
+    {
+        ActivityHostViewModelType = activityHostViewModelType;
+        FragmentContentId = fragmentContentId;
+        AddToBackStack = addToBackStack;
+        EnterAnimation = enterAnimation;
+        ExitAnimation = exitAnimation;
+        PopEnterAnimation = popEnterAnimation;
+        PopExitAnimation = popExitAnimation;
+        TransitionStyle = transitionStyle;
+        FragmentHostViewType = fragmentHostViewType;
+        IsCacheableFragment = isCacheableFragment;
+        Tag = tag;
+        PopBackStackImmediateName = popBackStackImmediateName;
+        PopBackStackImmediateFlag = popBackStackImmediateFlag;
+        AddFragment = addFragment;
+    }
+
+    public MvxFragmentPresentationAttribute(
+        Type? activityHostViewModelType = null,
+        string? fragmentContentResourceName = null,
+        bool addToBackStack = false,
+        string? enterAnimation = null,
+        string? exitAnimation = null,
+        string? popEnterAnimation = null,
+        string? popExitAnimation = null,
+        string? transitionStyle = null,
+        Type? fragmentHostViewType = null,
+        bool isCacheableFragment = false,
+        string? tag = null,
+        string popBackStackImmediateName = "",
+        MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
+        bool addFragment = false
+    )
+    {
+        if (Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
+            globals.ApplicationContext.Resources != null)
+        {
+            var context = globals.ApplicationContext;
+
+            FragmentContentId = !string.IsNullOrEmpty(fragmentContentResourceName) ?
+                context.Resources.GetIdentifier(fragmentContentResourceName, "id", context.PackageName) :
+                global::Android.Resource.Id.Content;
+
+            EnterAnimation = !string.IsNullOrEmpty(enterAnimation) ?
+                context.Resources.GetIdentifier(enterAnimation, "animation", context.PackageName) :
+                int.MinValue;
+
+            ExitAnimation = !string.IsNullOrEmpty(exitAnimation) ?
+                context.Resources.GetIdentifier(exitAnimation, "animation", context.PackageName) :
+                int.MinValue;
+
+            PopEnterAnimation = !string.IsNullOrEmpty(popEnterAnimation) ?
+                context.Resources.GetIdentifier(popEnterAnimation, "animation", context.PackageName) :
+                int.MinValue;
+
+            PopExitAnimation = !string.IsNullOrEmpty(popExitAnimation) ?
+                context.Resources.GetIdentifier(popExitAnimation, "animation", context.PackageName) :
+                int.MinValue;
+
+            TransitionStyle = !string.IsNullOrEmpty(transitionStyle) ?
+                context.Resources.GetIdentifier(transitionStyle, "style", context.PackageName) :
+                int.MinValue;
+        }
+
+        ActivityHostViewModelType = activityHostViewModelType;
+        AddToBackStack = addToBackStack;
+        FragmentHostViewType = fragmentHostViewType;
+        IsCacheableFragment = isCacheableFragment;
+        Tag = tag;
+        PopBackStackImmediateName = popBackStackImmediateName;
+        PopBackStackImmediateFlag = popBackStackImmediateFlag;
+        AddFragment = addFragment;
+    }
+
+    /// <summary>
+    /// Fragment parent activity ViewModel Type. This activity is shown if the current hosting activity viewmodel is different.
+    /// </summary>
+    public Type? ActivityHostViewModelType { get; set; }
+
+    /// <summary>
+    /// Fragment parent View Type. When set ChildFragmentManager of this Fragment will be used
+    /// </summary>
+    public Type? FragmentHostViewType { get; set; }
+
+    /// <summary>
+    /// Content id - place where to show fragment.
+    /// </summary>
+    public int FragmentContentId { get; set; } = global::Android.Resource.Id.Content;
+
+    public static bool DefaultAddToBackStack { get; }
+    /// <summary>
+    /// Will add the Fragment to the FragmentManager backstack
+    /// </summary>
+    public bool AddToBackStack { get; set; }
+
+    public static int DefaultEnterAnimation { get; } = int.MinValue;
+    /// <summary>
+    /// Animation when Fragment is shown
+    /// </summary>
+    public int EnterAnimation { get; set; } = DefaultEnterAnimation;
+
+    public static int DefaultExitAnimation { get; } = int.MinValue;
+    /// <summary>
+    /// Animation when Fragment is closed
+    /// </summary>
+    public int ExitAnimation { get; set; } = DefaultExitAnimation;
+
+    public static int DefaultPopEnterAnimation { get; } = int.MinValue;
+    public int PopEnterAnimation { get; set; } = DefaultPopEnterAnimation;
+
+    public static int DefaultPopExitAnimation { get; } = int.MinValue;
+    public int PopExitAnimation { get; set; } = DefaultPopExitAnimation;
+
+    public static int DefaultTransitionStyle { get; } = int.MinValue;
+    /// <summary>
+    /// TransitionStyle for Fragment
+    /// </summary>
+    public int TransitionStyle { get; set; } = DefaultTransitionStyle;
+
+    public static bool DefaultIsCacheableFragment { get; }
+
+    /// <summary>
+    /// Indicates if the fragment can be cached. False by default.
+    /// </summary>
+    public bool IsCacheableFragment { get; set; } = DefaultIsCacheableFragment;
+
+    /// <summary>
+    /// Tag for the Fragment. Used in transactions and for finding the Fragment at a later time
+    /// </summary>
+    public string? Tag { get; set; }
+
+    public static string DefaultPopBackStackImmediateName { get; } = string.Empty;
+
+    /// <summary>
+    /// The name to be passed into PopBackStackImmediate.
+    /// Assigning an empty string will default to using the FragmentJavaName
+    /// Assigning a null will pop the top fragment
+    /// </summary>
+    public string PopBackStackImmediateName { get; set; } = DefaultPopBackStackImmediateName;
+
+    public static MvxPopBackStack DefaultPopBackStackImmediateFlag { get; } = MvxPopBackStack.Inclusive;
+
+    /// <summary>
+    /// Flag to be used with PopBackStackImmediate. 
+    /// </summary>
+    public MvxPopBackStack PopBackStackImmediateFlag { get; set; } = DefaultPopBackStackImmediateFlag;
+
+    /// <summary>
+    /// Setting this to true, will use Add instead of Replace on the Fragment transaction
+    /// </summary>
+    public bool AddFragment { get; set; }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxPopBackStack.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxPopBackStack.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-namespace MvvmCross.Platforms.Android.Presenters.Attributes
+namespace MvvmCross.Platforms.Android.Presenters.Attributes;
+
+public enum MvxPopBackStack
 {
-    public enum MvxPopBackStack
-    {
-        /// <summary>
-        /// All entries up to but not including that entry will be removed.
-        /// </summary>
-        None = 0,
-        /// <summary>
-        /// All matching entries will be consumed until one that doesn't match is found or the bottom of the stack is reached.
-        /// </summary>
-        Inclusive = 1
-    }
+    /// <summary>
+    /// All entries up to but not including that entry will be removed.
+    /// </summary>
+    None = 0,
+    /// <summary>
+    /// All matching entries will be consumed until one that doesn't match is found or the bottom of the stack is reached.
+    /// </summary>
+    Inclusive = 1
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxTabLayoutPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxTabLayoutPresentationAttribute.cs
@@ -2,70 +2,65 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+namespace MvvmCross.Platforms.Android.Presenters.Attributes;
 
-namespace MvvmCross.Platforms.Android.Presenters.Attributes
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class MvxTabLayoutPresentationAttribute : MvxViewPagerFragmentPresentationAttribute
 {
-#nullable enable
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class MvxTabLayoutPresentationAttribute : MvxViewPagerFragmentPresentationAttribute
+    public MvxTabLayoutPresentationAttribute()
     {
-        public MvxTabLayoutPresentationAttribute()
-        {
-        }
-
-        public MvxTabLayoutPresentationAttribute(
-            string title,
-            int viewPagerResourceId,
-            int tabLayoutResourceId,
-            Type? activityHostViewModelType = null,
-            bool addToBackStack = false,
-            Type? fragmentHostViewType = null,
-            bool isCacheableFragment = false)
-            : base(
-                  title,
-                  viewPagerResourceId,
-                  activityHostViewModelType,
-                  addToBackStack,
-                  fragmentHostViewType,
-                  isCacheableFragment)
-        {
-            TabLayoutResourceId = tabLayoutResourceId;
-        }
-
-        public MvxTabLayoutPresentationAttribute(
-            string title,
-            string viewPagerResourceName,
-            string tabLayoutResourceName,
-            Type? activityHostViewModelType = null,
-            bool addToBackStack = false,
-            Type? fragmentHostViewType = null,
-            bool isCacheableFragment = false)
-            : base(
-                  title,
-                  viewPagerResourceName,
-                  activityHostViewModelType,
-                  addToBackStack,
-                  fragmentHostViewType,
-                  isCacheableFragment)
-        {
-            if (!string.IsNullOrEmpty(tabLayoutResourceName) &&
-                Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
-                globals.ApplicationContext.Resources != null)
-            {
-                TabLayoutResourceId = globals.ApplicationContext.Resources.GetIdentifier(
-                    tabLayoutResourceName, "id", globals.ApplicationContext.PackageName);
-            }
-            else
-            {
-                TabLayoutResourceId = global::Android.Resource.Id.Content;
-            }
-        }
-
-        /// <summary>
-        ///     The resource used to get the TabLayout from the view
-        /// </summary>
-        public int TabLayoutResourceId { get; set; }
     }
-#nullable  restore
+
+    public MvxTabLayoutPresentationAttribute(
+        string title,
+        int viewPagerResourceId,
+        int tabLayoutResourceId,
+        Type? activityHostViewModelType = null,
+        bool addToBackStack = false,
+        Type? fragmentHostViewType = null,
+        bool isCacheableFragment = false)
+        : base(
+              title,
+              viewPagerResourceId,
+              activityHostViewModelType,
+              addToBackStack,
+              fragmentHostViewType,
+              isCacheableFragment)
+    {
+        TabLayoutResourceId = tabLayoutResourceId;
+    }
+
+    public MvxTabLayoutPresentationAttribute(
+        string title,
+        string viewPagerResourceName,
+        string tabLayoutResourceName,
+        Type? activityHostViewModelType = null,
+        bool addToBackStack = false,
+        Type? fragmentHostViewType = null,
+        bool isCacheableFragment = false)
+        : base(
+              title,
+              viewPagerResourceName,
+              activityHostViewModelType,
+              addToBackStack,
+              fragmentHostViewType,
+              isCacheableFragment)
+    {
+        if (!string.IsNullOrEmpty(tabLayoutResourceName) &&
+            Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
+            globals.ApplicationContext.Resources != null)
+        {
+            TabLayoutResourceId = globals.ApplicationContext.Resources.GetIdentifier(
+                tabLayoutResourceName, "id", globals.ApplicationContext.PackageName);
+        }
+        else
+        {
+            TabLayoutResourceId = global::Android.Resource.Id.Content;
+        }
+    }
+
+    /// <summary>
+    ///     The resource used to get the TabLayout from the view
+    /// </summary>
+    public int TabLayoutResourceId { get; set; }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxViewPagerFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxViewPagerFragmentPresentationAttribute.cs
@@ -2,88 +2,83 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+namespace MvvmCross.Platforms.Android.Presenters.Attributes;
 
-namespace MvvmCross.Platforms.Android.Presenters.Attributes
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class MvxViewPagerFragmentPresentationAttribute : MvxFragmentPresentationAttribute
 {
-#nullable enable
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class MvxViewPagerFragmentPresentationAttribute : MvxFragmentPresentationAttribute
+    public MvxViewPagerFragmentPresentationAttribute()
     {
-        public MvxViewPagerFragmentPresentationAttribute()
-        {
-        }
-
-        public MvxViewPagerFragmentPresentationAttribute(
-            string title,
-            int viewPagerResourceId,
-            Type? activityHostViewModelType = null,
-            bool addToBackStack = false,
-            Type? fragmentHostViewType = null,
-            bool isCacheableFragment = false,
-            string? tag = null)
-            : base(
-                  activityHostViewModelType,
-                  int.MinValue,
-                  addToBackStack,
-                  int.MinValue,
-                  int.MinValue,
-                  int.MinValue,
-                  int.MinValue,
-                  int.MinValue,
-                  fragmentHostViewType,
-                  isCacheableFragment,
-                  tag)
-        {
-            Title = title;
-            ViewPagerResourceId = viewPagerResourceId;
-        }
-
-        public MvxViewPagerFragmentPresentationAttribute(
-            string title,
-            string viewPagerResourceName,
-            Type? activityHostViewModelType = null,
-            bool addToBackStack = false,
-            Type? fragmentHostViewType = null,
-            bool isCacheableFragment = false,
-            string? tag = null)
-            : base(
-                  activityHostViewModelType,
-                  null,
-                  addToBackStack,
-                  null,
-                  null,
-                  null,
-                  null,
-                  null,
-                  fragmentHostViewType,
-                  isCacheableFragment,
-                  tag)
-        {
-            Title = title;
-
-            if (!string.IsNullOrEmpty(viewPagerResourceName) &&
-                Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
-                globals.ApplicationContext.Resources != null)
-            {
-                ViewPagerResourceId = globals.ApplicationContext.Resources.GetIdentifier(
-                    viewPagerResourceName, "id", globals.ApplicationContext.PackageName);
-            }
-            else
-            {
-                ViewPagerResourceId = global::Android.Resource.Id.Content;
-            }
-        }
-
-        /// <summary>
-        /// The title for the ViewPager. Also used as Title for TabLayout when using MvxTabLayoutPresentationAttribute
-        /// </summary>
-        public string? Title { get; set; }
-
-        /// <summary>
-        /// The resource used to get the ViewPager from the view
-        /// </summary>
-        public int ViewPagerResourceId { get; set; }
     }
-#nullable restore
+
+    public MvxViewPagerFragmentPresentationAttribute(
+        string title,
+        int viewPagerResourceId,
+        Type? activityHostViewModelType = null,
+        bool addToBackStack = false,
+        Type? fragmentHostViewType = null,
+        bool isCacheableFragment = false,
+        string? tag = null)
+        : base(
+              activityHostViewModelType,
+              int.MinValue,
+              addToBackStack,
+              int.MinValue,
+              int.MinValue,
+              int.MinValue,
+              int.MinValue,
+              int.MinValue,
+              fragmentHostViewType,
+              isCacheableFragment,
+              tag)
+    {
+        Title = title;
+        ViewPagerResourceId = viewPagerResourceId;
+    }
+
+    public MvxViewPagerFragmentPresentationAttribute(
+        string title,
+        string viewPagerResourceName,
+        Type? activityHostViewModelType = null,
+        bool addToBackStack = false,
+        Type? fragmentHostViewType = null,
+        bool isCacheableFragment = false,
+        string? tag = null)
+        : base(
+              activityHostViewModelType,
+              null,
+              addToBackStack,
+              null,
+              null,
+              null,
+              null,
+              null,
+              fragmentHostViewType,
+              isCacheableFragment,
+              tag)
+    {
+        Title = title;
+
+        if (!string.IsNullOrEmpty(viewPagerResourceName) &&
+            Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
+            globals.ApplicationContext.Resources != null)
+        {
+            ViewPagerResourceId = globals.ApplicationContext.Resources.GetIdentifier(
+                viewPagerResourceName, "id", globals.ApplicationContext.PackageName);
+        }
+        else
+        {
+            ViewPagerResourceId = global::Android.Resource.Id.Content;
+        }
+    }
+
+    /// <summary>
+    /// The title for the ViewPager. Also used as Title for TabLayout when using MvxTabLayoutPresentationAttribute
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// The resource used to get the ViewPager from the view
+    /// </summary>
+    public int ViewPagerResourceId { get; set; }
 }

--- a/MvvmCross/Platforms/Android/Presenters/IMvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/IMvxAndroidViewPresenter.cs
@@ -4,12 +4,9 @@
 
 using MvvmCross.Presenters;
 
-namespace MvvmCross.Platforms.Android.Presenters
+namespace MvvmCross.Platforms.Android.Presenters;
+
+public interface IMvxAndroidViewPresenter
+    : IMvxViewPresenter
 {
-#nullable enable
-    public interface IMvxAndroidViewPresenter
-        : IMvxViewPresenter
-    {
-    }
-#nullable restore
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MvxFragmentPresentationAttribute.FragmentContentId has default value "0" when not explicitly initialized.

### :new: What is the new behavior (if this is a feature change)?
MvxFragmentPresentationAttribute.FragmentContentId has default value "Android.Resource.Id.Content".


### :boom: Does this PR introduce a breaking change?
No

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
