### PR TITLE
Fixed verbiage in the readme.txt that gets presented when MvvmCross is installed.

### DIFF
--- a/MvvmCross/Binding/Bindings/Source/Leaf/MvxLeafPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Leaf/MvxLeafPropertyInfoSourceBinding.cs
@@ -83,7 +83,7 @@ namespace MvvmCross.Binding.Bindings.Source.Leaf
             }
             catch (Exception exception)
             {
-                MvxBindingLog.Instance?.LogError(exception, "SetValue failed with exception");
+                MvxBindingLog.Instance?.LogError(exception, "SetValue failed with exception. Property Name: {PropertyName}, Value: {Value}", PropertyName, value);
             }
         }
     }

--- a/MvvmCross/readme.txt
+++ b/MvvmCross/readme.txt
@@ -43,7 +43,7 @@ However, any $rootnamespace$ instances will need to be changed to your project's
 Note: If you wish to use the AppCompat versions of Android classes, you can follow the above instructions with the following modifications
 4. Add the MvvmCross DroidX Material NuGet package (MvvmCross.DroidX.Material) to your Android platform-specific project.
 5. Add a new XML file that defines an AppCompat theme to the Resources/values folder called styles.xml. (See AndroidApp/Resources/styles.xml in the Starter sample files)
-6. Ensure the theme created in the previous step is referenced in the Attribute for the MainActivity class (Theme = "@style/MainTheme").
+6. Ensure the theme created in the previous step is referenced in the Attribute in each activity class (Theme = "@style/MainTheme") or in AndroidManifest.xml in the "application" section (<application android:label="@string/app_name" android:icon="@mipmap/Icon" android:theme="@style/MainTheme">)
 
 
 - iOS projects (ignore if not building for iOS) -


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Doc Update

### :arrow_heading_down: What is the current behavior?
Currently, the readme.txt says only to add the theme to the MainActivity if you want to use the AppCompat versions.  This only works for the MainActivity.  The theme either needs to be added to each activity or to the "application" entry in AndroidManifest.xml;

### :new: What is the new behavior (if this is a feature change)?
Verbiage


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Create an Android App that uses AppCompat and try to navigate to a ViewModel where the View does have the Theme attribute.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X] All projects build
- [X ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ X] Rebased onto current develop
