### PR TITLE
Fix InvertedVisibility valueconverter registration (#4749)

### DIFF
--- a/MvvmCross.Plugins/Visibility/BasePlugin.cs
+++ b/MvvmCross.Plugins/Visibility/BasePlugin.cs
@@ -18,6 +18,6 @@ public abstract class BasePlugin : IMvxPlugin
     private static void RegisterValueConverters(IMvxValueConverterRegistry registry)
     {
         registry.AddOrOverwrite("Visibility", new MvxVisibilityValueConverter());
-        registry.AddOrOverwrite("InvertedVisibility", new MvxVisibilityValueConverter());
+        registry.AddOrOverwrite("InvertedVisibility", new MvxInvertedVisibilityValueConverter());
     }
 }

--- a/MvvmCross.Plugins/Visibility/MvxBaseVisibilityValueConverter.cs
+++ b/MvvmCross.Plugins/Visibility/MvxBaseVisibilityValueConverter.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Globalization;
 using MvvmCross.Converters;
 using MvvmCross.UI;
@@ -23,9 +22,9 @@ namespace MvvmCross.Plugin.Visibility
     public abstract class MvxBaseVisibilityValueConverter
         : MvxValueConverter
     {
-        private IMvxNativeVisibility _nativeVisiblity;
+        private IMvxNativeVisibility _nativeVisibility;
 
-        private IMvxNativeVisibility NativeVisibility => _nativeVisiblity ?? (_nativeVisiblity = Mvx.IoCProvider.Resolve<IMvxNativeVisibility>());
+        private IMvxNativeVisibility NativeVisibility => _nativeVisibility ??= Mvx.IoCProvider.Resolve<IMvxNativeVisibility>();
 
         protected abstract MvxVisibility Convert(object value, object parameter, CultureInfo culture);
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes the InvertedVisibility value converter registration

### :arrow_heading_down: What is the current behavior?
The Visibility plugin incorrectly registers the normal `MvxVisibilityValueConverter` for the "InvertedVisibility" key.
Regression seemed to be introduced in PR #4739.

### :new: What is the new behavior (if this is a feature change)?
Correctly registers the `MvxInvertedVisibilityValueConverter`.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the InvertedVisibility binding in a layout

### :memo: Links to relevant issues/docs
Fixes #4749

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
