### PR TITLE
Add NuGet package attestation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -22,6 +22,13 @@
         "dotnet-sonarscanner"
       ],
       "rollForward": false
+    },
+    "cyclonedx": {
+      "version": "5.1.1",
+      "commands": [
+        "dotnet-CycloneDX"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
         fetch-tags: true
 
     - name: Install .NET ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: ${{ env.NET_VERSION }}
 
@@ -36,7 +36,7 @@ jobs:
         dotnet workload install android ios tvos macos maccatalyst --version ${{ env.NET_VERSION }}
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #v4.7.0
       with:
         distribution: ${{ env.JAVA_DISTRIBUTION }}
         java-version: ${{ env.JAVA_VERSION }}
@@ -45,7 +45,7 @@ jobs:
       run: dotnet cake --verbosity=Minimal --artifactsDir="output"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
       with:
         name: build-artifacts
         path: output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,21 @@ env:
 
 jobs:
   build:
+    permissions:
+      id-token: write
+      attestations: write
+
     runs-on: windows-latest
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
         fetch-tags: true
 
     - name: Install .NET ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: ${{ env.NET_VERSION }}
 
@@ -38,13 +42,15 @@ jobs:
         dotnet workload install android ios tvos macos maccatalyst --version ${{ env.NET_VERSION }}
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #v4.7.0
       with:
         distribution: ${{ env.JAVA_DISTRIBUTION }}
         java-version: ${{ env.JAVA_VERSION }}
 
     - name: Build
-      run: dotnet cake --verbosity=Minimal --artifactsDir="output"
+      run: dotnet cake --verbosity=Minimal --artifactsDir="output" --githubToken=${{ env.GITHUB_TOKEN }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install SignTool tool
       run: dotnet tool install --tool-path . SignClient
@@ -64,8 +70,15 @@ jobs:
         SIGNING_USER: ${{ secrets.SIGN_CLIENT_USER_ID }}
         SIGNING_SECRET: ${{ secrets.SIGN_CLIENT_SECRET }}
 
+    - name: Attest NuGet packages
+      uses: actions/attest-sbom@115c3be05ff3974bcbd596578934b3f9ce39bf68 # v2.2.0
+      with:
+        subject-path: ${{ github.workspace }}/output/NuGet/*.nupkg
+        sbom-path: ${{ github.workspace }}/output/sbom/bom.json
+        push-to-registry: true
+
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
       with:
         name: build-artifacts
         path: output
@@ -75,11 +88,11 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
         SOURCE_URL: https://api.nuget.org/v3/index.json
       run: |
-        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} ${{ github.workspace }}/output/**/*.nupkg
+        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} ${{ github.workspace }}/output/NuGet/*.nupkg
 
     - name: GitHub Packages Push
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_API_KEY }}
         SOURCE_URL: https://nuget.pkg.github.com/mvvmcross/index.json
       run: |
-        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} ${{ github.workspace }}/output/**/*.nupkg           
+        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} ${{ github.workspace }}/output/NuGet/*.nupkg           


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
CI

### :arrow_heading_down: What is the current behavior?
There is no way to validate the software bill of material of MvvmCross

### :new: What is the new behavior (if this is a feature change)?
- Added attestation to NuGet package releases going to NuGet and GitHub Packages
- Pinned GitHub Actions versions

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
