### PR TITLE
Move .NET version to env var + pin when restoring workloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
       - master
       - develop
 
+env:
+  JAVA_DISTRIBUTION: 'microsoft'
+  JAVA_VERSION: 17
+  NET_VERSION: 9.0.101
+
 jobs:
   build:
     runs-on: windows-latest
@@ -17,22 +22,24 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Install .NET 9.0.100
+    - name: Install .NET ${{ env.NET_VERSION }}
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: ${{ env.NET_VERSION }}
 
     - name: Restore .NET tools
       run: dotnet tool restore
 
     - name: Install .NET workloads
-      run: dotnet workload install android ios tvos macos maccatalyst
+      run: |
+        dotnet --version
+        dotnet workload install android ios tvos macos maccatalyst --version ${{ env.NET_VERSION }}
 
-    - name: Setup Java JDK
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'microsoft'
-        java-version: '17'
+        distribution: ${{ env.JAVA_DISTRIBUTION }}
+        java-version: ${{ env.JAVA_VERSION }}
 
     - name: Build
       run: dotnet cake --verbosity=Minimal --artifactsDir="output"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,11 @@ on:
   schedule:
     - cron: '41 5 * * 5'
 
+env:
+  JAVA_DISTRIBUTION: 'microsoft'
+  JAVA_VERSION: 17
+  NET_VERSION: 9.0.101
+
 jobs:
   analyze:
     name: Analyze
@@ -66,22 +71,24 @@ jobs:
         # queries: security-extended,security-and-quality
 
 
-    - name: Install .NET 9.0.100
+    - name: Install .NET ${{ env.NET_VERSION }}
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: ${{ env.NET_VERSION }}
 
     - name: Restore .NET tools
       run: dotnet tool restore
 
     - name: Install .NET workloads
-      run: dotnet workload install android ios tvos macos maccatalyst
+      run: |
+        dotnet --version
+        dotnet workload install android ios tvos macos maccatalyst --version ${{ env.NET_VERSION }}
 
-    - name: Setup Java JDK
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'microsoft'
-        java-version: '17'
+        distribution: ${{ env.JAVA_DISTRIBUTION }}
+        java-version: ${{ env.JAVA_VERSION }}
 
     - name: Build
       run: dotnet cake --verbosity=Minimal

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -2,6 +2,9 @@ name: dotnet format
 
 on: [pull_request]
 
+env:
+  NET_VERSION: 9.0.101
+
 jobs:
   lint:
 
@@ -10,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install .NET 9.0.100
+    - name: Install .NET ${{ env.NET_VERSION }}
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: ${{ env.NET_VERSION }}
 
     - name: Restore dependencies
       run: dotnet tool restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
       - release/**
       - hotfix/**
 
+env:
+  JAVA_DISTRIBUTION: 'microsoft'
+  JAVA_VERSION: 17
+  NET_VERSION: 9.0.101
+
 jobs:
   build:
     runs-on: windows-latest
@@ -19,22 +24,24 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Install .NET 9.0.100
+    - name: Install .NET ${{ env.NET_VERSION }}
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: ${{ env.NET_VERSION }}
 
     - name: Restore .NET tools
       run: dotnet tool restore
 
     - name: Install .NET workloads
-      run: dotnet workload install android ios tvos macos maccatalyst
+      run: |
+        dotnet --version
+        dotnet workload install android ios tvos macos maccatalyst --version ${{ env.NET_VERSION }}
 
-    - name: Setup Java JDK
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'microsoft'
-        java-version: '17'
+        distribution: ${{ env.JAVA_DISTRIBUTION }}
+        java-version: ${{ env.JAVA_VERSION }}
 
     - name: Build
       run: dotnet cake --verbosity=Minimal --artifactsDir="output"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,6 +11,7 @@ env:
   verbosity: 'minimal'
   sonarKey: 'MvvmCross_MvvmCross'
   sonarOrg: 'mvx'
+  NET_VERSION: 9.0.101
 
 jobs:
   build:
@@ -23,16 +24,18 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Install .NET 9.0.100
+    - name: Install .NET ${{ env.NET_VERSION }}
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: ${{ env.NET_VERSION }}
 
     - name: Restore .NET tools
       run: dotnet tool restore
 
     - name: Install .NET workloads
-      run: dotnet workload install android ios tvos macos maccatalyst
+      run: |
+        dotnet --version
+        dotnet workload install android ios tvos macos maccatalyst --version ${{ env.NET_VERSION }}
 
     - name: Build
       run: dotnet cake --verbosity=${{ env.verbosity }} --artifactsDir="output" --target=Sonar --sonarToken=${{ secrets.SONAR_TOKEN }} --sonarKey=${{ env.sonarKey }} --sonarOrg=${{ env.sonarOrg }}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
CI

### :arrow_heading_down: What is the current behavior?
When restoring workloads, the version of workloads is not pinned

### :new: What is the new behavior (if this is a feature change)?
Now using .NET version, specified in env vars, to pin to that versions workload-set
Bump .NET to 9.0.101

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
