### PR TITLE
Added MvxSceneDelegate for iOS SceneDelegate support

### DIFF
--- a/MvvmCross/Core/MvxLifetimeEvent.cs
+++ b/MvvmCross/Core/MvxLifetimeEvent.cs
@@ -2,16 +2,13 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-namespace MvvmCross.Core
+namespace MvvmCross.Core;
+
+public enum MvxLifetimeEvent
 {
-#nullable enable
-    public enum MvxLifetimeEvent
-    {
-        Launching,
-        ActivatedFromMemory,
-        ActivatedFromDisk,
-        Deactivated,
-        Closing
-    }
-#nullable restore
+    Launching,
+    ActivatedFromMemory,
+    ActivatedFromDisk,
+    Deactivated,
+    Closing
 }

--- a/MvvmCross/Core/MvxLifetimeEventArgs.cs
+++ b/MvvmCross/Core/MvxLifetimeEventArgs.cs
@@ -1,20 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using System;
-
-namespace MvvmCross.Core
-{
 #nullable enable
-    public class MvxLifetimeEventArgs : EventArgs
-    {
-        public MvxLifetimeEventArgs(MvxLifetimeEvent lifetimeEvent)
-        {
-            LifetimeEvent = lifetimeEvent;
-        }
 
-        public MvxLifetimeEvent LifetimeEvent { get; }
-    }
-#nullable restore
+namespace MvvmCross.Core;
+
+public class MvxLifetimeEventArgs(MvxLifetimeEvent lifetimeEvent) : EventArgs
+{
+    public MvxLifetimeEvent LifetimeEvent { get; } = lifetimeEvent;
 }

--- a/MvvmCross/Platforms/Ios/Core/IMvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/IMvxApplicationDelegate.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using MvvmCross.Core;
-using UIKit;
 
-namespace MvvmCross.Platforms.Ios.Core
-{
-    public interface IMvxApplicationDelegate : IUIApplicationDelegate, IMvxLifetime
-    {
-    }
-}
+namespace MvvmCross.Platforms.Ios.Core;
+
+public interface IMvxApplicationDelegate : IUIApplicationDelegate, IMvxLifetime;

--- a/MvvmCross/Platforms/Ios/Core/IMvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/IMvxIosSetup.cs
@@ -4,13 +4,12 @@
 
 using MvvmCross.Core;
 using MvvmCross.Platforms.Ios.Presenters;
-using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Core
 {
     public interface IMvxIosSetup : IMvxSetup
     {
-        void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, UIWindow window);
-        void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, IMvxIosViewPresenter presenter);
+        void PlatformInitialize(IMvxLifetime lifetimeInstance, UIWindow window);
+        void PlatformInitialize(IMvxLifetime lifetimeInstance, IMvxIosViewPresenter presenter);
     }
 }

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
@@ -25,20 +25,20 @@ namespace MvvmCross.Platforms.Ios.Core;
 public abstract class MvxIosSetup
     : MvxSetup, IMvxIosSetup
 {
-    protected IMvxApplicationDelegate? ApplicationDelegate { get; private set; }
+    protected IMvxLifetime? LifetimeInstance { get; private set; }
     protected UIWindow? Window { get; private set; }
 
     private IMvxIosViewPresenter? _presenter;
 
-    public virtual void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, UIWindow window)
+    public virtual void PlatformInitialize(IMvxLifetime lifetimeInstance, UIWindow window)
     {
         Window = window;
-        ApplicationDelegate = applicationDelegate;
+        LifetimeInstance = lifetimeInstance;
     }
 
-    public virtual void PlatformInitialize(IMvxApplicationDelegate applicationDelegate, IMvxIosViewPresenter presenter)
+    public virtual void PlatformInitialize(IMvxLifetime lifetimeInstance, IMvxIosViewPresenter presenter)
     {
-        ApplicationDelegate = applicationDelegate;
+        LifetimeInstance = lifetimeInstance;
         _presenter = presenter;
     }
 
@@ -92,7 +92,7 @@ public abstract class MvxIosSetup
     {
         ValidateArguments(iocProvider);
 
-        if (ApplicationDelegate == null)
+        if (LifetimeInstance == null)
         {
             SetupLog?.LogError(
                 "ApplicationDelegate is null in {MethodName}. Make sure to call {PlatformInitializeMethodName}",
@@ -100,7 +100,7 @@ public abstract class MvxIosSetup
             return;
         }
 
-        iocProvider.RegisterSingleton<IMvxLifetime>(ApplicationDelegate);
+        iocProvider.RegisterSingleton<IMvxLifetime>(LifetimeInstance);
     }
 
     protected IMvxIosViewPresenter? Presenter
@@ -114,14 +114,6 @@ public abstract class MvxIosSetup
 
     protected virtual IMvxIosViewPresenter? CreateViewPresenter()
     {
-        if (ApplicationDelegate == null)
-        {
-            SetupLog?.LogError(
-                "ApplicationDelegate is null in {MethodName}. Make sure to call {PlatformInitializeMethodName}",
-                nameof(CreateViewPresenter), nameof(PlatformInitialize));
-            return null;
-        }
-
         if (Window == null)
         {
             SetupLog?.LogError(
@@ -130,7 +122,7 @@ public abstract class MvxIosSetup
             return null;
         }
 
-        return new MvxIosViewPresenter(ApplicationDelegate, Window);
+        return new MvxIosViewPresenter(Window);
     }
 
     protected virtual void RegisterPresenter(IMvxIoCProvider iocProvider)

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetupSingleton.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetupSingleton.cs
@@ -3,25 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using MvvmCross.Core;
-using MvvmCross.Platforms.Ios.Presenters;
-using UIKit;
 
 namespace MvvmCross.Platforms.Ios.Core
 {
     public class MvxIosSetupSingleton
         : MvxSetupSingleton
     {
-        public static MvxIosSetupSingleton EnsureSingletonAvailable(IMvxApplicationDelegate applicationDelegate, UIWindow window)
+        public static MvxIosSetupSingleton EnsureSingletonAvailable(IMvxLifetime lifetimeInstance, UIWindow window)
         {
             var instance = EnsureSingletonAvailable<MvxIosSetupSingleton>();
-            instance.PlatformSetup<MvxIosSetup>()?.PlatformInitialize(applicationDelegate, window);
-            return instance;
-        }
-
-        public static MvxIosSetupSingleton EnsureSingletonAvailable(IMvxApplicationDelegate applicationDelegate, IMvxIosViewPresenter presenter)
-        {
-            var instance = EnsureSingletonAvailable<MvxIosSetupSingleton>();
-            instance.PlatformSetup<MvxIosSetup>()?.PlatformInitialize(applicationDelegate, presenter);
+            instance.PlatformSetup<MvxIosSetup>()?.PlatformInitialize(lifetimeInstance, window);
             return instance;
         }
     }

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneApplicationDelegate.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using MvvmCross.Core;
+
+namespace MvvmCross.Platforms.Ios.Core;
+
+public abstract class MvxSceneApplicationDelegate : UIApplicationDelegate, IMvxLifetime
+{
+    public event EventHandler<MvxLifetimeEventArgs>? LifetimeChanged;
+    public virtual string SceneConfigurationName { get; } = "MvxSceneConfiguration";
+    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+    {
+        return true;
+    }
+
+    public override UISceneConfiguration GetConfiguration(UIApplication application,
+        UISceneSession connectingSceneSession, UISceneConnectionOptions options) =>
+        new(SceneConfigurationName, connectingSceneSession.Role);
+}

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneApplicationDelegate.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 #nullable enable
 using MvvmCross.Core;
 

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
@@ -1,0 +1,84 @@
+#nullable enable
+using MvvmCross.Core;
+using MvvmCross.ViewModels;
+
+namespace MvvmCross.Platforms.Ios.Core;
+
+public abstract class MvxSceneDelegate : UIResponder, IUIWindowSceneDelegate, IMvxLifetime
+{
+    public event EventHandler<MvxLifetimeEventArgs>? LifetimeChanged;
+
+    [Export("window")] public UIWindow? Window { get; set; }
+
+    [Export("scene:willConnectToSession:options:")]
+    public virtual void WillConnect(
+        UIScene scene,
+        UISceneSession session,
+        UISceneConnectionOptions connectionOptions)
+    {
+        if (scene is UIWindowScene windowScene)
+        {
+            RegisterSetup();
+            Window = new UIWindow(windowScene);
+            MvxIosSetupSingleton
+                .EnsureSingletonAvailable(this, Window)
+                .EnsureInitialized();
+            RunAppStart();
+            FireLifetimeChanged(MvxLifetimeEvent.Launching);
+        }
+    }
+
+    [Export("sceneDidDisconnect:")]
+    public virtual void DidDisconnect(UIScene scene)
+    {
+    }
+
+    [Export("sceneDidBecomeActive:")]
+    public virtual void DidBecomeActive(UIScene scene)
+    {
+    }
+
+    [Export("sceneWillResignActive:")]
+    public void WillResignActive(UIScene scene)
+    {
+    }
+
+    [Export("sceneWillEnterForeground:")]
+    public void WillEnterForeground(UIScene scene)
+    {
+    }
+
+    [Export("sceneDidEnterBackground:")]
+    public void DidEnterBackground(UIScene scene)
+    {
+    }
+
+    protected virtual void RunAppStart()
+    {
+        if (Mvx.IoCProvider?.TryResolve(out IMvxAppStart? startup) == true &&
+            startup is { IsStarted: false })
+        {
+            startup.Start();
+        }
+
+        Window?.MakeKeyAndVisible();
+    }
+
+    protected abstract void RegisterSetup();
+
+    private void FireLifetimeChanged(MvxLifetimeEvent which)
+    {
+        var handler = LifetimeChanged;
+        handler?.Invoke(this, new MvxLifetimeEventArgs(which));
+    }
+}
+
+public abstract class MvxSceneDelegate<TMvxIosSetup, TApplication> : MvxSceneDelegate
+    where TMvxIosSetup : MvxIosSetup<TApplication>, new()
+    where TApplication : class, IMvxApplication, new()
+{
+    protected override void RegisterSetup()
+    {
+        this.RegisterSetupType<TMvxIosSetup>();
+    }
+}

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
@@ -40,11 +40,13 @@ public abstract class MvxSceneDelegate : UIResponder, IUIWindowSceneDelegate, IM
     [Export("sceneDidBecomeActive:")]
     public virtual void DidBecomeActive(UIScene scene)
     {
+        FireLifetimeChanged(MvxLifetimeEvent.ActivatedFromMemory);
     }
 
     [Export("sceneWillResignActive:")]
     public void WillResignActive(UIScene scene)
     {
+        FireLifetimeChanged(MvxLifetimeEvent.Deactivated);
     }
 
     [Export("sceneWillEnterForeground:")]

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 #nullable enable
 using MvvmCross.Core;
 using MvvmCross.ViewModels;

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -19,7 +19,6 @@ public class MvxIosViewPresenter : MvxAttributeViewPresenter, IMvxIosViewPresent
 {
     private readonly MvxIosMajorVersionChecker _iosVersion13Checker = new(13);
 
-    protected IUIApplicationDelegate ApplicationDelegate { get; }
     protected UIWindow Window { get; }
 
     public UINavigationController? MasterNavigationController { get; protected set; }
@@ -34,9 +33,8 @@ public class MvxIosViewPresenter : MvxAttributeViewPresenter, IMvxIosViewPresent
 
     public IMvxSplitViewController? SplitViewController { get; protected set; }
 
-    public MvxIosViewPresenter(IUIApplicationDelegate applicationDelegate, UIWindow window)
+    public MvxIosViewPresenter(UIWindow window)
     {
-        ApplicationDelegate = applicationDelegate;
         Window = window;
     }
 

--- a/Projects/Playground/Playground.iOS/AppDelegate.cs
+++ b/Projects/Playground/Playground.iOS/AppDelegate.cs
@@ -6,4 +6,4 @@ namespace Playground.iOS;
 // The UIApplicationDelegate for the application. This class is responsible for launching the
 // User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
 [Register("AppDelegate")]
-public partial class AppDelegate : MvxApplicationDelegate<Setup, App>;
+public class AppDelegate : MvxSceneApplicationDelegate;

--- a/Projects/Playground/Playground.iOS/Info.plist
+++ b/Projects/Playground/Playground.iOS/Info.plist
@@ -34,5 +34,22 @@
 	<string>Assets.xcassets/AppIcon.appiconset</string>
 	<key>CFBundleDisplayName</key>
 	<string>Playground</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneDelegateClassName</key>
+                    <string>SceneDelegate</string>
+                    <key>UISceneConfigurationName</key>
+                    <string>MvxSceneConfiguration</string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/Projects/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/Projects/Playground/Playground.iOS/Playground.iOS.csproj
@@ -17,11 +17,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
-    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>iossimulator-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Any CPU' ">
-    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>iossimulator-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Projects/Playground/Playground.iOS/SceneDelegate.cs
+++ b/Projects/Playground/Playground.iOS/SceneDelegate.cs
@@ -1,0 +1,7 @@
+using MvvmCross.Platforms.Ios.Core;
+using Playground.Core;
+
+namespace Playground.iOS;
+
+[Register("SceneDelegate")]
+public class SceneDelegate : MvxSceneDelegate<Setup, App>;


### PR DESCRIPTION
This feature was added when over 10km above sea level and going ~1000 km/h

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently we can only launch an App using AppDelegate. In order to support newer features, we need SceneDelegate support.

### :new: What is the new behavior (if this is a feature change)?
Added a new MvxSceneAppDelegate and MvxSceneDelegate classes to support scenarios when wanting to launch the App using SceneDelegate

### :boom: Does this PR introduce a breaking change?
Yes, it removes the AppDelegate property from the iOS presenter and changes a few methods to take IMvxLifecycle instead of AppDelegate instead.

### :bug: Recommendations for testing
Launch the playground app on iOS it is now using SceneDelegate

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
