### PR TITLE
IntPtr -> NativeHandle on Apple platforms

### DIFF
--- a/MvvmCross/Platforms/Mac/Binding/Views/MvxTableCellView.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Views/MvxTableCellView.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using AppKit;
-using CoreGraphics;
-using Foundation;
 using MvvmCross.Base;
 using MvvmCross.Binding.BindingContext;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Binding.Views
 {
@@ -15,7 +12,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Views
     public class MvxTableCellView : NSTableCellView, IMvxBindingContextOwner, IMvxDataConsumer
     {
         // Called when created from unmanaged code
-        public MvxTableCellView(IntPtr handle) : base(handle)
+        public MvxTableCellView(NativeHandle handle) : base(handle)
         {
             this.Initialize(string.Empty);
         }

--- a/MvvmCross/Platforms/Mac/Binding/Views/MvxTableColumn.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Views/MvxTableColumn.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using System;
-using AppKit;
-using Foundation;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Binding.Views
 {
@@ -12,7 +9,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Views
     public class MvxTableColumn : NSTableColumn
     {
         // Called when created from unmanaged code
-        public MvxTableColumn(IntPtr handle) : base(handle)
+        public MvxTableColumn(NativeHandle handle) : base(handle)
         {
             this.Initialize();
         }

--- a/MvvmCross/Platforms/Mac/Binding/Views/MvxView.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Views/MvxView.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Drawing;
-using AppKit;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Binding.Views
 {
@@ -21,7 +19,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Views
             this.CreateBindingContext();
         }
 
-        public MvxView(IntPtr handle)
+        public MvxView(NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext();

--- a/MvvmCross/Platforms/Mac/Views/Base/MvxEventSourceTabViewController.cs
+++ b/MvvmCross/Platforms/Mac/Views/Base/MvxEventSourceTabViewController.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using AppKit;
-using Foundation;
 using MvvmCross.Base;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Views.Base
 {
@@ -24,7 +22,7 @@ namespace MvvmCross.Platforms.Mac.Views.Base
             this.Initialize();
         }
 
-        protected MvxEventSourceTabViewController(IntPtr handle)
+        protected MvxEventSourceTabViewController(NativeHandle handle)
             : base(handle)
         {
             this.Initialize();
@@ -98,7 +96,7 @@ namespace MvvmCross.Platforms.Mac.Views.Base
         {
             if (disposing)
             {
-                this.DisposeCalled.Raise(this);
+                DisposeCalled?.Raise(this);
             }
             base.Dispose(disposing);
         }

--- a/MvvmCross/Platforms/Mac/Views/Base/MvxEventSourceViewController.cs
+++ b/MvvmCross/Platforms/Mac/Views/Base/MvxEventSourceViewController.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using AppKit;
-using Foundation;
 using MvvmCross.Base;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Views.Base
 {
@@ -17,7 +15,7 @@ namespace MvvmCross.Platforms.Mac.Views.Base
             this.Initialize();
         }
 
-        protected MvxEventSourceViewController(IntPtr handle)
+        protected MvxEventSourceViewController(NativeHandle handle)
             : base(handle)
         {
             this.Initialize();

--- a/MvvmCross/Platforms/Mac/Views/MvxTabViewController.cs
+++ b/MvvmCross/Platforms/Mac/Views/MvxTabViewController.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
-using AppKit;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Mac.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Views
 {
@@ -26,7 +23,7 @@ namespace MvvmCross.Platforms.Mac.Views
             this.Initialize();
         }
 
-        protected MvxTabViewController(IntPtr handle)
+        protected MvxTabViewController(NativeHandle handle)
             : base(handle)
         {
             this.Initialize();
@@ -131,7 +128,7 @@ namespace MvvmCross.Platforms.Mac.Views
         {
         }
 
-        public MvxTabViewController(IntPtr handle)
+        public MvxTabViewController(NativeHandle handle)
             : base(handle)
         {
         }

--- a/MvvmCross/Platforms/Mac/Views/MvxViewController.cs
+++ b/MvvmCross/Platforms/Mac/Views/MvxViewController.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using AppKit;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Mac.Views.Base;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Views
 {
@@ -16,7 +14,7 @@ namespace MvvmCross.Platforms.Mac.Views
             , IMvxMacView
     {
         // Called when created from unmanaged code
-        public MvxViewController(IntPtr handle) : base(handle)
+        public MvxViewController(NativeHandle handle) : base(handle)
         {
             Initialize();
         }
@@ -116,7 +114,7 @@ namespace MvvmCross.Platforms.Mac.Views
         {
         }
 
-        public MvxViewController(IntPtr handle)
+        public MvxViewController(NativeHandle handle)
             : base(handle)
         {
         }

--- a/MvvmCross/Platforms/Mac/Views/MvxWindowController.cs
+++ b/MvvmCross/Platforms/Mac/Views/MvxWindowController.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using AppKit;
-using Foundation;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Mac.Views
 {
@@ -12,7 +10,7 @@ namespace MvvmCross.Platforms.Mac.Views
         : NSWindowController
     {
         // Called when created from unmanaged code
-        public MvxWindowController(IntPtr handle) : base(handle)
+        public MvxWindowController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxActionBasedTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxActionBasedTableViewSource.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings;
 using MvvmCross.Logging;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
@@ -20,11 +17,11 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             Initialize();
         }
 
-        public MvxActionBasedTableViewSource(IntPtr handle)
+        public MvxActionBasedTableViewSource(NativeHandle handle)
             : base(handle)
         {
-            MvxLogHost.GetLog<MvxActionBasedTableViewSource>().Log(LogLevel.Warning,
-                "MvxActionBasedTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+            MvxLogHost.GetLog<MvxActionBasedTableViewSource>()?.Log(LogLevel.Warning,
+                "MvxActionBasedTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
             Initialize();
         }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxBaseTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxBaseTableViewSource.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Windows.Input;
-using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.BindingContext;
-using MvvmCross.Exceptions;
 using MvvmCross.Logging;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
@@ -22,11 +19,11 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             _tableView = tableView;
         }
 
-        protected MvxBaseTableViewSource(IntPtr handle)
+        protected MvxBaseTableViewSource(NativeHandle handle)
             : base(handle)
         {
             MvxLogHost.GetLog<MvxBaseTableViewSource>()?.Log(LogLevel.Warning,
-                "MvxBaseTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+                "MvxBaseTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         protected UITableView TableView => _tableView;

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxCollectionReusableView.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxCollectionReusableView.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using CoreGraphics;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
@@ -21,7 +19,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             this.CreateBindingContext();
         }
 
-        public MvxCollectionReusableView(IntPtr handle)
+        public MvxCollectionReusableView(NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext();

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxCollectionViewCell.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxCollectionViewCell.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using CoreGraphics;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
@@ -21,13 +18,13 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             this.CreateBindingContext(bindingText);
         }
 
-        public MvxCollectionViewCell(IntPtr handle)
+        public MvxCollectionViewCell(NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext();
         }
 
-        public MvxCollectionViewCell(string bindingText, IntPtr handle)
+        public MvxCollectionViewCell(string bindingText, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingText);

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxSimpleTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxSimpleTableViewSource.cs
@@ -2,26 +2,24 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
     public class MvxSimpleTableViewSource : MvxTableViewSource
     {
         private readonly NSString _cellIdentifier;
-        private readonly MvxTvosMajorVersionChecker _iosVersion6Checker = new MvxTvosMajorVersionChecker(6);
+        private readonly MvxTvosMajorVersionChecker _iosVersion6Checker = new(6);
 
         protected virtual NSString CellIdentifier => _cellIdentifier;
 
-        public MvxSimpleTableViewSource(IntPtr handle)
+        public MvxSimpleTableViewSource(NativeHandle handle)
             : base(handle)
         {
             MvxLogHost.GetLog<MvxBaseTableViewSource>()?.Log(LogLevel.Warning,
-                "MvxSimpleTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+                "MvxSimpleTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         public MvxSimpleTableViewSource(UITableView tableView, string nibName, string cellIdentifier = null,

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxStandardTableViewCell.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxStandardTableViewCell.cs
@@ -2,29 +2,26 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Windows.Input;
-using Foundation;
 using MvvmCross.Binding.Bindings;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
     public class MvxStandardTableViewCell
         : MvxTableViewCell
     {
-        public MvxStandardTableViewCell(IntPtr handle)
+        public MvxStandardTableViewCell(NativeHandle handle)
             : this("TitleText" /* default binding is ToString() on the passed in item */, handle)
         {
         }
 
-        public MvxStandardTableViewCell(string bindingText, IntPtr handle)
+        public MvxStandardTableViewCell(string bindingText, NativeHandle handle)
             : base(bindingText, handle)
         {
         }
 
-        public MvxStandardTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+        public MvxStandardTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, NativeHandle handle)
             : base(bindingDescriptions, handle)
         {
         }

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxStandardTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxStandardTableViewSource.cs
@@ -2,31 +2,27 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.Bindings;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Logging;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
     public class MvxStandardTableViewSource : MvxTableViewSource
     {
-        private static readonly NSString DefaultCellIdentifier = new NSString("SimpleBindableTableViewCell");
+        private static readonly NSString DefaultCellIdentifier = new("SimpleBindableTableViewCell");
 
-        private static readonly MvxBindingDescription[] DefaultBindingDescription = new[]
-            {
-                new MvxBindingDescription
-                    {
+        private static readonly MvxBindingDescription[] DefaultBindingDescription = {
+                new()
+                {
                         TargetName = "TitleText",
-                        Source = new MvxPathSourceStepDescription()
-                            {
-                                SourcePropertyPath = string.Empty
-                            }
+                        Source = new MvxPathSourceStepDescription
+                        {
+                            SourcePropertyPath = string.Empty
+                        }
                     },
             };
 
@@ -52,11 +48,11 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
         {
         }
 
-        public MvxStandardTableViewSource(IntPtr handle)
+        public MvxStandardTableViewSource(NativeHandle handle)
             : base(handle)
         {
             MvxLogHost.GetLog<MvxBaseTableViewSource>()?.Log(LogLevel.Warning,
-                "MvxStandardTableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+                "MvxStandardTableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         public MvxStandardTableViewSource(

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxTableViewCell.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxTableViewCell.cs
@@ -2,13 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using CoreGraphics;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Binding.Bindings;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
@@ -44,18 +40,18 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             this.CreateBindingContext(bindingDescriptions);
         }
 
-        public MvxTableViewCell(IntPtr handle)
+        public MvxTableViewCell(NativeHandle handle)
             : this(string.Empty, handle)
         {
         }
 
-        public MvxTableViewCell(string bindingText, IntPtr handle)
+        public MvxTableViewCell(string bindingText, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingText);
         }
 
-        public MvxTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, IntPtr handle)
+        public MvxTableViewCell(IEnumerable<MvxBindingDescription> bindingDescriptions, NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext(bindingDescriptions);

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxTableViewSource.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxTableViewSource.cs
@@ -2,17 +2,14 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Specialized;
-using System.Linq;
-using Foundation;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.Extensions;
 using MvvmCross.Logging;
 using MvvmCross.WeakSubscription;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
@@ -26,11 +23,11 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
         {
         }
 
-        protected MvxTableViewSource(IntPtr handle)
+        protected MvxTableViewSource(NativeHandle handle)
             : base(handle)
         {
             MvxLogHost.GetLog<MvxBaseTableViewSource>()?.Log(LogLevel.Warning,
-                "TableViewSource IntPtr constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
+                "TableViewSource NativeHandle constructor used - we expect this only to be called during memory leak debugging - see https://github.com/MvvmCross/MvvmCross/pull/467");
         }
 
         protected override void Dispose(bool disposing)
@@ -119,13 +116,13 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             {
                 case NotifyCollectionChangedAction.Add:
                     {
-                        var newIndexPaths = CreateNSIndexPathArray(args.NewStartingIndex, args.NewItems.Count);
+                        var newIndexPaths = CreateIndexPathArray(args.NewStartingIndex, args.NewItems.Count);
                         TableView.InsertRows(newIndexPaths, AddAnimation);
                         return true;
                     }
                 case NotifyCollectionChangedAction.Remove:
                     {
-                        var oldIndexPaths = CreateNSIndexPathArray(args.OldStartingIndex, args.OldItems.Count);
+                        var oldIndexPaths = CreateIndexPathArray(args.OldStartingIndex, args.OldItems.Count);
                         TableView.DeleteRows(oldIndexPaths, RemoveAnimation);
                         return true;
                     }
@@ -154,7 +151,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             }
         }
 
-        protected static NSIndexPath[] CreateNSIndexPathArray(int startingPosition, int count)
+        protected static NSIndexPath[] CreateIndexPathArray(int startingPosition, int count)
         {
             var newIndexPaths = new NSIndexPath[count];
             for (var i = 0; i < count; i++)
@@ -164,7 +161,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             return newIndexPaths;
         }
 
-        public override nint RowsInSection(UITableView tableview, nint section)
+        public override nint RowsInSection(UITableView tableView, nint section)
         {
             if (ItemsSource == null)
                 return 0;

--- a/MvvmCross/Platforms/Tvos/Binding/Views/MvxView.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Views/MvxView.cs
@@ -1,12 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using System;
-using CoreGraphics;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Views
 {
@@ -20,7 +17,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Views
             this.CreateBindingContext();
         }
 
-        public MvxView(IntPtr handle)
+        public MvxView(NativeHandle handle)
             : base(handle)
         {
             this.CreateBindingContext();

--- a/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceCollectionViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceCollectionViewController.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Base;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views.Base
 {
@@ -24,7 +22,7 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         {
         }
 
-        protected internal MvxEventSourceCollectionViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceCollectionViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -39,44 +37,44 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewWillDisappearCalled.Raise(this, animated);
+            ViewWillDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewDidAppearCalled.Raise(this, animated);
+            ViewDidAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewWillAppearCalled.Raise(this, animated);
+            ViewWillAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewDidDisappearCalled.Raise(this, animated);
+            ViewDidDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewDidLoadCalled.Raise(this);
+            ViewDidLoadCalled?.Raise(this);
         }
 
         public override void ViewDidLayoutSubviews()
         {
             base.ViewDidLayoutSubviews();
-            ViewDidLayoutSubviewsCalled.Raise(this);
+            ViewDidLayoutSubviewsCalled?.Raise(this);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                DisposeCalled.Raise(this);
+                DisposeCalled?.Raise(this);
             }
             base.Dispose(disposing);
         }

--- a/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourcePageViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourcePageViewController.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Base;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views.Base
 {
@@ -35,7 +33,7 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         {
         }
 
-        protected internal MvxEventSourcePageViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourcePageViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -50,43 +48,43 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewDidLoadCalled.Raise(this);
+            ViewDidLoadCalled?.Raise(this);
         }
 
         public override void ViewDidLayoutSubviews()
         {
             base.ViewDidLayoutSubviews();
-            ViewDidLayoutSubviewsCalled.Raise(this);
+            ViewDidLayoutSubviewsCalled?.Raise(this);
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewWillAppearCalled.Raise(this, animated);
+            ViewWillAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewDidAppearCalled.Raise(this, animated);
+            ViewDidAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewDidDisappearCalled.Raise(this, animated);
+            ViewDidDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewWillDisappearCalled.Raise(this, animated);
+            ViewWillDisappearCalled?.Raise(this, animated);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                DisposeCalled.Raise(this);
+                DisposeCalled?.Raise(this);
             base.Dispose(disposing);
         }
 

--- a/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceSplitViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceSplitViewController.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
-using Foundation;
 using MvvmCross.Base;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views.Base
 {
@@ -24,7 +21,7 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         {
         }
 
-        protected internal MvxEventSourceSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceSplitViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -35,44 +32,44 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewWillDisappearCalled.Raise(this, animated);
+            ViewWillDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewDidAppearCalled.Raise(this, animated);
+            ViewDidAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewWillAppearCalled.Raise(this, animated);
+            ViewWillAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewDidDisappearCalled.Raise(this, animated);
+            ViewDidDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewDidLoadCalled.Raise(this);
+            ViewDidLoadCalled?.Raise(this);
         }
 
         public override void ViewDidLayoutSubviews()
         {
             base.ViewDidLayoutSubviews();
-            ViewDidLayoutSubviewsCalled.Raise(this);
+            ViewDidLayoutSubviewsCalled?.Raise(this);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                DisposeCalled.Raise(this);
+                DisposeCalled?.Raise(this);
             }
             base.Dispose(disposing);
         }

--- a/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceTabBarController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceTabBarController.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Base;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views.Base
 {
@@ -24,7 +22,7 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         {
         }
 
-        protected internal MvxEventSourceTabBarController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceTabBarController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -41,38 +39,38 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewDidAppearCalled.Raise(this, animated);
+            ViewDidAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewWillAppearCalled.Raise(this, animated);
+            ViewWillAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewDidDisappearCalled.Raise(this, animated);
+            ViewDidDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewDidLoadCalled.Raise(this);
+            ViewDidLoadCalled?.Raise(this);
         }
 
         public override void ViewDidLayoutSubviews()
         {
             base.ViewDidLayoutSubviews();
-            ViewDidLayoutSubviewsCalled.Raise(this);
+            ViewDidLayoutSubviewsCalled?.Raise(this);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                DisposeCalled.Raise(this);
+                DisposeCalled?.Raise(this);
             }
             base.Dispose(disposing);
         }

--- a/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceTableViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceTableViewController.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Base;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views.Base
 {
@@ -20,7 +18,7 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         {
         }
 
-        protected internal MvxEventSourceTableViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceTableViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -35,44 +33,44 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewWillDisappearCalled.Raise(this, animated);
+            ViewWillDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewDidAppearCalled.Raise(this, animated);
+            ViewDidAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewWillAppearCalled.Raise(this, animated);
+            ViewWillAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewDidDisappearCalled.Raise(this, animated);
+            ViewDidDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewDidLoadCalled.Raise(this);
+            ViewDidLoadCalled?.Raise(this);
         }
 
         public override void ViewDidLayoutSubviews()
         {
             base.ViewDidLayoutSubviews();
-            ViewDidLayoutSubviewsCalled.Raise(this);
+            ViewDidLayoutSubviewsCalled?.Raise(this);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                DisposeCalled.Raise(this);
+                DisposeCalled?.Raise(this);
             }
             base.Dispose(disposing);
         }

--- a/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/Base/MvxEventSourceViewController.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Base;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views.Base
 {
@@ -24,7 +22,7 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         {
         }
 
-        protected internal MvxEventSourceViewController(IntPtr handle) : base(handle)
+        protected internal MvxEventSourceViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -35,44 +33,44 @@ namespace MvvmCross.Platforms.Tvos.Views.Base
         public override void ViewWillDisappear(bool animated)
         {
             base.ViewWillDisappear(animated);
-            ViewWillDisappearCalled.Raise(this, animated);
+            ViewWillDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidAppear(bool animated)
         {
             base.ViewDidAppear(animated);
-            ViewDidAppearCalled.Raise(this, animated);
+            ViewDidAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewWillAppearCalled.Raise(this, animated);
+            ViewWillAppearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidDisappear(bool animated)
         {
             base.ViewDidDisappear(animated);
-            ViewDidDisappearCalled.Raise(this, animated);
+            ViewDidDisappearCalled?.Raise(this, animated);
         }
 
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-            ViewDidLoadCalled.Raise(this);
+            ViewDidLoadCalled?.Raise(this);
         }
 
         public override void ViewDidLayoutSubviews()
         {
             base.ViewDidLayoutSubviews();
-            ViewDidLayoutSubviewsCalled.Raise(this);
+            ViewDidLayoutSubviewsCalled?.Raise(this);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                DisposeCalled.Raise(this);
+                DisposeCalled?.Raise(this);
             }
             base.Dispose(disposing);
         }

--- a/MvvmCross/Platforms/Tvos/Views/MvxBasePageViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxBasePageViewController.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Tvos.Views.Base;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -38,7 +36,7 @@ namespace MvvmCross.Platforms.Tvos.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxBasePageViewController(IntPtr handle) : base(handle)
+        protected internal MvxBasePageViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -153,7 +151,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxBasePageViewController(IntPtr handle) : base(handle)
+        protected internal MvxBasePageViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Tvos/Views/MvxBaseTabBarViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxBaseTabBarViewController.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Tvos.Views.Base;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -29,7 +27,7 @@ namespace MvvmCross.Platforms.Tvos.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxBaseTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxBaseTabBarViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -125,7 +123,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxBaseTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxBaseTabBarViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Tvos/Views/MvxCollectionViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxCollectionViewController.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Tvos.Views.Base;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -29,7 +27,7 @@ namespace MvvmCross.Platforms.Tvos.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxCollectionViewController(IntPtr handle) : base(handle)
+        protected internal MvxCollectionViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -127,7 +125,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxCollectionViewController(IntPtr handle) : base(handle)
+        protected internal MvxCollectionViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Tvos/Views/MvxNavigationController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxNavigationController.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
-using Foundation;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -35,7 +32,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxNavigationController(IntPtr handle) : base(handle)
+        protected internal MvxNavigationController(NativeHandle handle) : base(handle)
         {
         }
     }

--- a/MvvmCross/Platforms/Tvos/Views/MvxPageViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxPageViewController.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Tvos.Presenters.Attributes;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -35,7 +31,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxPageViewController(IntPtr handle) : base(handle)
+        protected internal MvxPageViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -102,7 +98,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        public MvxPageViewController(IntPtr handle) : base(handle)
+        public MvxPageViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Tvos/Views/MvxSplitViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxSplitViewController.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Tvos.Views.Base;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -30,7 +28,7 @@ namespace MvvmCross.Platforms.Tvos.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxSplitViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -124,7 +122,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxSplitViewController(IntPtr handle) : base(handle)
+        protected internal MvxSplitViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Tvos/Views/MvxTabBarViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxTabBarViewController.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Foundation;
 using MvvmCross.Platforms.Tvos.Presenters;
 using MvvmCross.Platforms.Tvos.Presenters.Attributes;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -30,7 +26,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxTabBarViewController(NativeHandle handle) : base(handle)
         {
         }
 
@@ -228,7 +224,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxTabBarViewController(IntPtr handle) : base(handle)
+        protected internal MvxTabBarViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/MvvmCross/Platforms/Tvos/Views/MvxTableViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxTableViewController.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Tvos.Views.Base;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -20,7 +18,7 @@ namespace MvvmCross.Platforms.Tvos.Views
             this.AdaptForBinding();
         }
 
-        protected MvxTableViewController(IntPtr handle)
+        protected MvxTableViewController(NativeHandle handle)
             : base(handle)
         {
             this.AdaptForBinding();
@@ -125,7 +123,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected MvxTableViewController(IntPtr handle)
+        protected MvxTableViewController(NativeHandle handle)
             : base(handle)
         {
         }

--- a/MvvmCross/Platforms/Tvos/Views/MvxViewController.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxViewController.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Tvos.Views.Base;
 using MvvmCross.ViewModels;
-using UIKit;
+using ObjCRuntime;
 
 namespace MvvmCross.Platforms.Tvos.Views
 {
@@ -29,7 +27,7 @@ namespace MvvmCross.Platforms.Tvos.Views
             this.AdaptForBinding();
         }
 
-        protected internal MvxViewController(IntPtr handle) : base(handle)
+        protected internal MvxViewController(NativeHandle handle) : base(handle)
         {
             this.AdaptForBinding();
         }
@@ -120,7 +118,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         {
         }
 
-        protected internal MvxViewController(IntPtr handle) : base(handle)
+        protected internal MvxViewController(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/CustomBindingView.cs
+++ b/Projects/Playground/Playground.iOS/Views/CustomBindingView.cs
@@ -16,7 +16,7 @@ namespace Playground.iOS.Views
     {
         private UIDatePicker _datePicker;
 
-        public CustomBindingView(IntPtr handle) : base(handle)
+        public CustomBindingView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/ModalNavView.cs
+++ b/Projects/Playground/Playground.iOS/Views/ModalNavView.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -10,7 +11,7 @@ namespace Playground.iOS.Views
     [MvxModalPresentation(WrapInNavigationController = true)]
     public partial class ModalNavView : MvxViewController<ModalNavViewModel>
     {
-        public ModalNavView(IntPtr handle) : base(handle)
+        public ModalNavView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/OverrideAttributeView.cs
+++ b/Projects/Playground/Playground.iOS/Views/OverrideAttributeView.cs
@@ -4,6 +4,7 @@ using MvvmCross.Platforms.Ios.Views;
 using MvvmCross.Presenters;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -12,7 +13,7 @@ namespace Playground.iOS.Views
     [MvxFromStoryboard("Main")]
     public partial class OverrideAttributeView : MvxViewController<OverrideAttributeViewModel>, IMvxOverridePresentationAttribute
     {
-        public OverrideAttributeView(IntPtr handle) : base(handle)
+        public OverrideAttributeView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/Page1View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Page1View.cs
@@ -7,6 +7,7 @@ using MvvmCross.Platforms.Ios.Binding.Views;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
 using MvvmCross.Platforms.Ios.Views.Expandable;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -19,7 +20,7 @@ namespace Playground.iOS.Views
         private UITableView _tableView;
         private TableSource _source;
 
-        public Page1View(IntPtr handle) : base(handle)
+        public Page1View(NativeHandle handle) : base(handle)
         {
         }
 
@@ -63,7 +64,7 @@ namespace Playground.iOS.Views
             private UIImageView _arrow;
             private UISwitch _switch;
 
-            public HeaderCell(IntPtr handle) : base(handle)
+            public HeaderCell(NativeHandle handle) : base(handle)
             {
                 Initialize();
             }
@@ -135,7 +136,7 @@ namespace Playground.iOS.Views
             public static NSString Identifier = new NSString(nameof(ItemCell));
             private UILabel _title;
 
-            public ItemCell(IntPtr handle) : base(handle)
+            public ItemCell(NativeHandle handle) : base(handle)
             {
                 Initialize();
             }

--- a/Projects/Playground/Playground.iOS/Views/Page2View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Page2View.cs
@@ -2,6 +2,7 @@ using System;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -10,7 +11,7 @@ namespace Playground.iOS.Views
     [MvxPagePresentation(WrapInNavigationController = false)]
     public partial class Page2View : MvxViewController<Page2ViewModel>
     {
-        public Page2View(IntPtr handle) : base(handle)
+        public Page2View(NativeHandle handle) : base(handle)
         {
         }
     }

--- a/Projects/Playground/Playground.iOS/Views/Page3View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Page3View.cs
@@ -1,7 +1,6 @@
-using System;
-using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -10,7 +9,7 @@ namespace Playground.iOS.Views
     [MvxPagePresentation(WrapInNavigationController = false)]
     public partial class Page3View : MvxViewController<Page3ViewModel>
     {
-        public Page3View(IntPtr handle) : base(handle)
+        public Page3View(NativeHandle handle) : base(handle)
         {
         }
     }

--- a/Projects/Playground/Playground.iOS/Views/PagesRootView.cs
+++ b/Projects/Playground/Playground.iOS/Views/PagesRootView.cs
@@ -2,6 +2,7 @@ using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
 using MvvmCross.ViewModels;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 using UIKit;
 
@@ -13,7 +14,7 @@ namespace Playground.iOS.Views
     {
         private bool _isPresentedFirstTime = true;
 
-        public PagesRootView(IntPtr handle) : base(handle)
+        public PagesRootView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/SecondChildView.cs
+++ b/Projects/Playground/Playground.iOS/Views/SecondChildView.cs
@@ -1,16 +1,15 @@
-using System;
 using MvvmCross;
 using MvvmCross.Platforms.Ios.Presenters;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
-using UIKit;
 
 namespace Playground.iOS.Views
 {
     [MvxFromStoryboard("Main")]
     public partial class SecondChildView : MvxViewController<SecondChildViewModel>
     {
-        public SecondChildView(IntPtr handle) : base(handle)
+        public SecondChildView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/SplitDetailNavView.cs
+++ b/Projects/Playground/Playground.iOS/Views/SplitDetailNavView.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -9,7 +10,7 @@ namespace Playground.iOS.Views
     [MvxSplitViewPresentation(WrapInNavigationController = true)]
     public partial class SplitDetailNavView : MvxViewController<SplitDetailNavViewModel>
     {
-        public SplitDetailNavView(IntPtr handle) : base(handle)
+        public SplitDetailNavView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/SplitDetailView.cs
+++ b/Projects/Playground/Playground.iOS/Views/SplitDetailView.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -9,7 +10,7 @@ namespace Playground.iOS.Views
     [MvxSplitViewPresentation]
     public partial class SplitDetailView : MvxViewController<SplitDetailViewModel>
     {
-        public SplitDetailView(IntPtr handle) : base(handle)
+        public SplitDetailView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/SplitMasterView.cs
+++ b/Projects/Playground/Playground.iOS/Views/SplitMasterView.cs
@@ -1,6 +1,6 @@
-using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -9,7 +9,7 @@ namespace Playground.iOS.Views
     [MvxSplitViewPresentation(MasterDetailPosition.Master)]
     public partial class SplitMasterView : MvxViewController<SplitMasterViewModel>
     {
-        public SplitMasterView(IntPtr handle) : base(handle)
+        public SplitMasterView(NativeHandle handle) : base(handle)
         {
         }
 

--- a/Projects/Playground/Playground.iOS/Views/SplitRootView.cs
+++ b/Projects/Playground/Playground.iOS/Views/SplitRootView.cs
@@ -1,6 +1,7 @@
 using System;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
+using ObjCRuntime;
 using Playground.Core.ViewModels;
 
 namespace Playground.iOS.Views
@@ -11,7 +12,7 @@ namespace Playground.iOS.Views
     {
         private bool _isPresentedFirstTime = true;
 
-        public SplitRootView(IntPtr handle) : base(handle)
+        public SplitRootView(NativeHandle handle) : base(handle)
         {
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Constructors that took IntPtr before on Apple platforms now need NativeHandle instead

### :new: What is the new behavior (if this is a feature change)?
Changing all occurences

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
