### PR TITLE
Throw more info in MvxWeakEventSubscription

### DIFF
--- a/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
@@ -176,7 +176,7 @@ namespace MvvmCross.WeakSubscription
 
             AddEventHandler();
         }
-        
+
         private static EventInfo GetEventInfo(string sourceEventName)
         {
             var eventInfo = typeof(TSource).GetEvent(sourceEventName);

--- a/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
@@ -27,7 +27,7 @@ namespace MvvmCross.WeakSubscription
             TSource source,
             string sourceEventName,
             EventHandler<TEventArgs> targetEventHandler)
-            : this(source, typeof(TSource).GetEvent(sourceEventName), targetEventHandler)
+            : this(source, GetEventInfo(sourceEventName), targetEventHandler)
         {
         }
 
@@ -51,6 +51,15 @@ namespace MvvmCross.WeakSubscription
             _ourEventHandler = Init();
 
             AddEventHandler();
+        }
+
+        private static EventInfo GetEventInfo(string sourceEventName)
+        {
+            var eventInfo = typeof(TSource).GetEvent(sourceEventName);
+            if (eventInfo == null)
+                throw new ArgumentOutOfRangeException(sourceEventName);
+
+            return eventInfo;
         }
 
         private Delegate Init()
@@ -149,7 +158,7 @@ namespace MvvmCross.WeakSubscription
             TSource source,
             string sourceEventName,
             EventHandler targetEventHandler)
-            : this(source, typeof(TSource).GetEvent(sourceEventName), targetEventHandler)
+            : this(source, GetEventInfo(sourceEventName), targetEventHandler)
         {
         }
 
@@ -174,6 +183,15 @@ namespace MvvmCross.WeakSubscription
             _ourEventHandler = CreateEventHandler();
 
             AddEventHandler();
+        }
+        
+        private static EventInfo GetEventInfo(string sourceEventName)
+        {
+            var eventInfo = typeof(TSource).GetEvent(sourceEventName);
+            if (eventInfo == null)
+                throw new ArgumentOutOfRangeException(sourceEventName);
+
+            return eventInfo;
         }
 
         protected virtual object? GetTargetObject()

--- a/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
@@ -33,15 +33,11 @@ namespace MvvmCross.WeakSubscription
 
         protected MvxWeakEventSubscription(
             TSource source,
-            EventInfo? sourceEventInfo,
+            EventInfo sourceEventInfo,
             EventHandler<TEventArgs> targetEventHandler)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source), "missing source in MvxWeakEventSubscription");
-
-            if (sourceEventInfo == null)
-                throw new ArgumentNullException(nameof(sourceEventInfo),
-                                                "missing source event info in MvxWeakEventSubscription");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(sourceEventInfo);
 
             _eventHandlerMethodInfo = targetEventHandler.GetMethodInfo();
             _targetReference = new WeakReference(targetEventHandler.Target);
@@ -164,15 +160,11 @@ namespace MvvmCross.WeakSubscription
 
         protected MvxWeakEventSubscription(
             TSource source,
-            EventInfo? sourceEventInfo,
+            EventInfo sourceEventInfo,
             EventHandler targetEventHandler)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source), "missing source in MvxWeakEventSubscription");
-
-            if (sourceEventInfo == null)
-                throw new ArgumentNullException(nameof(sourceEventInfo),
-                                                "missing source event info in MvxWeakEventSubscription");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(sourceEventInfo);
 
             _eventHandlerMethodInfo = targetEventHandler.GetMethodInfo();
             _targetReference = new WeakReference(targetEventHandler.Target);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
If creating `MvxWeakEventSubscrion` fails due to stripped out event we don't get much info about which event failed.

### :new: What is the new behavior (if this is a feature change)?
Throws new `ArgumentOutOfRangeException` with the event name

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4734

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
