### PR TITLE
Switch to NSubstitute in favor of Moq

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,8 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.11.0" />
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Moq;
 using MvvmCross.Base;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings;
@@ -10,9 +9,9 @@ using MvvmCross.Binding.Bindings.Source.Construction;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
-using MvvmCross.Tests;
 using MvvmCross.UnitTest.Binding.Mocks;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
+using NSubstitute;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Bindings
@@ -331,11 +330,11 @@ namespace MvvmCross.UnitTest.Binding.Bindings
             _fixture.ClearAll();
             _fixture.Ioc.RegisterSingleton<IMvxMainThreadAsyncDispatcher>(new InlineMockMainThreadDispatcher());
 
-            var mockSourceBindingFactory = new Mock<IMvxSourceBindingFactory>();
-            _fixture.Ioc.RegisterSingleton(mockSourceBindingFactory.Object);
+            var mockSourceBindingFactory = Substitute.For<IMvxSourceBindingFactory>();
+            _fixture.Ioc.RegisterSingleton(mockSourceBindingFactory);
 
-            var mockTargetBindingFactory = new Mock<IMvxTargetBindingFactory>();
-            _fixture.Ioc.RegisterSingleton(mockTargetBindingFactory.Object);
+            var mockTargetBindingFactory = Substitute.For<IMvxTargetBindingFactory>();
+            _fixture.Ioc.RegisterSingleton(mockTargetBindingFactory);
 
             var realSourceStepFactory = new MvxSourceStepFactory();
             realSourceStepFactory.AddOrOverwrite(typeof(MvxPathSourceStepDescription), new MvxPathSourceStepFactory());
@@ -365,12 +364,13 @@ namespace MvvmCross.UnitTest.Binding.Bindings
 
             var localSource = mockSource;
             mockSourceBindingFactory
-                .Setup(x => x.CreateBinding(It.IsAny<object>(), It.Is<string>(s => s == sourceText)))
-                .Returns((object a, string b) => localSource);
+                .CreateBinding(Arg.Any<object>(), Arg.Is<string>(s => s == sourceText))
+                .Returns(localSource);
+
             var localTarget = mockTarget;
             mockTargetBindingFactory
-                .Setup(x => x.CreateBinding(It.IsAny<object>(), It.Is<string>(s => s == targetName)))
-                .Returns((object a, string b) => localTarget);
+                .CreateBinding(Arg.Any<object>(), Arg.Is<string>(s => s == targetName))
+                .Returns(localTarget);
 
             mockSource.TryGetValueResult = true;
             mockSource.TryGetValueValue = "TryGetValueValue";

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingValueConversionTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingValueConversionTest.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Moq;
 using MvvmCross.Base;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings;
@@ -12,9 +10,9 @@ using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Converters;
-using MvvmCross.Tests;
 using MvvmCross.UnitTest.Binding.Mocks;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
+using NSubstitute;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Binding.Bindings
@@ -463,11 +461,11 @@ namespace MvvmCross.UnitTest.Binding.Bindings
             _fixture.ClearAll();
             _fixture.Ioc.RegisterSingleton<IMvxMainThreadAsyncDispatcher>(new InlineMockMainThreadDispatcher());
 
-            var mockSourceBindingFactory = new Mock<IMvxSourceBindingFactory>();
-            _fixture.Ioc.RegisterSingleton(mockSourceBindingFactory.Object);
+            var mockSourceBindingFactory = Substitute.For<IMvxSourceBindingFactory>();
+            _fixture.Ioc.RegisterSingleton(mockSourceBindingFactory);
 
-            var mockTargetBindingFactory = new Mock<IMvxTargetBindingFactory>();
-            _fixture.Ioc.RegisterSingleton(mockTargetBindingFactory.Object);
+            var mockTargetBindingFactory = Substitute.For<IMvxTargetBindingFactory>();
+            _fixture.Ioc.RegisterSingleton(mockTargetBindingFactory);
 
             var realSourceStepFactory = new MvxSourceStepFactory();
             realSourceStepFactory.AddOrOverwrite(typeof(MvxPathSourceStepDescription), new MvxPathSourceStepFactory());
@@ -496,12 +494,13 @@ namespace MvvmCross.UnitTest.Binding.Bindings
 
             var localSource = mockSource;
             mockSourceBindingFactory
-                .Setup(x => x.CreateBinding(It.IsAny<object>(), It.Is<string>(s => s == sourceText)))
-                .Returns((object a, string b) => localSource);
+                .CreateBinding(Arg.Any<object>(), Arg.Is<string>(s => s == sourceText))
+                .Returns(localSource);
+
             var localTarget = mockTarget;
             mockTargetBindingFactory
-                .Setup(x => x.CreateBinding(It.IsAny<object>(), It.Is<string>(s => s == targetName)))
-                .Returns((object a, string b) => localTarget);
+                .CreateBinding(Arg.Any<object>(), Arg.Is<string>(s => s == targetName))
+                .Returns(localTarget);
 
             mockSource.TryGetValueResult = true;
             mockSource.TryGetValueValue = "TryGetValueValue";

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/NavigationMockDispatcher.cs
@@ -2,13 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using MvvmCross.Base;
-using MvvmCross.Logging;
-using MvvmCross.Tests;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
 
@@ -17,13 +10,12 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
     public class NavigationMockDispatcher
         : IMvxViewDispatcher
     {
-        public readonly List<MvxViewModelRequest> Requests = new List<MvxViewModelRequest>();
-        public readonly List<MvxPresentationHint> Hints = new List<MvxPresentationHint>();
+        public readonly List<MvxViewModelRequest> Requests = [];
+        public readonly List<MvxPresentationHint> Hints = [];
 
         public bool IsOnMainThread => true;
 
-        public virtual bool RequestMainThreadAction(Action action,
-                                                    bool maskExceptions = true)
+        public bool RequestMainThreadAction(Action action, bool maskExceptions = true)
         {
             try
             {
@@ -39,13 +31,13 @@ namespace MvvmCross.UnitTest.Mocks.Dispatchers
             }
         }
 
-        public virtual Task<bool> ShowViewModel(MvxViewModelRequest request)
+        public Task<bool> ShowViewModel(MvxViewModelRequest request)
         {
             Requests.Add(request);
             return Task.FromResult(true);
         }
 
-        public virtual Task<bool> ChangePresentation(MvxPresentationHint hint)
+        public Task<bool> ChangePresentation(MvxPresentationHint hint)
         {
             Hints.Add(hint);
             return Task.FromResult(true);

--- a/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
+++ b/UnitTests/MvvmCross.UnitTest/MvvmCross.UnitTest.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/UnitTests/MvvmCross.UnitTest/MvxTestCollection.cs
+++ b/UnitTests/MvvmCross.UnitTest/MvxTestCollection.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Moq;
 using MvvmCross.Navigation;
 using MvvmCross.Tests;
 using MvvmCross.ViewModels;
+using NSubstitute;
 using Xunit;
 
 namespace MvvmCross.UnitTest
@@ -22,8 +22,8 @@ namespace MvvmCross.UnitTest
     {
         protected override void AdditionalSetup()
         {
-            var navigationServiceMock = new Mock<IMvxNavigationService>();
-            Ioc.RegisterSingleton(navigationServiceMock.Object);
+            var navigationServiceMock = Substitute.For<IMvxNavigationService>();
+            Ioc.RegisterSingleton(navigationServiceMock);
             Ioc.RegisterSingleton(new MvxDefaultViewModelLocator());
         }
     }

--- a/UnitTests/MvvmCross.UnitTest/ViewModels/MvxViewModelLoaderTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/ViewModels/MvxViewModelLoaderTest.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using Moq;
 using MvvmCross.Exceptions;
 using MvvmCross.Navigation.EventArguments;
-using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.ViewModels;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace MvvmCross.UnitTest.ViewModels
@@ -46,19 +44,23 @@ namespace MvvmCross.UnitTest.ViewModels
 
             IMvxViewModel outViewModel = new Test2ViewModel();
 
-            var mockLocator = new Mock<IMvxViewModelLocator>();
-            mockLocator.Setup(
-                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
-                       .Returns(() => outViewModel);
+            var mockLocator = Substitute.For<IMvxViewModelLocator>();
+            mockLocator.Load(
+                    Arg.Any<Type>(),
+                    Arg.Any<IMvxBundle>(),
+                    Arg.Any<IMvxBundle>(),
+                    Arg.Any<IMvxNavigateEventArgs>())
+                       .Returns(outViewModel);
 
-            var mockCollection = new Mock<IMvxViewModelLocatorCollection>();
-            mockCollection.Setup(m => m.FindViewModelLocator(It.IsAny<MvxViewModelRequest>()))
-                          .Returns(() => mockLocator.Object);
+            var mockCollection = Substitute.For<IMvxViewModelLocatorCollection>();
+            mockCollection
+                .FindViewModelLocator(Arg.Any<MvxViewModelRequest>())
+                .Returns(mockLocator);
 
             var parameters = new Dictionary<string, string> { { "foo", "bar" } };
             var request = new MvxViewModelRequest<Test2ViewModel>(new MvxBundle(parameters), null);
             var state = new MvxBundle();
-            var loader = new MvxViewModelLoader(mockCollection.Object);
+            var loader = new MvxViewModelLoader(mockCollection);
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
             var viewModel = loader.LoadViewModel(request, state, args);
 
@@ -70,19 +72,22 @@ namespace MvvmCross.UnitTest.ViewModels
         {
             _fixture.ClearAll();
 
-            var mockLocator = new Mock<IMvxViewModelLocator>();
-            mockLocator.Setup(
-                m => m.Load(It.IsAny<Type>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxBundle>(), It.IsAny<IMvxNavigateEventArgs>()))
-                       .Throws<MvxException>();
+            var mockLocator = Substitute.For<IMvxViewModelLocator>();
+            mockLocator.Load(
+                    Arg.Any<Type>(),
+                    Arg.Any<IMvxBundle>(),
+                    Arg.Any<IMvxBundle>(),
+                    Arg.Any<IMvxNavigateEventArgs>())
+                .Throws<MvxException>();
 
-            var mockCollection = new Mock<IMvxViewModelLocatorCollection>();
-            mockCollection.Setup(m => m.FindViewModelLocator(It.IsAny<MvxViewModelRequest>()))
-                          .Returns(() => mockLocator.Object);
+            var mockCollection = Substitute.For<IMvxViewModelLocatorCollection>();
+            mockCollection.FindViewModelLocator(Arg.Any<MvxViewModelRequest>())
+                          .Returns(mockLocator);
 
             var parameters = new Dictionary<string, string> { { "foo", "bar" } };
             var request = new MvxViewModelRequest<Test2ViewModel>(new MvxBundle(parameters), null);
             var state = new MvxBundle();
-            var loader = new MvxViewModelLoader(mockCollection.Object);
+            var loader = new MvxViewModelLoader(mockCollection);
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
             Assert.Throws<MvxException>(() =>
             {
@@ -95,14 +100,14 @@ namespace MvvmCross.UnitTest.ViewModels
         {
             _fixture.ClearAll();
 
-            var mockCollection = new Mock<IMvxViewModelLocatorCollection>();
-            mockCollection.Setup(m => m.FindViewModelLocator(It.IsAny<MvxViewModelRequest>()))
-                          .Returns(() => null);
+            var mockCollection = Substitute.For<IMvxViewModelLocatorCollection>();
+            mockCollection.FindViewModelLocator(Arg.Any<MvxViewModelRequest>())
+                .Returns((IMvxViewModelLocator?)null);
 
             var parameters = new Dictionary<string, string> { { "foo", "bar" } };
             var request = new MvxViewModelRequest<Test2ViewModel>(new MvxBundle(parameters), null);
             var state = new MvxBundle();
-            var loader = new MvxViewModelLoader(mockCollection.Object);
+            var loader = new MvxViewModelLoader(mockCollection);
             var args = new MvxNavigateEventArgs(NavigationMode.Show);
             Assert.Throws<MvxException>(() =>
             {

--- a/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
+++ b/UnitTests/Plugins.Color.UnitTest/MvvmCross.Plugins.Color.UnitTest.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.JsonLocalization.UnitTest/MvvmCross.Plugins.JsonLocalization.UnitTest.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
+++ b/UnitTests/Plugins.Messenger.UnitTest/MvvmCross.Plugins.Messenger.UnitTest.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
+++ b/UnitTests/Plugins.ResourceLoader.UnitTest/MvvmCross.Plugins.ResourceLoader.UnitTest.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
+++ b/UnitTests/Plugins.ResxLocalization.UnitTest/MvvmCross.Plugins.ResxLocalization.UnitTest.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
+++ b/UnitTests/Plugins.Visibility.UnitTest/MvvmCross.Plugins.Visibility.UnitTest.csproj
@@ -11,7 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Refactor

### :arrow_heading_down: What is the current behavior?
In our test suite we use an older version of Moq.

### :new: What is the new behavior (if this is a feature change)?
Since newer version of Moq do weird stuff with licensing, we've been stuck at the older one. Switching over to NSubstitute which has a more sane licensing structure.

### :boom: Does this PR introduce a breaking change?
No, these are unit tests in MvvmCross that are affected, we don't ship any libraries with dependencies on neither Moq or NSubstitute

### :bug: Recommendations for testing
Run the Unit Test suite

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
