### PR TITLE
Use structured logging

### DIFF
--- a/MvvmCross.DroidX/RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.DroidX/RecyclerView/MvxRecyclerAdapter.cs
@@ -319,7 +319,7 @@ public class MvxRecyclerAdapter
 
         if (value != null && value is not IList)
         {
-            MvxBindingLog.Warning("Binding to IEnumerable rather than IList - this can be inefficient, especially for large lists");
+            MvxAndroidLog.Instance?.LogWarning("Binding to IEnumerable rather than IList - this can be inefficient, especially for large lists");
         }
 
         if (value is INotifyCollectionChanged newObservable)

--- a/MvvmCross.Plugins/FieldBinding/MvxFieldSourceBindingFactoryExtension.cs
+++ b/MvvmCross.Plugins/FieldBinding/MvxFieldSourceBindingFactoryExtension.cs
@@ -5,10 +5,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Source;
 using MvvmCross.Binding.Bindings.Source.Construction;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
+using MvvmCross.Logging;
 
 namespace MvvmCross.Plugin.FieldBinding
 {
@@ -69,7 +71,8 @@ namespace MvvmCross.Plugin.FieldBinding
             var fieldValue = fieldInfo.GetValue(source) as INotifyChange;
             if (fieldValue == null)
             {
-                MvxBindingLog.Warning("INotifyChange is null for {0}", propertyNameToken.PropertyName);
+                MvxLogHost.GetLog("MvxBind")?.LogWarning("INotifyChange is null for {PropertyName}",
+                    propertyNameToken.PropertyName);
                 result = null;
                 return false;
             }

--- a/MvvmCross.Plugins/JsonLocalization/MvxTextProviderBuilder.cs
+++ b/MvvmCross.Plugins/JsonLocalization/MvxTextProviderBuilder.cs
@@ -56,8 +56,8 @@ namespace MvvmCross.Plugin.JsonLocalization
                 }
                 catch (Exception exception)
                 {
-                    MvxPluginLog.Instance?.Log(LogLevel.Warning, "Language file could not be loaded for {0}.{1} - {2}",
-                                   whichLocalizationFolder, kvp.Key, exception.ToLongString());
+                    MvxPluginLog.Instance?.LogWarning(exception, "Language file could not be loaded for {FolderName}.{FileName}",
+                                   whichLocalizationFolder, kvp.Key);
                 }
             }
         }

--- a/MvvmCross/Base/MvxMainThreadDispatcher.cs
+++ b/MvvmCross/Base/MvxMainThreadDispatcher.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
-using MvvmCross.Exceptions;
 using MvvmCross.Logging;
 
 namespace MvvmCross.Base
@@ -24,17 +22,17 @@ namespace MvvmCross.Base
             }
             catch (TargetInvocationException exception)
             {
-                MvxLogHost.Default?.Log(LogLevel.Warning, "Exception thrown when invoking action via dispatcher", exception);
+                MvxLogHost.Default?.LogWarning(exception, "Exception thrown when invoking action via dispatcher");
                 if (maskExceptions)
-                    MvxLogHost.Default?.Log(LogLevel.Warning, "TargetInvocationException masked " + exception.InnerException.ToLongString());
+                    MvxLogHost.Default?.LogWarning(exception.InnerException, "TargetInvocationException masked");
                 else
                     throw;
             }
             catch (Exception exception)
             {
-                MvxLogHost.Default?.Log(LogLevel.Warning, "Exception thrown when invoking action via dispatcher", exception);
+                MvxLogHost.Default?.LogWarning(exception, "Exception thrown when invoking action via dispatcher");
                 if (maskExceptions)
-                    MvxLogHost.Default?.Log(LogLevel.Warning, "Exception masked " + exception.ToLongString());
+                    MvxLogHost.Default?.LogWarning(exception, "Exception masked");
                 else
                     throw;
             }

--- a/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
+++ b/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
@@ -86,7 +86,7 @@ namespace MvvmCross.Binding.Binders
                     if (pair.Type.ContainsGenericParameters) continue;
 
                     var converter = Activator.CreateInstance(pair.Type) as T;
-                    MvxBindingLog.Trace("Registering value converter {0}:{1}", pair.Name, pair.Type.Name);
+                    MvxBindingLog.Instance?.LogTrace("Registering value converter {Name}:{Type}", pair.Name, pair.Type.Name);
                     registry.AddOrOverwrite(pair.Name, converter);
                 }
                 catch (Exception ex)

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.Bindings;
 using MvvmCross.Binding.Combiners;
@@ -165,7 +166,7 @@ namespace MvvmCross.Binding.BindingContext
 
             if (newBindingDescription.Count > 1)
             {
-                MvxBindingLog.Warning("More than one description found - only first will be used in {0}", bindingDescription);
+                MvxBindingLog.Instance?.LogWarning("More than one description found - only first will be used in: {BindingDescription}", bindingDescription);
             }
 
             return FullyDescribed(newBindingDescription.FirstOrDefault());
@@ -300,7 +301,9 @@ namespace MvvmCross.Binding.BindingContext
 
             if (newBindingDescription.Count > 1)
             {
-                MvxBindingLog.Warning("More than one description found - only first will be used in {0}", bindingDescription);
+                MvxBindingLog.Instance?.LogWarning(
+                    "More than one description found - only first will be used in: {BindingDescription}",
+                    bindingDescription);
             }
 
             return FullyDescribed(newBindingDescription.FirstOrDefault());

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Binding.Bindings;
 
@@ -76,7 +77,8 @@ namespace MvvmCross.Binding.BindingContext
                 }
                 else
                 {
-                    MvxBindingLog.Warning("Fluent binding description must implement {0} in order to add {1}",
+                    MvxBindingLog.Instance?.LogWarning(
+                        "Fluent binding description must implement {InterfaceName} in order to add {Description}",
                         nameof(IMvxBaseFluentBindingDescription),
                         nameof(IMvxBaseFluentBindingDescription.ClearBindingKey));
                 }

--- a/MvvmCross/Binding/Bindings/MvxBindingModeExtensions.cs
+++ b/MvvmCross/Binding/Bindings/MvxBindingModeExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 
 namespace MvvmCross.Binding.Bindings
@@ -20,7 +21,7 @@ namespace MvvmCross.Binding.Bindings
             switch (bindingMode)
             {
                 case MvxBindingMode.Default:
-                    MvxBindingLog.Warning("Mode of default seen for binding - assuming TwoWay");
+                    MvxBindingLog.Instance?.LogWarning("Mode of default seen for binding - assuming TwoWay");
                     return true;
 
                 case MvxBindingMode.OneWay:
@@ -41,7 +42,7 @@ namespace MvvmCross.Binding.Bindings
             switch (bindingMode)
             {
                 case MvxBindingMode.Default:
-                    MvxBindingLog.Warning("Mode of default seen for binding - assuming TwoWay");
+                    MvxBindingLog.Instance?.LogWarning("Mode of default seen for binding - assuming TwoWay");
                     return true;
 
                 case MvxBindingMode.OneWay:
@@ -62,7 +63,7 @@ namespace MvvmCross.Binding.Bindings
             switch (bindingMode)
             {
                 case MvxBindingMode.Default:
-                    MvxBindingLog.Warning("Mode of default seen for binding - assuming TwoWay");
+                    MvxBindingLog.Instance?.LogWarning("Mode of default seen for binding - assuming TwoWay");
                     return true;
 
                 case MvxBindingMode.OneWay:

--- a/MvvmCross/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Binding/Bindings/MvxFullBinding.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
@@ -118,7 +119,7 @@ namespace MvvmCross.Binding.Bindings
                 }
                 catch (Exception exception)
                 {
-                    MvxBindingLog.Trace("Exception masked in UpdateTargetOnBind {0}", exception.ToLongString());
+                    MvxBindingLog.Instance?.LogTrace(exception, "Exception masked in UpdateTargetOnBind {ExceptionMessage}", exception.ToLongString());
                 }
             }
         }
@@ -147,7 +148,7 @@ namespace MvvmCross.Binding.Bindings
 
             if (_targetBinding == null)
             {
-                MvxBindingLog.Warning("Failed to create target binding for {0}", _bindingDescription.ToString());
+                MvxBindingLog.Instance?.LogWarning("Failed to create target binding for {BindingDescription}", _bindingDescription.ToString());
                 _targetBinding = new MvxNullTargetBinding();
             }
 
@@ -183,8 +184,9 @@ namespace MvvmCross.Binding.Bindings
                 }
                 catch (Exception exception)
                 {
-                    MvxBindingLog.Error(
-                        "Problem seen during binding execution for {0} - problem {1}",
+                    MvxBindingLog.Instance?.LogError(
+                        exception,
+                        "Problem seen during binding execution for {BindingDescription} - problem {ExceptionMessage}",
                         _bindingDescription.ToString(),
                         exception.ToLongString());
                 }
@@ -205,8 +207,9 @@ namespace MvvmCross.Binding.Bindings
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Error(
-                    "Problem seen during binding execution for {0} - problem {1}",
+                MvxBindingLog.Instance?.LogError(
+                    exception,
+                    "Problem seen during binding execution for {BindingDescription} - problem {ExceptionMessage}",
                     _bindingDescription.ToString(),
                     exception.ToLongString());
             }

--- a/MvvmCross/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Binding/Bindings/MvxFullBinding.cs
@@ -119,7 +119,7 @@ namespace MvvmCross.Binding.Bindings
                 }
                 catch (Exception exception)
                 {
-                    MvxBindingLog.Instance?.LogTrace(exception, "Exception masked in UpdateTargetOnBind {ExceptionMessage}", exception.ToLongString());
+                    MvxBindingLog.Instance?.LogTrace(exception, "Exception masked in UpdateTargetOnBind");
                 }
             }
         }
@@ -186,9 +186,8 @@ namespace MvvmCross.Binding.Bindings
                 {
                     MvxBindingLog.Instance?.LogError(
                         exception,
-                        "Problem seen during binding execution for {BindingDescription} - problem {ExceptionMessage}",
-                        _bindingDescription.ToString(),
-                        exception.ToLongString());
+                        "Problem seen during binding execution for {BindingDescription}",
+                        _bindingDescription.ToString());
                 }
             });
         }
@@ -209,9 +208,8 @@ namespace MvvmCross.Binding.Bindings
             {
                 MvxBindingLog.Instance?.LogError(
                     exception,
-                    "Problem seen during binding execution for {BindingDescription} - problem {ExceptionMessage}",
-                    _bindingDescription.ToString(),
-                    exception.ToLongString());
+                    "Problem seen during binding execution for {BindingDescription}",
+                    _bindingDescription.ToString());
             }
         }
 

--- a/MvvmCross/Binding/Bindings/Source/Chained/MvxChainedSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Chained/MvxChainedSourceBinding.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.Source.Construction;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 using MvvmCross.Converters;
@@ -104,7 +105,7 @@ namespace MvvmCross.Binding.Bindings.Source.Chained
         {
             if (_currentChildBinding == null)
             {
-                MvxBindingLog.Warning("SetValue ignored in binding - target property path missing");
+                MvxBindingLog.Instance?.LogWarning("SetValue ignored in binding - target property path missing");
                 return;
             }
 

--- a/MvvmCross/Binding/Bindings/Source/Construction/MvxSourceBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Source/Construction/MvxSourceBindingFactory.cs
@@ -60,7 +60,7 @@ namespace MvvmCross.Binding.Bindings.Source.Construction
             if (source != null)
             {
                 MvxBindingLog.Instance?.LogWarning(
-                    "Unable to bind: source property source not found @{CurrentToken} on {SourceTypeName}", 
+                    "Unable to bind: source property source not found @{CurrentToken} on {SourceTypeName}",
                     currentToken,
                     source.GetType().Name);
             }

--- a/MvvmCross/Binding/Bindings/Source/Construction/MvxSourceBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Source/Construction/MvxSourceBindingFactory.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Parse.PropertyPath;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 using MvvmCross.Exceptions;
@@ -58,10 +59,10 @@ namespace MvvmCross.Binding.Bindings.Source.Construction
 
             if (source != null)
             {
-                MvxBindingLog.Warning(
-                    "Unable to bind: source property source not found {0} on {1}"
-                    , currentToken
-                    , source.GetType().Name);
+                MvxBindingLog.Instance?.LogWarning(
+                    "Unable to bind: source property source not found @{CurrentToken} on {SourceTypeName}", 
+                    currentToken,
+                    source.GetType().Name);
             }
 
             return new MvxMissingSourceBinding(source);

--- a/MvvmCross/Binding/Bindings/Source/Leaf/MvxDirectToSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Leaf/MvxDirectToSourceBinding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace MvvmCross.Binding.Bindings.Source.Leaf
 {
@@ -17,7 +18,7 @@ namespace MvvmCross.Binding.Bindings.Source.Leaf
 
         public override void SetValue(object value)
         {
-            MvxBindingLog.Warning("ToSource binding is not available for direct pathed source bindings");
+            MvxBindingLog.Instance?.LogWarning("ToSource binding is not available for direct pathed source bindings");
         }
 
         public override object GetValue()

--- a/MvvmCross/Binding/Bindings/Source/Leaf/MvxLeafPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Leaf/MvxLeafPropertyInfoSourceBinding.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Extensions;
 using MvvmCross.Converters;
 using MvvmCross.Exceptions;
@@ -33,7 +34,9 @@ namespace MvvmCross.Binding.Bindings.Source.Leaf
 
             if (!PropertyInfo.CanRead)
             {
-                MvxBindingLog.Error("GetValue ignored in binding - target property {0}.{1} is writeonly", PropertyInfo.DeclaringType?.Name, PropertyName);
+                MvxBindingLog.Instance?.LogError(
+                    "GetValue ignored in binding - target property {PropertyTypeName}.{PropertyName} is writeonly",
+                    PropertyInfo.DeclaringType?.Name, PropertyName);
                 return MvxBindingConstant.UnsetValue;
             }
 
@@ -55,13 +58,15 @@ namespace MvvmCross.Binding.Bindings.Source.Leaf
         {
             if (PropertyInfo == null)
             {
-                MvxBindingLog.Warning("SetValue ignored in binding - source property {0} is missing", PropertyName);
+                MvxBindingLog.Instance?.LogWarning("SetValue ignored in binding - source property {PropertyName} is missing", PropertyName);
                 return;
             }
 
             if (!PropertyInfo.CanWrite)
             {
-                MvxBindingLog.Warning("SetValue ignored in binding - target property {0}.{1} is readonly", PropertyInfo.DeclaringType?.Name, PropertyName);
+                MvxBindingLog.Instance?.LogWarning(
+                    "SetValue ignored in binding - target property {PropertyTypeName}.{PropertyName} is readonly",
+                    PropertyInfo.DeclaringType?.Name, PropertyName);
                 return;
             }
 
@@ -78,7 +83,7 @@ namespace MvvmCross.Binding.Bindings.Source.Leaf
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Error("SetValue failed with exception - " + exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(exception, "SetValue failed with exception");
             }
         }
     }

--- a/MvvmCross/Binding/Bindings/Source/MvxPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/MvxPropertyInfoSourceBinding.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.Binding.Bindings.Source
@@ -24,9 +25,8 @@ namespace MvvmCross.Binding.Bindings.Source
 
             if (Source == null)
             {
-                MvxBindingLog.Trace(
-                    "Unable to bind to source as it's null"
-                    , _propertyName);
+                MvxBindingLog.Instance?.LogTrace(
+                    "Unable to bind to source as it's null. PropertyName: {PropertyName}", _propertyName);
                 return;
             }
 

--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxSourceStep.cs
@@ -104,9 +104,8 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
                 // we expect this exception to occur sometimes - so only "Diagnostic" level logging here
                 MvxBindingLog.Instance?.LogTrace(
                     exception,
-                    "Problem seen during binding execution for {BindingDescription} - problem {ExceptionMessage}",
-                    _description.ToString(),
-                    exception.ToLongString());
+                    "Problem seen during binding execution for {BindingDescription}",
+                    _description.ToString());
             }
 
             return MvxBindingConstant.UnsetValue;

--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxSourceStep.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Converters;
 using MvvmCross.Exceptions;
 
@@ -101,8 +102,9 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
             {
                 // pokemon exception - force the use of Fallback in this case
                 // we expect this exception to occur sometimes - so only "Diagnostic" level logging here
-                MvxBindingLog.Trace(
-                    "Problem seen during binding execution for {0} - problem {1}",
+                MvxBindingLog.Instance?.LogTrace(
+                    exception,
+                    "Problem seen during binding execution for {BindingDescription} - problem {ExceptionMessage}",
                     _description.ToString(),
                     exception.ToLongString());
             }

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxCustomBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxCustomBindingFactory.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace MvvmCross.Binding.Bindings.Target.Construction
 {
@@ -30,10 +31,9 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
 
         public IMvxTargetBinding CreateBinding(object target, string targetName)
         {
-            var castTarget = target as TTarget;
-            if (castTarget == null)
+            if (target is not TTarget castTarget)
             {
-                MvxBindingLog.Error("Passed an invalid target for MvxCustomBindingFactory");
+                MvxBindingLog.Instance?.LogError("Passed an invalid target for MvxCustomBindingFactory");
                 return null;
             }
 

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxPropertyInfoTargetBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxPropertyInfoTargetBindingFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 
 namespace MvvmCross.Binding.Bindings.Target.Construction
 {
@@ -43,8 +44,9 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
                 }
                 catch (Exception exception)
                 {
-                    MvxBindingLog.Error(
-                        "Problem creating target binding for {0} - exception {1}", _targetType.Name,
+                    MvxBindingLog.Instance?.LogError(
+                        exception,
+                        "Problem creating target binding for {TargetName} - exception {ExceptionMessage}", _targetType.Name,
                         exception.ToString());
                 }
             }

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxSimplePropertyInfoTargetBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxSimplePropertyInfoTargetBindingFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 
 namespace MvvmCross.Binding.Bindings.Target.Construction
 {
@@ -37,7 +38,7 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
             var targetBinding = targetBindingCandidate as IMvxTargetBinding;
             if (targetBinding == null)
             {
-                MvxBindingLog.Warning("The TargetBinding created did not support IMvxTargetBinding");
+                MvxBindingLog.Instance?.LogWarning("The TargetBinding created did not support IMvxTargetBinding");
                 var disposable = targetBindingCandidate as IDisposable;
                 disposable?.Dispose();
             }

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 
 namespace MvvmCross.Binding.Bindings.Target.Construction
 {
@@ -30,7 +31,7 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
         {
             if (string.IsNullOrEmpty(targetName))
             {
-                MvxBindingLog.Error("Empty binding target passed to MvxTargetBindingFactoryRegistry");
+                MvxBindingLog.Instance?.LogError("Empty binding target passed to MvxTargetBindingFactoryRegistry");
                 binding = null;
                 return false;
             }

--- a/MvvmCross/Binding/Combiners/MvxFormatValueCombiner.cs
+++ b/MvvmCross/Binding/Combiners/MvxFormatValueCombiner.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Converters;
 
@@ -15,7 +16,7 @@ namespace MvvmCross.Binding.Combiners
 
             if (list.Count < 1)
             {
-                MvxBindingLog.Warning("Format called with no parameters - will fail");
+                MvxBindingLog.Instance?.LogWarning("Format called with no parameters - will fail");
                 value = MvxBindingConstant.DoNothing;
                 return true;
             }

--- a/MvvmCross/Binding/Combiners/MvxIfValueCombiner.cs
+++ b/MvvmCross/Binding/Combiners/MvxIfValueCombiner.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Extensions;
 using MvvmCross.Converters;
@@ -25,7 +26,7 @@ namespace MvvmCross.Binding.Combiners
                     return TryEvaluateif(list[0], list[1], list[2], out value);
 
                 default:
-                    MvxBindingLog.Warning("Unexpected substep count of {0} in 'If' ValueCombiner", list.Count);
+                    MvxBindingLog.Instance?.LogWarning("Unexpected substep count of {Count} in 'If' ValueCombiner", list.Count);
                     return base.TryGetValue(list, out value);
             }
         }

--- a/MvvmCross/Binding/MvxBindingLog.cs
+++ b/MvvmCross/Binding/MvxBindingLog.cs
@@ -8,7 +8,7 @@ using MvvmCross.Logging;
 
 namespace MvvmCross.Binding;
 
-internal static class MvxBindingLog
+public static class MvxBindingLog
 {
     public static ILogger? Instance { get; } = MvxLogHost.GetLog("MvxBind");
 }

--- a/MvvmCross/Binding/MvxBindingLog.cs
+++ b/MvvmCross/Binding/MvxBindingLog.cs
@@ -2,39 +2,13 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
 
-namespace MvvmCross.Binding
+namespace MvvmCross.Binding;
+
+internal static class MvxBindingLog
 {
-#nullable enable
-    public static class MvxBindingLog
-    {
-        public static ILogger? Instance { get; } = MvxLogHost.GetLog("MvxBind");
-
-        public static LogLevel TraceBindingLevel { get; set; } = LogLevel.Warning;
-
-        private static void Trace(LogLevel level, string message, params object[] args)
-        {
-            if ((int)level < (int)TraceBindingLevel) return;
-
-            Instance?.Log(level, message, args);
-        }
-
-        public static void Trace(string message, params object[] args)
-        {
-            Trace(LogLevel.Trace, message, args);
-        }
-
-        public static void Warning(string message, params object[] args)
-        {
-            Trace(LogLevel.Warning, message, args);
-        }
-
-        public static void Error(string message, params object[] args)
-        {
-            Trace(LogLevel.Error, message, args);
-        }
-    }
-#nullable restore
+    public static ILogger? Instance { get; } = MvxLogHost.GetLog("MvxBind");
 }

--- a/MvvmCross/Binding/MvxCoreBindingBuilder.cs
+++ b/MvvmCross/Binding/MvxCoreBindingBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
@@ -163,10 +164,10 @@ namespace MvvmCross.Binding
         {
             if (iocProvider.CanResolve<IMvxBindingParser>())
             {
-                MvxBindingLog.Trace("Binding Parser already registered - so skipping Default parser");
+                MvxBindingLog.Instance?.LogTrace("Binding Parser already registered - so skipping Default parser");
                 return;
             }
-            MvxBindingLog.Trace("Registering Default Binding Parser");
+            MvxBindingLog.Instance?.LogTrace("Registering Default Binding Parser");
             iocProvider.RegisterSingleton(CreateBindingParser());
         }
 
@@ -179,10 +180,10 @@ namespace MvvmCross.Binding
         {
             if (iocProvider.CanResolve<IMvxLanguageBindingParser>())
             {
-                MvxBindingLog.Trace("Binding Parser already registered - so skipping Language parser");
+                MvxBindingLog.Instance?.LogTrace("Binding Parser already registered - so skipping Language parser");
                 return;
             }
-            MvxBindingLog.Trace("Registering Language Binding Parser");
+            MvxBindingLog.Instance?.LogTrace("Registering Language Binding Parser");
             iocProvider.RegisterSingleton(CreateLanguageBindingParser());
         }
 

--- a/MvvmCross/Binding/Parse/Binding/MvxBindingParser.cs
+++ b/MvvmCross/Binding/Parse/Binding/MvxBindingParser.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Exceptions;
 
@@ -26,7 +27,8 @@ namespace MvvmCross.Binding.Parse.Binding
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Error("Problem parsing binding {0}", exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(exception, "Problem parsing binding {ExceptionMessage}",
+                    exception.ToLongString());
                 requestedDescription = null;
                 return false;
             }
@@ -52,7 +54,7 @@ namespace MvvmCross.Binding.Parse.Binding
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Error("Problem parsing binding {0}", exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(exception, "Problem parsing binding {ExceptionMessage}", exception.ToLongString());
                 requestedBindings = null;
                 return false;
             }

--- a/MvvmCross/Binding/Parse/Binding/MvxBindingParser.cs
+++ b/MvvmCross/Binding/Parse/Binding/MvxBindingParser.cs
@@ -27,8 +27,7 @@ namespace MvvmCross.Binding.Parse.Binding
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Instance?.LogError(exception, "Problem parsing binding {ExceptionMessage}",
-                    exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(exception, "Problem parsing binding");
                 requestedDescription = null;
                 return false;
             }
@@ -54,7 +53,7 @@ namespace MvvmCross.Binding.Parse.Binding
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Instance?.LogError(exception, "Problem parsing binding {ExceptionMessage}", exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(exception, "Problem parsing binding");
                 requestedBindings = null;
                 return false;
             }

--- a/MvvmCross/Binding/Parse/Binding/Swiss/MvxSwissBindingParser.cs
+++ b/MvvmCross/Binding/Parse/Binding/Swiss/MvxSwissBindingParser.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 
 namespace MvvmCross.Binding.Parse.Binding.Swiss
@@ -28,7 +29,7 @@ namespace MvvmCross.Binding.Parse.Binding.Swiss
             ParseEquals(block);
             var converter = ReadTargetPropertyName();
             if (!string.IsNullOrEmpty(description.Converter))
-                MvxBindingLog.Warning("Overwriting existing Converter with {0}", converter);
+                MvxBindingLog.Instance?.LogWarning("Overwriting existing Converter with {ConverterName}", converter);
             description.Converter = converter;
         }
 
@@ -36,7 +37,7 @@ namespace MvvmCross.Binding.Parse.Binding.Swiss
         {
             ParseEquals(block);
             if (description.ConverterParameter != null)
-                MvxBindingLog.Warning("Overwriting existing ConverterParameter");
+                MvxBindingLog.Instance?.LogWarning("Overwriting existing ConverterParameter");
             description.ConverterParameter = ReadValue();
         }
 
@@ -53,7 +54,7 @@ namespace MvvmCross.Binding.Parse.Binding.Swiss
             {
                 ParseEquals(block);
                 if (!string.IsNullOrEmpty(description.Converter))
-                    MvxBindingLog.Warning("Overwriting existing Converter with CommandParameter");
+                    MvxBindingLog.Instance?.LogWarning("Overwriting existing Converter with CommandParameter");
                 description.Converter = "CommandParameter";
                 description.ConverterParameter = ReadValue();
             }
@@ -63,7 +64,7 @@ namespace MvvmCross.Binding.Parse.Binding.Swiss
         {
             ParseEquals(block);
             if (description.FallbackValue != null)
-                MvxBindingLog.Warning("Overwriting existing FallbackValue");
+                MvxBindingLog.Instance?.LogWarning("Overwriting existing FallbackValue");
             description.FallbackValue = ReadValue();
         }
 

--- a/MvvmCross/Exceptions/MvxExceptionExtensions.cs
+++ b/MvvmCross/Exceptions/MvxExceptionExtensions.cs
@@ -2,44 +2,26 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
-namespace MvvmCross.Exceptions
-{
 #nullable enable
-    public static class MvxExceptionExtensions
+namespace MvvmCross.Exceptions;
+
+public static class MvxExceptionExtensions
+{
+    public static Exception MvxWrap(this Exception exception)
     {
-        public static string ToLongString(this Exception? exception)
-        {
-            if (exception == null)
-                return "null exception";
+        if (exception is MvxException)
+            return exception;
 
-            if (exception.InnerException != null)
-            {
-                var innerExceptionText = exception.InnerException.ToLongString();
-                return
-                    $"{exception.GetType().Name}: {exception.Message ?? "-"}\n\t{exception.StackTrace}\nInnerException was {innerExceptionText}";
-            }
-            return $"{exception.GetType().Name}: {exception.Message ?? "-"}\n\t{exception.StackTrace}";
-        }
-
-        public static Exception MvxWrap(this Exception exception)
-        {
-            if (exception is MvxException)
-                return exception;
-
-            return MvxWrap(exception, exception.Message);
-        }
-
-        public static Exception MvxWrap(this Exception exception, string message)
-        {
-            return new MvxException(exception, message);
-        }
-
-        public static Exception MvxWrap(this Exception exception, string messageFormat, params object[] formatArguments)
-        {
-            return new MvxException(exception, messageFormat, formatArguments);
-        }
+        return MvxWrap(exception, exception.Message);
     }
-#nullable restore
+
+    public static Exception MvxWrap(this Exception exception, string message)
+    {
+        return new MvxException(exception, message);
+    }
+
+    public static Exception MvxWrap(this Exception exception, string messageFormat, params object[] formatArguments)
+    {
+        return new MvxException(exception, messageFormat, formatArguments);
+    }
 }

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -23,16 +23,15 @@ namespace MvvmCross.IoC
                 // MvxLog.Instance can be null, when reflecting for Setup.cs
                 // Check for null
 
-                MvxLogHost.Default?.Log(LogLevel.Warning,
-                    "ReflectionTypeLoadException masked during loading of {AssemblyName} - error {ErrorMessage}",
-                    assembly.FullName, e.ToLongString());
+                MvxLogHost.Default?.LogWarning(e,
+                    "ReflectionTypeLoadException masked during loading of {AssemblyName}",
+                    assembly.FullName);
 
                 if (e.LoaderExceptions != null)
                 {
                     foreach (var exception in e.LoaderExceptions)
                     {
-                        MvxLogHost.Default?.Log(LogLevel.Warning, exception, "Failed to load type: {Message}",
-                            exception.ToLongString());
+                        MvxLogHost.Default?.LogWarning(exception, "Failed to load type");
                     }
                 }
 

--- a/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewBinder.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewBinder.cs
@@ -9,6 +9,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Util;
 using Android.Views;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.Bindings;
@@ -69,8 +70,7 @@ namespace MvvmCross.Platforms.Android.Binding.Binders
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Error("Exception thrown during the view binding {0}",
-                                      exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(exception, "Exception thrown during the view binding");
             }
         }
 
@@ -92,8 +92,7 @@ namespace MvvmCross.Platforms.Android.Binding.Binders
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Error("Exception thrown during the view language binding {0}",
-                                      exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(exception, "Exception thrown during the view language binding");
                 throw;
             }
         }

--- a/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewFactory.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewFactory.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Android.Content;
 using Android.Util;
 using Android.Views;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Exceptions;
 using MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers;
@@ -37,8 +38,9 @@ namespace MvvmCross.Platforms.Android.Binding.Binders
                 var view = Activator.CreateInstance(viewType, context, attrs) as View;
                 if (view == null)
                 {
-                    MvxBindingLog.Error("Unable to load view {0} from type {1}", name,
-                                          viewType.FullName ?? string.Empty);
+                    MvxBindingLog.Instance?.LogError("Unable to load view {ViewName} from type {ViewTypeName}", 
+                        name,
+                        viewType.FullName);
                 }
                 return view;
             }
@@ -48,9 +50,9 @@ namespace MvvmCross.Platforms.Android.Binding.Binders
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Error(
-                                      "Exception during creation of {0} from type {1} - exception {2}", name,
-                                      viewType.FullName ?? string.Empty, exception.ToLongString());
+                MvxBindingLog.Instance?.LogError(
+                    exception,
+                    "Exception during creation of {ViewName} from type {ViewTypeName}", name, viewType.FullName);
                 return null;
             }
         }

--- a/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewFactory.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewFactory.cs
@@ -38,7 +38,7 @@ namespace MvvmCross.Platforms.Android.Binding.Binders
                 var view = Activator.CreateInstance(viewType, context, attrs) as View;
                 if (view == null)
                 {
-                    MvxBindingLog.Instance?.LogError("Unable to load view {ViewName} from type {ViewTypeName}", 
+                    MvxBindingLog.Instance?.LogError("Unable to load view {ViewName} from type {ViewTypeName}",
                         name,
                         viewType.FullName);
                 }

--- a/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/MvxAxmlNameViewTypeResolver.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/MvxAxmlNameViewTypeResolver.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Android.Views;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.IoC;
 
@@ -44,7 +45,7 @@ namespace MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers
                     }
                     else
                     {
-                        MvxBindingLog.Trace("Abbreviation not found {0}", abbreviate);
+                        MvxBindingLog.Instance?.LogTrace("Abbreviation not found {Abbreviation}", abbreviate);
                     }
                 }
             }

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatAutoCompleteTextViewPartialTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatAutoCompleteTextViewPartialTextTargetBinding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Platforms.Android.Binding.Views;
 using MvvmCross.Platforms.Android.WeakSubscription;
@@ -21,8 +22,8 @@ public class MvxAppCompatAutoCompleteTextViewPartialTextTargetBinding
         var autoComplete = View;
         if (autoComplete == null)
         {
-            MvxBindingLog.Error(
-                "Error - autoComplete is null in MvxAppCompatAutoCompleteTextViewPartialTextTargetBinding");
+            MvxBindingLog.Instance?.LogError(
+                "autoComplete is null in MvxAppCompatAutoCompleteTextViewPartialTextTargetBinding");
         }
     }
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatAutoCompleteTextViewSelectedObjectTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatAutoCompleteTextViewSelectedObjectTargetBinding.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Platforms.Android.Binding.Views;
 using MvvmCross.Platforms.Android.WeakSubscription;
@@ -21,8 +22,8 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             var autoComplete = this.View;
             if (autoComplete == null)
             {
-                MvxBindingLog.Error(
-                    "Error - autoComplete is null in MvxAppCompatAutoCompleteTextViewSelectedObjectTargetBinding");
+                MvxBindingLog.Instance?.LogError(
+                    "autoComplete is null in MvxAppCompatAutoCompleteTextViewSelectedObjectTargetBinding");
             }
         }
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatBaseImageViewTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatBaseImageViewTargetBinding.cs
@@ -5,6 +5,7 @@
 using System;
 using Android.Graphics;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Exceptions;
 
@@ -35,7 +36,7 @@ namespace MvvmCross.Platforms.Android.Binding.Target
             }
             catch (Exception ex)
             {
-                MvxBindingLog.Error(ex.ToLongString());
+                MvxBindingLog.Instance?.LogError(ex, "Failed to set value");
                 throw;
             }
         }

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxCompoundButtonCheckedTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxCompoundButtonCheckedTargetBinding.cs
@@ -5,6 +5,7 @@
 #nullable enable
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Platforms.Android.WeakSubscription;
 
@@ -25,8 +26,8 @@ public class MvxCompoundButtonCheckedTargetBinding(
         var compoundButton = View;
         if (compoundButton == null)
         {
-            MvxBindingLog.Error(
-                "Error - compoundButton is null in MvxCompoundButtonCheckedTargetBinding");
+            MvxBindingLog.Instance?.LogError(
+                "compoundButton is null in MvxCompoundButtonCheckedTargetBinding");
             return;
         }
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableNameTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableNameTargetBinding.cs
@@ -35,8 +35,8 @@ public class MvxImageViewDrawableNameTargetBinding(ImageView imageView)
         var id = resources.GetIdentifier(drawableName, "drawable", appContext.PackageName);
         if (id == 0)
         {
-            MvxBindingLog.Warning(
-                "Value '{0}' was not a known drawable name", drawableName);
+            MvxBindingLog.Instance?.LogWarning(
+                "Value '{DrawableName}' was not a known drawable name", drawableName);
             view.SetImageDrawable(null);
             return;
         }

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxImageViewDrawableTargetBinding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 using Android.Graphics.Drawables;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 
 namespace MvvmCross.Platforms.Android.Binding.Target;
@@ -22,8 +23,7 @@ public class MvxImageViewDrawableTargetBinding(ImageView imageView)
 
         if (value is not int resourceIdentifier)
         {
-            MvxBindingLog.Warning(
-                "Value was not a valid Drawable");
+            MvxBindingLog.Instance?.LogWarning("Value '{ResourceIdentifier}' was not a valid Drawable", value);
             view.SetImageDrawable(null);
             return;
         }

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxSeekBarProgressTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxSeekBarProgressTargetBinding.cs
@@ -5,6 +5,7 @@
 #nullable enable
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.WeakSubscription;
@@ -45,7 +46,7 @@ public class MvxSeekBarProgressTargetBinding
         var seekBar = View;
         if (seekBar == null)
         {
-            MvxBindingLog.Error("Error - SeekBar is null in MvxSeekBarProgressTargetBinding");
+            MvxBindingLog.Instance?.LogError("SeekBar is null in MvxSeekBarProgressTargetBinding");
             return;
         }
 

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxSpinnerSelectedItemBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxSpinnerSelectedItemBinding.cs
@@ -59,7 +59,7 @@ public class MvxSpinnerSelectedItemBinding
 
         if (value == null)
         {
-            MvxBindingLog.Warning("Null values not permitted in spinner SelectedItem binding currently");
+            MvxBindingLog.Instance?.LogWarning("Null values not permitted in spinner SelectedItem binding currently");
             return;
         }
 

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxAdapter.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxAdapter.cs
@@ -186,7 +186,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         {
             if (ItemsSource == null)
             {
-                MvxBindingLog.Error("GetView called when ItemsSource is null");
+                MvxBindingLog.Instance?.LogError("GetView called when ItemsSource is null");
                 return null;
             }
 

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxAppCompatRadioGroup.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxAppCompatRadioGroup.cs
@@ -11,6 +11,7 @@ using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
@@ -101,7 +102,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                 }
                 else
                 {
-                    MvxBindingLog.Warning(
+                    MvxBindingLog.Instance?.LogWarning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
 

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLinearLayout.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLinearLayout.cs
@@ -10,6 +10,7 @@ using Android.Runtime;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
@@ -87,7 +88,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                 }
                 else
                 {
-                    MvxBindingLog.Warning(
+                    MvxBindingLog.Instance?.LogWarning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
 

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxRadioGroup.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxRadioGroup.cs
@@ -11,6 +11,7 @@ using Android.Runtime;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.BindingContext;
@@ -101,7 +102,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                 }
                 else
                 {
-                    MvxBindingLog.Warning(
+                    MvxBindingLog.Instance?.LogWarning(
                         "Setting Adapter to null is not recommended - you may lose ItemsSource binding when doing this");
                 }
 

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlTargetBinding.cs
@@ -5,6 +5,7 @@
 #nullable enable
 using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.WeakSubscription;
@@ -130,7 +131,7 @@ public class MvxUIControlTargetBinding : MvxConvertingTargetBinding
                 _controlEventSubscription = control.WeakSubscribe(nameof(control.AllEvents), ControlEvent);
                 break;
             default:
-                MvxBindingLog.Error("Error - Invalid controlEvent in MvxUIControlTargetBinding");
+                MvxBindingLog.Instance?.LogError("Error - Invalid controlEvent in MvxUIControlTargetBinding");
                 break;
         }
     }
@@ -155,7 +156,7 @@ public class MvxUIControlTargetBinding : MvxConvertingTargetBinding
                 _controlEventSubscription?.Dispose();
                 break;
             default:
-                MvxBindingLog.Error("Error - Invalid controlEvent in MvxUIControlTargetBinding");
+                MvxBindingLog.Instance?.LogError("Error - Invalid controlEvent in MvxUIControlTargetBinding");
                 break;
         }
     }

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIStepperValueTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIStepperValueTargetBinding.cs
@@ -5,6 +5,7 @@
 #nullable enable
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.WeakSubscription;
@@ -42,7 +43,7 @@ public class MvxUIStepperValueTargetBinding(
         var stepper = View;
         if (stepper == null)
         {
-            MvxBindingLog.Error("UIStepper is null in MvxUIStepperValueTargetBinding");
+            MvxBindingLog.Instance?.LogError("UIStepper is null in MvxUIStepperValueTargetBinding");
             return;
         }
 

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUISwitchOnTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUISwitchOnTargetBinding.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.WeakSubscription;
@@ -27,7 +28,7 @@ public class MvxUISwitchOnTargetBinding(
         var uiSwitch = Target;
         if (uiSwitch == null)
         {
-            MvxBindingLog.Error("Error - Switch is null in MvxUISwitchOnTargetBinding");
+            MvxBindingLog.Instance?.LogError("Switch is null in MvxUISwitchOnTargetBinding");
             return;
         }
 

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxBaseNSDatePickerTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxBaseNSDatePickerTargetBinding.cs
@@ -4,6 +4,7 @@
 
 using System;
 using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 
 namespace MvvmCross.Platforms.Mac.Binding.Target
@@ -28,8 +29,8 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
 
             if (datePicker == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - NSDatePicker is null in MvxBaseNSDatePickerTargetBinding");
+                MvxBindingLog.Instance?.LogError(
+                                      "NSDatePicker is null in MvxBaseNSDatePickerTargetBinding");
                 return;
             }
             datePicker.Activated += HandleActivated;

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSButtonTitleTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSButtonTitleTargetBinding.cs
@@ -4,6 +4,7 @@
 
 using System;
 using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 
 namespace MvvmCross.Platforms.Mac.Binding.Target
@@ -20,7 +21,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
         {
             if (button == null)
             {
-                MvxBindingLog.Error("Error - NSButton is null in MvxNSButtonTitleTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSButton is null in MvxNSButtonTitleTargetBinding");
             }
         }
 

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSMenuItemOnTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSMenuItemOnTargetBinding.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 
@@ -18,7 +19,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var checkBox = View;
             if (checkBox == null)
             {
-                MvxBindingLog.Error("Error - NSButton is null in MvxNSSwitchOnTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSButton is null in MvxNSSwitchOnTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSPopUpButtonSelectedTagTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSPopUpButtonSelectedTagTargetBinding.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 
@@ -37,7 +38,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var popupButton = View;
             if (popupButton == null)
             {
-                MvxBindingLog.Error("Error - NSPopUpButton is null in MvxNSPopUpButtonSelectedTagTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSPopUpButton is null in MvxNSPopUpButtonSelectedTagTargetBinding");
                 return;
             }
 

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSearchFieldTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSearchFieldTextTargetBinding.cs
@@ -5,6 +5,7 @@
 using System.Reflection;
 using AppKit;
 using Foundation;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using ObjCRuntime;
@@ -21,8 +22,8 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var searchField = View;
             if (searchField == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - NSSearchField is null in MvxNSSearchFieldTextTargetBinding");
+                MvxBindingLog.Instance?.LogError(
+                                      "NSSearchField is null in MvxNSSearchFieldTextTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSegmentedControlSelectedSegmentTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSegmentedControlSelectedSegmentTargetBinding.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 
@@ -37,7 +38,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var segmentedControl = View;
             if (segmentedControl == null)
             {
-                MvxBindingLog.Error("Error - NSSegmentedControl is null in MvxNSSegmentedControlSelectedSegmentTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSSegmentedControl is null in MvxNSSegmentedControlSelectedSegmentTargetBinding");
                 return;
             }
 

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSliderValueTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSliderValueTargetBinding.cs
@@ -6,6 +6,7 @@ using System;
 using System.Reflection;
 using AppKit;
 using Foundation;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 
@@ -19,7 +20,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var slider = View;
             if (slider == null)
             {
-                MvxBindingLog.Error("Error - NSSlider is null in MvxNSSliderValueTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSSlider is null in MvxNSSliderValueTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSwitchOnTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSSwitchOnTargetBinding.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
-using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 
@@ -18,7 +17,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var checkBox = View;
             if (checkBox == null)
             {
-                MvxBindingLog.Error("Error - NSButton is null in MvxNSSwitchOnTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSButton is null in MvxNSSwitchOnTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
-using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Platforms.Mac.Views.Base;
@@ -38,7 +37,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var view = View;
             if (view == null)
             {
-                MvxBindingLog.Error("Error - NSTabViewController is null in MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSTabViewController is null in MvxNSTabViewControllerSelectedTabViewItemIndexTargetBinding");
                 return;
             }
 
@@ -55,7 +54,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
                 }
                 catch (Exception ex)
                 {
-                    MvxBindingLog.Error(ex.Message);
+                    MvxBindingLog.Instance?.LogError(ex, "Failed to subscribe to events");
                 }
             }
         }
@@ -89,7 +88,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
                         }
                         catch (Exception ex)
                         {
-                            MvxBindingLog.Error(ex.Message);
+                            MvxBindingLog.Instance?.LogError(ex, "Failed to unsubscribe from event");
                         }
                     }
                     _subscribed = false;

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextFieldTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextFieldTextTargetBinding.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
-using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 
@@ -18,8 +17,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var editText = View;
             if (editText == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - NSTextField is null in MvxNSTextFieldTextTargetBinding");
+                MvxBindingLog.Instance?.LogError("NSTextField is null in MvxNSTextFieldTextTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewTextTargetBinding.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
-using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 
@@ -18,8 +17,8 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             var editText = View;
             if (editText == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - NSTextView is null in MvxNSTextViewTextTargetBinding");
+                MvxBindingLog.Instance?.LogError(
+                                      "NSTextView is null in MvxNSTextViewTextTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSViewVisibilityTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSViewVisibilityTargetBinding.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using AppKit;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.UI;
 
@@ -49,7 +48,7 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
                     break;
 
                 default:
-                    MvxBindingLog.Warning("Visibility out of range {0}", value);
+                    MvxBindingLog.Instance?.LogWarning("Visibility out of range {Value}", value);
                     break;
             }
         }

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIActivityIndicatorViewHiddenTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIActivityIndicatorViewHiddenTargetBinding.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -20,7 +19,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
         {
             if (target == null)
             {
-                MvxBindingLog.Error("Error - UIActivityIndicatorView is null in MvxUIActivityIndicatorViewHiddenTargetBinding");
+                MvxBindingLog.Instance?.LogError("UIActivityIndicatorView is null in MvxUIActivityIndicatorViewHiddenTargetBinding");
             }
         }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIButtonTitleTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIButtonTitleTargetBinding.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -21,7 +20,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             _state = state;
             if (button == null)
             {
-                MvxBindingLog.Error("Error - UIButton is null in MvxUIButtonTitleTargetBinding");
+                MvxBindingLog.Instance?.LogError("UIButton is null in MvxUIButtonTitleTargetBinding");
             }
         }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlTouchUpInsideTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlTouchUpInsideTargetBinding.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Windows.Input;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.WeakSubscription;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -24,7 +23,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
         {
             if (control == null)
             {
-                MvxBindingLog.Error("Error - UIControl is null in MvxUIControlTouchUpInsideTargetBinding");
+                MvxBindingLog.Instance?.LogError("UIControl is null in MvxUIControlTouchUpInsideTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlValueChangedTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIControlValueChangedTargetBinding.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Windows.Input;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.WeakSubscription;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -25,8 +24,8 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
         {
             if (control == null)
             {
-                MvxBindingLog.Error(
-                    "Error - UIControl is null in MvxUIControlValueChangedTargetBinding");
+                MvxBindingLog.Instance?.LogError(
+                    "UIControl is null in MvxUIControlValueChangedTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUILabelTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUILabelTextTargetBinding.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -19,8 +18,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
         {
             if (target == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - UILabel is null in MvxUILabelTextTargetBinding");
+                MvxBindingLog.Instance?.LogError("UILabel is null in MvxUILabelTextTargetBinding");
             }
         }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUISearchBarTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUISearchBarTextTargetBinding.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -17,8 +17,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             var searchBar = View;
             if (searchBar == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - UISearchBar is null in MvxUISearchBarTextTargetBinding");
+                MvxBindingLog.Instance?.LogError("UISearchBar is null in MvxUISearchBarTextTargetBinding");
             }
             else
             {

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUISegmentedControlSelectedSegmentTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUISegmentedControlSelectedSegmentTargetBinding.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -34,7 +33,8 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             var segmentedControl = View;
             if (segmentedControl == null)
             {
-                MvxBindingLog.Error("Error - UISegmentedControl is null in MvxUISegmentedControlSelectedSegmentTargetBinding");
+                MvxBindingLog.Instance?.LogError(
+                    "UISegmentedControl is null in MvxUISegmentedControlSelectedSegmentTargetBinding");
                 return;
             }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextFieldTextTargetBinding.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Extensions;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -38,8 +37,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             var target = View;
             if (target == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - UITextField is null in MvxUITextFieldTextTargetBinding");
+                MvxBindingLog.Instance?.LogError("UITextField is null in MvxUITextFieldTextTargetBinding");
                 return;
             }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextViewTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUITextViewTextTargetBinding.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -36,8 +35,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
             var target = View;
             if (target == null)
             {
-                MvxBindingLog.Error(
-                                      "Error - UITextView is null in MvxUITextViewTextTargetBinding");
+                MvxBindingLog.Instance?.LogError("UITextView is null in MvxUITextViewTextTargetBinding");
                 return;
             }
 

--- a/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewVisibilityTargetBinding.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/Target/MvxUIViewVisibilityTargetBinding.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.UI;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Binding.Target
 {
@@ -38,7 +37,7 @@ namespace MvvmCross.Platforms.Tvos.Binding.Target
                     break;
 
                 default:
-                    MvxBindingLog.Warning("Visibility out of range {0}", value);
+                    MvxBindingLog.Instance?.LogWarning("Visibility out of range {Value}", value);
                     break;
             }
         }

--- a/MvvmCross/Platforms/WinUi/Binding/MvxBinding/MvxWindowsTargetBindingFactoryRegistry.cs
+++ b/MvvmCross/Platforms/WinUi/Binding/MvxBinding/MvxWindowsTargetBindingFactoryRegistry.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
@@ -33,8 +34,7 @@ namespace MvvmCross.Platforms.WinUi.Binding.MvxBinding
 
             if (string.IsNullOrEmpty(targetName))
             {
-                MvxBindingLog.Error(
-                                      "Empty binding target passed to MvxWindowsTargetBindingFactoryRegistry");
+                MvxBindingLog.Instance?.LogError("Empty binding target passed to MvxWindowsTargetBindingFactoryRegistry");
                 binding = null;
                 return false;
             }

--- a/MvvmCross/Platforms/WinUi/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
+++ b/MvvmCross/Platforms/WinUi/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
@@ -74,7 +74,7 @@ namespace MvvmCross.Platforms.WinUi.Binding.MvxBinding.Target
 
         protected override void SetValueImpl(object target, object value)
         {
-            MvxBindingLog.Trace("Receiving setValue to " + (value ?? ""));
+            MvxBindingLog.Instance?.LogTrace("Receiving setValue to {Value}", value);
             var frameworkElement = target as FrameworkElement;
             if (frameworkElement == null)
             {

--- a/MvvmCross/Platforms/WinUi/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
+++ b/MvvmCross/Platforms/WinUi/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using MvvmCross.Binding;
@@ -64,7 +65,7 @@ namespace MvvmCross.Platforms.WinUi.Binding.MvxBinding.Target
             var target = Target as FrameworkElement;
             if (target == null)
             {
-                MvxBindingLog.Warning("Weak Target is null in {0} - skipping Get", GetType().Name);
+                MvxBindingLog.Instance?.LogWarning("Weak Target is null in {TypeName} - skipping Get", GetType().Name);
                 return null;
             }
 
@@ -77,7 +78,7 @@ namespace MvvmCross.Platforms.WinUi.Binding.MvxBinding.Target
             var frameworkElement = target as FrameworkElement;
             if (frameworkElement == null)
             {
-                MvxBindingLog.Trace("Weak Target is null in {0} - skipping set", GetType().Name);
+                MvxBindingLog.Instance?.LogTrace("Weak Target is null in {TypeName} - skipping set", GetType().Name);
                 return;
             }
 

--- a/MvvmCross/Platforms/Wpf/Binding/MvxBinding/MvxWindowsTargetBindingFactoryRegistry.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/MvxBinding/MvxWindowsTargetBindingFactoryRegistry.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
@@ -33,7 +34,7 @@ namespace MvvmCross.Platforms.Wpf.Binding.MvxBinding
 
             if (string.IsNullOrEmpty(targetName))
             {
-                MvxBindingLog.Error(
+                MvxBindingLog.Instance?.LogError(
                                       "Empty binding target passed to MvxWindowsTargetBindingFactoryRegistry");
                 binding = null;
                 return false;

--- a/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
+using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Extensions;
@@ -63,7 +64,7 @@ namespace MvvmCross.Platforms.Wpf.Binding.MvxBinding.Target
             var target = Target as FrameworkElement;
             if (target == null)
             {
-                MvxBindingLog.Warning("Weak Target is null in {0} - skipping Get", GetType().Name);
+                MvxBindingLog.Instance?.LogWarning("Weak Target is null in {TypeName} - skipping Get", GetType().Name);
                 return null;
             }
 
@@ -72,11 +73,11 @@ namespace MvvmCross.Platforms.Wpf.Binding.MvxBinding.Target
 
         protected override void SetValueImpl(object target, object value)
         {
-            MvxBindingLog.Trace("Receiving setValue to " + (value ?? ""));
+            MvxBindingLog.Instance?.LogTrace("Receiving setValue to " + (value ?? ""));
             var frameworkElement = target as FrameworkElement;
             if (frameworkElement == null)
             {
-                MvxBindingLog.Warning("Weak Target is null in {0} - skipping set", GetType().Name);
+                MvxBindingLog.Instance?.LogWarning("Weak Target is null in {TypeName} - skipping set", GetType().Name);
                 return;
             }
 

--- a/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
+++ b/MvvmCross/Platforms/Wpf/Binding/MvxBinding/Target/MvxDependencyPropertyTargetBinding.cs
@@ -73,7 +73,7 @@ namespace MvvmCross.Platforms.Wpf.Binding.MvxBinding.Target
 
         protected override void SetValueImpl(object target, object value)
         {
-            MvxBindingLog.Instance?.LogTrace("Receiving setValue to " + (value ?? ""));
+            MvxBindingLog.Instance?.LogTrace("Receiving setValue to {Value}", value);
             var frameworkElement = target as FrameworkElement;
             if (frameworkElement == null)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
We had a lot of instances where unstructured logging was used. Also we had a `ToLongString` method to create messages for logging with stack traces.

### :new: What is the new behavior (if this is a feature change)?
- Using structured logging and constant log templates where appropriate.
- Removed `ToLongString` extension for `MvxException`
- Removed extension methods in `MvxBindingLog` which didn't support structured logging

### :boom: Does this PR introduce a breaking change?
Yes, if you were using `ToLongString` extension on `MvxException` then this is removed.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
