### PR TITLE
EnsureTargetNameSet should ensure a target name or throw

### DIFF
--- a/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
@@ -290,8 +290,17 @@ namespace MvvmCross.Binding.BindingContext
             if (!string.IsNullOrEmpty(BindingDescription.TargetName))
                 return;
 
-            BindingDescription.TargetName =
-                MvxBindingSingletonCache.Instance.DefaultBindingNameLookup.DefaultFor(typeof(TTarget));
+            var defaultTargetName =
+                MvxBindingSingletonCache.Instance?.DefaultBindingNameLookup.DefaultFor(typeof(TTarget));
+
+            if (string.IsNullOrEmpty(defaultTargetName))
+            {
+                throw new MvxException(
+                    "Default Target Name, could not be found for Target: {0}. Did you register a default?",
+                    typeof(TTarget));
+            }
+
+            BindingDescription.TargetName = defaultTargetName;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
If you have a class where you attempt to use a default binding target which doesn't exist, we currently throw deep inside of the binding engine, instead of further up where it makes sense.

### :new: What is the new behavior (if this is a feature change)?
Issue #4603 suggested that `EnsureTargetBindingName()` should ensure should actually ensure a name. I think it is a great idea. In cases where it cannot ensure a name, I now throw a MvxException explaining that Default Target Binding doesn't exist for the class being bound.

### :boom: Does this PR introduce a breaking change?
Yes

### :bug: Recommendations for testing
Create a new class and try bind it like so:

```csharp
class Herp {}

_herp = new Herp();

...

set.Bind(_herp).To(vm => vm.Something);
```

### :memo: Links to relevant issues/docs
Fixes #4603

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
