### PR TITLE
Move plugin registration to before Last chance

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -176,11 +176,11 @@ namespace MvvmCross.Core
                 InitializeInpcInterception(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: InpcInterception start");
                 InitializeViewModelCache(_iocProvider);
-                SetupLog?.Log(LogLevel.Trace, "Setup: LastChance start");
-                InitializeLastChance(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: PluginManagerFramework start");
                 var pluginManager = InitializePluginFramework(_iocProvider);
                 app.LoadPlugins(pluginManager);
+                SetupLog?.Log(LogLevel.Trace, "Setup: LastChance start");
+                InitializeLastChance(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: Secondary end");
                 State = MvxSetupState.Initialized;
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug

### :arrow_heading_down: What is the current behavior?
When I moved when plugins are registered in #4739 I broke the possibility for stuff in InitializeLastChance to make use of plugins if the code in there is depending on some of them.

### :new: What is the new behavior (if this is a feature change)?
Moving plugin registration to just before InitializeLastChance.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#4739
Fixes #4752


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
