### PR TITLE
Ensuring unoverridable code returns to the main thread...

### DIFF
--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -188,9 +188,9 @@ namespace MvvmCross.Platforms.Ios.Presenters
         {
             SetupWindowRootNavigation(viewController, attribute);
 
-            if (!await CloseModalViewControllers().ConfigureAwait(false)) return false;
-            if (!await CloseTabBarViewController().ConfigureAwait(false)) return false;
-            if (!await CloseSplitViewController().ConfigureAwait(false)) return false;
+            if (!await CloseModalViewControllers().ConfigureAwait(true)) return false;
+            if (!await CloseTabBarViewController().ConfigureAwait(true)) return false;
+            if (!await CloseSplitViewController().ConfigureAwait(true)) return false;
             return true;
         }
 
@@ -202,8 +202,8 @@ namespace MvvmCross.Platforms.Ios.Presenters
             // set root
             SetupWindowRootNavigation(viewController, attribute);
 
-            if (!await CloseModalViewControllers().ConfigureAwait(false)) return false;
-            if (!await CloseTabBarViewController().ConfigureAwait(false)) return false;
+            if (!await CloseModalViewControllers().ConfigureAwait(true)) return false;
+            if (!await CloseTabBarViewController().ConfigureAwait(true)) return false;
 
             return true;
         }
@@ -216,8 +216,8 @@ namespace MvvmCross.Platforms.Ios.Presenters
             // set root
             SetupWindowRootNavigation(viewController, attribute);
 
-            if (!await CloseModalViewControllers().ConfigureAwait(false)) return false;
-            if (!await CloseSplitViewController().ConfigureAwait(false)) return false;
+            if (!await CloseModalViewControllers().ConfigureAwait(true)) return false;
+            if (!await CloseSplitViewController().ConfigureAwait(true)) return false;
 
             return true;
         }


### PR DESCRIPTION
…after calling virtual (i.e. overridable) methods

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix: for [#4832](https://github.com/MvvmCross/MvvmCross/issues/4832)

### :arrow_heading_down: What is the current behavior?

Code can crash if a subclass override causes execution to leave main thread

### :new: What is the new behavior (if this is a feature change)?

Execution returns to the main thread

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
