### PR TITLE
Fix TryInitializeBindingResourcePaths throwing exception

### DIFF
--- a/MvvmCross.DroidX/RecyclerView/MvxRecyclerView.cs
+++ b/MvvmCross.DroidX/RecyclerView/MvxRecyclerView.cs
@@ -41,7 +41,7 @@ public class MvxRecyclerView : AndroidX.RecyclerView.Widget.RecyclerView
     /// <param name="defStyle"></param>
     /// <param name="adapter"><para><see cref="IMvxRecyclerAdapter"/> to use.</para>
     /// <para>If this is set to <code>null</code>, then it is up to you setting a <see cref="ItemTemplateSelector"/>.</para></param>
-    public MvxRecyclerView(Context context, IAttributeSet attrs, int defStyle, IMvxRecyclerAdapter adapter)
+    public MvxRecyclerView(Context context, IAttributeSet attrs, int defStyle, IMvxRecyclerAdapter? adapter)
         : base(context, attrs, defStyle)
     {
         // Note: Any calling derived class passing a null adapter is responsible for setting
@@ -64,7 +64,7 @@ public class MvxRecyclerView : AndroidX.RecyclerView.Widget.RecyclerView
         if (itemTemplateId == 0)
             itemTemplateId = global::Android.Resource.Layout.SimpleListItem1;
 
-        if (itemTemplateSelector.GetType() == typeof(MvxDefaultTemplateSelector))
+        if (itemTemplateSelector?.GetType() == typeof(MvxDefaultTemplateSelector))
             ItemTemplateId = itemTemplateId;
     }
 

--- a/Projects/Playground/Playground.Droid/Setup.cs
+++ b/Projects/Playground/Playground.Droid/Setup.cs
@@ -50,7 +50,7 @@ namespace Playground.Droid
         protected override ILoggerFactory CreateLogFactory()
         {
             Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Debug()
+                .MinimumLevel.Verbose()
                 .WriteTo.Async(a => a.AndroidLog())
                 .WriteTo.Async(a => a.Trace())
                 .CreateLogger();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
In one of my production Apps, MvxRecyclerView throws on inflation inside of the TryInitializeBindingResourcePaths method. This is unexpected, and I would rather have it to not throw as the name indicates.

### :new: What is the new behavior (if this is a feature change)?
Change it to return a bool for success and make the method not have side effects.

### :boom: Does this PR introduce a breaking change?
Not really

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4710

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
