### PR TITLE
Make unit tests run on net7

### DIFF
--- a/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
+++ b/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.UnitTest</RootNamespace>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
+++ b/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Color.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Color.UnitTest</RootNamespace>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.JsonLocalization.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.JsonLocalization.UnitTest</RootNamespace>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
+++ b/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Messenger.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Messenger.UnitTest</RootNamespace>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
+++ b/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.ResourceLoader.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.ResourceLoader.UnitTest</RootNamespace>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.ResxLocalization.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.ResxLocalization.UnitTest</RootNamespace>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
+++ b/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Visibility.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Visibility.UnitTest</RootNamespace>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
Currently unit tests are not running at all when you you have NET7+ SDK installed only

### :new: What is the new behavior (if this is a feature change)?
Roll forward major version

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
