### PR TITLE
Added new result awaiting and setting ViewModel navigation

### DIFF
--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -12,6 +12,7 @@ using MvvmCross.Logging;
 using MvvmCross.Navigation;
 using MvvmCross.Plugin;
 using MvvmCross.ViewModels;
+using MvvmCross.ViewModels.Result;
 using MvvmCross.Views;
 
 namespace MvvmCross.Core;
@@ -154,6 +155,8 @@ public abstract class MvxSetup : IMvxSetup
             var app = InitializeMvxApplication(_iocProvider);
             SetupLog?.Log(LogLevel.Trace, "Setup: NavigationService");
             InitializeNavigationService(_iocProvider);
+            SetupLog?.Log(LogLevel.Trace, "Setup: ResultViewModelManager");
+            InitializeResultViewModelManager(_iocProvider);
             SetupLog?.Log(LogLevel.Trace, "Setup: ViewModelTypeFinder start");
             InitializeViewModelTypeFinder(_iocProvider);
             SetupLog?.Log(LogLevel.Trace, "Setup: ViewsContainer start");
@@ -345,6 +348,7 @@ public abstract class MvxSetup : IMvxSetup
         iocProvider.LazyConstructAndRegisterSingleton<IMvxViewModelLoader, MvxViewModelLoader>();
         iocProvider.LazyConstructAndRegisterSingleton<IMvxNavigationService, IMvxViewModelLoader, IMvxViewDispatcher, IMvxIoCProvider>(
             (loader, dispatcher, p) => new MvxNavigationService(loader, dispatcher, p));
+        iocProvider.LazyConstructAndRegisterSingleton<IMvxResultViewModelManager, MvxResultViewModelManager>();
         iocProvider.RegisterSingleton(() => new MvxViewModelByNameLookup());
         iocProvider.LazyConstructAndRegisterSingleton<IMvxViewModelByNameLookup, MvxViewModelByNameLookup>(
             nameLookup => nameLookup);
@@ -575,6 +579,20 @@ public abstract class MvxSetup : IMvxSetup
     protected virtual IEnumerable<Assembly> GetBootstrapOwningAssemblies()
     {
         return GetViewAssemblies().Distinct();
+    }
+
+    protected virtual IMvxResultViewModelManager? InitializeResultViewModelManager(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        return CreateResultViewModelManager(iocProvider);
+    }
+
+    protected virtual IMvxResultViewModelManager? CreateResultViewModelManager(IMvxIoCProvider iocProvider)
+    {
+        ValidateArguments(iocProvider);
+
+        return iocProvider.Resolve<IMvxResultViewModelManager>();
     }
 
     protected abstract IMvxNameMapping CreateViewToViewModelNaming();

--- a/MvvmCross/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Navigation/MvxNavigationExtensions.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using MvvmCross.ViewModels;
+using MvvmCross.ViewModels.Result;
 
 namespace MvvmCross.Navigation;
 
@@ -36,5 +37,76 @@ public static class MvxNavigationExtensions
     public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
         return navigationService.Navigate(path.ToString(), param, presentationBundle, cancellationToken);
+    }
+
+    /// <summary>
+    /// Navigate from a Result Awaiting ViewModel to a Result Setting ViewModel determined by its type
+    /// </summary>
+    /// <param name="navigationService">Navigation service</param>
+    /// <param name="fromViewModel">Result Awaiting ViewModel</param>
+    /// <param name="presentationBundle">(optional) presentation bundle</param>
+    /// <param name="cancellationToken">(optional) CancellationToken to cancel the navigation</param>
+    /// <typeparam name="TViewModel">Type of <see cref="IMvxResultSettingViewModel{TResult}"/></typeparam>
+    /// <typeparam name="TResult">Result awaited by Result Awaiting ViewModel and set by Result Setting ViewModel</typeparam>
+    /// <returns>Boolean indicating successful navigation</returns>
+    public static async Task<bool> NavigateRegisteringToResult<TViewModel, TResult>(
+        this IMvxNavigationService navigationService,
+        IMvxResultAwaitingViewModel<TResult> fromViewModel,
+        IMvxBundle? presentationBundle = null,
+        CancellationToken cancellationToken = default)
+        where TViewModel : IMvxResultSettingViewModel<TResult>
+    {
+        bool navigated = await navigationService.Navigate(typeof(TViewModel), presentationBundle, cancellationToken);
+        if (navigated)
+            fromViewModel.RegisterToResult();
+        return navigated;
+    }
+
+    /// <summary>
+    /// Navigate from a Result Awaiting ViewModel to a Result Setting ViewModel determined by its type, with parameter
+    /// </summary>
+    /// <param name="navigationService">Navigation service</param>
+    /// <param name="fromViewModel">Result Awaiting ViewModel</param>
+    /// <param name="parameter">ViewModel parameter</param>
+    /// <param name="presentationBundle">(optional) presentation bundle</param>
+    /// <param name="cancellationToken">(optional) CancellationToken to cancel the navigation</param>
+    /// <typeparam name="TViewModel">Type of <see cref="IMvxResultSettingViewModel{TResult}"/> and <see cref="IMvxViewModel{TParameter}"/></typeparam>
+    /// <typeparam name="TResult">Result awaited by Result Awaiting ViewModel and set by Result Setting ViewModel</typeparam>
+    /// <returns>Boolean indicating successful navigation</returns>
+    public static async Task<bool> NavigateRegisteringToResult<TViewModel, TParameter, TResult>(
+        this IMvxNavigationService navigationService,
+        IMvxResultAwaitingViewModel<TResult> fromViewModel,
+        TParameter parameter,
+        IMvxBundle? presentationBundle = null,
+        CancellationToken cancellationToken = default)
+        where TViewModel : IMvxResultSettingViewModel<TResult>, IMvxViewModel<TParameter>
+    {
+        bool navigated = await navigationService.Navigate(typeof(TViewModel), parameter, presentationBundle, cancellationToken);
+        if (navigated)
+            fromViewModel.RegisterToResult();
+        return navigated;
+    }
+
+    /// <summary>
+    /// Closes the View attached to the Result Setting ViewModel, with result
+    /// </summary>
+    /// <param name="navigationService">Navigation service</param>
+    /// <param name="viewModel">Result Setting ViewModel to close</param>
+    /// <param name="result">Result set by Result Setting ViewModel</param>
+    /// <param name="cancellationToken">(optional) CancellationToken to cancel the closing</param>
+    /// <typeparam name="TViewModel">Type of <see cref="IMvxResultSettingViewModel{TResult}"/></typeparam>
+    /// <typeparam name="TResult">Result set by Result Setting ViewModel</typeparam>
+    /// <returns></returns>
+    public static async Task<bool> CloseSettingResult<TViewModel, TResult>(
+        this IMvxNavigationService navigationService,
+        TViewModel viewModel,
+        TResult result,
+        CancellationToken cancellationToken = default)
+        where TViewModel : IMvxResultSettingViewModel<TResult>
+    {
+        bool closed = await navigationService.Close(viewModel, cancellationToken);
+        if (closed)
+            viewModel.SetResult(result);
+        return closed;
     }
 }

--- a/MvvmCross/ViewModels/MvxNavigationViewModel.cs
+++ b/MvvmCross/ViewModels/MvxNavigationViewModel.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Navigation;
+using MvvmCross.ViewModels.Result;
 
 namespace MvvmCross.ViewModels
 {
@@ -27,10 +27,79 @@ namespace MvvmCross.ViewModels
         protected virtual ILogger Log => _log ??= LoggerFactory.CreateLogger(GetType().Name);
     }
 
-    public abstract class MvxNavigationViewModel<TParameter> : MvxNavigationViewModel, IMvxViewModel<TParameter>
-        where TParameter : class
+    public abstract class MvxNavigationViewModel<TParameter>
+        : MvxNavigationViewModel, IMvxViewModel<TParameter>
     {
         protected MvxNavigationViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService)
+            : base(logFactory, navigationService)
+        {
+        }
+
+        public abstract void Prepare(TParameter parameter);
+    }
+
+    public abstract class MvxNavigationResultAwaitingViewModel<TResult>
+        : MvxNavigationViewModel, IMvxResultAwaitingViewModel<TResult>
+    {
+        protected MvxNavigationResultAwaitingViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService)
+            : base(logFactory, navigationService)
+        {
+        }
+
+        protected override void ReloadFromBundle(IMvxBundle state)
+        {
+            base.ReloadFromBundle(state);
+            this.ReloadAndRegisterToResult(state);
+        }
+
+        protected override void SaveStateToBundle(IMvxBundle bundle)
+        {
+            base.SaveStateToBundle(bundle);
+            this.SaveRegisterToResult(bundle);
+        }
+
+        public override void ViewDestroy(bool viewFinishing = true)
+        {
+            base.ViewDestroy(viewFinishing);
+
+            if (viewFinishing)
+            {
+                this.UnregisterToResult();
+            }
+        }
+
+        public abstract bool ResultSet(IMvxResultSettingViewModel<TResult> viewModel, TResult result);
+    }
+
+    public abstract class MvxNavigationResultAwaitingViewModel<TParameter, TResult>
+        : MvxNavigationResultAwaitingViewModel<TResult>, IMvxViewModel<TParameter>
+    {
+        protected MvxNavigationResultAwaitingViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService)
+            : base(logFactory, navigationService)
+        {
+        }
+
+        public abstract void Prepare(TParameter parameter);
+    }
+
+    public abstract class MvxNavigationResultSettingViewModel<TResult>
+        : MvxNavigationViewModel, IMvxResultSettingViewModel<TResult>
+    {
+        protected MvxNavigationResultSettingViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService)
+            : base(logFactory, navigationService)
+        {
+        }
+
+        public virtual void SetResult(TResult result)
+        {
+            this.SetResult<TResult>(result);
+        }
+    }
+
+    public abstract class MvxNavigationResultSettingViewModel<TParameter, TResult>
+        : MvxNavigationResultSettingViewModel<TResult>, IMvxViewModel<TParameter>
+    {
+        protected MvxNavigationResultSettingViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService)
             : base(logFactory, navigationService)
         {
         }

--- a/MvvmCross/ViewModels/Result/IMvxResultAwaitingViewModel.cs
+++ b/MvvmCross/ViewModels/Result/IMvxResultAwaitingViewModel.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.ViewModels.Result;
+
+/// <summary>
+/// Implementing this interface requires to manually register and unregister ViewModel to result:
+/// <code>
+/// protected override void ReloadFromBundle(IMvxBundle state)
+/// {
+///     base.ReloadFromBundle(state);
+///     this.ReloadAndRegisterToResult&lt;<typeparamref name="TResult"/>&gt;(state);
+/// }
+/// protected override void SaveStateToBundle(IMvxBundle bundle)
+/// {
+///     base.SaveStateToBundle(bundle);
+///     this.SaveRegisterToResult&lt;<typeparamref name="TResult"/>&gt;(bundle);
+/// }
+/// public override ViewDestroy(bool viewFinishing = true)
+/// {
+///     base.ViewDestroy();
+///     if (viewFinishing)
+///         this.UnregisterToResult&lt;<typeparamref name="TResult"/>&gt;();
+/// }
+/// </code>
+/// </summary>
+/// <typeparam name="TResult"></typeparam>
+public interface IMvxResultAwaitingViewModel<TResult> : IMvxViewModel
+{
+    bool ResultSet(IMvxResultSettingViewModel<TResult> viewModel, TResult result);
+}

--- a/MvvmCross/ViewModels/Result/IMvxResultSettingViewModel.cs
+++ b/MvvmCross/ViewModels/Result/IMvxResultSettingViewModel.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.ViewModels.Result;
+
+public interface IMvxResultSettingViewModel<in TResult> : IMvxViewModel
+{
+    void SetResult(TResult result);
+}

--- a/MvvmCross/ViewModels/Result/IMvxResultViewModelManager.cs
+++ b/MvvmCross/ViewModels/Result/IMvxResultViewModelManager.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.ViewModels.Result;
+
+public interface IMvxResultViewModelManager
+{
+    void RegisterToResult<TResult>(IMvxResultAwaitingViewModel<TResult> viewModel);
+
+    bool UnregisterToResult<TResult>(IMvxResultAwaitingViewModel<TResult> viewModel);
+
+    bool IsRegistered<TResult>(IMvxResultAwaitingViewModel<TResult> viewModel);
+
+    void SetResult<TResult>(IMvxResultSettingViewModel<TResult> viewModel, TResult result);
+}

--- a/MvvmCross/ViewModels/Result/MvxResultAwaitingViewModel.cs
+++ b/MvvmCross/ViewModels/Result/MvxResultAwaitingViewModel.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.ViewModels.Result;
+
+public abstract class MvxResultAwaitingViewModel<TResult>
+    : MvxViewModel, IMvxResultAwaitingViewModel<TResult>
+{
+    protected override void ReloadFromBundle(IMvxBundle state)
+    {
+        base.ReloadFromBundle(state);
+        ReloadAndRegisterToResult(state);
+    }
+
+    protected override void SaveStateToBundle(IMvxBundle bundle)
+    {
+        base.SaveStateToBundle(bundle);
+        SaveRegisterToResult(bundle);
+    }
+
+    public override void ViewDestroy(bool viewFinishing = true)
+    {
+        base.ViewDestroy(viewFinishing);
+
+        if (viewFinishing)
+        {
+            UnregisterToResult();
+        }
+    }
+
+    public virtual void ReloadAndRegisterToResult(IMvxBundle state)
+    {
+        this.ReloadAndRegisterToResult<TResult>(state);
+    }
+
+    public virtual void SaveRegisterToResult(IMvxBundle state)
+    {
+        this.SaveRegisterToResult<TResult>(state);
+    }
+
+    public virtual void UnregisterToResult()
+    {
+        this.UnregisterToResult<TResult>();
+    }
+
+    public abstract bool ResultSet(IMvxResultSettingViewModel<TResult> viewModel, TResult result);
+}
+
+public abstract class MvxResultAwaitingViewModel<TParameter, TResult>
+    : MvxResultAwaitingViewModel<TResult>, IMvxViewModel<TParameter>
+{
+    public abstract void Prepare(TParameter parameter);
+}
+
+public abstract class MvxResultAwaitingViewModel<TParameter, TResult1, TResult2>
+    : MvxMultiResultAwaitingViewModel<TResult1, TResult2>, IMvxViewModel<TParameter>
+{
+    public abstract void Prepare(TParameter parameter);
+}
+
+public abstract class MvxResultAwaitingViewModel<TParameter, TResult1, TResult2, TResult3>
+    : MvxMultiResultAwaitingViewModel<TResult1, TResult2, TResult3>, IMvxViewModel<TParameter>
+{
+    public abstract void Prepare(TParameter parameter);
+}
+
+public abstract class MvxMultiResultAwaitingViewModel<TResult1, TResult2>
+    : MvxResultAwaitingViewModel<TResult1>, IMvxResultAwaitingViewModel<TResult2>
+{
+    public override void ReloadAndRegisterToResult(IMvxBundle state)
+    {
+        base.ReloadAndRegisterToResult(state);
+        this.ReloadAndRegisterToResult<TResult2>(state);
+    }
+
+    public override void SaveRegisterToResult(IMvxBundle state)
+    {
+        base.SaveRegisterToResult(state);
+        this.SaveRegisterToResult<TResult2>(state);
+    }
+
+    public override void UnregisterToResult()
+    {
+        base.UnregisterToResult();
+        this.UnregisterToResult<TResult2>();
+    }
+
+    public abstract bool ResultSet(IMvxResultSettingViewModel<TResult2> viewModel, TResult2 result);
+}
+
+public abstract class MvxMultiResultAwaitingViewModel<TResult1, TResult2, TResult3>
+    : MvxMultiResultAwaitingViewModel<TResult1, TResult2>, IMvxResultAwaitingViewModel<TResult3>
+{
+    public override void ReloadAndRegisterToResult(IMvxBundle state)
+    {
+        base.ReloadAndRegisterToResult(state);
+        this.ReloadAndRegisterToResult<TResult3>(state);
+    }
+
+    public override void SaveRegisterToResult(IMvxBundle state)
+    {
+        base.SaveRegisterToResult(state);
+        this.SaveRegisterToResult<TResult3>(state);
+    }
+
+    public override void UnregisterToResult()
+    {
+        base.UnregisterToResult();
+        this.UnregisterToResult<TResult3>();
+    }
+
+    public abstract bool ResultSet(IMvxResultSettingViewModel<TResult3> viewModel, TResult3 result);
+}

--- a/MvvmCross/ViewModels/Result/MvxResultSettingViewModel.cs
+++ b/MvvmCross/ViewModels/Result/MvxResultSettingViewModel.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.ViewModels.Result;
+
+public abstract class MvxResultSettingViewModel<TResult> : MvxViewModel, IMvxResultSettingViewModel<TResult>
+{
+    public virtual void SetResult(TResult result)
+    {
+        this.SetResult<TResult>(result);
+    }
+}
+
+public abstract class MvxResultSettingViewModel<TParameter, TResult> : MvxResultSettingViewModel<TResult>, IMvxViewModel<TParameter>
+{
+    public abstract void Prepare(TParameter parameter);
+}

--- a/MvvmCross/ViewModels/Result/MvxResultViewModelExtensions.cs
+++ b/MvvmCross/ViewModels/Result/MvxResultViewModelExtensions.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.ViewModels.Result;
+
+public static class MvxResultViewModelExtensions
+{
+    public const string BundleRegisterKey = "__mvxResultVMRegisterKey";
+
+    public static void ReloadAndRegisterToResult<TResult>(this IMvxResultAwaitingViewModel<TResult> viewModel, IMvxBundle savedStateBundle)
+    {
+        if (Mvx.IoCProvider?.TryResolve<IMvxResultViewModelManager>(out var manager) == true &&
+            savedStateBundle?.Data?.TryGetValue(BundleRegisterKey, out string restoreRegisterStr) == true &&
+            bool.TryParse(restoreRegisterStr, out bool restoreRegister) && restoreRegister)
+        {
+            manager.RegisterToResult(viewModel);
+        }
+    }
+
+    public static void SaveRegisterToResult<TResult>(this IMvxResultAwaitingViewModel<TResult> viewModel, IMvxBundle savedStateBundle)
+    {
+        if (Mvx.IoCProvider?.TryResolve<IMvxResultViewModelManager>(out var manager) == true &&
+            manager.IsRegistered(viewModel) &&
+            savedStateBundle?.Data is { } data)
+        {
+            data[BundleRegisterKey] = true.ToString();
+        }
+    }
+
+    public static void RegisterToResult<TResult>(this IMvxResultAwaitingViewModel<TResult> viewModel)
+    {
+        if (Mvx.IoCProvider?.TryResolve<IMvxResultViewModelManager>(out var manager) == true)
+        {
+            manager.RegisterToResult(viewModel);
+        }
+    }
+
+    public static void UnregisterToResult<TResult>(this IMvxResultAwaitingViewModel<TResult> viewModel)
+    {
+        if (Mvx.IoCProvider?.TryResolve<IMvxResultViewModelManager>(out var manager) == true)
+        {
+            manager.UnregisterToResult(viewModel);
+        }
+    }
+
+    public static void SetResult<TResult>(this IMvxResultSettingViewModel<TResult> viewModel, TResult result)
+    {
+        if (Mvx.IoCProvider?.TryResolve<IMvxResultViewModelManager>(out var manager) == true)
+        {
+            manager.SetResult(viewModel, result);
+        }
+    }
+}

--- a/MvvmCross/ViewModels/Result/MvxResultViewModelManager.cs
+++ b/MvvmCross/ViewModels/Result/MvxResultViewModelManager.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace MvvmCross.ViewModels.Result;
+
+public class MvxResultViewModelManager : IMvxResultViewModelManager
+{
+    private readonly Dictionary<Type, HashSet<IMvxViewModel>> _registrations = new();
+
+    public void RegisterToResult<TResult>(IMvxResultAwaitingViewModel<TResult> viewModel)
+    {
+        if (!_registrations.TryGetValue(typeof(TResult), out var resultRegistrations))
+        {
+            resultRegistrations = new();
+            _registrations[typeof(TResult)] = resultRegistrations;
+        }
+
+        resultRegistrations.Add(viewModel);
+    }
+
+    public bool UnregisterToResult<TResult>(IMvxResultAwaitingViewModel<TResult> viewModel)
+    {
+        if (_registrations.TryGetValue(typeof(TResult), out var resultRegistrations) &&
+            resultRegistrations.Remove(viewModel))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public bool IsRegistered<TResult>(IMvxResultAwaitingViewModel<TResult> viewModel)
+    {
+        if (_registrations.TryGetValue(typeof(TResult), out var resultRegistrations) &&
+            resultRegistrations.Contains(viewModel))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public void SetResult<TResult>(IMvxResultSettingViewModel<TResult> viewModel, TResult result)
+    {
+        if (_registrations.TryGetValue(typeof(TResult), out var resultRegistrations))
+        {
+            foreach (var resultRegistration in resultRegistrations.Cast<IMvxResultAwaitingViewModel<TResult>>().ToArray())
+            {
+                if (resultRegistration.ResultSet(viewModel, result))
+                {
+                    resultRegistrations.Remove(resultRegistration);
+                }
+            }
+        }
+    }
+}

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/ChildViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/ChildViewModel.cs
@@ -8,11 +8,12 @@ using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
 using MvvmCross.ViewModels;
+using MvvmCross.ViewModels.Result;
 using Playground.Core.Models;
 
 namespace Playground.Core.ViewModels
 {
-    public class ChildViewModel : MvxNavigationViewModel<SampleModel>
+    public class ChildViewModel : MvxNavigationResultSettingViewModel<SampleModel, SampleModel>
     {
         public string BrokenTextValue { get => _brokenTextValue; set => SetProperty(ref _brokenTextValue, value); }
         public string AnotherBrokenTextValue { get => _anotherBrokenTextValue; set => SetProperty(ref _anotherBrokenTextValue, value); }
@@ -24,7 +25,11 @@ namespace Playground.Core.ViewModels
         public ChildViewModel(ILoggerFactory logProvider, IMvxNavigationService navigationService)
             : base(logProvider, navigationService)
         {
-            CloseCommand = new MvxAsyncCommand(() => NavigationService.Close(this));
+            CloseCommand = new MvxAsyncCommand(() => NavigationService.CloseSettingResult(this, new SampleModel
+            {
+                Message = "This returned correctly",
+                Value = 5.67m
+            }));
 
             ShowSecondChildCommand = new MvxAsyncCommand(() => NavigationService.Navigate<SecondChildViewModel>());
 

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -13,6 +13,7 @@ using MvvmCross.Logging;
 using MvvmCross.Navigation;
 using MvvmCross.Plugin.Messenger;
 using MvvmCross.ViewModels;
+using MvvmCross.ViewModels.Result;
 using Playground.Core.Models;
 using Playground.Core.Services;
 using Playground.Core.ViewModels.Bindings;
@@ -21,7 +22,7 @@ using Playground.Core.ViewModels.Samples;
 
 namespace Playground.Core.ViewModels
 {
-    public class RootViewModel : MvxNavigationViewModel
+    public class RootViewModel : MvxNavigationResultAwaitingViewModel<SampleModel>
     {
         private readonly IMvxViewModelLoader _mvxViewModelLoader;
 
@@ -48,7 +49,7 @@ namespace Playground.Core.ViewModels
                 Console.WriteLine(e.ToString());
             }
 
-            ShowChildCommand = new MvxAsyncCommand(() => NavigationService.Navigate<ChildViewModel, SampleModel>(new SampleModel
+            ShowChildCommand = new MvxAsyncCommand(() => NavigationService.NavigateRegisteringToResult<ChildViewModel, SampleModel, SampleModel>(this, new SampleModel
             {
                 Message = "Hey",
                 Value = 1.23m
@@ -290,6 +291,12 @@ namespace Playground.Core.ViewModels
             TimeToResolve = $"Time to resolve - NO reflection - {resolved}";
             TotalTime = $"Total time - NO reflection - {total}";
             await RaiseAllPropertiesChanged();
+        }
+
+        public override bool ResultSet(IMvxResultSettingViewModel<SampleModel> viewModel, SampleModel result)
+        {
+            Log.LogInformation($"Result {result} from {viewModel}");
+            return true;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds new `IMvxResultAwaitingViewModel<TResult>` and `IMvxResultSettingViewModel<TResult>` interfaces and corresponding abstract classes to create a result navigation contract between the awaiting and setting the result ViewModels. Under the hood it uses a new `IMvxResultViewModelManager` that registers, unregisters and sets result to registered result awaiting ViewModels.

It's better to use predefined abstract classes `MvxResultAwaitingViewModel<TResult>`, `MvxMultiResultAwaitingViewModel<TResult1, TResult2>`, `MvxResultSettingViewModel<TResult>`, `MvxNavigationResultAwaitingViewModel<TResult>`, `MvxNavigationResultSettingViewModel<TResult>`, and their overloads with parameters. Because when implementing `IMvxResultAwaitingViewModel<TResult>` and `IMvxResultSettingViewModel<TResult>` manually it requires implementing ViewModels registering, saving, restoration, unregistering, and setting the result manually as well.

### :arrow_heading_down: What is the current behavior?
No navigation with awaiting the result.

### :new: What is the new behavior (if this is a feature change)?
Navigation with awaiting the result.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
0. Prepare an Android 13+ device or emulator since we need runtime Notification permissions.
1. Deploy the Playground.Droid app.
2. Start it **without** debugging since the app will be shut down later.
3. Click "SHOW CHILD" button - it will show a child `Fragment` on bottom
4. Minimize the app (not close) by clicking Home or Overview.
5. Go to the Playground.Droid app system settings.
6. Make sure Notifications permissions are granted.
7. Disable Notifications permissions.
8. Go back to the app.
9. The app will be restored with the child `Fragment` on bottom.
10. Click "CLOSE" in the child `Fragment`.
11. Check the logcat (via your preferred IDE): it should display
```
Info (26885) / RootViewModel: [Information] Result Playground.Core.Models.SampleModel from Playground.Core.ViewModels.ChildViewModel
```
12. We received the awaited result after the full app restoration (with shutting down).

You can test this with any dangerous permissions.
Developer option "Don't keep activities" works differently - it does not shut down the app. Though the feature also works in this case.

For other platforms it just works without restoration issues.

### :memo: Links to relevant issues/docs
PRs: #4312 #4652 
Issues: #3342 #3980 #4230 #4262 #4553 #4651 

### :thinking: Checklist before submitting
- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop

### 🧠 Extra
I am open for discussing changes for the implementation.
Here are some ideas:
- move 3 new navigation extensions to the navigation service directly
- handle default implementations differently through default interface declaration
- rename those long interface and class names to shorter ones