### PR TITLE
Keep the (conditional) strong reference to the NSWindowController. Th…

### DIFF
--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using AppKit;
 using CoreGraphics;
@@ -24,6 +25,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
         : MvxAttributeViewPresenter, IMvxMacViewPresenter, IMvxAttributeViewPresenter
     {
         private readonly INSApplicationDelegate _applicationDelegate;
+        protected readonly ConditionalWeakTable<NSWindow, NSWindowController> windowsToWindowControllers = new();
 
         public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
         {
@@ -147,6 +149,10 @@ namespace MvvmCross.Platforms.Mac.Presenters
 
             if (!Windows.Contains(window))
                 Windows.Add(window);
+
+            // ConditionalWeakTable automatically removes entries when the key (window) is garbage collected,
+            // so we don't need to manually remove items when windows are closed
+            windowsToWindowControllers.AddOrUpdate(window, windowController);
 
             window.Identifier = attribute.Identifier ?? viewController.GetType().Name;
 

--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -25,7 +25,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
         : MvxAttributeViewPresenter, IMvxMacViewPresenter, IMvxAttributeViewPresenter
     {
         private readonly INSApplicationDelegate _applicationDelegate;
-        
+
         /// <summary>
         /// NSWindow keeps only the *weak* reference to its NSWindowController. So, the controller will be
         /// prematurely disposed if no other references exist. This table keeps a strong reference to the

--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -25,7 +25,13 @@ namespace MvvmCross.Platforms.Mac.Presenters
         : MvxAttributeViewPresenter, IMvxMacViewPresenter, IMvxAttributeViewPresenter
     {
         private readonly INSApplicationDelegate _applicationDelegate;
-        protected readonly ConditionalWeakTable<NSWindow, NSWindowController> windowsToWindowControllers = new();
+        
+        /// <summary>
+        /// NSWindow keeps only the *weak* reference to its NSWindowController. So, the controller will be
+        /// prematurely disposed if no other references exist. This table keeps a strong reference to the
+        /// controller keeping it alive while the associated NSWindow is alive. Ref. issue #2198
+        /// </summary>
+        protected readonly ConditionalWeakTable<NSWindow, NSWindowController> _windowsToWindowControllers = new();
 
         public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
         {
@@ -152,7 +158,7 @@ namespace MvvmCross.Platforms.Mac.Presenters
 
             // ConditionalWeakTable automatically removes entries when the key (window) is garbage collected,
             // so we don't need to manually remove items when windows are closed
-            windowsToWindowControllers.AddOrUpdate(window, windowController);
+            _windowsToWindowControllers.AddOrUpdate(window, windowController);
 
             window.Identifier = attribute.Identifier ?? viewController.GetType().Name;
 


### PR DESCRIPTION
…is prevents the controller from premature disposal. Fixes #2198

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
NSWindowController may be disposed even it is used.

### :new: What is the new behavior (if this is a feature change)?
Window controller keeps alive while associated NSWindow is alive.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
See #2198, specifically https://github.com/MvvmCross/MvvmCross/issues/2198#issuecomment-2949825569

### :memo: Links to relevant issues/docs
Fixes #2198 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
