### PR TITLE
Fix issues with Window exports in AppDelegate

### DIFF
--- a/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
@@ -12,10 +12,7 @@ public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplic
 {
     public event EventHandler<MvxLifetimeEventArgs>? LifetimeChanged;
 
-    /// <summary>
-    /// UIApplicationDelegate.Window doesn't really exist / work. It was added by Xamarin.iOS templates 
-    /// </summary>
-    public new virtual UIWindow? Window { get; set; }
+    public virtual UIWindow? MainWindow { get; set; }
 
     protected MvxApplicationDelegate()
     {
@@ -39,9 +36,9 @@ public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplic
 
     public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
     {
-        Window ??= new UIWindow(UIScreen.MainScreen.Bounds);
+        MainWindow ??= new UIWindow(UIScreen.MainScreen.Bounds);
 
-        MvxIosSetupSingleton.EnsureSingletonAvailable(this, Window).EnsureInitialized();
+        MvxIosSetupSingleton.EnsureSingletonAvailable(this, MainWindow).EnsureInitialized();
 
         RunAppStart(launchOptions);
 
@@ -56,7 +53,7 @@ public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplic
             startup.Start(GetAppStartHint(hint));
         }
 
-        Window?.MakeKeyAndVisible();
+        MainWindow?.MakeKeyAndVisible();
     }
 
     protected virtual object? GetAppStartHint(object? hint = null)

--- a/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Foundation;
 using MvvmCross.Core;
 using MvvmCross.ViewModels;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Core
 {
@@ -15,19 +12,18 @@ namespace MvvmCross.Platforms.Tvos.Core
         /// <summary>
         /// UIApplicationDelegate.Window doesn't really exist / work. It was added by Xamarin.iOS templates 
         /// </summary>
-        public new virtual UIWindow Window { get; set; }
+        public virtual UIWindow MainWindow { get; set; }
 
-        public MvxApplicationDelegate() : base()
+        protected MvxApplicationDelegate()
         {
             RegisterSetup();
         }
 
         public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
-            if (Window == null)
-                Window = new UIWindow(UIScreen.MainScreen.Bounds);
+            MainWindow ??= new UIWindow(UIScreen.MainScreen.Bounds);
 
-            MvxTvosSetupSingleton.EnsureSingletonAvailable(this, Window).EnsureInitialized();
+            MvxTvosSetupSingleton.EnsureSingletonAvailable(this, MainWindow).EnsureInitialized();
             RunAppStart(launchOptions);
 
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
@@ -40,7 +36,7 @@ namespace MvvmCross.Platforms.Tvos.Core
             {
                 startup.Start(GetAppStartHint(hint));
             }
-            Window.MakeKeyAndVisible();
+            MainWindow.MakeKeyAndVisible();
         }
 
         protected virtual object GetAppStartHint(object hint = null)

--- a/Projects/Playground/Playground.iOS/AppDelegate.cs
+++ b/Projects/Playground/Playground.iOS/AppDelegate.cs
@@ -1,16 +1,9 @@
-using Foundation;
-using MvvmCross;
 using MvvmCross.Platforms.Ios.Core;
-using MvvmCross.ViewModels;
 using Playground.Core;
-using UIKit;
 
-namespace Playground.iOS
-{
-    // The UIApplicationDelegate for the application. This class is responsible for launching the
-    // User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
-    [Register("AppDelegate")]
-    public partial class AppDelegate : MvxApplicationDelegate<Setup, App>
-    {
-    }
-}
+namespace Playground.iOS;
+
+// The UIApplicationDelegate for the application. This class is responsible for launching the
+// User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
+[Register("AppDelegate")]
+public partial class AppDelegate : MvxApplicationDelegate<Setup, App>;

--- a/Projects/Playground/Playground.iOS/Info.plist
+++ b/Projects/Playground/Playground.iOS/Info.plist
@@ -19,8 +19,6 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Projects/Playground/Playground.iOS/Main.cs
+++ b/Projects/Playground/Playground.iOS/Main.cs
@@ -1,15 +1,12 @@
-using UIKit;
+namespace Playground.iOS;
 
-namespace Playground.iOS
+public class Application
 {
-    public class Application
+    // This is the main entry point of the application.
+    private static void Main(string[] args)
     {
-        // This is the main entry point of the application.
-        private static void Main(string[] args)
-        {
-            // if you want to use a different Application Delegate class from "AppDelegate"
-            // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
-        }
+        // if you want to use a different Application Delegate class from "AppDelegate"
+        // you can specify it here.
+        UIApplication.Main(args, null, "AppDelegate");
     }
 }

--- a/Projects/Playground/Playground.iOS/Main.storyboard
+++ b/Projects/Playground/Playground.iOS/Main.storyboard
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Projects/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/Projects/Playground/Playground.iOS/Playground.iOS.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="Microsoft.Maui.Essentials" />
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Async" />
+    <PackageReference Include="Serilog.Sinks.Trace" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Projects/Playground/Playground.iOS/Setup.cs
+++ b/Projects/Playground/Playground.iOS/Setup.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Platforms.Ios.Core;
 using MvvmCross.Plugin;
-using MvvmCross.Plugin.Json;
 using Playground.Core;
 using Playground.iOS.Bindings;
 using Playground.iOS.Controls;

--- a/Projects/Playground/Playground.iOS/Setup.cs
+++ b/Projects/Playground/Playground.iOS/Setup.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Platforms.Ios.Core;
+using MvvmCross.Plugin;
+using MvvmCross.Plugin.Json;
 using Playground.Core;
 using Playground.iOS.Bindings;
 using Playground.iOS.Controls;
@@ -20,6 +22,7 @@ namespace Playground.iOS
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
+                .WriteTo.Async(a => a.Trace())
                 .CreateLogger();
 
             return new SerilogLoggerFactory();
@@ -32,6 +35,12 @@ namespace Playground.iOS
                 (arg) => new BinaryEditTargetBinding(arg));
 
             base.FillTargetFactories(registry);
+        }
+
+        public override void LoadPlugins(IMvxPluginManager pluginManager)
+        {
+            base.LoadPlugins(pluginManager);
+            pluginManager.EnsurePluginLoaded<MvvmCross.Plugin.Json.Plugin>();
         }
     }
 }

--- a/docs/_documentation/platform/ios/ios-user-interfaces-approaches.md
+++ b/docs/_documentation/platform/ios/ios-user-interfaces-approaches.md
@@ -27,7 +27,7 @@ XIB files are XML files that describe visual elements. You can edit them using t
 
 ### Storyboards
 
-Storyboards are XML files that can be visually edited using the Xamarin Designer or XCode Interface Builder. These files are very similar to XIB ones, but they normally contain more than a single user interface, alongisde some "segues" to navigate between them (although is not the recommended approach, you can use segues for navigation in MvvmCross).
+Storyboards are XML files that can be visually edited using the Xamarin Designer or XCode Interface Builder. These files are very similar to XIB ones, but they normally contain more than a single user interface, alongside some "segues" to navigate between them (although is not the recommended approach, you can use segues for navigation in MvvmCross).
 
 Storyboards are definitely a step forward when working with XIBs, but keep in mind that you still need to set up the Outlets (XCode IB) / Names (X Designer) to be able to bind your controls later. And since the generated XML code is not intended to be human readable, it is difficult to resolve conflicts for them in merge situations (you can have multiple storyboards to leverage this).
 
@@ -43,6 +43,11 @@ To use a view generated in a Storyboard, all you have to do is to add an `MvxFro
 
 **Note:** It is very important that you drag and drop the correct ViewController type (for example, if you want to add a TabBarController, you need to drag and drop a UITabBarViewController). Otherwise your app might not crash, but you might encounter some weird situations.
 
+#### Storyboard caveats
+
+- MvvmCross does not support defining main storyboard in Info.plist using the `UIMainStoryboardFile` key and this might be ignored
+- Remove `initiaViewController` attribute in the root `document` node to prevent issues with iOS instantiating ViewControllers twice
+- You can omit the name in the `MvxFromStoryboard` attribute, in such cases make sure that you ViewController and `storyboardIdentifier="{ViewName}"` have the same names otherwise you will get a crash 
 
 ## MvxBaseViewController
 
@@ -57,7 +62,6 @@ The feature requires there to be a UIScrollView in the view hierarchy in order t
 You can make use of this class using the following standard inheritance syntax:
 
 ```c#
-[Register("KeyboardHandlingView")]
 public class KeyboardHandlingView
     : MvxBaseViewController<KeyboardHandlingViewModel>
 {
@@ -94,4 +98,3 @@ public override bool HandlesKeyboardNotifications()
     return true;
 }
 ```
-


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When a MvvmCross App is launched through Appium when built with .NET Sdk 8.0.401+ and using a storyboard set in Info.plist as `UIMainStoryboardFile`, which has a `initialViewController` set. Then the App crashes with a null ref as both MvvmCross and the Storyboard mechanism on iOS will instantiate the VC. The MvvmCross path will work, but how the Storyboard launches the VC without a lot of info will crash the App. This is mainly due to `Window` now being exported.

### :new: What is the new behavior (if this is a feature change)?
1. Renamed `Window` in `MvxApplicationDelegate` to `MainWindow`
2. Clean up Playground.iOS sample
3. Updated docs with caveats for storyboards

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4872 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
