### PR TITLE
Bugfix. ModalControllerDelegate.WillDismiss() closes a ViewController when the ViewController is not actually dismissed by a user

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxModalPresentationControllerDelegate.cs
@@ -3,26 +3,24 @@
 // See the LICENSE file in the project root for more information.
 
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
-using UIKit;
 
-namespace MvvmCross.Platforms.Ios.Presenters
+namespace MvvmCross.Platforms.Ios.Presenters;
+
+public class MvxModalPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
 {
-    public class MvxModalPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
+    private readonly MvxIosViewPresenter _presenter;
+    private readonly UIViewController _viewController;
+    private readonly MvxModalPresentationAttribute _attribute;
+
+    public MvxModalPresentationControllerDelegate(MvxIosViewPresenter presenter, UIViewController viewController, MvxModalPresentationAttribute attribute)
     {
-        private readonly MvxIosViewPresenter _presenter;
-        private readonly UIViewController _viewController;
-        private readonly MvxModalPresentationAttribute _attribute;
+        _presenter = presenter;
+        _viewController = viewController;
+        _attribute = attribute;
+    }
 
-        public MvxModalPresentationControllerDelegate(MvxIosViewPresenter presenter, UIViewController viewController, MvxModalPresentationAttribute attribute)
-        {
-            _presenter = presenter;
-            _viewController = viewController;
-            _attribute = attribute;
-        }
-
-        public override void WillDismiss(UIPresentationController presentationController)
-        {
-            _presenter.CloseModalViewController(_viewController, _attribute);
-        }
+    public override async void DidDismiss(UIPresentationController presentationController)
+    {
+        await _presenter.CloseModalViewController(_viewController, _attribute).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix for #4781 

### :arrow_heading_down: What is the current behavior?
A ViewController is closed by MvvmCross when the ViewController is not actually dismissed by a user.

### :new: What is the new behavior (if this is a feature change)?
A ViewController is only closed when a user has dismissed it.

### :boom: Does this PR introduce a breaking change?
No

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
