### PR TITLE
Added multi window support for WinUI 3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
     <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="PInvoke.User32" Version="0.7.124" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.9.0" />
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -18,6 +18,13 @@ This package contains the 'Core' libraries for MvvmCross</Description>
     <None Include="Platforms\**\*.cs" />
     <None Include="Resources\*.cs" />
     <Compile Remove="Resources\*.cs" />
+    <None Remove="Platforms\WinUi\Presenters\Attributes\MvxNewWindowPresentationAttribute.cs" />
+    <None Remove="Platforms\WinUi\Presenters\IMvxMultiWindowsService.cs" />
+    <None Remove="Platforms\WinUi\Presenters\Models\INeedWindow.cs" />
+    <None Remove="Platforms\WinUi\Presenters\Models\WindowInformation.cs" />
+    <None Remove="Platforms\WinUi\Presenters\MvxMultiWindowViewPresenter.cs" />
+    <None Remove="Platforms\WinUi\Presenters\Utils\AppWindowUtils.cs" />
+
     <None Include="readme.txt" pack="true" PackagePath="." />
   </ItemGroup>
   
@@ -61,6 +68,7 @@ This package contains the 'Core' libraries for MvvmCross</Description>
     <RootNamespace>MvvmCross</RootNamespace>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <UseWindowsForms>true</UseWindowsForms>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
 
@@ -77,5 +85,6 @@ This package contains the 'Core' libraries for MvvmCross</Description>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="PInvoke.User32" />
   </ItemGroup>
 </Project>

--- a/MvvmCross/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Navigation/IMvxNavigationService.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using MvvmCross.Navigation.EventArguments;
 using MvvmCross.ViewModels;
 
@@ -177,6 +173,100 @@ namespace MvvmCross.Navigation
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task<bool> ChangePresentation(MvxPresentationHint hint, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Loads a view model targeting the window for the given source.
+        /// </summary>
+        /// <typeparam name="TViewModel">The viewmodel type.</typeparam>
+        /// <typeparam name="TParameter">The parameter type.</typeparam>
+        /// <param name="param">The parameter value.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bungle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if navigation was successful.</returns>
+        Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+            CancellationToken cancellationToken = default) where TViewModel : IMvxViewModel<TParameter>
+            where TParameter : notnull;
+
+        /// <summary>
+        ///     Loads a view model targeting the window for the given source.
+        /// </summary>
+        /// <typeparam name="TParameter">The parameter</typeparam>
+        /// <param name="viewModelType">The viewmodel type.</param>
+        /// <param name="param">The parameter value.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bungle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if navigation was successful.</returns>
+        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+            CancellationToken cancellationToken = default)
+            where TParameter : notnull;
+
+        /// <summary>
+        ///     Navigates to a view for the given type.
+        /// </summary>
+        /// <param name="viewModelType">The type of the viewmodel to navigate to.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">A presentation bundle.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        Task<bool> Navigate(Type viewModelType, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Navigates to the viewmodel for the given type.
+        /// </summary>
+        /// <typeparam name="TViewModel">The type of the viewmodel to navigate to.</typeparam>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bundle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        Task<bool> Navigate<TViewModel>(IMvxViewModel source,
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+            where TViewModel : IMvxViewModel;
+
+        /// <summary>
+        ///     Navigates to a view for the given viewmodel.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to navigate to.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bundle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        Task<bool> Navigate(
+            IMvxViewModel viewModel, IMvxViewModel source, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Navigates to a view for the given viewmodel.
+        /// </summary>
+        /// <typeparam name="TParameter">The parameter type.</typeparam>
+        /// <param name="viewModel">The viewmodel to navigate to.</param>
+        /// <param name="param">Any parameters.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bundle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxViewModel source,
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+            where TParameter : notnull;
     }
 #nullable restore
 }

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -481,6 +481,186 @@ namespace MvvmCross.Navigation
             if (viewModel == null)
                 throw new ArgumentNullException(nameof(viewModel));
         }
+
+        /// <summary>
+        ///     Loads a view model targeting the window for the given source.
+        /// </summary>
+        /// <typeparam name="TViewModel">The viewmodel type.</typeparam>
+        /// <typeparam name="TParameter">The parameter type.</typeparam>
+        /// <param name="param">The parameter value.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bungle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if navigation was successful.</returns>
+        public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+            CancellationToken cancellationToken = default) where TViewModel : IMvxViewModel<TParameter>
+            where TParameter : notnull
+        {
+            return this.Navigate(typeof(TViewModel), param, source, presentationBundle, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Loads a view model targeting the window for the given source.
+        /// </summary>
+        /// <typeparam name="TParameter">The parameter</typeparam>
+        /// <param name="viewModelType">The viewmodel type.</param>
+        /// <param name="param">The parameter value.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bungle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if navigation was successful.</returns>
+        public virtual Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+            CancellationToken cancellationToken = default)
+            where TParameter : notnull
+        {
+            var mvxViewModelInstanceRequest = new MvxViewModelInstanceRequestWithSource(viewModelType, source)
+            {
+                PresentationValues = presentationBundle?.SafeGetData()
+            };
+            mvxViewModelInstanceRequest.ViewModelInstance = this.ViewModelLoader.LoadViewModel(mvxViewModelInstanceRequest, param, null);
+            return this.NavigateAsync(mvxViewModelInstanceRequest, mvxViewModelInstanceRequest.ViewModelInstance, presentationBundle, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Navigates to a view for the given type.
+        /// </summary>
+        /// <param name="viewModelType">The type of the viewmodel to navigate to.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">A presentation bundle.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        public virtual Task<bool> Navigate(Type viewModelType, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new MvxViewModelInstanceRequestWithSource(viewModelType, source)
+            {
+                PresentationValues = presentationBundle?.SafeGetData()
+            };
+            request.ViewModelInstance = this.ViewModelLoader.LoadViewModel(request, null);
+            return this.NavigateAsync(request, request.ViewModelInstance, presentationBundle, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Navigates to the viewmodel for the given type.
+        /// </summary>
+        /// <typeparam name="TViewModel">The type of the viewmodel to navigate to.</typeparam>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bundle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        public virtual Task<bool> Navigate<TViewModel>(IMvxViewModel source,
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+            where TViewModel : IMvxViewModel
+        {
+            return this.Navigate(typeof(TViewModel), source, presentationBundle, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Navigates to a view for the given viewmodel.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to navigate to.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bundle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        public virtual Task<bool> Navigate(
+            IMvxViewModel viewModel, IMvxViewModel source, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+        {
+            var request = new MvxViewModelInstanceRequestWithSource(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
+            this.ViewModelLoader.ReloadViewModel(viewModel, request, null);
+            return this.NavigateAsync(request, viewModel, presentationBundle, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Navigates to a view for the given viewmodel.
+        /// </summary>
+        /// <typeparam name="TParameter">The parameter type.</typeparam>
+        /// <param name="viewModel">The viewmodel to navigate to.</param>
+        /// <param name="param">Any parameters.</param>
+        /// <param name="source">
+        ///     This is used to find the window to execute the navigate in.
+        ///     This is usually the viewmodel instance which calls this method. 
+        /// </param>
+        /// <param name="presentationBundle">The presentation bundle.</param>
+        /// <param name="cancellationToken">Any cancellation token.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        public virtual Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param, IMvxViewModel source,
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+            where TParameter : notnull
+        {
+            var request = new MvxViewModelInstanceRequestWithSource(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
+            this.ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
+            return this.NavigateAsync(request, viewModel, presentationBundle, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Shows the ViewModel for the given request.
+        /// </summary>
+        /// <param name="request">The request to show the viewmodel for.</param>
+        /// <param name="viewModel">The viewmodel for the navigation arguments.</param>
+        /// <param name="presentationBundle">The presentation bundle.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>True is successful. False otherwise.</returns>
+        protected virtual async Task<bool> NavigateAsync(MvxViewModelInstanceRequestWithSource request, IMvxViewModel viewModel,
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+        {
+            ValidateArguments(request, viewModel);
+
+            var args = new MvxNavigateEventArgs(viewModel, NavigationMode.Show, cancellationToken);
+            this.OnWillNavigate(this, args);
+
+            if (args.Cancel)
+            {
+                return false;
+            }
+
+            bool hasNavigated = await this.ViewDispatcher.ShowViewModel(request).ConfigureAwait(false);
+            if (!hasNavigated)
+            {
+                return false;
+            }
+
+            if (viewModel.InitializeTask?.Task != null)
+            {
+                await viewModel.InitializeTask.Task.ConfigureAwait(false);
+            }
+
+            this.OnDidNavigate(this, args);
+            return true;
+        }
+
+        private static void ValidateArguments(MvxViewModelInstanceRequestWithSource request, IMvxViewModel viewModel)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (request.Source == null)
+            {
+                throw new ArgumentNullException(nameof(request.Source));
+            }
+
+            if (viewModel == null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
+            }
+        }
     }
 #nullable restore
 }

--- a/MvvmCross/Platforms/WinUi/Core/MvxWindowsSetup.cs
+++ b/MvvmCross/Platforms/WinUi/Core/MvxWindowsSetup.cs
@@ -109,7 +109,7 @@ namespace MvvmCross.Platforms.WinUi.Core
 
         protected virtual IMvxWindowsViewPresenter CreateViewPresenter(IMvxWindowsFrame rootFrame)
         {
-            return new MvxWindowsViewPresenter(rootFrame);
+            return new MvxMultiWindowViewPresenter(rootFrame);
         }
 
         protected virtual MvxWindowsViewDispatcher CreateViewDispatcher(IMvxWindowsFrame rootFrame)

--- a/MvvmCross/Platforms/WinUi/Presenters/Attributes/MvxNewWindowPresentationAttribute.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/Attributes/MvxNewWindowPresentationAttribute.cs
@@ -1,0 +1,39 @@
+namespace MvvmCross.Platforms.WinUi.Presenters.Attributes
+{
+    using MvvmCross.Presenters.Attributes;
+
+    /// <summary>
+    /// Attribute to indicate that a view should be shown in a new window.
+    /// When using this attribute make sure not to do any long operation that after completion will update the UI.
+    /// </summary>
+    public class MvxNewWindowPresentationAttribute : MvxBasePresentationAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MvxNewWindowPresentationAttribute"/> class.
+        /// </summary>
+        public MvxNewWindowPresentationAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MvxNewWindowPresentationAttribute"/> class.
+        /// </summary>
+        /// <param name="width">The start width of the window.</param>
+        /// <param name="height">The start height of the window.</param>
+        public MvxNewWindowPresentationAttribute(int width, int height)
+        {
+            this.Width = width;
+            this.Height = height;
+        }
+
+        /// <summary>
+        /// Gets the width.
+        /// </summary>
+        public int? Width { get; }
+
+        /// <summary>
+        /// Gets the height.
+        /// </summary>
+        public int? Height { get; }
+    }
+}

--- a/MvvmCross/Platforms/WinUi/Presenters/IMvxMultiWindowsService.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/IMvxMultiWindowsService.cs
@@ -1,0 +1,18 @@
+using Microsoft.UI.Xaml;
+using MvvmCross.ViewModels;
+
+namespace MvvmCross.Platforms.WinUi.Presenters
+{
+    /// <summary>
+    /// Defines public services for the MultiWindow support.
+    /// </summary>
+    public interface IMvxMultiWindowsService
+    {
+        /// <summary>
+        /// Gets the window for the given view model.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel instance to find the window it belongs to for</param>
+        /// <returns>The window found, or the application main window if not found.</returns>
+        public Window GetWindow(IMvxViewModel viewModel);
+    }
+}

--- a/MvvmCross/Platforms/WinUi/Presenters/Models/INeedWindow.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/Models/INeedWindow.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+
+namespace MvvmCross.Platforms.WinUi.Presenters.Models
+{
+
+    /// <summary>
+    /// Interface for Window root views to allow the View Presenter to set the current appwindow.
+    /// </summary>
+    public interface INeedWindow
+    {
+        /// <summary>
+        /// Sets the AppWindow for the current view.
+        /// </summary>
+        /// <param name="window">The window.</param>
+        /// <param name="appWindow">The app window instance.</param>
+        public void SetWindow(Window window, AppWindow appWindow);
+
+        /// <summary>
+        /// Executed when the close button is clicked. Return true if the window can be closed, false if it cannot be closed.
+        /// </summary>
+        /// <returns>A bool indicating true if the window can be closed.</returns>
+        public bool CanClose();
+    }
+}

--- a/MvvmCross/Platforms/WinUi/Presenters/Models/WindowInformation.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/Models/WindowInformation.cs
@@ -1,0 +1,106 @@
+#nullable enable
+using MvvmCross.ViewModels;
+using Microsoft.UI.Xaml;
+using System.Collections.Concurrent;
+using MvvmCross.Platforms.WinUi.Views;
+
+namespace MvvmCross.Platforms.WinUi.Presenters.Models
+{
+    /// <summary>
+    /// Holds information regarding the different windows.
+    /// </summary>
+    public class WindowInformation
+    {
+        private readonly ConcurrentDictionary<string, IMvxViewModel> _subViewModels = new();
+
+        /// <summary>
+        /// Initializes a new instance of the WindowInformation class.
+        /// </summary>
+        /// <param name="window">The Window.</param>
+        /// <param name="rootFrame">The root frame of the window.</param>
+        /// <param name="viewModel">The viewmodel belonging to the root frame.</param>
+        public WindowInformation(Window window, IMvxWindowsFrame rootFrame, IMvxViewModel? viewModel)
+        {
+            this.Window = window;
+            this.RootFrame = rootFrame;
+            this.ViewModel = viewModel;
+        }
+
+        /// <summary>
+        /// Gets or sets the Window.
+        /// </summary>
+        public Window Window { get; }
+
+        /// <summary>
+        /// Gets or sets the root frame belonging to this window.
+        /// </summary>
+        public IMvxWindowsFrame RootFrame { get; }
+
+        /// <summary>
+        /// Gets or sets the ViewModel belonging to this window.
+        /// </summary>
+        public IMvxViewModel? ViewModel { get; }
+
+        /// <summary>
+        /// Registers the given viewmodel to a specific key (usually region name).
+        /// </summary>
+        /// <param name="key">The key to register the subview model under.</param>
+        /// <param name="viewModel">the viewmodel to register.</param>
+        public void RegisterSubViewModel(string key, IMvxViewModel viewModel)
+        {
+            this._subViewModels.AddOrUpdate(key, viewModel, (_,_) => viewModel);
+        }
+
+        /// <summary>
+        /// Gets a list of sub view models.
+        /// </summary>
+        /// <returns>The list of subview models currently registered.</returns>
+        public List<IMvxViewModel> GetSubViewModels()
+        {
+            return this._subViewModels.Values.ToList();
+        }
+
+        /// <summary>
+        /// Removes the viewmodel registration.
+        /// </summary>
+        /// <param name="key">The key to remove the viewmodel registration for.</param>
+        public void UnregisterSubViewModel(string key)
+        {
+            this._subViewModels.TryRemove(key, out _);
+        }
+
+        /// <summary>
+        /// Removes the viewmodel registration.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to remove the viewmodel registration for.</param>
+        public void UnregisterSubViewModel(IMvxViewModel viewModel)
+        {
+            var key = this._subViewModels.FirstOrDefault(v => v.Value == viewModel).Key;
+            if (key != null)
+            {
+                this.UnregisterSubViewModel(key);
+            }
+        }
+
+        /// <summary>
+        /// Checks if this instance belongs to the given Window.
+        /// </summary>
+        /// <param name="w">The window to check against.</param>
+        /// <returns>True if it is a match.</returns>
+        public bool IsFor(Window w)
+        {
+            return this.Window == w;
+        }
+
+        /// <summary>
+        /// Checks if this instance or any of the registered subViewModels belongs to the given viewmodel.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to check against.</param>
+        /// <returns>True if it is a match.</returns>
+        public bool IsFor(IMvxViewModel viewModel)
+        {
+            return this.ViewModel == viewModel || this._subViewModels.Any(v => v.Value == viewModel);
+        }
+    }
+}
+

--- a/MvvmCross/Platforms/WinUi/Presenters/MvxMultiWindowViewPresenter.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/MvxMultiWindowViewPresenter.cs
@@ -1,0 +1,772 @@
+#nullable enable
+
+using System.Windows;
+using Windows.Graphics;
+using Windows.Graphics.Display;
+using Windows.UI.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Animation;
+using MvvmCross.Base;
+using MvvmCross.Exceptions;
+using MvvmCross.Localization;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+using MvvmCross.Platforms.WinUi.Presenters.Attributes;
+using MvvmCross.Platforms.WinUi.Presenters.Models;
+using MvvmCross.Platforms.WinUi.Presenters.Utils;
+using MvvmCross.Platforms.WinUi.Views;
+using MvvmCross.Presenters;
+using MvvmCross.Presenters.Attributes;
+using MvvmCross.ViewModels;
+using MvvmCross.Views;
+using Control = Microsoft.UI.Xaml.Controls.Control;
+using HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment;
+using MvxApplication = MvvmCross.Platforms.WinUi.Views.MvxApplication;
+using Window = Microsoft.UI.Xaml.Window;
+
+namespace MvvmCross.Platforms.WinUi.Presenters
+{
+    /// <summary>
+    ///     Defines a view presenter with multi-windows support.
+    /// </summary>
+    public class MvxMultiWindowViewPresenter
+        : MvxAttributeViewPresenter, IMvxWindowsViewPresenter, IMvxMultiWindowsService
+    {
+        private const int DefaultWindowHeight = 456;
+        private const int DefaultWindowWidth = 786;
+
+        private const string DialogSubViewmodelName = "DIALOG_SUB_VIEWMODEL";
+        private const string WindowTitle = "WindowTitle";
+        private readonly ILogger<MvxWindowsViewPresenter>? _logger;
+        private readonly WindowInformation _mainFrame;
+        private readonly List<WindowInformation> _windowInformation = new();
+
+        private readonly object _windowInformationLock = new();
+
+        private IMvxViewModelLoader? _viewModelLoader;
+
+        /// <summary>
+        ///     Initializes a new instance of <see cref="MvxMultiWindowViewPresenter" />.
+        /// </summary>
+        /// <param name="rootFrame">The root frame.</param>
+        public MvxMultiWindowViewPresenter(IMvxWindowsFrame rootFrame)
+        {
+            var window = (Microsoft.UI.Xaml.Application.Current as MvxApplication)?.MainWindow;
+            this._mainFrame = new WindowInformation(window!, rootFrame, null);
+            this._logger = MvxLogHost.GetLog<MvxWindowsViewPresenter>();
+
+            if (Window.Current != null)
+            {
+                SystemNavigationManager.GetForCurrentView().BackRequested += this.BackButtonOnBackRequested;
+            }
+        }
+
+        /// <summary>
+        ///     Get or sets the viewmodel loader instance.
+        /// </summary>
+        public IMvxViewModelLoader? ViewModelLoader
+        {
+            get => this._viewModelLoader ??= Mvx.IoCProvider?.Resolve<IMvxViewModelLoader>();
+            set => this._viewModelLoader = value;
+        }
+
+        /// <summary>
+        ///     Creates a presentation attribute.
+        /// </summary>
+        /// <param name="viewModelType"></param>
+        /// <param name="viewType"></param>
+        /// <returns></returns>
+        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
+        {
+            this._logger?.LogTrace("PresentationAttribute not found for {viewTypeName}. Assuming new page presentation",
+                viewType.Name);
+            return new MvxPagePresentationAttribute { ViewType = viewType, ViewModelType = viewModelType };
+        }
+
+        /// <summary>
+        ///     Registers default attribute types.
+        /// </summary>
+        public override void RegisterAttributeTypes()
+        {
+            this.AttributeTypesToActionsDictionary.Register<MvxPagePresentationAttribute>(this.ShowPage,
+                this.ClosePage);
+            this.AttributeTypesToActionsDictionary.Register<MvxSplitViewPresentationAttribute>(this.ShowSplitView,
+                this.CloseSplitView);
+            this.AttributeTypesToActionsDictionary.Register<MvxRegionPresentationAttribute>(this.ShowRegionView,
+                this.CloseRegionView);
+            this.AttributeTypesToActionsDictionary.Register<MvxDialogViewPresentationAttribute>(this.ShowDialogAsync,
+                this.CloseDialog);
+            this.AttributeTypesToActionsDictionary.Add(
+                typeof(MvxNewWindowPresentationAttribute),
+                new MvxPresentationAttributeAction
+                {
+                    ShowAction = async (_, attribute, request) =>
+                    {
+                        if (attribute is not MvxNewWindowPresentationAttribute presentationAttribute)
+                        {
+                            return false;
+                        }
+
+                        await this.ShowNewWindowAsync(request, presentationAttribute);
+                        return true;
+                    },
+                    CloseAction = (viewModel, _) =>
+                    {
+                        viewModel.ViewDisappearing();
+                        viewModel.ViewDisappeared();
+                        viewModel.ViewDestroy();
+                        viewModel.DisposeIfDisposable();
+                        return Task.FromResult(true);
+                    }
+                });
+        }
+
+        /// <summary>
+        ///     Closes all windows, except the main window, and the view models belonging to those windows.
+        /// </summary>
+        public void CloseAllWindows()
+        {
+            List<WindowInformation> windows;
+            lock (this._windowInformation)
+            {
+                windows = this._windowInformation.ToList();
+            }
+
+            foreach (var wi in windows)
+            {
+                try
+                {
+                    this.CloseWindow(wi.Window);
+                }
+                catch (Exception)
+                {
+                    // Swallow all exceptions.
+                }
+
+                wi.Window.Close();
+            }
+        }
+
+        /// <summary>
+        ///     Creates a control for the given view type.
+        /// </summary>
+        /// <param name="viewType">The view type.</param>
+        /// <param name="request">The request.</param>
+        /// <param name="attribute">Any attributes.</param>
+        /// <returns></returns>
+        /// <exception cref="MvxException"></exception>
+        public virtual Control? CreateControl(Type viewType, MvxViewModelRequest request,
+            MvxBasePresentationAttribute attribute)
+        {
+            try
+            {
+                var control = Activator.CreateInstance(viewType) as Control;
+                if (control is IMvxView mvxControl)
+                {
+                    if (request is MvxViewModelInstanceRequest instanceRequest)
+                    {
+                        mvxControl.ViewModel = instanceRequest.ViewModelInstance;
+                    }
+                    else
+                    {
+                        mvxControl.ViewModel = this.ViewModelLoader?.LoadViewModel(request, null);
+                    }
+                }
+
+                return control;
+            }
+            catch (Exception ex)
+            {
+                throw new MvxException(ex,
+                    $"Cannot create Control '{viewType.FullName}'. Are you use the wrong base class?");
+            }
+        }
+
+        /// <summary>
+        ///     Executed when the onBack is requested.
+        /// </summary>
+        /// <param name="sender">The sender of the event.</param>
+        /// <param name="backRequestedEventArgs">The event arguments.</param>
+        protected virtual async void BackButtonOnBackRequested(object? sender,
+            BackRequestedEventArgs backRequestedEventArgs)
+        {
+            if (backRequestedEventArgs.Handled)
+            {
+                return;
+            }
+
+            var currentView = this.GetWindowInformation(Window.Current).RootFrame.Content as IMvxView;
+            if (currentView == null)
+            {
+                this._logger?.LogWarning("Ignoring close for viewmodel - root frame has no current page");
+                return;
+            }
+
+            var navigationService = Mvx.IoCProvider?.Resolve<IMvxNavigationService>();
+            if (navigationService != null && currentView.ViewModel != null)
+            {
+                backRequestedEventArgs.Handled = await navigationService.Close(currentView.ViewModel);
+            }
+        }
+
+        /// <summary>
+        ///     CLoses the dialog belonging to the given viewmodel.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to close the dialog for.</param>
+        /// <param name="attribute">The presentation attributes.</param>
+        /// <returns>True upon success, false otherwise.</returns>
+        protected virtual Task<bool> CloseDialog(IMvxViewModel viewModel, MvxBasePresentationAttribute attribute)
+        {
+            var windowInformation = this.GetWindowInformation(viewModel);
+            if (!(windowInformation.RootFrame.UnderlyingControl is Frame frame))
+            {
+                return Task.FromResult(false);
+            }
+
+            var popups = VisualTreeHelper.GetOpenPopupsForXamlRoot(frame.XamlRoot).FirstOrDefault(p =>
+            {
+                if (attribute.ViewType != null && attribute.ViewType.IsInstanceOfType(p.Child)
+                                               && p.Child is IMvxWindowsContentDialog dialog)
+                {
+                    return dialog.ViewModel == viewModel;
+                }
+
+                return false;
+            });
+
+            (popups?.Child as ContentDialog)?.Hide();
+            windowInformation.UnregisterSubViewModel(viewModel);
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        ///     Closes teh page for the given view model.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to close the page for.</param>
+        /// <param name="attribute">The presentation attributes</param>
+        /// <returns>True if closed, false otherwise.</returns>
+        protected virtual Task<bool> ClosePage(IMvxViewModel viewModel, MvxBasePresentationAttribute attribute)
+        {
+            var windowInformation = this.GetWindowInformation(viewModel);
+            var currentView = windowInformation.RootFrame.Content as IMvxView;
+            if (currentView == null)
+            {
+                this._logger?.LogWarning("Ignoring close for viewmodel - root frame has no current page");
+                return Task.FromResult(false);
+            }
+
+            if (currentView.ViewModel != viewModel)
+            {
+                this._logger?.LogWarning(
+                    "Ignoring close for viewmodel - root frame's current page is not the view for the requested viewmodel");
+                return Task.FromResult(false);
+            }
+
+            if (!windowInformation.RootFrame.CanGoBack)
+            {
+                this._logger?.LogWarning("Ignoring close for viewmodel - root frame refuses to go back");
+                return Task.FromResult(false);
+            }
+
+            windowInformation.RootFrame.GoBack();
+
+            this.HandleBackButtonVisibility();
+            windowInformation.UnregisterSubViewModel(viewModel);
+
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        ///     Closes the region view for the given viewmodel.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to close the region for.</param>
+        /// <param name="attribute">Any presentation attribute.</param>
+        /// <returns>True if successful. False otherwise.</returns>
+        /// <exception cref="MvxException">If no region is found for the given viewmodel.</exception>
+        protected virtual Task<bool> CloseRegionView(IMvxViewModel viewModel, MvxRegionPresentationAttribute attribute)
+        {
+            var windowInformation = this.GetWindowInformation(viewModel);
+            var viewFinder = Mvx.IoCProvider?.Resolve<IMvxViewsContainer>();
+            if (viewFinder == null)
+            {
+                return Task.FromResult(false);
+            }
+
+            var viewType = viewFinder.GetViewType(viewModel.GetType());
+            if (viewType.HasRegionAttribute())
+            {
+                var containerView =
+                    windowInformation.RootFrame.UnderlyingControl?.FindControl<Frame>(viewType.GetRegionName());
+
+                if (containerView == null)
+                {
+                    // This can happen if a parent view is already removed.
+                    return Task.FromResult(false);
+                }
+
+                if (containerView.CanGoBack)
+                {
+                    containerView.GoBack();
+                    if (containerView.BackStackDepth == 0)
+                    {
+                        if (containerView.ContentTransitions.Any(ct
+                                => ((ct as NavigationThemeTransition)?.DefaultNavigationTransitionInfo as
+                                       SlideNavigationTransitionInfo)?.Effect ==
+                                   SlideNavigationTransitionEffect.FromLeft))
+                        {
+                            containerView.HorizontalAlignment = HorizontalAlignment.Right;
+                        }
+
+                        containerView.HorizontalAlignment = HorizontalAlignment.Left;
+                    }
+
+                    windowInformation.UnregisterSubViewModel(viewModel);
+                    return Task.FromResult(true);
+                }
+            }
+
+            return this.ClosePage(viewModel, attribute);
+        }
+
+        /// <summary>
+        ///     Closes the splitview.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to close the splitview for.</param>
+        /// <param name="attribute">Any presentation attribute.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        protected virtual Task<bool> CloseSplitView(IMvxViewModel viewModel,
+            MvxSplitViewPresentationAttribute attribute)
+        {
+            return this.ClosePage(viewModel, attribute);
+        }
+
+        /// <summary>
+        ///     Converts a request to a string format.
+        ///     A Frame won't allow serialization of it's nav-state if it gets a non-simple type as a nav param
+        /// </summary>
+        /// <param name="request">The request to convert.</param>
+        /// <returns>A text representation of the request.</returns>
+        protected virtual string GetRequestText(MvxViewModelRequest request)
+        {
+            var requestTranslator = Mvx.IoCProvider?.Resolve<IMvxWindowsViewModelRequestTranslator>();
+            if (requestTranslator == null)
+            {
+                return "Request translator is not found";
+            }
+
+            string requestText;
+            requestText = request is MvxViewModelInstanceRequest
+                ? requestTranslator.GetRequestTextWithKeyFor(((MvxViewModelInstanceRequest)request).ViewModelInstance)
+                : requestTranslator.GetRequestTextFor(request);
+
+            return requestText;
+        }
+
+        /// <summary>
+        ///     Gets the correct root frame for the request.
+        ///     There is no window or viewmodel for the original root frame.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>The root frame, if no special root frame from a window is found the mainframe is returned.</returns>
+        protected WindowInformation GetWindowInformation(MvxViewModelRequest request)
+        {
+            lock (this._windowInformationLock)
+            {
+                var frame = this._mainFrame;
+                if (request is MvxViewModelInstanceRequestWithSource targetRequest)
+                {
+                    frame = this._windowInformation.Find(wi => wi.IsFor(targetRequest.Source)) ??
+                            this._mainFrame;
+                }
+
+                return frame;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the correct root frame for the request.
+        ///     There is no window or viewmodel for the original root frame.
+        /// </summary>
+        /// <param name="viewModel">The viewmodel to get the root frame for.</param>
+        /// <returns>The root frame, if no special root frame from a window is found the mainframe is returned.</returns>
+        protected WindowInformation GetWindowInformation(IMvxViewModel viewModel)
+        {
+            lock (this._windowInformationLock)
+            {
+                return this._windowInformation.Find(wi => wi.IsFor(viewModel)) ?? this._mainFrame;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the correct root frame for the request.
+        ///     There is no window or viewmodel for the original root frame.
+        /// </summary>
+        /// <param name="window">The window to get the root frame for.</param>
+        /// <returns>The root frame, if no special root frame from a window is found the mainframe is returned.</returns>
+        protected WindowInformation GetWindowInformation(Window window)
+        {
+            lock (this._windowInformationLock)
+            {
+                return this._windowInformation.Find(wi => wi.IsFor(window)) ?? this._mainFrame;
+            }
+        }
+
+        /// <summary>
+        ///     Updates the visibility state of the back button.
+        /// </summary>
+        protected virtual void HandleBackButtonVisibility()
+        {
+            if (Window.Current == null)
+            {
+                return;
+            }
+
+            var rootFrame = this.GetWindowInformation(Window.Current).RootFrame;
+
+            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
+                rootFrame.CanGoBack ? AppViewBackButtonVisibility.Visible : AppViewBackButtonVisibility.Collapsed;
+        }
+
+        /// <summary>
+        ///     Shows a dialog for the given request.
+        /// </summary>
+        /// <param name="viewType">The type of the content.</param>
+        /// <param name="attribute">Any presentation attribute.</param>
+        /// <param name="request">The request to show the dialog for.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        protected virtual async Task<bool> ShowDialogAsync(Type viewType, MvxDialogViewPresentationAttribute attribute,
+            MvxViewModelRequest request)
+        {
+            try
+            {
+                var contentDialog = this.CreateControl(viewType, request, attribute) as ContentDialog;
+
+                if (contentDialog != null)
+                {
+                    var windowInfo = this.GetWindowInformation(request);
+                    if (windowInfo.RootFrame.UnderlyingControl is Frame frame)
+                    {
+                        contentDialog.XamlRoot = frame.XamlRoot;
+                    }
+
+                    await contentDialog.ShowAsync(attribute.Placement);
+                    if (contentDialog is IMvxView mvxControl && mvxControl.ViewModel != null)
+                    {
+                        windowInfo.RegisterSubViewModel(DialogSubViewmodelName, mvxControl.ViewModel);
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
+            catch (Exception exception)
+            {
+                this._logger?.LogTrace(exception, "Error seen during navigation request to {viewModelTypeName}",
+                    request.ViewModelType?.Name ?? "ViewModelType is null.");
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Shows a page for the given request.
+        /// </summary>
+        /// <param name="viewType">The type of the content.</param>
+        /// <param name="attribute">Any presentation attribute.</param>
+        /// <param name="request">The request to show the page.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        protected virtual Task<bool> ShowPage(Type viewType, MvxBasePresentationAttribute attribute,
+            MvxViewModelRequest request)
+        {
+            return this.ShowPage(this.GetWindowInformation(request).RootFrame, viewType, request);
+        }
+
+        /// <summary>
+        ///     Shows content in a region.
+        /// </summary>
+        /// <param name="viewType">The type of content to show.</param>
+        /// <param name="attribute">Any presentation attributes.</param>
+        /// <param name="request">The request.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        protected virtual Task<bool> ShowRegionView(Type viewType, MvxRegionPresentationAttribute attribute,
+            MvxViewModelRequest request)
+        {
+            if (viewType.HasRegionAttribute())
+            {
+                var windowInformation = this.GetWindowInformation(request);
+                var requestText = this.GetRequestText(request);
+                var containerView =
+                    windowInformation.RootFrame.UnderlyingControl.FindControl<Frame>(viewType.GetRegionName());
+                if (request is MvxViewModelInstanceRequestWithSource targetRequest &&
+                    targetRequest.ViewModelInstance != null)
+                {
+                    windowInformation.RegisterSubViewModel(viewType.GetRegionName(), targetRequest.ViewModelInstance);
+                }
+
+                if (containerView != null)
+                {
+                    containerView.Navigate(viewType, requestText);
+
+                    containerView.HorizontalAlignment = HorizontalAlignment.Stretch;
+                    return Task.FromResult(true);
+                }
+            }
+
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        ///     Shows a splitview.
+        /// </summary>
+        /// <param name="viewType">The type of content to show.</param>
+        /// <param name="attribute">Any presentation attributes.</param>
+        /// <param name="request">The request.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        protected virtual Task<bool> ShowSplitView(Type viewType, MvxSplitViewPresentationAttribute attribute,
+            MvxViewModelRequest request)
+        {
+            var windowInformation = this.GetWindowInformation(request);
+            if (windowInformation.RootFrame.Content is MvxWindowsPage currentPage)
+            {
+                var splitView = currentPage.Content.FindControl<SplitView>();
+                if (splitView == null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                if (attribute.Position == SplitPanePosition.Content)
+                {
+                    var nestedFrame = splitView.Content as Frame;
+                    if (nestedFrame == null)
+                    {
+                        nestedFrame = new Frame();
+                        splitView.Content = nestedFrame;
+                    }
+
+                    var requestText = this.GetRequestText(request);
+                    nestedFrame.Navigate(viewType, requestText);
+
+                    if (request is MvxViewModelInstanceRequest instanceReq && instanceReq.ViewModelInstance != null)
+                    {
+                        windowInformation.RegisterSubViewModel(SplitPanePosition.Content.ToString(),
+                            instanceReq.ViewModelInstance);
+                    }
+                }
+                else if (attribute.Position == SplitPanePosition.Pane)
+                {
+                    var nestedFrame = splitView.Pane as Frame;
+                    if (nestedFrame == null)
+                    {
+                        nestedFrame = new Frame();
+                        splitView.Pane = nestedFrame;
+                    }
+
+                    var requestText = this.GetRequestText(request);
+                    nestedFrame.Navigate(viewType, requestText);
+
+                    if (request is MvxViewModelInstanceRequest instanceReq && instanceReq.ViewModelInstance != null)
+                    {
+                        windowInformation.RegisterSubViewModel(SplitPanePosition.Pane.ToString(),
+                            instanceReq.ViewModelInstance);
+                    }
+                }
+            }
+
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        ///     Invokes a given function on the target <see cref="DispatcherQueue" /> and returns a
+        ///     <see cref="Task" /> that completes when the invocation of the function is completed.
+        /// </summary>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue" /> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Action" /> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task" /> that completes when the invocation of <paramref name="function" /> is over.</returns>
+        /// <remarks>
+        ///     If the current thread has access to <paramref name="dispatcher" />, <paramref name="function" /> will be
+        ///     invoked directly.
+        /// </remarks>
+        private static Task EnqueueAsync(DispatcherQueue dispatcher, Action function,
+            DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            // Run the function directly when we have thread access.
+            // Also reuse Task.CompletedTask in case of success,
+            // to skip an unnecessary heap allocation for every invocation.
+            if (dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    function();
+
+                    return Task.CompletedTask;
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
+            }
+
+            static Task TryEnqueue(DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<object?>();
+
+                if (!dispatcher.TryEnqueue(
+                        priority,
+                        () =>
+                        {
+                            try
+                            {
+                                function();
+
+                                taskCompletionSource.SetResult(null);
+                            }
+                            catch (Exception e)
+                            {
+                                taskCompletionSource.SetException(e);
+                            }
+                        }))
+                {
+                    taskCompletionSource.SetException(new Exception("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueue(dispatcher, function, priority);
+        }
+
+        private void CloseWindow(Window newWindow)
+        {
+            var windowInformation = this.GetWindowInformation(newWindow);
+            windowInformation.GetSubViewModels().ForEach(subModel => { this.Close(subModel); });
+            if (windowInformation.ViewModel != null)
+            {
+                this.Close(windowInformation.ViewModel);
+            }
+        }
+
+        private async Task ShowNewWindowAsync(MvxViewModelRequest request, MvxNewWindowPresentationAttribute attribute)
+        {
+            var newWindow = new Window();
+            var viewsContainer = Mvx.IoCProvider!.Resolve<IMvxViewsContainer>();
+            var viewType = viewsContainer?.GetViewType(request.ViewModelType);
+            if (viewType == null)
+            {
+                return;
+            }
+
+            var frame = new MvxWrappedFrame(new Frame());
+            await this.ShowPage(frame, viewType, request);
+
+            newWindow.Content = frame.UnderlyingControl;
+
+            var page = (Page)frame.Content;
+            var appWindow = AppWindowUtils.GetAppWindowForCurrentWindow(newWindow);
+
+            if (page.DataContext is IMvxLocalizedTextSourceOwner viewModel)
+            {
+                appWindow.Title = viewModel.LocalizedTextSource.GetText(WindowTitle);
+            }
+
+            // Set size of new window based on the main window.
+            AppWindowUtils.TryGetAppWindow(out var mainWindow);
+
+            if (mainWindow is null)
+            {
+                return;
+            }
+
+            double scaleFactor = appWindow.ClientSize.Width / newWindow.Bounds.Width;
+            //if (Screen.PrimaryScreen != default)
+            //{
+            //    scaleFactor = Screen.PrimaryScreen.Bounds.Width / SystemParameters.PrimaryScreenWidth;
+            //}
+
+            var height = attribute.Height.HasValue
+                ? attribute.Height.Value * scaleFactor
+                : DefaultWindowHeight * scaleFactor;
+            var width = attribute.Width.HasValue
+                ? attribute.Width.Value * scaleFactor
+                : DefaultWindowWidth * scaleFactor;
+
+            var size = new SizeInt32((int)width, (int)height);
+            appWindow.ResizeClient(size);
+
+            // NOTE: This line comes from the community toolkit which is not installed. So we Copied it in.
+            // await newWindow.DispatcherQueue.EnqueueAsync(newWindow.Activate);
+            await EnqueueAsync(newWindow.DispatcherQueue, newWindow.Activate);
+
+            var model = (IMvxViewModel)page.DataContext;
+
+            lock (this._windowInformationLock)
+            {
+                this._windowInformation.Add(new WindowInformation(newWindow, frame, model));
+            }
+
+            if (page is INeedWindow needWindow)
+            {
+                needWindow.SetWindow(newWindow, appWindow);
+            }
+
+            // Closing will be handled before Closed of the Window.
+            appWindow.Closing += (_, e) =>
+            {
+                if (page is INeedWindow needWindow2 && !needWindow2.CanClose())
+                {
+                    e.Cancel = true;
+                    return;
+                }
+
+                this.CloseWindow(newWindow);
+            };
+
+            newWindow.Closed += (_, _) =>
+            {
+                page.DisposeIfDisposable();
+
+                lock (this._windowInformationLock)
+                {
+                    this._windowInformation.Remove(this.GetWindowInformation(model));
+                }
+            };
+        }
+
+        /// <summary>
+        ///     Shows a page for the given request.
+        /// </summary>
+        /// <param name="rootFrame">The root frame to show the page in.</param>
+        /// <param name="viewType">The type of the content.</param>
+        /// <param name="request">The request to show the page.</param>
+        /// <returns>True if successful, false otherwise.</returns>
+        // ReSharper disable once UnusedParameter.Local
+        private Task<bool> ShowPage(IMvxWindowsFrame rootFrame, Type viewType, MvxViewModelRequest request)
+        {
+            try
+            {
+                var requestText = this.GetRequestText(request);
+
+                rootFrame.Navigate(viewType,
+                    requestText); //Frame won't allow serialization of it's nav-state if it gets a non-simple type as a nav param
+
+                this.HandleBackButtonVisibility();
+                return Task.FromResult(true);
+            }
+            catch (Exception exception)
+            {
+                this._logger?.LogTrace(exception, "Error seen during navigation request to {viewModelTypeName}",
+                    request.ViewModelType?.Name ?? "No view model type specified.");
+                return Task.FromResult(false);
+            }
+        }
+
+        /// <inheritdoc />
+        public Window GetWindow(IMvxViewModel viewModel)
+        {
+            return this.GetWindowInformation(viewModel).Window;
+        }
+    }
+}

--- a/MvvmCross/Platforms/WinUi/Presenters/MvxWindowsViewPresenter.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/MvxWindowsViewPresenter.cs
@@ -19,6 +19,7 @@ using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 using Windows.UI.Core;
+using Control = Microsoft.UI.Xaml.Controls.Control;
 
 namespace MvvmCross.Platforms.WinUi.Presenters
 {

--- a/MvvmCross/Platforms/WinUi/Presenters/Utils/AppWindowUtils.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/Utils/AppWindowUtils.cs
@@ -1,0 +1,71 @@
+#nullable enable
+using System.Reflection;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using MvvmCross.Platforms.WinUi.Views;
+using WinRT.Interop;
+using Application = Microsoft.UI.Xaml.Application;
+
+namespace MvvmCross.Platforms.WinUi.Presenters.Utils
+{
+
+    /// <summary>
+    /// Extension methods for MvxWindowsPage.
+    /// </summary>
+    public static class AppWindowUtils
+    {
+        /// <summary>
+        /// Try to get the <see cref="AppWindow"/> based on the currently opened window.
+        /// </summary>
+        /// <param name="appWindow">The AppWindow.</param>
+        /// <returns>False if no AppWindow can be retrieved.</returns>
+        public static bool TryGetAppWindow(out AppWindow? appWindow)
+        {
+            Window? mainWidow = (Application.Current as MvxApplication)?.MainWindow;
+            appWindow = null;
+
+            if (mainWidow is not null)
+            {
+                appWindow = GetAppWindowForCurrentWindow(mainWidow);
+            }
+
+            return appWindow is not null;
+        }
+
+        /// <summary>
+        /// Sets the TitleBar of the app depending on the given parameters.
+        /// </summary>
+        /// <param name="appWindow">Optional appWindow.</param>
+        /// <param name="iconPath">The path to the icon.</param>
+        public static void SetTitleBar(AppWindow? appWindow = null, string? iconPath = null)
+        {
+            if (appWindow is null && !TryGetAppWindow(out appWindow))
+            {
+                return;
+            }
+            
+            if (string.IsNullOrEmpty(appWindow!.Title))
+            {
+                appWindow.Title = Assembly.GetEntryAssembly()?.GetName().Name ?? "Bronkhorst FlowSuite 2";
+            }
+
+            if (iconPath != null)
+            {
+                appWindow.SetIcon(iconPath);
+            }
+        }
+
+        /// <summary>
+        /// Get the <see cref="AppWindow"/> based on a window.
+        /// </summary>
+        /// <param name="window">The window.</param>
+        /// <returns>The appWindow.</returns>
+        public static AppWindow GetAppWindowForCurrentWindow(Window window)
+        {
+            IntPtr hWnd = WindowNative.GetWindowHandle(window);
+            WindowId wndId = Win32Interop.GetWindowIdFromWindow(hWnd);
+            return AppWindow.GetFromWindowId(wndId);
+        }
+    }
+}

--- a/MvvmCross/Platforms/WinUi/Views/IMvxWindowsFrame.cs
+++ b/MvvmCross/Platforms/WinUi/Views/IMvxWindowsFrame.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Control = Microsoft.UI.Xaml.Controls.Control;
 
 namespace MvvmCross.Platforms.WinUi.Views
 {

--- a/MvvmCross/Platforms/WinUi/Views/MvxWrappedFrame.cs
+++ b/MvvmCross/Platforms/WinUi/Views/MvxWrappedFrame.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Control = Microsoft.UI.Xaml.Controls.Control;
 
 namespace MvvmCross.Platforms.WinUi.Views
 {

--- a/MvvmCross/ViewModels/MvxViewModelInstanceRequestWithSource.cs
+++ b/MvvmCross/ViewModels/MvxViewModelInstanceRequestWithSource.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace MvvmCross.ViewModels
+{
+
+    /// <summary>
+    ///     Extension of MvxViewModelInstanceRequest with a target.
+    /// </summary>
+    public class MvxViewModelInstanceRequestWithSource : MvxViewModelInstanceRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="MvxViewModelInstanceRequestWithSource"/>
+        /// </summary>
+        /// <param name="viewModelType">The viewmodel type.</param>
+        /// <param name="source">The instance of the viewmodel which is the source of the request.</param>
+        public MvxViewModelInstanceRequestWithSource(Type viewModelType, IMvxViewModel source) : base(viewModelType)
+        {
+            this.Source = source;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MvxViewModelInstanceRequestWithSource"/>
+        /// </summary>
+        /// <param name="viewModelInstance">The viewmodel instance.</param>
+        /// <param name="source">The instance of the viewmodel which is the source of the request.</param>
+        public MvxViewModelInstanceRequestWithSource(IMvxViewModel viewModelInstance, IMvxViewModel source) : base(viewModelInstance)
+        {
+            this.Source = source;
+        }
+
+        /// <summary>
+        ///     The instance of the viewmodel which is the source of the request.
+        /// </summary>
+        public IMvxViewModel Source { get; }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/RegionViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/RegionViewModel.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels.Navigation
+{
+    public class RegionViewModel : MvxNavigationViewModel
+    {
+        public RegionViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : base(logFactory, navigationService)
+        {
+        }
+
+        public IMvxAsyncCommand CloseRegionCommand =>
+            new MvxAsyncCommand(() => this.NavigationService.Close(this));
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/NewWindowViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/NewWindowViewModel.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+using Playground.Core.ViewModels.Navigation;
+
+namespace Playground.Core.ViewModels
+{
+    public class NewWindowViewModel : MvxNavigationViewModel
+    {
+        private string _welcomeText = "Default welcome";
+
+        public NewWindowViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : base(logFactory, navigationService)
+        {
+        }
+
+        public IMvxAsyncCommand ShowRegionCommand =>
+            new MvxAsyncCommand(() => this.NavigationService.Navigate<RegionViewModel>(this));
+
+        public string WelcomeText
+        {
+            get => _welcomeText;
+            set
+            {
+                ShouldLogInpc(true);
+                SetProperty(ref _welcomeText, value);
+                ShouldLogInpc(false);
+            }
+        }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -151,6 +151,11 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowConvertersCommand =>
             new MvxAsyncCommand(() => NavigationService.Navigate<ConvertersViewModel>());
 
+        public IMvxAsyncCommand ShowNewWindowCommand =>
+            new MvxAsyncCommand(() => NavigationService.Navigate<NewWindowViewModel>());
+        public IMvxAsyncCommand ShowRegionCommand =>
+            new MvxAsyncCommand(() => this.NavigationService.Navigate<RegionViewModel>(this));
+
         public IMvxAsyncCommand ShowSharedElementsCommand { get; }
 
         public IMvxAsyncCommand ShowFluentBindingCommand { get; }

--- a/Projects/Playground/Playground.WinUi3/Playground.WinUi3.csproj
+++ b/Projects/Playground/Playground.WinUi3/Playground.WinUi3.csproj
@@ -7,8 +7,14 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="Views\BlankPage.xaml" />
+    <None Remove="Views\NewWindow.xaml" />
+    <None Remove="Views\RegionView.xaml" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
@@ -26,5 +32,20 @@
        package has not yet been restored -->
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\BlankPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\RegionView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\NewWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 </Project>

--- a/Projects/Playground/Playground.WinUi3/Views/BlankPage.xaml
+++ b/Projects/Playground/Playground.WinUi3/Views/BlankPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="Playground.WinUi3.Views.BlankPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Playground.WinUi3.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+
+    </Grid>
+</Page>

--- a/Projects/Playground/Playground.WinUi3/Views/BlankPage.xaml.cs
+++ b/Projects/Playground/Playground.WinUi3/Views/BlankPage.xaml.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace Playground.WinUi3.Views
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class BlankPage : Page
+    {
+        public BlankPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/Projects/Playground/Playground.WinUi3/Views/NewWindow.xaml
+++ b/Projects/Playground/Playground.WinUi3/Views/NewWindow.xaml
@@ -1,0 +1,24 @@
+<app:NewWindowPage x:Class="Playground.WinUi3.Views.NewWindow"
+                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                   xmlns:app="using:Playground.WinUi3.Views"
+                   mc:Ignorable="d">
+    <StackPanel>
+        <TextBlock Text="{StaticResource WelcomeText}" />
+        <Button Content="Show Region"
+                Command="{Binding ShowRegionCommand}"
+                Margin="5"
+                Padding="5" />
+        <Frame HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Visibility="Visible" x:Name="PopupLocation">
+            <Frame.ContentTransitions>
+                <TransitionCollection>
+                    <NavigationThemeTransition>
+                        <SuppressNavigationTransitionInfo></SuppressNavigationTransitionInfo>
+                    </NavigationThemeTransition>
+                </TransitionCollection>
+            </Frame.ContentTransitions>
+        </Frame>
+    </StackPanel>
+</app:NewWindowPage>

--- a/Projects/Playground/Playground.WinUi3/Views/NewWindow.xaml.cs
+++ b/Projects/Playground/Playground.WinUi3/Views/NewWindow.xaml.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Windowing;
+using MvvmCross.Platforms.WinUi.Presenters.Attributes;
+using MvvmCross.Platforms.WinUi.Presenters.Models;
+using MvvmCross.Platforms.WinUi.Presenters.Utils;
+using MvvmCross.Platforms.WinUi.Views;
+using MvvmCross.ViewModels;
+using Playground.Core.ViewModels;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace Playground.WinUi3.Views
+{
+    [MvxViewFor(typeof(NewWindowViewModel))]
+    [MvxNewWindowPresentation]
+    public sealed partial class NewWindow : NewWindowPage, INeedWindow
+    {
+        public NewWindow()
+        {
+            this.InitializeComponent();
+            this.PopupLocation.Navigate(typeof(BlankPage));
+        }
+
+        public void SetWindow(Window window, AppWindow appWindow)
+        {
+            this.AppWindow = appWindow;
+            AppWindowUtils.SetTitleBar(appWindow, "Hello new window");
+        }
+
+        public AppWindow AppWindow { get; set; }
+
+        public bool CanClose()
+        {
+            return true;
+        }
+    }
+
+
+    public abstract class NewWindowPage : MvxWindowsPage<NewWindowViewModel>
+    {
+    }
+}

--- a/Projects/Playground/Playground.WinUi3/Views/RegionView.xaml
+++ b/Projects/Playground/Playground.WinUi3/Views/RegionView.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<app:RegionViewPage
+    x:Class="Playground.WinUi3.Views.RegionView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Playground.WinUi3.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:app="using:Playground.WinUi3.Views"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+        <TextBlock Text="Region is here."></TextBlock>
+        <Button Content="Close region" Command="{Binding CloseRegionCommand}"></Button>
+    </StackPanel>
+</app:RegionViewPage>

--- a/Projects/Playground/Playground.WinUi3/Views/RegionView.xaml.cs
+++ b/Projects/Playground/Playground.WinUi3/Views/RegionView.xaml.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using MvvmCross.Platforms.WinUi.Presenters.Attributes;
+using MvvmCross.Platforms.WinUi.Views;
+using MvvmCross.ViewModels;
+using Playground.Core.ViewModels;
+using Playground.Core.ViewModels.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace Playground.WinUi3.Views
+{
+    [MvxViewFor(typeof(RegionViewModel))]
+    [MvxRegionPresentation("PopupLocation")]
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class RegionView : RegionViewPage
+    {
+        public RegionView()
+        {
+            this.InitializeComponent();
+        }
+    }
+
+    public abstract class RegionViewPage : MvxWindowsPage<RegionViewModel>;
+}

--- a/Projects/Playground/Playground.WinUi3/Views/RootView.xaml
+++ b/Projects/Playground/Playground.WinUi3/Views/RootView.xaml
@@ -16,11 +16,18 @@
                 Command="{Binding ShowSplitCommand}"
                 Margin="5"
                 Padding="5" />
-        <Button Content="Show Modaliew"
+        <Button Content="Show ModalView"
                 Command="{Binding ShowModalCommand}"
                 Margin="5"
                 Padding="5" />
-
+        <Button Content="Show RegionView"
+                Command="{Binding ShowRegionCommand}"
+                Margin="5"
+                Padding="5" />
+        <Button Content="Show new window"
+                Command="{Binding ShowNewWindowCommand}"
+                Margin="5"
+                Padding="5" />
         <Button Content="Register and Resolve With Reflection"
                 Command="{Binding RegisterAndResolveWithReflectionCommand}"
                 Margin="5"
@@ -32,5 +39,15 @@
         <TextBlock Text="{Binding TimeToRegister}" />
         <TextBlock Text="{Binding TimeToResolve}" />
         <TextBlock Text="{Binding TotalTime}" />
+        <Frame HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Visibility="Visible" x:Name="PopupLocation">
+            <Frame.ContentTransitions>
+                <TransitionCollection>
+                    <NavigationThemeTransition>
+                        <SuppressNavigationTransitionInfo></SuppressNavigationTransitionInfo>
+                    </NavigationThemeTransition>
+                </TransitionCollection>
+            </Frame.ContentTransitions>
+        </Frame>
+
     </StackPanel>
 </app:RootViewPage>

--- a/Projects/Playground/Playground.WinUi3/Views/RootView.xaml.cs
+++ b/Projects/Playground/Playground.WinUi3/Views/RootView.xaml.cs
@@ -2,6 +2,7 @@ using MvvmCross.Platforms.WinUi.Presenters.Attributes;
 using MvvmCross.Platforms.WinUi.Views;
 using MvvmCross.ViewModels;
 using Playground.Core.ViewModels;
+using Playground.WinUi3.Views;
 
 namespace Playground.WinUi.Views
 {
@@ -12,6 +13,7 @@ namespace Playground.WinUi.Views
         public RootView()
         {
             this.InitializeComponent();
+            this.PopupLocation.Navigate(typeof(BlankPage));
         }
     }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
I have added support for navigating to a view that opens in a new window. Also supports navigation inside the new window. The same viewmodel can therefore be used to navigate to from multiple different windows. (You do get a new viewmodel instance each time of course)

### :arrow_heading_down: What is the current behavior?
There is no multi window support

### :new: What is the new behavior (if this is a feature change)?
We will now support multiple windows.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
The Playground app for Windows is updated with samples. I recommend testing more advanced navigation scenarios.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
