### PR TITLE
Bugfix: MvxDialogFragmentPresentationAttribute.Cancelable is 'false' when using empty ctor.

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxDialogFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxDialogFragmentPresentationAttribute.cs
@@ -62,10 +62,8 @@ public class MvxDialogFragmentPresentationAttribute : MvxFragmentPresentationAtt
         Cancelable = cancelable;
     }
 
-    public static bool DefaultCancelable { get; } = true;
-
     /// <summary>
-    ///     Indicates if the dialog can be canceled
+    /// Indicates if the dialog can be canceled
     /// </summary>
-    public bool Cancelable { get; set; }
+    public bool Cancelable { get; set; } = true;
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix #4588 

### :arrow_heading_down: What is the current behavior?
MvxDialogFragmentPresentationAttribute.Cancelable is 'false' when using empty ctor.

### :new: What is the new behavior (if this is a feature change)?
MvxDialogFragmentPresentationAttribute.Cancelable is 'true' when using empty ctor.

### :boom: Does this PR introduce a breaking change?
No.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
