### PR TITLE
Fixed creating and loading an Activity VM and its lifecycle twice after restoring on Android

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
@@ -111,7 +111,7 @@ public class MvxAndroidViewsContainer
 
         if (Mvx.IoCProvider?.TryResolve(out IMvxViewModelLoader? viewModelLoader) == true && viewModelLoader != null)
         {
-            viewModelLoader.LoadViewModel(viewModelRequest, savedState);
+            return viewModelLoader.LoadViewModel(viewModelRequest, savedState);
         }
 
         return null;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
An Android `Activity` restores its VM from `Intent` first, loads the VM, runs its lifecycle but eventually returns `null` to the restoration process so it does the direct loading from the VM type and repeats the process. In the end it does create and load the same VM twice and the first one stays in memory while the second one gets actually loaded (always `false` on line 65): https://github.com/MvvmCross/MvvmCross/blob/93c88422263385e69d60d8c9407f9ea6ed86c55a/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs#L64-L69

### :new: What is the new behavior (if this is a feature change)?
An Android `Activity` restores its VM from `Intent` and if succeeded then doesn't do direct loading so eventually there is only one VM lifecycle happens

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Try the same steps from #4848.

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
