### PR TITLE
Remove .NET 7 TFMs

### DIFF
--- a/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
+++ b/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net8.0-android</TargetFrameworks>
+    <TargetFramework>net8.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.Leanback</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.Leanback</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
+++ b/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net8.0-android</TargetFrameworks>
+    <TargetFramework>net8.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.Material</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.Material</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
+++ b/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net8.0-android</TargetFrameworks>
+    <TargetFramework>net8.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.RecyclerView</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.RecyclerView</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
+++ b/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net8.0-android</TargetFrameworks>
+    <TargetFramework>net8.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.SwipeRefreshLayout</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.SwipeRefreshLayout</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/All/MvvmCross.Plugin.All.csproj
+++ b/MvvmCross.Plugins/All/MvvmCross.Plugin.All.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Plugin.All</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.All</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
+++ b/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/MvvmCross.Plugins/FieldBinding/MvvmCross.Plugin.FieldBinding.csproj
+++ b/MvvmCross.Plugins/FieldBinding/MvvmCross.Plugin.FieldBinding.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Plugin.FieldBinding</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.FieldBinding</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Json/MvvmCross.Plugin.Json.csproj
+++ b/MvvmCross.Plugins/Json/MvvmCross.Plugin.Json.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Plugin.Json</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.Json</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/JsonLocalization/MvvmCross.Plugin.JsonLocalization.csproj
+++ b/MvvmCross.Plugins/JsonLocalization/MvvmCross.Plugin.JsonLocalization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Plugin.JsonLocalization</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.JsonLocalization</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Messenger/MvvmCross.Plugin.Messenger.csproj
+++ b/MvvmCross.Plugins/Messenger/MvvmCross.Plugin.Messenger.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Plugin.Messenger</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.Messenger</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/MethodBinding/MvvmCross.Plugin.MethodBinding.csproj
+++ b/MvvmCross.Plugins/MethodBinding/MvvmCross.Plugin.MethodBinding.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Plugin.MethodBinding</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.MethodBinding</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MvvmCross.Plugins/ResxLocalization/MvvmCross.Plugin.ResxLocalization.csproj
+++ b/MvvmCross.Plugins/ResxLocalization/MvvmCross.Plugin.ResxLocalization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Plugin.ResxLocalization</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.ResxLocalization</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MvvmCross.Tests/MvvmCross.Tests.csproj
+++ b/MvvmCross.Tests/MvvmCross.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MvvmCross.Tests</AssemblyName>
     <RootNamespace>MvvmCross.Tests</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
+++ b/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <AssemblyName>MvvmCross.Platforms.Wpf</AssemblyName>
     <RootNamespace>MvvmCross.Platforms.Wpf</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-tvos;net7.0-macos;net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-tvos;net8.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-tvos;net8.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,7 +22,7 @@ This package contains the 'Core' libraries for MvvmCross</Description>
     <None Include="readme.txt" pack="true" PackagePath="." />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <Compile Include="Platforms\Netstandard\**\*.cs" />
     <Compile Include="Platforms\Console\**\*.cs" />
   </ItemGroup>

--- a/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
+++ b/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.UnitTest</RootNamespace>

--- a/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
+++ b/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Color.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Color.UnitTest</RootNamespace>

--- a/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.JsonLocalization.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.JsonLocalization.UnitTest</RootNamespace>

--- a/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
+++ b/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Messenger.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Messenger.UnitTest</RootNamespace>

--- a/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
+++ b/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.ResourceLoader.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.ResourceLoader.UnitTest</RootNamespace>

--- a/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.ResxLocalization.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.ResxLocalization.UnitTest</RootNamespace>

--- a/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
+++ b/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>MvvmCross.Plugins.Visibility.UnitTest</AssemblyName>
     <RootNamespace>MvvmCross.Plugins.Visibility.UnitTest</RootNamespace>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Maintenance

### :arrow_heading_down: What is the current behavior?
.NET7 is out of support May 14th. See announcement here: https://devblogs.microsoft.com/dotnet/donet-7-end-of-support/

### :new: What is the new behavior (if this is a feature change)?
Removing .NET7 support from MvvmCross

### :boom: Does this PR introduce a breaking change?
Only if you are still on .NET7

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
