### PR TITLE
Use WeakRef for Single ViewModel Cache

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.6.0.74858" />
     <PackageVersion Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+    <PackageVersion Include="Xamarin.Android.Glide" Version="4.15.1.2" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.6.1.3" />
     <PackageVersion Include="Xamarin.AndroidX.CardView" Version="1.0.0.21" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,8 @@
     </PackageVersion>
     <PackageVersion Include="Serilog" Version="3.0.1" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="1.5.0" />
+    <PackageVersion Include="Serilog.Sinks.Trace" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageVersion Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.6.0.74858" />

--- a/MvvmCross/Platforms/Android/Views/IMvxSingleViewModelCache.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxSingleViewModelCache.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using Android.OS;
+#nullable enable
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Android.Views
@@ -11,6 +10,6 @@ namespace MvvmCross.Platforms.Android.Views
     {
         void Cache(IMvxViewModel toCache, Bundle bundle);
 
-        IMvxViewModel GetAndClear(Bundle bundle);
+        IMvxViewModel? GetAndClear(Bundle bundle);
     }
 }

--- a/MvvmCross/Platforms/Android/Views/MvxSingleViewModelCache.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxSingleViewModelCache.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using Android.OS;
+#nullable enable
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Android.Views
@@ -14,11 +13,11 @@ namespace MvvmCross.Platforms.Android.Views
 
         private int _counter;
 
-        private IMvxViewModel _currentViewModel;
+        private WeakReference<IMvxViewModel>? _currentViewModel;
 
         public void Cache(IMvxViewModel toCache, Bundle bundle)
         {
-            _currentViewModel = toCache;
+            _currentViewModel = new WeakReference<IMvxViewModel>(toCache);
             _counter++;
 
             if (_currentViewModel == null)
@@ -29,17 +28,26 @@ namespace MvvmCross.Platforms.Android.Views
             bundle.PutInt(BundleCacheKey, _counter);
         }
 
-        public IMvxViewModel GetAndClear(Bundle bundle)
+        public IMvxViewModel? GetAndClear(Bundle? bundle)
         {
-            var storedViewModel = _currentViewModel;
-            _currentViewModel = null;
+            try
+            {
+                if (bundle == null)
+                    return null;
 
-            if (bundle == null)
-                return null;
+                if (_currentViewModel?.TryGetTarget(out var storedViewModel) == true)
+                {
+                    var key = bundle.GetInt(BundleCacheKey);
+                    var toReturn = key == _counter ? storedViewModel : null;
+                    return toReturn;
+                }
+            }
+            finally
+            {
+                _currentViewModel = null;
+            }
 
-            var key = bundle.GetInt(BundleCacheKey);
-            var toReturn = key == _counter ? storedViewModel : null;
-            return toReturn;
+            return null;
         }
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Issues/CollectionViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Issues/CollectionViewModel.cs
@@ -7,12 +7,13 @@ using MvvmCross.ViewModels;
 
 namespace Playground.Core.ViewModels
 {
-    public class CollectionViewModel : MvxViewModel
+    public record CollectionViewParameter(int InitialCount = 40);
+    
+    public class CollectionViewModel : MvxViewModel<CollectionViewParameter>
     {
         private readonly Random _random;
 
-        public MvxObservableCollection<AnimalViewModel> Animals { get; }
-            = new MvxObservableCollection<AnimalViewModel>();
+        public MvxObservableCollection<AnimalViewModel> Animals { get; } = new();
 
         public MvxCommand<AnimalViewModel> DeleteAnimalCommand { get; }
         public MvxCommand<int> AddAnimalCommand { get; }
@@ -25,12 +26,14 @@ namespace Playground.Core.ViewModels
             DeleteAnimalCommand = new MvxCommand<AnimalViewModel>(DoDeleteAnimalCommand);
             AddAnimalCommand = new MvxCommand<int>(DoAddAnimalCommand);
             MarkFavoriteCommand = new MvxCommand<AnimalViewModel>(DoMarkFavoriteCommand);
-
-            DoAddAnimalCommand(40);
         }
 
-        private string[] _catImageUrls = new[]
+        public override void Prepare(CollectionViewParameter parameter)
         {
+            DoAddAnimalCommand(parameter.InitialCount);
+        }
+
+        private readonly string[] _catImageUrls = {
             "https://loremflickr.com/320/240/cat",
             "https://www.hillspet.com/content/dam/cp-sites/hills/hills-pet/en_us/exported/cat-care/new-pet-parent/images/mother-cat-and-kitten-sleeping.jpg",
             "https://www.hillspet.com/content/dam/cp-sites/hills/hills-pet/en_us/exported/cat-care/new-pet-parent/images/calico-kitten-hiding-under-chair.jpg",
@@ -41,8 +44,7 @@ namespace Playground.Core.ViewModels
             "https://www.petmd.com/sites/default/files/petmd-kitten-facts.jpg"
         };
 
-        private string[] _dogImageUrls = new[]
-        {
+        private readonly string[] _dogImageUrls = {
             "https://loremflickr.com/320/240/dog",
             "https://i.imgur.com/KSftE11.jpg",
             "https://www.thekennelclub.org.uk/media/220388/puppy_environment_alison_spiers.jpg",
@@ -52,8 +54,7 @@ namespace Playground.Core.ViewModels
             "https://www.fomobones.com/blog/wp-content/uploads/2018/12/puppy-grows-out.jpg"
         };
 
-        private string[] _monkeyImageUrls = new[]
-        {
+        private readonly string[] _monkeyImageUrls = {
             "https://loremflickr.com/320/240/monkey",
             "https://allthatsinteresting.com/wordpress/wp-content/uploads/2019/04/baby-primate.jpg",
             "https://images.law.com/contrib/content/uploads/sites/403/2018/04/monkey-selfie-Article-201804131946.jpg",
@@ -64,15 +65,13 @@ namespace Playground.Core.ViewModels
             "https://heritagecorridoraletrail.com/wp-content/uploads/2018/01/babymonkey.jpg"
         };
 
-        private string[] _names = new[]
-        {
+        private readonly string[] _names = {
             "Martijn", "Nicolas", "Nick", "Tomasz", "Stuart", "Marc", "Jeremy", "Jonathan", "Maurits", "Kerry",
             "Will", "Garfield", "Chris", "Przemyslaw", "Guillaume", "Trevor", "Mihal", "Sylvain", "Andres",
             "Erik", "Daniel", "Aaron", "Emmanuel", "Iain", "Martin"
         };
 
-        private Color[] _colors = new[]
-        {
+        private readonly Color[] _colors = {
             Color.Yellow, Color.Green, Color.Blue, Color.Red, Color.Brown,
             Color.Gold, Color.Orange, Color.Purple, Color.Teal, Color.Pink,
             Color.Azure, Color.Crimson, Color.Cyan, Color.Gray, Color.Silver,

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -81,7 +81,7 @@ namespace Playground.Core.ViewModels
                 await NavigationService.Navigate<DictionaryBindingViewModel>());
 
             ShowCollectionViewCommand =
-                new MvxAsyncCommand(() => NavigationService.Navigate<CollectionViewModel>());
+                new MvxAsyncCommand(() => NavigationService.Navigate<CollectionViewModel, CollectionViewParameter>(new CollectionViewParameter(50)));
 
             ShowSharedElementsCommand = new MvxAsyncCommand(async () =>
                 await NavigationService.Navigate<SharedElementRootChildViewModel>());

--- a/Projects/Playground/Playground.Droid/Activities/CollectionView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/CollectionView.cs
@@ -1,5 +1,3 @@
-using Android.App;
-using Android.OS;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using Playground.Core.ViewModels;

--- a/Projects/Playground/Playground.Droid/Activities/GlideImageView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/GlideImageView.cs
@@ -1,0 +1,45 @@
+using Android.Content;
+using Android.Runtime;
+using Android.Util;
+using Bumptech.Glide;
+
+namespace Playground.Droid.Activities;
+
+[Register("playground.droid.GlideImageView")]
+public sealed class GlideImageView : ImageView
+{
+    private string _imagePath;
+
+    public string ImagePath
+    {
+        get => _imagePath;
+        set
+        {
+            if (value == null)
+                return;
+
+            _imagePath = value;
+            Glide.With(Context).Load(_imagePath).Into(this);
+        }
+    }
+
+    public GlideImageView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+    {
+    }
+
+    public GlideImageView(Context context) : base(context)
+    {
+    }
+
+    public GlideImageView(Context context, IAttributeSet attrs) : base(context, attrs)
+    {
+    }
+
+    public GlideImageView(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
+    {
+    }
+
+    public GlideImageView(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes) : base(context, attrs, defStyleAttr, defStyleRes)
+    {
+    }
+}

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -14,8 +14,7 @@
     <PackageReference Include="Serilog.Sinks.Trace" />
     <PackageReference Include="Serilog.Sinks.Xamarin" />
     <PackageReference Include="Serilog.Extensions.Logging" />
-    <PackageReference Include="Xamarin.FFImageLoading" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.Android.Glide" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Async" />
+    <PackageReference Include="Serilog.Sinks.Trace" />
     <PackageReference Include="Serilog.Sinks.Xamarin" />
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Xamarin.FFImageLoading" />

--- a/Projects/Playground/Playground.Droid/Resources/layout/itemtemplate_cat.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/itemtemplate_cat.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="80dp">
-    <FFImageLoading.Cross.MvxCachedImageView
+    <GlideImageView
         android:id="@+id/image"
         android:layout_height="match_parent"
         android:layout_width="80dp"

--- a/Projects/Playground/Playground.Droid/Resources/layout/itemtemplate_dog.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/itemtemplate_dog.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="80dp">
-    <FFImageLoading.Cross.MvxCachedImageView
+    <GlideImageView
         android:id="@+id/image"
         android:layout_height="match_parent"
         android:layout_width="80dp"

--- a/Projects/Playground/Playground.Droid/Resources/layout/itemtemplate_monkey.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/itemtemplate_monkey.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="80dp">
-    <FFImageLoading.Cross.MvxCachedImageView
+    <GlideImageView
         android:id="@+id/image"
         android:layout_height="match_parent"
         android:layout_width="match_parent"

--- a/Projects/Playground/Playground.Droid/Setup.cs
+++ b/Projects/Playground/Playground.Droid/Setup.cs
@@ -6,7 +6,9 @@ using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.DroidX.RecyclerView;
+using MvvmCross.IoC;
 using MvvmCross.Platforms.Android.Core;
+using MvvmCross.Platforms.Android.Views;
 using Playground.Core;
 using Playground.Droid.Bindings;
 using Playground.Droid.Controls;
@@ -41,7 +43,8 @@ namespace Playground.Droid
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
-                .WriteTo.AndroidLog()
+                .WriteTo.Async(a => a.AndroidLog())
+                .WriteTo.Async(a => a.Trace())
                 .CreateLogger();
 
             return new SerilogLoggerFactory();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
SingleViewModel Cache would hold strong refs to ViewModels which is dangerous and could lead to leaks

### :new: What is the new behavior (if this is a feature change)?
Make the strong ref a weak ref instead

### :boom: Does this PR introduce a breaking change?
Shouldn't no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
