### PR TITLE
Apply window insets to support Android edge-to-edge

### DIFF
--- a/Projects/Playground/Playground.Droid/Activities/RootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/RootView.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Android.Views;
+using AndroidX.Core.View;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using Playground.Core.ViewModels;
@@ -12,13 +13,28 @@ namespace Playground.Droid.Activities
     [MvxActivityPresentation]
     [Activity(Theme = "@style/AppTheme",
         WindowSoftInputMode = SoftInput.AdjustPan)]
-    public class RootView : MvxActivity<RootViewModel>
+    public class RootView : MvxActivity<RootViewModel>, IOnApplyWindowInsetsListener
     {
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
 
             SetContentView(Resource.Layout.RootView);
+
+            ViewCompat.SetOnApplyWindowInsetsListener(FindViewById(Resource.Id.main_frame), this);
+        }
+
+        public WindowInsetsCompat OnApplyWindowInsets(View v, WindowInsetsCompat insets)
+        {
+            var inset = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+
+            (v.LayoutParameters as FrameLayout.LayoutParams).SetMargins(
+                inset.Left,
+                inset.Top,
+                inset.Right,
+                inset.Bottom);
+
+            return WindowInsetsCompat.Consumed;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Playground.Droid root view on API36+ goes under the status bar on devices with cutout and looks weird

### :new: What is the new behavior (if this is a feature change)?
Listens and applies window insets to avoid system bars

| before | after |
|--------|-------|
|<img width="1280" height="2856" alt="Screenshot_1752832349" src="https://github.com/user-attachments/assets/ab0018b6-ddce-4170-87dc-c7afe34f3a73" /> | <img width="1280" height="2856" alt="Screenshot_1752832437" src="https://github.com/user-attachments/assets/97043e8e-732e-446e-b078-fbe06142714b" /> |


### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
