### PR TITLE
Fix some native plugins not working

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
     <!--<Nullable>enable</Nullable>-->
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
-    <NoWarn>$(NoWarn);CS0109;CS0108;CS0618;CS0114;NU1603</NoWarn>
+    <NoWarn>$(NoWarn);CS0109;CS0108;CS0618;CS0114;NU1603;CS1591</NoWarn>
 
     <IsTestProject>$(MSBuildProjectName.Contains('UnitTest'))</IsTestProject>
     <IsLibraryProject>$(MSBuildProjectName.Contains('MvvmCross'))</IsLibraryProject>

--- a/MvvmCross.Plugins/Color/Platforms/Android/Plugin.cs
+++ b/MvvmCross.Plugins/Color/Platforms/Android/Plugin.cs
@@ -15,9 +15,9 @@ namespace MvvmCross.Plugin.Color.Platforms.Android
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeColor>(new MvxAndroidColor());
             RegisterDefaultBindings(provider);
+            base.Load(provider);
         }
 
         private static void RegisterDefaultBindings(IMvxIoCProvider provider)

--- a/MvvmCross.Plugins/Color/Platforms/Android/Plugin.cs
+++ b/MvvmCross.Plugins/Color/Platforms/Android/Plugin.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.IoC;
 using MvvmCross.Plugin.Color.Platforms.Android.BindingTargets;
 using MvvmCross.UI;

--- a/MvvmCross.Plugins/Color/Platforms/Ios/Plugin.cs
+++ b/MvvmCross.Plugins/Color/Platforms/Ios/Plugin.cs
@@ -13,8 +13,8 @@ namespace MvvmCross.Plugin.Color.Platforms.Ios
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeColor>(new MvxIosColor());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Color/Platforms/Uap/Plugin.cs
+++ b/MvvmCross.Plugins/Color/Platforms/Uap/Plugin.cs
@@ -12,8 +12,8 @@ namespace MvvmCross.Plugin.Color.Platforms.Uap
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeColor>(new MvxWindowsColor());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Color/Platforms/WinUi/Plugin.cs
+++ b/MvvmCross.Plugins/Color/Platforms/WinUi/Plugin.cs
@@ -12,8 +12,8 @@ namespace MvvmCross.Plugin.Color.Platforms.WinUi
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeColor>(new MvxWindowsColor());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Color/Platforms/Wpf/Plugin.cs
+++ b/MvvmCross.Plugins/Color/Platforms/Wpf/Plugin.cs
@@ -12,8 +12,8 @@ namespace MvvmCross.Plugin.Color.Platforms.Wpf
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeColor>(new MvxWpfColor());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Visibility/BasePlugin.cs
+++ b/MvvmCross.Plugins/Visibility/BasePlugin.cs
@@ -5,20 +5,19 @@
 using MvvmCross.Converters;
 using MvvmCross.IoC;
 
-namespace MvvmCross.Plugin.Visibility
-{
-    public abstract class BasePlugin : IMvxPlugin
-    {
-        public virtual void Load(IMvxIoCProvider provider)
-        {
-            if (provider.TryResolve(out IMvxValueConverterRegistry registry))
-                RegisterValueConverters(registry);
-        }
+namespace MvvmCross.Plugin.Visibility;
 
-        private void RegisterValueConverters(IMvxValueConverterRegistry registry)
-        {
-            registry.AddOrOverwrite("Visibility", new MvxVisibilityValueConverter());
-            registry.AddOrOverwrite("InvertedVisibility", new MvxVisibilityValueConverter());
-        }
+public abstract class BasePlugin : IMvxPlugin
+{
+    public virtual void Load(IMvxIoCProvider provider)
+    {
+        if (provider.TryResolve(out IMvxValueConverterRegistry registry))
+            RegisterValueConverters(registry);
+    }
+
+    private static void RegisterValueConverters(IMvxValueConverterRegistry registry)
+    {
+        registry.AddOrOverwrite("Visibility", new MvxVisibilityValueConverter());
+        registry.AddOrOverwrite("InvertedVisibility", new MvxVisibilityValueConverter());
     }
 }

--- a/MvvmCross.Plugins/Visibility/BasePlugin.cs
+++ b/MvvmCross.Plugins/Visibility/BasePlugin.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
-using MvvmCross.Binding.Combiners;
+using MvvmCross.Converters;
 using MvvmCross.IoC;
 
 namespace MvvmCross.Plugin.Visibility
@@ -12,13 +11,14 @@ namespace MvvmCross.Plugin.Visibility
     {
         public virtual void Load(IMvxIoCProvider provider)
         {
-            if (provider.TryResolve(out IMvxValueCombinerRegistry registry))
+            if (provider.TryResolve(out IMvxValueConverterRegistry registry))
                 RegisterValueConverters(registry);
         }
 
-        private void RegisterValueConverters(IMvxValueCombinerRegistry registry)
+        private void RegisterValueConverters(IMvxValueConverterRegistry registry)
         {
-            registry.AddOrOverwriteFrom(GetType().GetTypeInfo().Assembly);
+            registry.AddOrOverwrite("Visibility", new MvxVisibilityValueConverter());
+            registry.AddOrOverwrite("InvertedVisibility", new MvxVisibilityValueConverter());
         }
     }
 }

--- a/MvvmCross.Plugins/Visibility/Platforms/Android/Plugin.cs
+++ b/MvvmCross.Plugins/Visibility/Platforms/Android/Plugin.cs
@@ -13,8 +13,8 @@ namespace MvvmCross.Plugin.Visibility.Platforms.Android
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeVisibility>(new MvxDroidVisibility());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Visibility/Platforms/Console/Plugin.cs
+++ b/MvvmCross.Plugins/Visibility/Platforms/Console/Plugin.cs
@@ -13,8 +13,8 @@ namespace MvvmCross.Plugin.Visibility.Platforms.Console
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeVisibility>(new MvxConsoleVisibility());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Visibility/Platforms/Ios/Plugin.cs
+++ b/MvvmCross.Plugins/Visibility/Platforms/Ios/Plugin.cs
@@ -13,8 +13,8 @@ namespace MvvmCross.Plugin.Visibility.Platforms.Ios
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeVisibility>(new MvxIosVisibility());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Visibility/Platforms/Uap/Plugin.cs
+++ b/MvvmCross.Plugins/Visibility/Platforms/Uap/Plugin.cs
@@ -12,8 +12,8 @@ namespace MvvmCross.Plugin.Visibility.Platforms.Uap
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeVisibility>(new MvxWinRTVisibility());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Visibility/Platforms/WinUi/Plugin.cs
+++ b/MvvmCross.Plugins/Visibility/Platforms/WinUi/Plugin.cs
@@ -12,8 +12,8 @@ namespace MvvmCross.Plugin.Visibility.Platforms.WinUi
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeVisibility>(new MvxWinRTVisibility());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross.Plugins/Visibility/Platforms/Wpf/Plugin.cs
+++ b/MvvmCross.Plugins/Visibility/Platforms/Wpf/Plugin.cs
@@ -12,8 +12,8 @@ namespace MvvmCross.Plugin.Visibility.Platforms.Wpf
     {
         public override void Load(IMvxIoCProvider provider)
         {
-            base.Load(provider);
             provider.RegisterSingleton<IMvxNativeVisibility>(new MvxWpfVisibility());
+            base.Load(provider);
         }
     }
 }

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -154,14 +154,12 @@ namespace MvvmCross.Core
                 InitializeStringToTypeParser(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: FillableStringToTypeParser start");
                 InitializeFillableStringToTypeParser(_iocProvider);
-                SetupLog?.Log(LogLevel.Trace, "Setup: PluginManagerFramework start");
-                var pluginManager = InitializePluginFramework(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: Create App");
                 var app = InitializeMvxApplication(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: NavigationService");
                 InitializeNavigationService(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: App start");
-                InitializeApp(pluginManager, app);
+                InitializeApp(app);
                 SetupLog?.Log(LogLevel.Trace, "Setup: ViewModelTypeFinder start");
                 InitializeViewModelTypeFinder(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: ViewsContainer start");
@@ -180,6 +178,9 @@ namespace MvvmCross.Core
                 InitializeViewModelCache(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: LastChance start");
                 InitializeLastChance(_iocProvider);
+                SetupLog?.Log(LogLevel.Trace, "Setup: PluginManagerFramework start");
+                var pluginManager = InitializePluginFramework(_iocProvider);
+                app.LoadPlugins(pluginManager);
                 SetupLog?.Log(LogLevel.Trace, "Setup: Secondary end");
                 State = MvxSetupState.Initialized;
             }
@@ -472,12 +473,10 @@ namespace MvvmCross.Core
             return app;
         }
 
-        protected virtual void InitializeApp(IMvxPluginManager pluginManager, IMvxApplication app)
+        protected virtual void InitializeApp(IMvxApplication app)
         {
-            if (app == null)
-                throw new ArgumentNullException(nameof(app));
+            ArgumentNullException.ThrowIfNull(app);
 
-            app.LoadPlugins(pluginManager);
             SetupLog?.Log(LogLevel.Trace, "Setup: Application Initialize - On background thread");
             app.Initialize();
         }

--- a/Projects/Playground/Playground.Core/Converters/StringToLowerValueConverter.cs
+++ b/Projects/Playground/Playground.Core/Converters/StringToLowerValueConverter.cs
@@ -1,16 +1,20 @@
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using MvvmCross.Converters;
 
-namespace Playground.Core.Converters
+namespace Playground.Core.Converters;
+
+public sealed class StringToLowerValueConverter : MvxValueConverter<string, string>
 {
-    public class StringToLowerValueConverter : MvxValueConverter<string, string>
+    protected override string Convert(string value, Type targetType, object parameter, CultureInfo culture)
     {
-        protected override string Convert(string value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return value.ToLower();
-        }
+        return value.ToLower();
+    }
+}
+
+public sealed class StringToUpperValueConverter : MvxValueConverter<string, string>
+{
+    protected override string Convert(string value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value.ToUpper();
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -148,7 +148,7 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowContentViewCommand =>
             new MvxAsyncCommand(() => NavigationService.Navigate<ParentContentViewModel>());
 
-        public IMvxAsyncCommand ConvertersCommand =>
+        public IMvxAsyncCommand ShowConvertersCommand =>
             new MvxAsyncCommand(() => NavigationService.Navigate<ConvertersViewModel>());
 
         public IMvxAsyncCommand ShowSharedElementsCommand { get; }

--- a/Projects/Playground/Playground.Core/ViewModels/Samples/ConvertersViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Samples/ConvertersViewModel.cs
@@ -1,14 +1,35 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Windows.Input;
+using MvvmCross.Commands;
 using MvvmCross.ViewModels;
 
-namespace Playground.Core.ViewModels.Samples
-{
-    public class ConvertersViewModel : MvxViewModel
-    {
-        public string UppercaseConverterTest => "this text was lowercase";
+namespace Playground.Core.ViewModels.Samples;
 
-        public string LowercaseConverterTest => "THIS TEXT WAS UPPERCASE";
+public sealed class ConvertersViewModel : MvxViewModel
+{
+    private bool _showText = true;
+    
+    public string UppercaseConverterTestText => "this text was lowercase";
+
+    public string LowercaseConverterTestText => "THIS TEXT WAS UPPERCASE";
+
+    public bool ShowText
+    {
+        get => _showText;
+        set => SetProperty(ref _showText, value);
+    }
+    
+    public ICommand ToggleVisibilityCommand { get; }
+
+    public ConvertersViewModel()
+    {
+        ToggleVisibilityCommand = new MvxCommand(DoToggleVisibility);
+    }
+
+    private void DoToggleVisibility()
+    {
+        ShowText = !ShowText;
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Samples/ConvertersViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Samples/ConvertersViewModel.cs
@@ -1,6 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Drawing;
 using System.Windows.Input;
 using MvvmCross.Commands;
 using MvvmCross.ViewModels;
@@ -10,7 +8,11 @@ namespace Playground.Core.ViewModels.Samples;
 public sealed class ConvertersViewModel : MvxViewModel
 {
     private bool _showText = true;
-    
+    private string _colorText;
+    private Color _textColor;
+    private int _colorPairIndex;
+    private readonly (string, Color)[] _colorPairs;
+
     public string UppercaseConverterTestText => "this text was lowercase";
 
     public string LowercaseConverterTestText => "THIS TEXT WAS UPPERCASE";
@@ -20,12 +22,41 @@ public sealed class ConvertersViewModel : MvxViewModel
         get => _showText;
         set => SetProperty(ref _showText, value);
     }
-    
+
+    public string ColorText
+    {
+        get => _colorText;
+        set => SetProperty(ref _colorText, value);
+    }
+
+    public Color TextColor
+    {
+        get => _textColor;
+        set => SetProperty(ref _textColor, value);
+    }
+
     public ICommand ToggleVisibilityCommand { get; }
+    public ICommand ToggleColorCommand { get; }
 
     public ConvertersViewModel()
     {
         ToggleVisibilityCommand = new MvxCommand(DoToggleVisibility);
+        ToggleColorCommand = new MvxCommand(DoToggleColor);
+
+        _colorText = "I am green!";
+        _textColor = Color.Green;
+        _colorPairs = new[]
+        {
+            ("green", Color.Green), ("yellow", Color.Yellow), ("brown", Color.Brown), ("orange", Color.Orange)
+        };
+    }
+
+    private void DoToggleColor()
+    {
+        var nextColorPair = _colorPairs[++_colorPairIndex % _colorPairs.Length];
+
+        ColorText = $"I am {nextColorPair.Item1}!";
+        TextColor = nextColorPair.Item2;
     }
 
     private void DoToggleVisibility()

--- a/Projects/Playground/Playground.Droid/Activities/ConvertersActivity.cs
+++ b/Projects/Playground/Playground.Droid/Activities/ConvertersActivity.cs
@@ -1,0 +1,16 @@
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.Platforms.Android.Views;
+using Playground.Core.ViewModels.Samples;
+
+namespace Playground.Droid.Activities;
+
+[MvxActivityPresentation]
+[Activity(Theme = "@style/AppTheme")]
+public sealed class ConvertersActivity : MvxActivity<ConvertersViewModel>
+{
+    protected override void OnCreate(Bundle savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        SetContentView(Resource.Layout.activity_converters);
+    }
+}

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\JsonLocalization\MvvmCross.Plugin.JsonLocalization.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\Json\MvvmCross.Plugin.Json.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\ResourceLoader\MvvmCross.Plugin.ResourceLoader.csproj" />
+    <ProjectReference Include="..\..\..\MvvmCross.Plugins\Visibility\MvvmCross.Plugin.Visibility.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross\MvvmCross.csproj" />
     <ProjectReference Include="..\Playground.Core\Playground.Core.csproj" />
   </ItemGroup>

--- a/Projects/Playground/Playground.Droid/Resources/layout/RootView.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/RootView.xml
@@ -110,21 +110,27 @@
                 android:layout_marginTop="10dp"
                 android:text="Location"
                 local:MvxBind="Click ShowLocationCommand;" />
+            <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Converters"
+                local:MvxBind="Click ShowConvertersCommand;" />
             <TextView
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:textSize="40dp"
-        local:MvxBind="Text TimeToRegister" />
-          <TextView
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:textSize="40dp"
-        local:MvxBind="Text TimeToResolve" />
-             <TextView
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:textSize="40dp"
-        local:MvxBind="Text TotalTime" />
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:textSize="40dp"
+                local:MvxBind="Text TimeToRegister" />
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:textSize="40dp"
+                local:MvxBind="Text TimeToResolve" />
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:textSize="40dp"
+                local:MvxBind="Text TotalTime" />
         </LinearLayout>
     </ScrollView>
     <FrameLayout

--- a/Projects/Playground/Playground.Droid/Resources/layout/RootView.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/RootView.xml
@@ -109,13 +109,13 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
                 android:text="Location"
-                local:MvxBind="Click ShowLocationCommand;" />
+                local:MvxBind="Click ShowLocationCommand" />
             <Button
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
                 android:text="Converters"
-                local:MvxBind="Click ShowConvertersCommand;" />
+                local:MvxBind="Click ShowConvertersCommand" />
             <TextView
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"

--- a/Projects/Playground/Playground.Droid/Resources/layout/activity_converters.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/activity_converters.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout 
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+    
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        local:MvxBind="Text StringToLower(LowercaseConverterTestText)"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        local:MvxBind="Text StringToUpper(UppercaseConverterTestText)"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="I am visible! Click button below to hide me."
+        local:MvxBind="Visibility Visibility(ShowText)"/>
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Toggle Visibility"
+        local:MvxBind="Click ToggleVisibilityCommand" />
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/activity_converters.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/activity_converters.xml
@@ -31,4 +31,16 @@
         android:layout_height="wrap_content"
         android:text="Toggle Visibility"
         local:MvxBind="Click ToggleVisibilityCommand" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        local:MvxBind="Text ColorText; TextColor NativeColor(TextColor)"/>
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Toggle Color"
+        local:MvxBind="Click ToggleColorCommand" />
 </LinearLayout>

--- a/Projects/Playground/Playground.Droid/Setup.cs
+++ b/Projects/Playground/Playground.Droid/Setup.cs
@@ -8,7 +8,6 @@ using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.DroidX.RecyclerView;
 using MvvmCross.Platforms.Android.Core;
 using MvvmCross.Plugin;
-using MvvmCross.Plugin.Color.Platforms.Android;
 using Playground.Core;
 using Playground.Droid.Bindings;
 using Playground.Droid.Controls;
@@ -38,7 +37,8 @@ namespace Playground.Droid
         {
             base.LoadPlugins(pluginManager);
 
-            pluginManager.EnsurePluginLoaded<Plugin>();
+            pluginManager.EnsurePluginLoaded<MvvmCross.Plugin.Visibility.Platforms.Android.Plugin>();
+            pluginManager.EnsurePluginLoaded<MvvmCross.Plugin.Color.Platforms.Android.Plugin>();
             pluginManager.EnsurePluginLoaded<MvvmCross.Plugin.Json.Plugin>();
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
Not so long ago I removed the ability to listen to callbacks from the Mvx IoCProvider for when certain things in MvvmCross were registered. This broke the Color and Visibility plugin, which are registering value conveters.

### :new: What is the new behavior (if this is a feature change)?
I've moved loading of plugins to be the last thing to happen when MvvmCross initializes.

Also, I've fixed how Color and Visibility plugins register themselves. They did it in the wrong order, resulting in their value converters not working.

There is still the issue of assembly scanning not working properly which I will try to address in a different PR. So you still have to load plugins manually in your Setup.cs like:

```csharp
public override void LoadPlugins(IMvxPluginManager pluginManager)
{
    base.LoadPlugins(pluginManager);

    pluginManager.EnsurePluginLoaded<MvvmCross.Plugin.Visibility.Platforms.Android.Plugin>();
    pluginManager.EnsurePluginLoaded<MvvmCross.Plugin.Color.Platforms.Android.Plugin>();
    pluginManager.EnsurePluginLoaded<MvvmCross.Plugin.Json.Plugin>();
}
```

Or adding your plugin assemblies in a `GetPluginAssemblies` override.

### :boom: Does this PR introduce a breaking change?
Only if someone relies on a speicific order.

### :bug: Recommendations for testing
Fire up the Playground.Droid project and check out the new Converter playground in there.

### :memo: Links to relevant issues/docs
Fixes #4736

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
