### PR TITLE
Reimplement NSTextView binding. Fixes #4909.

### DIFF
--- a/MvvmCross/Platforms/Mac/Binding/MvxMacBindingBuilder.cs
+++ b/MvvmCross/Platforms/Mac/Binding/MvxMacBindingBuilder.cs
@@ -80,10 +80,9 @@ namespace MvvmCross.Platforms.Mac.Binding
                 typeof(NSTextField),
                 MvxMacPropertyBinding.NSTextField_StringValue);
 
-            registry.RegisterPropertyInfoBindingFactory(
-                typeof(MvxNSTextViewTextTargetBinding),
-                typeof(NSTextView),
-                MvxMacPropertyBinding.NSTextView_StringValue);
+            registry.RegisterCustomBindingFactory<NSTextView>(
+                MvxMacPropertyBinding.NSTextView_StringValue,
+                textView => new MvxNSTextViewTextTargetBinding(textView));
 
             registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxNSSwitchOnTargetBinding),

--- a/MvvmCross/Platforms/Mac/Binding/MvxMacPropertyBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/MvxMacPropertyBinding.cs
@@ -14,7 +14,7 @@ namespace MvvmCross.Platforms.Mac.Binding
         public const string NSDatePicker_Time = "Time";
         public const string NSDatePicker_Date = "Date";
         public const string NSTextField_StringValue = "StringValue";
-        public const string NSTextView_StringValue = "StringValue";
+        public const string NSTextView_StringValue = "TextStorageInternalFakeId";
         public const string NSButton_State = "State";
         public const string NSMenuItem_State = "State";
         public const string NSSearchField_Text = "Text";


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The content (text) binding for the `NSTextView` does not work.

### :new: What is the new behavior (if this is a feature change)?
The content (text) binding for the `NSTextView` works as expected.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Configure bidirectional binding for the `NSTextView` and check the following
* binding works in both directions
* the text caret maintains a meaningful position during the text input/pasting from the clipboard/VM updates.

### :memo: Links to relevant issues/docs
Fixes https://github.com/MvvmCross/MvvmCross/issues/4909

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
