### PR TITLE
Run continuations from TaskCompletionSource on TaskPool

### DIFF
--- a/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
+++ b/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
@@ -28,7 +28,7 @@ namespace MvvmCross.Base
             if (action == null)
                 return;
 
-            var completion = new TaskCompletionSource<bool>();
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var syncAction = new Action(async () =>
             {
                 await action();

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Core;
@@ -33,9 +32,6 @@ public class MvxNavigationService : IMvxNavigationService
     protected Dictionary<Regex, Type> Routes { get; } = new();
 
     protected IMvxViewModelLoader ViewModelLoader { get; set; }
-
-    protected ConditionalWeakTable<IMvxViewModel, TaskCompletionSource<object?>> TaskCompletionResults { get; } =
-        new();
 
     public event EventHandler<IMvxNavigateEventArgs>? WillNavigate;
 

--- a/MvvmCross/Platforms/Ios/MvxIosTask.cs
+++ b/MvvmCross/Platforms/Ios/MvxIosTask.cs
@@ -11,7 +11,7 @@ public class MvxIosTask
     {
         var sharedApp = UIApplication.SharedApplication;
         var options = new UIApplicationOpenUrlOptions { UniversalLinksOnly = false };
-        var tcs = new TaskCompletionSource<bool>();
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         if (sharedApp.CanOpenUrl(url))
         {
             sharedApp.OpenUrl(url, options, ok => tcs.TrySetResult(ok));

--- a/MvvmCross/Platforms/WinUi/Presenters/MvxMultiWindowViewPresenter.cs
+++ b/MvvmCross/Platforms/WinUi/Presenters/MvxMultiWindowViewPresenter.cs
@@ -611,7 +611,8 @@ public class MvxMultiWindowViewPresenter
 
         static Task TryEnqueue(DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority)
         {
-            var taskCompletionSource = new TaskCompletionSource<object?>();
+            var taskCompletionSource =
+                new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             if (!dispatcher.TryEnqueue(
                     priority,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug fix

### :arrow_heading_down: What is the current behavior?

We use TaskCompletionSource (TCS) in a few places, without providing the option to run continuations asynchronously. This can be dangerous, especially if awaiting the TCS from UI thread and the continuation tries to happen inline on the same thread, it can lead to deadlocks in the App and make it crash.

### :new: What is the new behavior (if this is a feature change)?

Now using `TaskCreationOptions.RunContinuationsAsynchronously` to make continuations from TCS return on a TaskPool Thread

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
