### PR TITLE
Fix MvxColorValueConverter not working

### DIFF
--- a/MvvmCross.Plugins/Color/MvxColorValueConverter.cs
+++ b/MvvmCross.Plugins/Color/MvxColorValueConverter.cs
@@ -1,44 +1,35 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using System;
+#nullable enable
 using System.Globalization;
 using MvvmCross.Converters;
 using MvvmCross.UI;
 
-namespace MvvmCross.Plugin.Color
+namespace MvvmCross.Plugin.Color;
+
+public abstract class MvxColorValueConverter : MvxValueConverter
 {
-#nullable enable
-    public abstract class MvxColorValueConverter : MvxValueConverter
+    private readonly Lazy<IMvxNativeColor?> _nativeColor = new(() => Mvx.IoCProvider?.Resolve<IMvxNativeColor>());
+
+    protected abstract System.Drawing.Color Convert(object value, object? parameter, CultureInfo? culture);
+
+    public sealed override object Convert(object value, Type? targetType, object? parameter,
+        CultureInfo? culture)
     {
-        private readonly IMvxNativeColor? _nativeColor;
+        return _nativeColor.Value?.ToNative(Convert(value, parameter, culture)) ?? MvxBindingConstant.UnsetValue;
+    }
+}
 
-        protected MvxColorValueConverter()
-        {
-            Mvx.IoCProvider?.TryResolve<IMvxNativeColor>(out _nativeColor);
-        }
+public abstract class MvxColorValueConverter<T> : MvxColorValueConverter
+{
+    protected sealed override System.Drawing.Color Convert(object value, object? parameter, CultureInfo? culture)
+    {
+        if (value is T t)
+            return Convert(t, parameter, culture);
 
-        protected abstract System.Drawing.Color Convert(object value, object? parameter, CultureInfo? culture);
-
-        public sealed override object Convert(object value, Type? targetType, object? parameter,
-                                       CultureInfo? culture)
-        {
-            return _nativeColor?.ToNative(Convert(value, parameter, culture)) ?? MvxBindingConstant.UnsetValue;
-        }
+        return default;
     }
 
-    public abstract class MvxColorValueConverter<T> : MvxColorValueConverter
-    {
-        protected sealed override System.Drawing.Color Convert(object value, object? parameter, CultureInfo? culture)
-        {
-            if (value is T t)
-                return Convert(t, parameter, culture);
-
-            return default;
-        }
-
-        protected abstract System.Drawing.Color Convert(T value, object? parameter, CultureInfo? culture);
-    }
-#nullable restore
+    protected abstract System.Drawing.Color Convert(T value, object? parameter, CultureInfo? culture);
 }

--- a/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
+++ b/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.IoC;
 
@@ -88,9 +89,10 @@ namespace MvvmCross.Binding.Binders
                     MvxBindingLog.Trace("Registering value converter {0}:{1}", pair.Name, pair.Type.Name);
                     registry.AddOrOverwrite(pair.Name, converter);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    // ignore this
+                    MvxBindingLog.Instance?.LogError(ex, "Failed to register {Name} from {Type}", pair.Name,
+                        pair.Type.Name);
                 }
             }
         }

--- a/Projects/Playground/Playground.Core/Converters/TextToColorValueConverter.cs
+++ b/Projects/Playground/Playground.Core/Converters/TextToColorValueConverter.cs
@@ -1,0 +1,24 @@
+using System.Drawing;
+using System.Globalization;
+using MvvmCross.Plugin.Color;
+
+namespace Playground.Core.Converters;
+
+// Sample converter to show issue found in GH issue #4803
+public sealed class TextToColorValueConverter : MvxColorValueConverter
+{
+    protected override Color Convert(object value, object parameter, CultureInfo culture)
+    {
+        if (value is not string stringValue)
+            return Color.Magenta;
+
+        return stringValue switch
+        {
+            "I am green!" => Color.Green,
+            "I am yellow!" => Color.Yellow,
+            "I am brown!" => Color.Brown,
+            "I am orange!" => Color.Orange,
+            _ => Color.Black
+        };
+    }
+}

--- a/Projects/Playground/Playground.Core/Playground.Core.csproj
+++ b/Projects/Playground/Playground.Core/Playground.Core.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\MvvmCross.Plugins\Color\MvvmCross.Plugin.Color.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\JsonLocalization\MvvmCross.Plugin.JsonLocalization.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\Json\MvvmCross.Plugin.Json.csproj" />
     <ProjectReference Include="..\..\..\MvvmCross.Plugins\Messenger\MvvmCross.Plugin.Messenger.csproj" />

--- a/Projects/Playground/Playground.Droid/Resources/layout/activity_converters.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/activity_converters.xml
@@ -36,7 +36,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        local:MvxBind="Text ColorText; TextColor NativeColor(TextColor)"/>
+        local:MvxBind="Text ColorText; TextColor TextToColor(ColorText)"/>
 
     <Button
         android:layout_width="match_parent"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
`MvxColorValueConverter` tries to load `IMvxNativeColor` in its ctor, which fails due to loading order. So at the time of resolution it is not registered just quite yet.

### :new: What is the new behavior (if this is a feature change)?
- I've improved the logging from the registry filler if something goes wrong
- Lazily load `IMvxNativeColor` in `MvxColorValueConverter`

I did try moving the plugins to load after the binding builder, but it causes more issues than it fixes. So won't do that here. Just fixing the color plugin, which is the only plugin which has the issue.

### :boom: Does this PR introduce a breaking change?
Nop

### :bug: Recommendations for testing
Launch the Converters sample in the Playground

### :memo: Links to relevant issues/docs
Fixes #4803

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
