### PR TITLE
Move initialization of binding builder to before plugin registration

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -174,6 +174,8 @@ namespace MvvmCross.Core
                 InitializeInpcInterception(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: InpcInterception start");
                 InitializeViewModelCache(_iocProvider);
+                SetupLog?.Log(LogLevel.Trace, "Setup: BindingBuilder start");
+                InitializeBindingBuilder(_iocProvider);
                 SetupLog?.Log(LogLevel.Trace, "Setup: PluginManagerFramework start");
                 var pluginManager = InitializePluginFramework(_iocProvider);
                 app.LoadPlugins(pluginManager);
@@ -597,6 +599,11 @@ namespace MvvmCross.Core
             var container = iocProvider.Resolve<IMvxViewsContainer>();
             container.AddAll(viewModelViewLookup);
             return container;
+        }
+
+        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+        {
+            
         }
 
         protected virtual void InitializeLastChance(IMvxIoCProvider iocProvider)

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -167,12 +167,10 @@ public abstract class MvxAndroidSetup
         ValidateArguments(iocProvider);
 
         InitializeSavedStateConverter(iocProvider);
-
-        InitializeBindingBuilder(iocProvider);
         base.InitializeLastChance(iocProvider);
     }
 
-    protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+    protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
     {
         ValidateArguments(iocProvider);
 

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
@@ -129,13 +129,7 @@ namespace MvvmCross.Platforms.Ios.Core
             return new MvxPopoverPresentationSourceProvider();
         }
 
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            InitializeBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+        protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             var bindingBuilder = CreateBindingBuilder();
             bindingBuilder.DoRegistration(iocProvider);

--- a/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
@@ -112,13 +112,7 @@ namespace MvvmCross.Platforms.Mac.Core
             iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
         }
 
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            InitialiseBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitialiseBindingBuilder(IMvxIoCProvider iocProvider)
+        protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             var bindingBuilder = CreateBindingBuilder();
             bindingBuilder.DoRegistration(iocProvider);

--- a/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
+++ b/MvvmCross/Platforms/Tizen/Core/MvxTizenSetup.cs
@@ -77,13 +77,7 @@ namespace MvvmCross.Platforms.Tizen.Core
             iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
         }
 
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            InitializeBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+        protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             RegisterBindingBuilderCallbacks(iocProvider);
             var bindingBuilder = CreateBindingBuilder();

--- a/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
@@ -126,13 +126,7 @@ namespace MvvmCross.Platforms.Tvos.Core
             iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
         }
 
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            InitializeBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+        protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             var bindingBuilder = CreateBindingBuilder();
             bindingBuilder.DoRegistration(iocProvider);

--- a/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platforms/Uap/Core/MvxWindowsSetup.cs
@@ -132,13 +132,7 @@ namespace MvvmCross.Platforms.Uap.Core
             iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
         }
 
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            InitializeBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+        protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             RegisterBindingBuilderCallbacks(iocProvider);
             var bindingBuilder = CreateBindingBuilder();

--- a/MvvmCross/Platforms/WinUi/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platforms/WinUi/Core/MvxWindowsSetup.cs
@@ -133,13 +133,7 @@ namespace MvvmCross.Platforms.WinUi.Core
             iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
         }
 
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            InitializeBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+        protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             var bindingBuilder = CreateBindingBuilder();
             bindingBuilder.DoRegistration(iocProvider);

--- a/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
+++ b/MvvmCross/Platforms/Wpf/Core/MvxWpfSetup.cs
@@ -103,13 +103,7 @@ namespace MvvmCross.Platforms.Wpf.Core
             base.InitializeFirstChance(iocProvider);
         }
 
-        protected override void InitializeLastChance(IMvxIoCProvider iocProvider)
-        {
-            InitializeBindingBuilder(iocProvider);
-            base.InitializeLastChance(iocProvider);
-        }
-
-        protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
+        protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             var bindingBuilder = CreateBindingBuilder();
             bindingBuilder.DoRegistration(iocProvider);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
As part of moving around some of the plugin registration and removing the callbacks. ValueCombiners and ValueConverters registered from callbacks in Plugins now don't work. This affects some of the plugins like the color plugin which relied on that mechanism, to register value combiners and value converters after the binding builder was registered.

### :new: What is the new behavior (if this is a feature change)?
Moved init of Binding builder to before plugins loading

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4797

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
