### PR TITLE
Enable nullable attributes in MvxRecyclerView lib

### DIFF
--- a/MvvmCross.DroidX/RecyclerView/AttributeHelpers/MvxRecyclerViewAttributeExtensions.cs
+++ b/MvvmCross.DroidX/RecyclerView/AttributeHelpers/MvxRecyclerViewAttributeExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
@@ -14,7 +13,7 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
     public static class MvxRecyclerViewAttributeExtensions
     {
         private static bool _areBindingResourcesInitialized;
-        private static int[] _recyclerViewItemTemplateSelectorGroupId;
+        private static int[]? _recyclerViewItemTemplateSelectorGroupId;
         private static int _recyclerViewItemTemplateSelector;
 
         private static string ReadRecyclerViewItemTemplateSelectorClassName(Context context, IAttributeSet attrs)
@@ -64,7 +63,7 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
             if (type == null)
             {
                 const string message =
-                    "Sorry but type with class name: {TemplateSelectorClassName} does not exist." +
+                    "Type with class name: {TemplateSelectorClassName} does not exist." +
                     "Make sure you have provided full Type name: namespace + class name, AssemblyName." +
                     "Example (check Example.Droid sample!): Example.Droid.Common.TemplateSelectors.MultiItemTemplateModelTemplateSelector, Example.Droid";
                 MvxAndroidLog.Instance?.Log(LogLevel.Error, message, templateSelectorClassName);
@@ -73,14 +72,14 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
 
             if (!typeof(IMvxTemplateSelector).IsAssignableFrom(type))
             {
-                const string message = "Sorry but type: {Type} does not implement {TemplateSelectorType} interface.";
+                const string message = "Type: {Type} does not implement {TemplateSelectorType} interface.";
                 MvxAndroidLog.Instance?.Log(LogLevel.Error, message, type, nameof(IMvxTemplateSelector));
                 throw new InvalidOperationException(message);
             }
 
             if (type.IsAbstract)
             {
-                const string message = "Sorry can not instatiate {TemplateSelectorType} as provided type: {Type} is abstract/interface.";
+                const string message = "Cannot instantiate {TemplateSelectorType} as provided type: {Type} is abstract/interface.";
                 MvxAndroidLog.Instance?.Log(LogLevel.Error, message, nameof(IMvxTemplateSelector), type);
                 throw new InvalidOperationException(message);
             }
@@ -101,7 +100,7 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
                 if (Mvx.IoCProvider?.TryResolve(
                     out MvvmCross.Platforms.Android.Binding.ResourceHelpers.IMvxAppResourceTypeFinder? resourceTypeFinder) != true)
                 {
-                    selectorGroup = Array.Empty<int>();
+                    selectorGroup = [];
                     selector = 0;
                     return false;
                 }
@@ -110,7 +109,7 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
                 if (resourceType == null)
                 {
                     MvxAndroidLog.Instance?.LogWarning("Could not find Resource Type - MvxRecyclerView binding won't work correctly");
-                    selectorGroup = Array.Empty<int>();
+                    selectorGroup = [];
                     selector = 0;
                     return false;
                 }
@@ -119,7 +118,7 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
                 if (styleableType == null)
                 {
                     MvxAndroidLog.Instance?.LogWarning("Could not find Styleable Type - MvxRecyclerView binding won't work correctly");
-                    selectorGroup = Array.Empty<int>();
+                    selectorGroup = [];
                     selector = 0;
                     return false;
                 }
@@ -133,7 +132,7 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
                 if (styleableType == null)
                 {
                     MvxAndroidLog.Instance?.LogWarning("Could not find Styleable Type - MvxRecyclerView binding won't work correctly");
-                    selectorGroup = Array.Empty<int>();
+                    selectorGroup = [];
                     selector = 0;
                     return false;
                 }
@@ -149,7 +148,7 @@ namespace MvvmCross.DroidX.RecyclerView.AttributeHelpers
                 MvxAndroidLog.Instance?.LogError(e, "Failed to initialize MvxRecyclerView binding resources");
             }
 
-            selectorGroup = Array.Empty<int>();
+            selectorGroup = [];
             selector = 0;
             return false;
         }

--- a/MvvmCross.DroidX/RecyclerView/GuardedLayoutManagers/MvxGuardedGridLayoutManager.cs
+++ b/MvvmCross.DroidX/RecyclerView/GuardedLayoutManagers/MvxGuardedGridLayoutManager.cs
@@ -2,50 +2,47 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Android.Content;
 using Android.Runtime;
 using AndroidX.RecyclerView.Widget;
 using Java.Lang;
 using Microsoft.Extensions.Logging;
-using MvvmCross.Logging;
 
-namespace MvvmCross.DroidX.RecyclerView
+namespace MvvmCross.DroidX.RecyclerView;
+
+[Register("mvvmcross.droidx.recyclerview.MvxGuardedGridLayoutManager")]
+public class MvxGuardedGridLayoutManager : GridLayoutManager
 {
-    [Register("mvvmcross.droidx.recyclerview.MvxGuardedGridLayoutManager")]
-    public class MvxGuardedGridLayoutManager : GridLayoutManager
+    public MvxGuardedGridLayoutManager(Context context, int spanCount) : base(context, spanCount)
     {
-        public MvxGuardedGridLayoutManager(Context context, int spanCount) : base(context, spanCount)
+    }
+
+    [Android.Runtime.Preserve(Conditional = true)]
+    protected MvxGuardedGridLayoutManager(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+    {
+    }
+
+    /// <summary>
+    /// Fix issue like https://code.google.com/p/android/issues/detail?id=77846#c1 but may not be exactly the same.
+    /// https://stackoverflow.com/questions/30220771/recyclerview-inconsistency-detected-invalid-item-position?page=1&tab=active#tab-top
+    /// </summary>
+    public override bool SupportsPredictiveItemAnimations() => false;
+
+    /// <summary>
+    /// This should not be needed anymore, as it should be caused by SupportsPredictiveItemAnimations.
+    /// </summary>
+    public override void OnLayoutChildren(
+        AndroidX.RecyclerView.Widget.RecyclerView.Recycler? recycler,
+        AndroidX.RecyclerView.Widget.RecyclerView.State? state)
+    {
+        try
         {
+            base.OnLayoutChildren(recycler, state);
         }
-
-        [Android.Runtime.Preserve(Conditional = true)]
-        protected MvxGuardedGridLayoutManager(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        catch (IndexOutOfBoundsException e)
         {
-        }
-
-        /// <summary>
-        /// Fix issue like https://code.google.com/p/android/issues/detail?id=77846#c1 but may not be exactly the same.
-        /// https://stackoverflow.com/questions/30220771/recyclerview-inconsistency-detected-invalid-item-position?page=1&tab=active#tab-top
-        /// </summary>
-        public override bool SupportsPredictiveItemAnimations() => false;
-
-        /// <summary>
-        /// This should not be needed anymore, as it should be caused by SupportsPredictiveItemAnimations.
-        /// </summary>
-        public override void OnLayoutChildren(AndroidX.RecyclerView.Widget.RecyclerView.Recycler recycler,
-            AndroidX.RecyclerView.Widget.RecyclerView.State state)
-        {
-            try
-            {
-                base.OnLayoutChildren(recycler, state);
-            }
-            catch (IndexOutOfBoundsException e)
-            {
-                MvxAndroidLog.Instance.Log(LogLevel.Warning,
-                    "Workaround of issue - https://code.google.com/p/android/issues/detail?id=77846#c1 - IndexOutOfBoundsException " +
-                    e.Message);
-            }
+            MvxAndroidLog.Instance?.LogWarning(e,
+                "Workaround of issue - https://code.google.com/p/android/issues/detail?id=77846#c1 - IndexOutOfBoundsException");
         }
     }
 }

--- a/MvvmCross.DroidX/RecyclerView/GuardedLayoutManagers/MvxGuardedLinearLayoutManager.cs
+++ b/MvvmCross.DroidX/RecyclerView/GuardedLayoutManagers/MvxGuardedLinearLayoutManager.cs
@@ -2,50 +2,47 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Android.Content;
 using Android.Runtime;
 using AndroidX.RecyclerView.Widget;
 using Java.Lang;
 using Microsoft.Extensions.Logging;
-using MvvmCross.Logging;
 
-namespace MvvmCross.DroidX.RecyclerView
+namespace MvvmCross.DroidX.RecyclerView;
+
+[Register("mvvmcross.droidx.recyclerview.MvxGuardedLinearLayoutManager")]
+public class MvxGuardedLinearLayoutManager : LinearLayoutManager
 {
-    [Register("mvvmcross.droidx.recyclerview.MvxGuardedLinearLayoutManager")]
-    public class MvxGuardedLinearLayoutManager : LinearLayoutManager
+    public MvxGuardedLinearLayoutManager(Context context) : base(context)
     {
-        public MvxGuardedLinearLayoutManager(Context context) : base(context)
+    }
+
+    [Android.Runtime.Preserve(Conditional = true)]
+    protected MvxGuardedLinearLayoutManager(IntPtr ptr, JniHandleOwnership transfer) : base(ptr, transfer)
+    {
+    }
+
+    /// <summary>
+    /// Fix issue like https://code.google.com/p/android/issues/detail?id=77846#c1 but may not be exactly the same.
+    /// https://stackoverflow.com/questions/30220771/recyclerview-inconsistency-detected-invalid-item-position?page=1&tab=active#tab-top
+    /// </summary>
+    public override bool SupportsPredictiveItemAnimations() => false;
+
+    /// <summary>
+    /// This should not be needed anymore, as it should be caused by SupportsPredictiveItemAnimations
+    /// </summary>
+    public override void OnLayoutChildren(
+        AndroidX.RecyclerView.Widget.RecyclerView.Recycler? recycler,
+        AndroidX.RecyclerView.Widget.RecyclerView.State? state)
+    {
+        try
         {
+            base.OnLayoutChildren(recycler, state);
         }
-
-        [Android.Runtime.Preserve(Conditional = true)]
-        protected MvxGuardedLinearLayoutManager(IntPtr ptr, JniHandleOwnership transfer) : base(ptr, transfer)
+        catch (IndexOutOfBoundsException e)
         {
-        }
-
-        /// <summary>
-        /// Fix issue like https://code.google.com/p/android/issues/detail?id=77846#c1 but may not be exactly the same.
-        /// https://stackoverflow.com/questions/30220771/recyclerview-inconsistency-detected-invalid-item-position?page=1&tab=active#tab-top
-        /// </summary>
-        public override bool SupportsPredictiveItemAnimations() => false;
-
-        /// <summary>
-        /// This should not be needed anymore, as it should be caused by SupportsPredictiveItemAnimations
-        /// </summary>
-        public override void OnLayoutChildren(AndroidX.RecyclerView.Widget.RecyclerView.Recycler recycler,
-            AndroidX.RecyclerView.Widget.RecyclerView.State state)
-        {
-            try
-            {
-                base.OnLayoutChildren(recycler, state);
-            }
-            catch (IndexOutOfBoundsException e)
-            {
-                MvxAndroidLog.Instance.Log(LogLevel.Warning,
-                    "Workaround of issue - https://code.google.com/p/android/issues/detail?id=77846#c1 - IndexOutOfBoundsException " +
-                    e.Message);
-            }
+            MvxAndroidLog.Instance?.LogWarning(e,
+                "Workaround of issue - https://code.google.com/p/android/issues/detail?id=77846#c1 - IndexOutOfBoundsException");
         }
     }
 }

--- a/MvvmCross.DroidX/RecyclerView/IMvxRecyclerAdapter.cs
+++ b/MvvmCross.DroidX/RecyclerView/IMvxRecyclerAdapter.cs
@@ -7,19 +7,18 @@ using System.Windows.Input;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.DroidX.RecyclerView.ItemTemplates;
 
-namespace MvvmCross.DroidX.RecyclerView
+namespace MvvmCross.DroidX.RecyclerView;
+
+public interface IMvxRecyclerAdapter
 {
-    public interface IMvxRecyclerAdapter
-    {
-        [MvxSetToNullAfterBinding]
-        IEnumerable ItemsSource { get; set; }
+    [MvxSetToNullAfterBinding]
+    IEnumerable? ItemsSource { get; set; }
 
-        IMvxTemplateSelector ItemTemplateSelector { get; set; }
-        ICommand ItemClick { get; set; }
-        ICommand ItemLongClick { get; set; }
+    IMvxTemplateSelector? ItemTemplateSelector { get; set; }
+    ICommand? ItemClick { get; set; }
+    ICommand? ItemLongClick { get; set; }
 
-        object GetItem(int viewPosition);
+    object? GetItem(int viewPosition);
 
-        int ItemTemplateId { get; set; }
-    }
+    int ItemTemplateId { get; set; }
 }

--- a/MvvmCross.DroidX/RecyclerView/IMvxRecyclerAdapterBindableHolder.cs
+++ b/MvvmCross.DroidX/RecyclerView/IMvxRecyclerAdapterBindableHolder.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using MvvmCross.DroidX.RecyclerView.Model;
 
-namespace MvvmCross.DroidX.RecyclerView
+namespace MvvmCross.DroidX.RecyclerView;
+
+public interface IMvxRecyclerAdapterBindableHolder
 {
-    public interface IMvxRecyclerAdapterBindableHolder
-    {
-        event Action<MvxViewHolderBoundEventArgs> MvxViewHolderBound;
-    }
+    event EventHandler<MvxViewHolderBoundEventArgs> MvxViewHolderBound;
 }

--- a/MvvmCross.DroidX/RecyclerView/IMvxRecyclerViewHolder.cs
+++ b/MvvmCross.DroidX/RecyclerView/IMvxRecyclerViewHolder.cs
@@ -2,21 +2,19 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using MvvmCross.Binding.BindingContext;
 
-namespace MvvmCross.DroidX.RecyclerView
+namespace MvvmCross.DroidX.RecyclerView;
+
+public interface IMvxRecyclerViewHolder : IMvxBindingContextOwner
 {
-    public interface IMvxRecyclerViewHolder : IMvxBindingContextOwner
-    {
-        int Id { get; set; }
-        object DataContext { get; set; }
+    event EventHandler<EventArgs>? Click;
+    event EventHandler<EventArgs>? LongClick;
 
-        void OnAttachedToWindow();
-        void OnDetachedFromWindow();
-        void OnViewRecycled();
+    int Id { get; set; }
+    object? DataContext { get; set; }
 
-        event EventHandler<EventArgs> Click;
-        event EventHandler<EventArgs> LongClick;
-    }
+    void OnAttachedToWindow();
+    void OnDetachedFromWindow();
+    void OnViewRecycled();
 }

--- a/MvvmCross.DroidX/RecyclerView/ItemTemplates/IMvxTemplateSelector.cs
+++ b/MvvmCross.DroidX/RecyclerView/ItemTemplates/IMvxTemplateSelector.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-namespace MvvmCross.DroidX.RecyclerView.ItemTemplates
-{
-    public interface IMvxTemplateSelector
-    {
-        int ItemTemplateId { get; set; }
-        int GetItemViewType(object forItemObject);
+namespace MvvmCross.DroidX.RecyclerView.ItemTemplates;
 
-        int GetItemLayoutId(int fromViewType);
-    }
+public interface IMvxTemplateSelector
+{
+    int ItemTemplateId { get; set; }
+    int GetItemViewType(object? forItemObject);
+
+    int GetItemLayoutId(int fromViewType);
 }

--- a/MvvmCross.DroidX/RecyclerView/ItemTemplates/MvxDefaultTemplateSelector.cs
+++ b/MvvmCross.DroidX/RecyclerView/ItemTemplates/MvxDefaultTemplateSelector.cs
@@ -2,26 +2,24 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-namespace MvvmCross.DroidX.RecyclerView.ItemTemplates
+namespace MvvmCross.DroidX.RecyclerView.ItemTemplates;
+
+public class MvxDefaultTemplateSelector : IMvxTemplateSelector
 {
-    //MvxDefaultTemplateSelector
-    public class MvxDefaultTemplateSelector : IMvxTemplateSelector
+    public int ItemTemplateId { get; set; }
+
+    public MvxDefaultTemplateSelector(int itemTemplateId)
     {
-        public int ItemTemplateId { get; set; }
-
-        public MvxDefaultTemplateSelector(int itemTemplateId)
-        {
-            ItemTemplateId = itemTemplateId;
-        }
-
-        public MvxDefaultTemplateSelector()
-        {
-        }
-
-        public int GetItemViewType(object forItemObject)
-            => 0;
-
-        public int GetItemLayoutId(int fromViewType)
-            => ItemTemplateId;
+        ItemTemplateId = itemTemplateId;
     }
+
+    public MvxDefaultTemplateSelector()
+    {
+    }
+
+    public int GetItemViewType(object? forItemObject)
+        => 0;
+
+    public int GetItemLayoutId(int fromViewType)
+        => ItemTemplateId;
 }

--- a/MvvmCross.DroidX/RecyclerView/ItemTemplates/MvxTemplateSelector.cs
+++ b/MvvmCross.DroidX/RecyclerView/ItemTemplates/MvxTemplateSelector.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-namespace MvvmCross.DroidX.RecyclerView.ItemTemplates
+namespace MvvmCross.DroidX.RecyclerView.ItemTemplates;
+
+public abstract class MvxTemplateSelector<TItem> : IMvxTemplateSelector
+    where TItem : class
 {
-    public abstract class MvxTemplateSelector<TItem> : IMvxTemplateSelector where TItem : class
+    public int ItemTemplateId { get; set; }
+
+    public int GetItemViewType(object? forItemObject)
     {
-        public int ItemTemplateId { get; set; }
-
-        public int GetItemViewType(object forItemObject)
-        {
-            return SelectItemViewType(forItemObject as TItem);
-        }
-
-        public abstract int GetItemLayoutId(int fromViewType);
-
-        protected abstract int SelectItemViewType(TItem forItemObject);
+        return SelectItemViewType(forItemObject as TItem);
     }
+
+    public abstract int GetItemLayoutId(int fromViewType);
+
+    protected abstract int SelectItemViewType(TItem? forItemObject);
 }

--- a/MvvmCross.DroidX/RecyclerView/Model/MvxViewHolderBoundEventArgs.cs
+++ b/MvvmCross.DroidX/RecyclerView/Model/MvxViewHolderBoundEventArgs.cs
@@ -2,21 +2,17 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-namespace MvvmCross.DroidX.RecyclerView.Model
+namespace MvvmCross.DroidX.RecyclerView.Model;
+
+public class MvxViewHolderBoundEventArgs(
+    int itemPosition,
+    object? dataContext,
+    AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder holder)
+    : EventArgs
 {
-    public class MvxViewHolderBoundEventArgs
-    {
-        public MvxViewHolderBoundEventArgs(int itemPosition, object dataContext, AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder holder)
-        {
-            ItemPosition = itemPosition;
-            DataContext = dataContext;
-            Holder = holder;
-        }
+    public int ItemPosition { get; } = itemPosition;
 
-        public int ItemPosition { get; }
+    public object? DataContext { get; } = dataContext;
 
-        public object DataContext { get; }
-
-        public AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder Holder { get; }
-    }
+    public AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder Holder { get; } = holder;
 }

--- a/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
+++ b/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
@@ -7,6 +7,8 @@
 
 This package contains AndroidX RecyclerView support for MvvmCross.</Description>
     <PackageId>MvvmCross.DroidX.RecyclerView</PackageId>
+    
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/MvvmCross.DroidX/RecyclerView/MvxAndroidLog.cs
+++ b/MvvmCross.DroidX/RecyclerView/MvxAndroidLog.cs
@@ -5,10 +5,9 @@
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
 
-namespace MvvmCross
+namespace MvvmCross.DroidX.RecyclerView;
+
+internal static class MvxAndroidLog
 {
-    internal static class MvxAndroidLog
-    {
-        internal static ILogger Instance { get; } = MvxLogHost.GetLog("RecyclerView");
-    }
+    internal static ILogger? Instance { get; } = MvxLogHost.GetLog("RecyclerView");
 }

--- a/MvvmCross.DroidX/RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.DroidX/RecyclerView/MvxRecyclerAdapter.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-#nullable enable
+
 using System.Collections;
 using System.Collections.Specialized;
 using System.Windows.Input;
@@ -9,7 +9,6 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using Microsoft.Extensions.Logging;
-using MvvmCross.Binding;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.Extensions;
 using MvvmCross.DroidX.RecyclerView.ItemTemplates;
@@ -26,7 +25,7 @@ namespace MvvmCross.DroidX.RecyclerView;
 public class MvxRecyclerAdapter
     : RecyclerViewAdapter, IMvxRecyclerAdapter, IMvxRecyclerAdapterBindableHolder
 {
-    public event Action<MvxViewHolderBoundEventArgs>? MvxViewHolderBound;
+    public event EventHandler<MvxViewHolderBoundEventArgs>? MvxViewHolderBound;
 
     private ICommand? _itemClick, _itemLongClick;
     private IEnumerable? _itemsSource;
@@ -91,7 +90,7 @@ public class MvxRecyclerAdapter
 
             if (_itemLongClick != null && value != null)
             {
-                MvxAndroidLog.Instance.Log(LogLevel.Warning,
+                MvxAndroidLog.Instance?.Log(LogLevel.Warning,
                     "Changing ItemLongClick may cause inconsistencies where some items still call the old command");
             }
 
@@ -168,8 +167,8 @@ public class MvxRecyclerAdapter
 
     public override ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
     {
-        if (parent == null)
-            throw new ArgumentNullException(nameof(parent), "parent is null, cannot get Android Context.");
+        if (parent.Context == null)
+            throw new ArgumentNullException(nameof(parent), "parent context is null");
 
         if (BindingContext == null)
             throw new InvalidOperationException("BindingContext is null. Cannot inflate view for ViewHolder");
@@ -307,7 +306,7 @@ public class MvxRecyclerAdapter
     {
         if (Looper.MainLooper != Looper.MyLooper())
         {
-            MvxAndroidLog.Instance.Log(LogLevel.Error,
+            MvxAndroidLog.Instance?.Log(LogLevel.Error,
                 "ItemsSource property set on a worker thread. This leads to crash in the RecyclerView. It must be set only from the main thread");
         }
 
@@ -340,7 +339,7 @@ public class MvxRecyclerAdapter
         }
         else
         {
-            MvxAndroidLog.Instance.Log(LogLevel.Error,
+            MvxAndroidLog.Instance?.Log(LogLevel.Error,
                 "ItemsSource collection content changed on a worker thread." +
                 "This leads to crash in the RecyclerView as it will not be aware of changes" +
                 "immediately and may get a deleted item or update an item with a bad item template." +
@@ -379,7 +378,7 @@ public class MvxRecyclerAdapter
 
     protected virtual void OnMvxViewHolderBound(MvxViewHolderBoundEventArgs obj)
     {
-        MvxViewHolderBound?.Invoke(obj);
+        MvxViewHolderBound?.Invoke(this, obj);
     }
 
     private void AttachClickListeners(IMvxRecyclerViewHolder viewHolder)

--- a/MvvmCross.DroidX/RecyclerView/MvxRecyclerView.cs
+++ b/MvvmCross.DroidX/RecyclerView/MvxRecyclerView.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-#nullable enable
+
 using System.Collections;
 using System.Windows.Input;
 using Android.Content;

--- a/MvvmCross.DroidX/RecyclerView/MvxRecyclerViewHolder.cs
+++ b/MvvmCross.DroidX/RecyclerView/MvxRecyclerViewHolder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross.Base;
@@ -10,112 +9,111 @@ using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.WeakSubscription;
 
-namespace MvvmCross.DroidX.RecyclerView
+namespace MvvmCross.DroidX.RecyclerView;
+
+[Register("mvvmcross.droidx.recyclerview.MvxRecyclerViewHolder")]
+public class MvxRecyclerViewHolder
+    : AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder, IMvxRecyclerViewHolder
 {
-    [Register("mvvmcross.droidx.recyclerview.MvxRecyclerViewHolder")]
-    public class MvxRecyclerViewHolder
-        : AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder, IMvxRecyclerViewHolder
+    public event EventHandler<EventArgs>? Click;
+    public event EventHandler<EventArgs>? LongClick;
+
+    private IMvxBindingContext? _bindingContext;
+    private object? _cachedDataContext;
+    private IDisposable? _itemViewClickSubscription, _itemViewLongClickSubscription;
+
+    public IMvxBindingContext? BindingContext
     {
-        private IMvxBindingContext _bindingContext;
-        private IDisposable clickSubscription, longClickSubscription;
-        private object _cachedDataContext;
-        private IDisposable itemViewClickSubscription, itemViewLongClickSubscription;
+        get => _bindingContext;
+        set => throw new NotImplementedException("BindingContext is readonly in the list item");
+    }
 
-        public event EventHandler<EventArgs> Click;
-        public event EventHandler<EventArgs> LongClick;
+    public int Id { get; set; }
 
-        public IMvxBindingContext BindingContext
+    public object? DataContext
+    {
+        get => _bindingContext?.DataContext;
+        set
         {
-            get => _bindingContext;
-            set => throw new NotImplementedException("BindingContext is readonly in the list item");
-        }
-
-        public int Id { get; set; }
-
-        public object DataContext
-        {
-            get => _bindingContext.DataContext;
-            set
-            {
+            if (_bindingContext != null)
                 _bindingContext.DataContext = value;
 
-                // This is just a precaution.  If we've set the DataContext to something
-                // then we don't need to have the old one still cached.
-                _cachedDataContext = null;
-            }
-        }
-
-        public MvxRecyclerViewHolder(View itemView, IMvxAndroidBindingContext context)
-            : base(itemView)
-        {
-            _bindingContext = context;
-        }
-
-        [Preserve(Conditional = true)]
-        protected MvxRecyclerViewHolder(IntPtr handle, JniHandleOwnership ownership)
-            : base(handle, ownership)
-        {
-        }
-
-        public virtual void OnAttachedToWindow()
-        {
-            if (_cachedDataContext != null && DataContext == null)
-                _bindingContext.DataContext = _cachedDataContext;
+            // This is just a precaution.  If we've set the DataContext to something
+            // then we don't need to have the old one still cached.
             _cachedDataContext = null;
-
-            if (itemViewClickSubscription == null)
-                itemViewClickSubscription = ItemView.WeakSubscribe(nameof(View.Click), OnItemViewClick);
-            if (itemViewLongClickSubscription == null)
-                itemViewLongClickSubscription = ItemView.WeakSubscribe<View, View.LongClickEventArgs>(nameof(View.LongClick), OnItemViewLongClick);
         }
+    }
 
-        public virtual void OnDetachedFromWindow()
-        {
-            itemViewClickSubscription.Dispose();
-            itemViewClickSubscription = null;
-            itemViewLongClickSubscription.Dispose();
-            itemViewLongClickSubscription = null;
+    public MvxRecyclerViewHolder(View itemView, IMvxAndroidBindingContext context)
+        : base(itemView)
+    {
+        _bindingContext = context;
+    }
 
-            _cachedDataContext = DataContext;
+    [Preserve(Conditional = true)]
+    protected MvxRecyclerViewHolder(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    public virtual void OnAttachedToWindow()
+    {
+        if (_cachedDataContext != null && DataContext == null && _bindingContext != null)
+            _bindingContext.DataContext = _cachedDataContext;
+
+        _cachedDataContext = null;
+
+        _itemViewClickSubscription ??= ItemView.WeakSubscribe(nameof(View.Click), OnItemViewClick);
+        _itemViewLongClickSubscription ??=
+            ItemView.WeakSubscribe<View, View.LongClickEventArgs>(nameof(View.LongClick), OnItemViewLongClick);
+    }
+
+    public virtual void OnDetachedFromWindow()
+    {
+        _itemViewClickSubscription?.Dispose();
+        _itemViewClickSubscription = null;
+        _itemViewLongClickSubscription?.Dispose();
+        _itemViewLongClickSubscription = null;
+
+        _cachedDataContext = DataContext;
+        if (_bindingContext != null)
             _bindingContext.DataContext = null;
-        }
+    }
 
-        protected virtual void OnItemViewClick(object sender, EventArgs e)
-        {
-            Click?.Invoke(this, e);
-        }
+    protected virtual void OnItemViewClick(object? sender, EventArgs e)
+    {
+        Click?.Invoke(this, e);
+    }
 
-        protected virtual void OnItemViewLongClick(object sender, EventArgs e)
-        {
-            LongClick?.Invoke(this, e);
-        }
+    protected virtual void OnItemViewLongClick(object? sender, EventArgs e)
+    {
+        LongClick?.Invoke(this, e);
+    }
 
-        public virtual void OnViewRecycled()
-        {
-            _cachedDataContext = null;
+    public virtual void OnViewRecycled()
+    {
+        _cachedDataContext = null;
+        if (_bindingContext != null)
             _bindingContext.DataContext = null;
-        }
+    }
 
-        protected override void Dispose(bool disposing)
+    protected override void Dispose(bool disposing)
+    {
+        _itemViewClickSubscription?.Dispose();
+        _itemViewClickSubscription = null;
+        _itemViewLongClickSubscription?.Dispose();
+        _itemViewLongClickSubscription = null;
+
+        _cachedDataContext = null;
+
+        if (_bindingContext != null)
         {
-            itemViewClickSubscription?.Dispose();
-            itemViewClickSubscription = null;
-            itemViewLongClickSubscription?.Dispose();
-            itemViewLongClickSubscription = null;
-
-            _cachedDataContext = null;
-            clickSubscription?.Dispose();
-            longClickSubscription?.Dispose();
-
-            if (_bindingContext != null)
-            {
-                _bindingContext.DataContext = null;
-                _bindingContext.ClearAllBindings();
-                _bindingContext.DisposeIfDisposable();
-                _bindingContext = null;
-            }
-
-            base.Dispose(disposing);
+            _bindingContext.DataContext = null;
+            _bindingContext.ClearAllBindings();
+            _bindingContext.DisposeIfDisposable();
+            _bindingContext = null;
         }
+
+        base.Dispose(disposing);
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Potential null refs

### :new: What is the new behavior (if this is a feature change)?
Enabled nullable attributes and handled null warnings.

Also fixed event in `IMvxRecyclerAdapterBindableHolder` returning action, which is not not how events work, just using regular EventHandler instead.

### :boom: Does this PR introduce a breaking change?
Yes, See changes above

### :bug: Recommendations for testing
You could run the Droid playground and check out the collectionview sample

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
