### PR TITLE
Combiners registration via Setup.FillValueCombiners() override

### DIFF
--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -9,6 +9,7 @@ using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Combiners;
 using MvvmCross.Converters;
 using MvvmCross.Core;
 using MvvmCross.Exceptions;
@@ -185,6 +186,7 @@ public abstract class MvxAndroidSetup
         ValidateArguments(iocProvider);
 
         iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+        iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
         iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
         iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         iocProvider.CallbackWhenRegistered<IMvxTypeCache<View>>(FillViewTypes);
@@ -238,6 +240,11 @@ public abstract class MvxAndroidSetup
 
         registry.Fill(ValueConverterAssemblies);
         registry.Fill(ValueConverterHolders);
+    }
+
+    protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+    {
+        // this base class does nothing
     }
 
     protected virtual IEnumerable<Type> ValueConverterHolders => new List<Type>();

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
@@ -7,6 +7,7 @@ using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Combiners;
 using MvvmCross.Converters;
 using MvvmCross.Core;
 using MvvmCross.IoC;
@@ -144,6 +145,7 @@ namespace MvvmCross.Platforms.Ios.Core
         protected virtual void RegisterBindingBuilderCallbacks(IMvxIoCProvider iocProvider)
         {
             iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
             iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
             iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         }
@@ -162,6 +164,11 @@ namespace MvvmCross.Platforms.Ios.Core
         {
             registry.Fill(ValueConverterAssemblies);
             registry.Fill(ValueConverterHolders);
+        }
+
+        protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+        {
+            // this base class does nothing
         }
 
         protected virtual List<Type> ValueConverterHolders => new List<Type>();

--- a/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
@@ -9,6 +9,7 @@ using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Combiners;
 using MvvmCross.Converters;
 using MvvmCross.Core;
 using MvvmCross.IoC;
@@ -129,6 +130,7 @@ namespace MvvmCross.Platforms.Mac.Core
             ValidateArguments(iocProvider);
 
             iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
             iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
             iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         }
@@ -147,6 +149,11 @@ namespace MvvmCross.Platforms.Mac.Core
         {
             registry.Fill(ValueConverterAssemblies);
             registry.Fill(ValueConverterHolders);
+        }
+
+        protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+        {
+            // this base class does nothing
         }
 
         protected virtual List<Assembly> ValueConverterAssemblies

--- a/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
+++ b/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
@@ -95,6 +95,7 @@ namespace MvvmCross.Platforms.Tizen.Core
             ValidateArguments(iocProvider);
 
             iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
             iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
             iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         }
@@ -123,6 +124,11 @@ namespace MvvmCross.Platforms.Tizen.Core
         {
             registry.Fill(ValueConverterAssemblies);
             registry.Fill(ValueConverterHolders);
+        }
+        
+        protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+        {
+            // this base class does nothing
         }
 
         protected virtual List<Type> ValueConverterHolders => new List<Type>();

--- a/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
@@ -9,6 +9,7 @@ using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Combiners;
 using MvvmCross.Converters;
 using MvvmCross.Core;
 using MvvmCross.IoC;
@@ -143,6 +144,7 @@ namespace MvvmCross.Platforms.Tvos.Core
             ValidateArguments(iocProvider);
 
             iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
             iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
             iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         }
@@ -161,6 +163,11 @@ namespace MvvmCross.Platforms.Tvos.Core
         {
             registry.Fill(ValueConverterAssemblies);
             registry.Fill(ValueConverterHolders);
+        }
+
+        protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+        {
+            // this base class does nothing
         }
 
         protected virtual List<Type> ValueConverterHolders => new List<Type>();

--- a/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
@@ -150,6 +150,7 @@ namespace MvvmCross.Platforms.Uap.Core
             ValidateArguments(iocProvider);
 
             iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
             iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
             iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         }
@@ -163,6 +164,11 @@ namespace MvvmCross.Platforms.Uap.Core
         {
             registry.Fill(ValueConverterAssemblies);
             registry.Fill(ValueConverterHolders);
+        }
+
+        protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+        {
+            // this base class does nothing
         }
 
         protected virtual void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)

--- a/MvvmCross/Platforms/WinUi/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platforms/WinUi/Core/MvxWindowsSetup.cs
@@ -10,6 +10,7 @@ using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Combiners;
 using MvvmCross.Converters;
 using MvvmCross.Core;
 using MvvmCross.Exceptions;
@@ -150,6 +151,7 @@ namespace MvvmCross.Platforms.WinUi.Core
             ValidateArguments(iocProvider);
 
             iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
             iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
             iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         }
@@ -163,6 +165,11 @@ namespace MvvmCross.Platforms.WinUi.Core
         {
             registry.Fill(ValueConverterAssemblies);
             registry.Fill(ValueConverterHolders);
+        }
+
+        protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+        {
+            // this base class does nothing
         }
 
         protected virtual void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)

--- a/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
+++ b/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
@@ -12,6 +12,7 @@ using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings.Target.Construction;
+using MvvmCross.Binding.Combiners;
 using MvvmCross.Converters;
 using MvvmCross.Core;
 using MvvmCross.IoC;
@@ -120,6 +121,7 @@ namespace MvvmCross.Platforms.Wpf.Core
             ValidateArguments(iocProvider);
 
             iocProvider.CallbackWhenRegistered<IMvxValueConverterRegistry>(FillValueConverters);
+            iocProvider.CallbackWhenRegistered<IMvxValueCombinerRegistry>(FillValueCombiners);
             iocProvider.CallbackWhenRegistered<IMvxTargetBindingFactoryRegistry>(FillTargetFactories);
             iocProvider.CallbackWhenRegistered<IMvxBindingNameRegistry>(FillBindingNames);
         }
@@ -133,6 +135,11 @@ namespace MvvmCross.Platforms.Wpf.Core
         {
             registry.Fill(ValueConverterAssemblies);
             registry.Fill(ValueConverterHolders);
+        }
+
+        protected virtual void FillValueCombiners(IMvxValueCombinerRegistry registry)
+        {
+            // this base class does nothing
         }
 
         protected virtual void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)

--- a/MvvmCross/ViewModels/MvxObservableCollection.cs
+++ b/MvvmCross/ViewModels/MvxObservableCollection.cs
@@ -96,7 +96,7 @@ namespace MvvmCross.ViewModels
 
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, itemsList, startingIndex));
         }
-        
+
         /// <summary>
         /// Inserts the specified items collection in the current <see cref="MvxObservableCollection{T}"/> instance at the specified index.
         /// </summary>
@@ -110,7 +110,7 @@ namespace MvvmCross.ViewModels
             {
                 throw new ArgumentNullException(nameof(items));
             }
-            
+
             if (index < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));

--- a/docs/_documentation/fundamentals/value-combiners.md
+++ b/docs/_documentation/fundamentals/value-combiners.md
@@ -71,6 +71,18 @@ Note that it's unusual for a ValueCombiner to meaningfully implement `SetValue` 
 
 Developers are very welcome to write their own ValueCombiners if they wish to - please do - but please also be aware that it's likely that this internal `IMvxValueCombiner` API will change in future MvvmCross revisions - we are looking at ways to either simplify this Tibet binding interface and/or ways to make the binding structure more Type-aware so that conversions can be performed at more places within the binding engine. (Developers are also very welcome to suggest improvements for this API!)
 
+To manually register additional value combiners, you can do this in your `Setup` class using an override of the `FillValueCombiners` method - e.g.
+
+```c#
+protected override void FillValueCombiners(IMvxValueCombinerRegistry registry)
+{
+    base.FillValueCombiners(registry);
+    registry.AddOrOverwrite("CustomCombiner", new MyCustomValueCombiner(42));
+    registry.AddOrOverwrite("CustomCombiner2", new MvxCustomCombiner2ValueCombiner("Summer"));
+}
+```
+
+
 ### Available ValueCombiners
 
 The 'standard' ValueCombiners available in MvvmCross are:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
There is no easy way to register `ValueCombiner`. The only way is to provide a custom implementation of `BindingBuilder`, which seems like overkill for such a task.

### :new: What is the new behavior (if this is a feature change)?

This PR adds the `FillValueCombiners(IMvxValueCombinerRegistry registry)` overload to the platform-specific Setup classes (`MvxIosSetup`, `MvxMacSetup`, etc.). This behaves the same way as the `void FillValueConverters(IMvxValueConverterRegistry registry)` for the converters. This gives the user with exactly the same experience as the for converters (except the naming-convention-based autoregistration, which was considered problematic from a performance point of view). With this overload, the developer able to easily register the combiners, either manually one-by-one or with assembly-scan or whatever.


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Nothing special, but worth remembering that `name` in the registration process should be without suffixes and prefixes. For example, for the `MvxMySuperValueCombiner` the name `MySuper` should be used during registration.

### :memo: Links to relevant issues/docs
https://github.com/MvvmCross/MvvmCross/issues/4371

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
