### PR TITLE
Fix sonar args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: 
       - main
       - develop
+  workflow_dispatch:
 
 env:
   JAVA_DISTRIBUTION: 'temurin'

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,6 +6,7 @@ on:
     - develop
   pull_request_target:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 env:
   verbosity: 'minimal'

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -154,8 +154,9 @@ public sealed class SonarStartTask : FrostingTask<BuildContext>
 
     public override void Run(BuildContext context)
     {
-        var xunitReportsPaths = context.GetFiles(context.MakeAbsolute(context.OutputDir.Combine("Tests/")) + "/**/*.trx");
-        var corverageReportsPaths = context.GetFiles(context.MakeAbsolute(context.OutputDir.Combine("Tests/")) + "/**/*.coverage");
+        var testReportFolder = context.MakeAbsolute(context.OutputDir.Combine("Tests/"));
+        var xunitReportsPaths = testReportFolder + "/*.trx";
+        var corverageReportsPaths = testReportFolder + "/*.coverage";
 
         var settings = new DotNetToolSettings
         {
@@ -165,8 +166,8 @@ public sealed class SonarStartTask : FrostingTask<BuildContext>
                 .Append("/o:{0}", context.SonarOrg)
                 .Append("/d:sonar.host.url={0}", "https://sonarcloud.io")
                 .Append("/d.sonar.exclusions={0}", "docs/**,Projects/**,vendor/**,ContentFiles/**")
-                .Append("/d:sonar.cs.vstest.reportsPaths={0}", string.Join(",", xunitReportsPaths.Select(p => p.FullPath)))
-                .Append("/d:sonar.flex.cobertura.reportPaths={0}", string.Join(",", corverageReportsPaths.Select(p => p.FullPath)))
+                .Append("/d:sonar.cs.xunit.reportsPaths={0}", xunitReportsPaths)
+                .Append("/d:sonar.cs.cobertura.reportPaths={0}", corverageReportsPaths)
                 .Append("/d:sonar.scanner.skipJreProvisioning={0}", "true")
                 .AppendSecret("/d:sonar.token={0}", context.SonarToken)
         };

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -166,8 +166,8 @@ public sealed class SonarStartTask : FrostingTask<BuildContext>
                 .Append("/o:{0}", context.SonarOrg)
                 .Append("/d:sonar.host.url={0}", "https://sonarcloud.io")
                 .Append("/d.sonar.exclusions={0}", "docs/**,Projects/**,vendor/**,ContentFiles/**")
-                .Append("/d:sonar.cs.xunit.reportsPaths={0}", xunitReportsPaths)
-                .Append("/d:sonar.cs.cobertura.reportPaths={0}", corverageReportsPaths)
+                .Append("/d:sonar.cs.xunit.reportsPaths=\"{0}\"", xunitReportsPaths)
+                .Append("/d:sonar.cs.cobertura.reportPaths=\"{0}\"", corverageReportsPaths)
                 .Append("/d:sonar.scanner.skipJreProvisioning={0}", "true")
                 .AppendSecret("/d:sonar.token={0}", context.SonarToken)
         };


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
CI

### :arrow_heading_down: What is the current behavior?
I messed up some of the sonar args

### :new: What is the new behavior (if this is a feature change)?
Turns out cobertura is supported for c# and supports ant pattern, which is usefull because when starting sonar, we don't have the reports ready yet and no paths would be returned when getting files from the glob pattern

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
