### PR TITLE
Allow null values bound to Text in UILabel Text Target Binding

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUILabelTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUILabelTextTargetBinding.cs
@@ -20,9 +20,9 @@ public class MvxUILabelTextTargetBinding(UILabel target)
     protected override void SetValueImpl(object target, object? value)
     {
         var view = (UILabel?)target;
-        if (view == null || value == null)
+        if (view == null)
             return;
 
-        view.Text = (string)value;
+        view.Text = (string?)value;
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
As part of some of the nullability fixes I did back in March I accidentally disallowed setting Text to null on UILabel when using MvvmCross bindings

### :new: What is the new behavior (if this is a feature change)?
Allow nulls again

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4882

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
