### PR TITLE
Conditionally exclude iOS/macOS targets in .csproj files for Linux bu…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <StripSymbols>false</StripSymbols>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>

--- a/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
+++ b/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net9.0;net9.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net9.0;net9.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net9.0;net9.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-tvos;net8.0-macos;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-tvos;net9.0-macos</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net9.0;net9.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst;net8.0-tvos;net8.0-macos;net9.0-ios;net9.0-maccatalyst;net9.0-tvos;net9.0-macos</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
…ilds

Modified .csproj files to exclude Apple-related targets (net9.0-ios, net9.0-macos) when building on non-macOS systems using MSBuild's IsOSPlatform('OSX') condition. This allows Linux developers to build and test MvvmCross without requiring macOS hardware, addressing errors like NETSDK1178 (missing iOS workload). The change preserves full functionality for macOS users, ensuring no build issues on platforms that support iOS/macOS.

Also added EnableWindowsTargeting=true in Directory.Build.props to allow Windows targeting from Linux systems, which is required for cross-platform .NET development.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Compatability For Linux Devs to be able to build the project

### :arrow_heading_down: What is the current behavior?
The project doesn't build

### :new: What is the new behavior (if this is a feature change)?
The project build android and windows

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Build on Mac and Windows

### :memo: Links to relevant issues/docs
NA

### :thinking: Checklist before submitting

- [x ] All projects build
- [ x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ x] Rebased onto current develop
