### PR TITLE
CloseWindow is now called when the Window is actually closed

### DIFF
--- a/MvvmCross/Platforms/WinUi/Presenters/MvxMultiWindowViewPresenter.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/MvxMultiWindowViewPresenter.cs
@@ -702,14 +702,13 @@ public class MvxMultiWindowViewPresenter
             if (page is IMvxNeedWindow needWindow2 && !needWindow2.CanClose())
             {
                 e.Cancel = true;
-                return;
             }
 
-            CloseWindow(newWindow);
         };
 
         newWindow.Closed += (_, _) =>
         {
+            CloseWindow(newWindow);
             page.DisposeIfDisposable();
 
             lock (_windowInformationLock)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This is a bug fix.

### :arrow_heading_down: What is the current behavior?
When a window is closed by calling "window.close()" the Closing event isn't called. This even is only called when the Cross in the window is clicked. As a result, the CloseWindow function wasn't called and the ViewModel wasn't disposed.

### :new: What is the new behavior (if this is a feature change)?
By calling CloseWindow in the Closed event, when the CloseWindow function is called again and the ViewModel is disposed.
This is needed when you for example, want to show a popup to ask the user if they actually want to close, but you have to do this asynchrously.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Nothing special.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [V ] All projects build
- [ V] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ V] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ V] Rebased onto current develop
