### PR TITLE
Add trimming annotations to most core code

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NuGetAudit>enable</NuGetAudit>
     <NuGetAuditMode>all</NuGetAuditMode>
+
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MvvmCross/Base/IMvxNamedInstanceRegistry.cs
+++ b/MvvmCross/Base/IMvxNamedInstanceRegistry.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.Base
@@ -12,6 +13,7 @@ namespace MvvmCross.Base
     {
         void AddOrOverwrite(string name, T instance);
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         void AddOrOverwriteFrom(Assembly assembly);
     }
 #nullable restore

--- a/MvvmCross/Base/IMvxTextSerializer.cs
+++ b/MvvmCross/Base/IMvxTextSerializer.cs
@@ -3,12 +3,16 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.Base
 {
     public interface IMvxTextSerializer
     {
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         T? DeserializeObject<T>(string inputText);
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         object? DeserializeObject(Type type, string inputText);
 
         string SerializeObject(object toSerialise);

--- a/MvvmCross/Base/MvxBootstrapRunner.cs
+++ b/MvvmCross/Base/MvxBootstrapRunner.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.IoC;
@@ -11,6 +12,7 @@ namespace MvvmCross.Base
 {
     public class MvxBootstrapRunner
     {
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public virtual void Run(Assembly assembly)
         {
             var types = assembly.CreatableTypes()
@@ -22,7 +24,7 @@ namespace MvvmCross.Base
             }
         }
 
-        protected virtual void Run(Type type)
+        protected virtual void Run([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             ArgumentNullException.ThrowIfNull(type);
 

--- a/MvvmCross/Base/MvxCoreExtensions.cs
+++ b/MvvmCross/Base/MvxCoreExtensions.cs
@@ -14,9 +14,11 @@ namespace MvvmCross.Base
     public static class MvxCoreExtensions
     {
         // core implementation of ConvertToBoolean
-        public static bool ConvertToBooleanCore(this object? result)
+        [UnconditionalSuppressMessage("Trimming", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' requirements",
+            Justification = "The types returned by Nullable.GetUnderlyingType on a type with DynamicallyAccessedMemberTypes.PublicParameterlessConstructor are safe to process")]
+        public static bool ConvertToBooleanCore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(this T? result)
         {
-            if (result == null)
+            if (EqualityComparer<T?>.Default.Equals(result, default))
                 return false;
 
             var s = result as string;
@@ -26,7 +28,7 @@ namespace MvvmCross.Base
             if (result is bool x)
                 return x;
 
-            var resultType = result.GetType();
+            var resultType = result!.GetType();
             if (resultType.GetTypeInfo().IsValueType)
             {
                 var underlyingType = Nullable.GetUnderlyingType(resultType) ?? resultType;

--- a/MvvmCross/Base/MvxCoreExtensions.cs
+++ b/MvvmCross/Base/MvxCoreExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using MvvmCross.IoC;
@@ -22,8 +23,8 @@ namespace MvvmCross.Base
             if (s != null)
                 return !string.IsNullOrEmpty(s);
 
-            if (result is bool)
-                return (bool)result;
+            if (result is bool x)
+                return x;
 
             var resultType = result.GetType();
             if (resultType.GetTypeInfo().IsValueType)
@@ -36,7 +37,9 @@ namespace MvvmCross.Base
         }
 
         // core implementation of MakeSafeValue
-        public static object? MakeSafeValueCore(this Type propertyType, object? value)
+        public static object? MakeSafeValueCore(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type propertyType,
+            object? value)
         {
             if (value == null)
             {

--- a/MvvmCross/Base/MvxDictionaryExtensions.cs
+++ b/MvvmCross/Base/MvxDictionaryExtensions.cs
@@ -15,7 +15,7 @@ public static class MvxDictionaryExtensions
             return dict;
 
         var propertyInfos =
-            typeof(T).GetProperties(
+            input.GetType().GetProperties(
                     BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy)
                 .Where(p => p.CanRead);
 

--- a/MvvmCross/Base/MvxDictionaryExtensions.cs
+++ b/MvvmCross/Base/MvxDictionaryExtensions.cs
@@ -1,11 +1,12 @@
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.Base;
 
 public static class MvxDictionaryExtensions
 {
-    public static IDictionary<string, object> ToPropertyDictionary(this object? input)
+    public static IDictionary<string, object> ToPropertyDictionary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]T>(this T? input) where T : class
     {
         if (input == null)
             return new Dictionary<string, object>();
@@ -14,7 +15,7 @@ public static class MvxDictionaryExtensions
             return dict;
 
         var propertyInfos =
-            input.GetType().GetProperties(
+            typeof(T).GetProperties(
                     BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy)
                 .Where(p => p.CanRead);
 

--- a/MvvmCross/Base/MvxDictionaryExtensions.cs
+++ b/MvvmCross/Base/MvxDictionaryExtensions.cs
@@ -6,7 +6,7 @@ namespace MvvmCross.Base;
 
 public static class MvxDictionaryExtensions
 {
-    public static IDictionary<string, object> ToPropertyDictionary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]T>(this T? input) where T : class
+    public static IDictionary<string, object> ToPropertyDictionary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(this T? input) where T : class
     {
         if (input == null)
             return new Dictionary<string, object>();

--- a/MvvmCross/Binding/Binders/IMvxValueConverterRegistryFiller.cs
+++ b/MvvmCross/Binding/Binders/IMvxValueConverterRegistryFiller.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Base;
 using MvvmCross.Converters;
@@ -13,8 +14,11 @@ namespace MvvmCross.Binding.Binders
     {
         string FindName(Type type);
 
-        void FillFrom(IMvxNamedInstanceRegistry<T> registry, Type type);
+        void FillFrom(
+            IMvxNamedInstanceRegistry<T> registry,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type type);
 
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         void FillFrom(IMvxNamedInstanceRegistry<T> registry, Assembly assembly);
     }
 

--- a/MvvmCross/Binding/Binders/MvxNamedInstanceRegistry.cs
+++ b/MvvmCross/Binding/Binders/MvxNamedInstanceRegistry.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Base;
 
@@ -32,6 +32,7 @@ namespace MvvmCross.Binding.Binders
             _converters[name] = instance;
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         public void AddOrOverwriteFrom(Assembly assembly)
         {
             this.Fill(assembly);

--- a/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
+++ b/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -14,7 +15,9 @@ namespace MvvmCross.Binding.Binders
     public class MvxNamedInstanceRegistryFiller<T> : IMvxNamedInstanceRegistryFiller<T>
         where T : class
     {
-        protected virtual void FillFromInstance(IMvxNamedInstanceRegistry<T> registry, Type type)
+        protected virtual void FillFromInstance(
+            IMvxNamedInstanceRegistry<T> registry,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type type)
         {
             var instance = Activator.CreateInstance(type);
 
@@ -36,7 +39,9 @@ namespace MvvmCross.Binding.Binders
             }
         }
 
-        protected virtual void FillFromStatic(IMvxNamedInstanceRegistry<T> registry, Type type)
+        protected virtual void FillFromStatic(
+            IMvxNamedInstanceRegistry<T> registry,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
         {
             var pairs = from field in type.GetFields()
                         where field.IsStatic
@@ -56,7 +61,9 @@ namespace MvvmCross.Binding.Binders
             }
         }
 
-        public virtual void FillFrom(IMvxNamedInstanceRegistry<T> registry, Type type)
+        public virtual void FillFrom(
+            IMvxNamedInstanceRegistry<T> registry,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type type)
         {
             if (type.GetTypeInfo().IsAbstract)
             {
@@ -68,6 +75,7 @@ namespace MvvmCross.Binding.Binders
             }
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public virtual void FillFrom(IMvxNamedInstanceRegistry<T> registry, Assembly assembly)
         {
             var pairs = from type in assembly.ExceptionSafeGetTypes()

--- a/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
+++ b/MvvmCross/Binding/Binders/MvxNamedInstanceRegistryFiller.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
@@ -115,14 +113,14 @@ namespace MvvmCross.Binding.Binders
         protected static string RemoveHead(string name, string word)
         {
             if (name.StartsWith(word))
-                name = name.Substring(word.Length);
+                name = name[word.Length..];
             return name;
         }
 
         protected static string RemoveTail(string name, string word)
         {
             if (name.EndsWith(word))
-                name = name.Substring(0, name.Length - word.Length);
+                name = name[..^word.Length];
             return name;
         }
     }

--- a/MvvmCross/Binding/Binders/MvxRegistryFillerExtensions.cs
+++ b/MvvmCross/Binding/Binders/MvxRegistryFillerExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Base;
 
@@ -11,6 +12,7 @@ namespace MvvmCross.Binding.Binders
 {
     public static class MvxRegistryFillerExtensions
     {
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public static void Fill<T>(
             this IMvxNamedInstanceRegistry<T> registry, IEnumerable<Assembly> assemblies, IEnumerable<Type> types)
             where T : notnull
@@ -20,6 +22,7 @@ namespace MvvmCross.Binding.Binders
             registry.Fill(filler, types);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public static void Fill<T>(this IMvxNamedInstanceRegistry<T> registry, IEnumerable<Assembly> assemblies)
             where T : notnull
         {
@@ -30,6 +33,7 @@ namespace MvvmCross.Binding.Binders
             registry.Fill(filler, assemblies);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public static void Fill<T>(
             this IMvxNamedInstanceRegistry<T> registry, IMvxNamedInstanceRegistryFiller<T> filler,
             IEnumerable<Assembly> assemblies)
@@ -44,6 +48,7 @@ namespace MvvmCross.Binding.Binders
             }
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public static void Fill<T>(this IMvxNamedInstanceRegistry<T> registry, Assembly assembly)
             where T : notnull
         {
@@ -51,6 +56,7 @@ namespace MvvmCross.Binding.Binders
             registry.Fill(filler, assembly);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public static void Fill<T>(this IMvxNamedInstanceRegistry<T> registry, IMvxNamedInstanceRegistryFiller<T> filler,
                                 Assembly assembly)
             where T : notnull
@@ -58,6 +64,7 @@ namespace MvvmCross.Binding.Binders
             filler.FillFrom(registry, assembly);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
         public static void Fill<T>(this IMvxNamedInstanceRegistry<T> registry, IEnumerable<Type> types)
             where T : notnull
         {
@@ -68,8 +75,11 @@ namespace MvvmCross.Binding.Binders
             registry.Fill(filler, types);
         }
 
-        public static void Fill<T>(this IMvxNamedInstanceRegistry<T> registry, IMvxNamedInstanceRegistryFiller<T> filler,
-                                IEnumerable<Type> types)
+        [RequiresUnreferencedCode("This method uses reflection to check for creatable types, which may not be preserved by trimming")]
+        public static void Fill<T>(
+            this IMvxNamedInstanceRegistry<T> registry,
+            IMvxNamedInstanceRegistryFiller<T> filler,
+            IEnumerable<Type> types)
         {
             if (types == null)
                 return;
@@ -81,13 +91,16 @@ namespace MvvmCross.Binding.Binders
         }
 
         public static void Fill<T>(
-            this IMvxNamedInstanceRegistry<T> registry, IMvxNamedInstanceRegistryFiller<T> filler, Type type)
+            this IMvxNamedInstanceRegistry<T> registry, IMvxNamedInstanceRegistryFiller<T> filler,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type type)
             where T : notnull
         {
             filler.FillFrom(registry, type);
         }
 
-        public static void Fill<T>(this IMvxNamedInstanceRegistry<T> registry, Type type)
+        public static void Fill<T>(
+            this IMvxNamedInstanceRegistry<T> registry,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type type)
             where T : notnull
         {
             var filler = Mvx.IoCProvider.Resolve<IMvxNamedInstanceRegistryFiller<T>>();

--- a/MvvmCross/Binding/BindingContext/IMvxBindingNameLookup.cs
+++ b/MvvmCross/Binding/BindingContext/IMvxBindingNameLookup.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Binding.BindingContext
 {
     public interface IMvxBindingNameLookup
     {
-        string DefaultFor(Type type);
+        string DefaultFor(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type);
     }
 }

--- a/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using MvvmCross.Base;
 using MvvmCross.Binding.Binders;
@@ -138,7 +135,7 @@ namespace MvvmCross.Binding.BindingContext
                     Converter = inputs.Converter,
                     ConverterParameter = inputs.ConverterParameter,
                     FallbackValue = inputs.FallbackValue,
-                    InnerSteps = innerSteps.ToList()
+                    InnerSteps = [.. innerSteps]
                 };
             }
         }
@@ -154,10 +151,7 @@ namespace MvvmCross.Binding.BindingContext
                     Converter = inputs.Converter,
                     ConverterParameter = inputs.ConverterParameter,
                     FallbackValue = inputs.FallbackValue,
-                    InnerSteps = new List<MvxSourceStepDescription>()
-                            {
-                                sourceStepDescription
-                            }
+                    InnerSteps = [ sourceStepDescription ]
                 };
             }
         }

--- a/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using MvvmCross.Base;
@@ -16,7 +17,7 @@ using MvvmCross.Exceptions;
 
 namespace MvvmCross.Binding.BindingContext
 {
-    public class MvxBaseFluentBindingDescription<TTarget>
+    public class MvxBaseFluentBindingDescription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget>
         : MvxApplicableTo<TTarget>, IMvxBaseFluentBindingDescription
         where TTarget : class
     {

--- a/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBaseFluentBindingDescription.cs
@@ -151,7 +151,7 @@ namespace MvvmCross.Binding.BindingContext
                     Converter = inputs.Converter,
                     ConverterParameter = inputs.ConverterParameter,
                     FallbackValue = inputs.FallbackValue,
-                    InnerSteps = [ sourceStepDescription ]
+                    InnerSteps = [sourceStepDescription]
                 };
             }
         }

--- a/MvvmCross/Binding/BindingContext/MvxBindExtensions.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBindExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using MvvmCross.Binding.Bindings;

--- a/MvvmCross/Binding/BindingContext/MvxBindExtensions.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBindExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using MvvmCross.Binding.Bindings;
 using MvvmCross.Converters;
@@ -25,7 +26,7 @@ namespace MvvmCross.Binding.BindingContext
             return element;
         }
 
-        public static T Bind<T, TViewModel>(this T element,
+        public static T Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T, TViewModel>(this T element,
                                             MvxInlineBindingTarget<TViewModel> target,
                                             Expression<Func<TViewModel, object>> sourcePropertyPath,
                                             string converterName = null,
@@ -36,7 +37,7 @@ namespace MvvmCross.Binding.BindingContext
             return element.Bind(target, null, sourcePropertyPath, converterName, converterParameter, fallbackValue, mode);
         }
 
-        public static T Bind<T, TViewModel>(this T element,
+        public static T Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T, TViewModel>(this T element,
                                             MvxInlineBindingTarget<TViewModel> target,
                                             Expression<Func<TViewModel, object>> sourcePropertyPath,
                                             IMvxValueConverter converter,
@@ -47,7 +48,7 @@ namespace MvvmCross.Binding.BindingContext
             return element.Bind(target, null, sourcePropertyPath, converter, converterParameter, fallbackValue, mode);
         }
 
-        public static T Bind<T, TViewModel>(this T element,
+        public static T Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T, TViewModel>(this T element,
                                             MvxInlineBindingTarget<TViewModel> target,
                                             Expression<Func<T, object>> targetPropertyPath,
                                             Expression<Func<TViewModel, object>> sourcePropertyPath,
@@ -61,7 +62,7 @@ namespace MvvmCross.Binding.BindingContext
                                 fallbackValue, mode);
         }
 
-        public static T Bind<T, TViewModel>(this T element,
+        public static T Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T, TViewModel>(this T element,
                                             MvxInlineBindingTarget<TViewModel> target,
                                             Expression<Func<T, object>> targetPropertyPath,
                                             Expression<Func<TViewModel, object>> sourcePropertyPath,
@@ -76,7 +77,7 @@ namespace MvvmCross.Binding.BindingContext
             return element.Bind(target, targetPath, sourcePath, converter, converterParameter, fallbackValue, mode);
         }
 
-        public static T Bind<T, TViewModel>(this T element,
+        public static T Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T, TViewModel>(this T element,
                                             MvxInlineBindingTarget<TViewModel> target,
                                             string targetPath,
                                             string sourcePath,

--- a/MvvmCross/Binding/BindingContext/MvxBindingContextOwnerExtensions.Fluent.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBindingContextOwnerExtensions.Fluent.cs
@@ -2,33 +2,40 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.Binding.BindingContext
 {
     public static partial class MvxBindingContextOwnerExtensions
     {
-        public static MvxFluentBindingDescriptionSet<TTarget, TSource> CreateBindingSet<TTarget, TSource>(
-            this TTarget target)
-            where TTarget : class, IMvxBindingContextOwner
+        public static MvxFluentBindingDescriptionSet<TTarget, TSource> CreateBindingSet<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget, TSource>(
+                this TTarget target)
+                    where TTarget : class, IMvxBindingContextOwner
         {
             return new MvxFluentBindingDescriptionSet<TTarget, TSource>(target);
         }
 
-        public static MvxFluentBindingDescriptionSet<TTarget, TSource> CreateBindingSet<TTarget, TSource>(
-            this TTarget target, string clearBindingKey)
-            where TTarget : class, IMvxBindingContextOwner
+        public static MvxFluentBindingDescriptionSet<TTarget, TSource> CreateBindingSet<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget, TSource>(
+                this TTarget target, string clearBindingKey)
+                    where TTarget : class, IMvxBindingContextOwner
         {
             return new MvxFluentBindingDescriptionSet<TTarget, TSource>(target, clearBindingKey);
         }
 
-        public static MvxFluentBindingDescription<TTarget> CreateBinding<TTarget>(this TTarget target)
-            where TTarget : class, IMvxBindingContextOwner
+        public static MvxFluentBindingDescription<TTarget> CreateBinding<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget>(
+            this TTarget target)
+                where TTarget : class, IMvxBindingContextOwner
         {
             return new MvxFluentBindingDescription<TTarget>(target, target);
         }
 
-        public static MvxFluentBindingDescription<TTarget> CreateBinding<TTarget>(
-            this IMvxBindingContextOwner contextOwner, TTarget target)
-            where TTarget : class
+        public static MvxFluentBindingDescription<TTarget> CreateBinding<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget>(
+                this IMvxBindingContextOwner contextOwner, TTarget target)
+                    where TTarget : class
         {
             return new MvxFluentBindingDescription<TTarget>(contextOwner, target);
         }

--- a/MvvmCross/Binding/BindingContext/MvxBindingContextOwnerExtensions.Language.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBindingContextOwnerExtensions.Language.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using MvvmCross.Binding.Bindings;
 using MvvmCross.Binding.Bindings.SourceSteps;
@@ -15,7 +16,7 @@ namespace MvvmCross.Binding.BindingContext
     {
         // note that we don't add more default parameters here
         // - otherwise this overrides the other existing methods
-        public static void BindLanguage<TTarget>(this IMvxBindingContextOwner owner
+        public static void BindLanguage<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget>(this IMvxBindingContextOwner owner
                                                  , TTarget target
                                                  , string sourceKey)
         {
@@ -23,7 +24,7 @@ namespace MvvmCross.Binding.BindingContext
             owner.BindLanguage(target, targetPath, sourceKey);
         }
 
-        public static void BindLanguage<TTarget>(this IMvxBindingContextOwner owner
+        public static void BindLanguage<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget>(this IMvxBindingContextOwner owner
                                                  , TTarget target
                                                  , string sourceKey
                                                  , MvxBindingMode bindingMode)
@@ -32,7 +33,7 @@ namespace MvvmCross.Binding.BindingContext
             owner.BindLanguage(target, targetPath, sourceKey, bindingMode: bindingMode);
         }
 
-        public static void BindLanguage<TTarget, TViewModel>(this IMvxBindingContextOwner owner
+        public static void BindLanguage<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget, TViewModel>(this IMvxBindingContextOwner owner
                                                              , TTarget target
                                                              , string sourceKey
                                                              , Expression<Func<TViewModel, IMvxTextProvider>> textProvider

--- a/MvvmCross/Binding/BindingContext/MvxBindingNameRegistry.cs
+++ b/MvvmCross/Binding/BindingContext/MvxBindingNameRegistry.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -12,16 +13,22 @@ namespace MvvmCross.Binding.BindingContext
     public class MvxBindingNameRegistry
         : IMvxBindingNameLookup, IMvxBindingNameRegistry
     {
-        private readonly Dictionary<Type, string> _lookup = new Dictionary<Type, string>();
+        private readonly Dictionary<Type, string> _lookup = [];
 
-        public string DefaultFor(Type type)
+        public string DefaultFor(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
         {
             string toReturn;
             TryDefaultFor(type, out toReturn, true);
             return toReturn;
         }
 
-        private bool TryDefaultFor(Type type, out string toReturn, bool includeInterfaces = true)
+        [UnconditionalSuppressMessage("Trimming", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' requirements",
+            Justification = "The interface types returned by GetInterfaces() on a type with DynamicallyAccessedMemberTypes.Interfaces are safe to process")]
+        private bool TryDefaultFor(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type,
+            out string toReturn,
+            bool includeInterfaces = true)
         {
             if (type == typeof(object))
             {

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescription.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
@@ -14,7 +15,7 @@ using MvvmCross.Converters;
 
 namespace MvvmCross.Binding.BindingContext
 {
-    public class MvxFluentBindingDescription<TTarget, TSource>
+    public class MvxFluentBindingDescription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget, TSource>
         : MvxBaseFluentBindingDescription<TTarget>
         where TTarget : class
     {
@@ -185,7 +186,7 @@ namespace MvvmCross.Binding.BindingContext
         }
     }
 
-    public class MvxFluentBindingDescription<TTarget>
+    public class MvxFluentBindingDescription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget>
         : MvxBaseFluentBindingDescription<TTarget>
         where TTarget : class
     {

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionExtensions.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Converters;
 using MvvmCross.Localization;
@@ -12,11 +11,12 @@ namespace MvvmCross.Binding.BindingContext
 {
     public static class MvxFluentBindingDescriptionExtensions
     {
-        public static MvxFluentBindingDescription<TTarget, TSource> ToLocalizationId<TTarget, TSource>(
-            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
-            string localizationId)
-            where TSource : IMvxLocalizedTextSourceOwner
-            where TTarget : class
+        public static MvxFluentBindingDescription<TTarget, TSource> ToLocalizationId<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget, TSource>(
+                this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
+                string localizationId)
+                    where TSource : IMvxLocalizedTextSourceOwner
+                    where TTarget : class
         {
             var valueConverter = Mvx.IoCProvider.Resolve<IMvxValueConverterLookup>().Find("Language");
             return bindingDescription.To(vm => vm.LocalizedTextSource)
@@ -24,19 +24,25 @@ namespace MvvmCross.Binding.BindingContext
                 .WithConversion(valueConverter, localizationId);
         }
 
-        public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TTarget, TSource, TFrom, TTo>(
-            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
-            IDictionary<TFrom, TTo> converterParameter)
-            where TTarget : class
-            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), new Tuple<IDictionary<TFrom, TTo>, TTo, bool>(converterParameter, default(TTo), false))
-            .OneWay();
+        public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget, TSource, TFrom, TTo>(
+                this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
+                IDictionary<TFrom, TTo> converterParameter)
+                    where TTarget : class
+                => bindingDescription.WithConversion(
+                    new MvxDictionaryValueConverter<TFrom, TTo>(), new Tuple<IDictionary<TFrom, TTo>, TTo, bool>(
+                        converterParameter, default, false))
+                        .OneWay();
 
-        public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<TTarget, TSource, TFrom, TTo>(
-            this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
-            IDictionary<TFrom, TTo> converterParameter,
-            TTo fallback)
-            where TTarget : class
-            => bindingDescription.WithConversion(new MvxDictionaryValueConverter<TFrom, TTo>(), new Tuple<IDictionary<TFrom, TTo>, TTo, bool>(converterParameter, fallback, true))
-            .OneWay();
+        public static MvxFluentBindingDescription<TTarget, TSource> WithDictionaryConversion<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TTarget, TSource, TFrom, TTo>(
+                this MvxFluentBindingDescription<TTarget, TSource> bindingDescription,
+                IDictionary<TFrom, TTo> converterParameter,
+                TTo fallback)
+                    where TTarget : class
+                => bindingDescription.WithConversion(
+                    new MvxDictionaryValueConverter<TFrom, TTo>(),
+                    new Tuple<IDictionary<TFrom, TTo>, TTo, bool>(converterParameter, fallback, true))
+                    .OneWay();
     }
 }

--- a/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
+++ b/MvvmCross/Binding/BindingContext/MvxFluentBindingDescriptionSet.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Binding.Bindings;
 
 namespace MvvmCross.Binding.BindingContext
 {
-    public class MvxFluentBindingDescriptionSet<TOwningTarget, TSource>
-        : MvxApplicable, IDisposable
-        where TOwningTarget : class, IMvxBindingContextOwner
+    public class MvxFluentBindingDescriptionSet<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TOwningTarget, TSource>
+            : MvxApplicable, IDisposable
+                where TOwningTarget : class, IMvxBindingContextOwner
     {
-        private readonly List<IMvxApplicable> _applicables = new List<IMvxApplicable>();
+        private readonly List<IMvxApplicable> _applicables = [];
         private readonly TOwningTarget _bindingContextOwner;
         private readonly string _clearBindingKey;
 
@@ -28,32 +28,36 @@ namespace MvvmCross.Binding.BindingContext
         }
         public MvxFluentBindingDescription<TOwningTarget, TSource> Bind()
         {
-            var toReturn = new MvxFluentBindingDescription<TOwningTarget, TSource>(_bindingContextOwner,
-                                                                                   _bindingContextOwner);
+            var toReturn = new MvxFluentBindingDescription<TOwningTarget, TSource>(
+                _bindingContextOwner, _bindingContextOwner);
             _applicables.Add(toReturn);
             return toReturn;
         }
 
-        public MvxFluentBindingDescription<TChildTarget, TSource> Bind<TChildTarget>(TChildTarget childTarget)
-            where TChildTarget : class
+        public MvxFluentBindingDescription<TChildTarget, TSource> Bind<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TChildTarget>(TChildTarget childTarget)
+                where TChildTarget : class
         {
             var toReturn = new MvxFluentBindingDescription<TChildTarget, TSource>(_bindingContextOwner, childTarget);
             _applicables.Add(toReturn);
             return toReturn;
         }
 
-        public MvxFluentBindingDescription<TChildTarget, TSource> Bind<TChildTarget>(TChildTarget childTarget,
-                                                                                     string bindingDescription)
-            where TChildTarget : class
+        public MvxFluentBindingDescription<TChildTarget, TSource> Bind<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TChildTarget>(
+                TChildTarget childTarget,
+                string bindingDescription)
+                    where TChildTarget : class
         {
             var toReturn = Bind(childTarget);
             toReturn.FullyDescribed(bindingDescription);
             return toReturn;
         }
 
-        public MvxFluentBindingDescription<TChildTarget, TSource> Bind<TChildTarget>(TChildTarget childTarget,
-                                                                                     MvxBindingDescription bindingDescription)
-            where TChildTarget : class
+        public MvxFluentBindingDescription<TChildTarget, TSource> Bind<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TChildTarget>(
+                TChildTarget childTarget, MvxBindingDescription bindingDescription)
+                    where TChildTarget : class
         {
             var toReturn = Bind(childTarget);
             toReturn.FullyDescribed(bindingDescription);

--- a/MvvmCross/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Binding/Bindings/MvxFullBinding.cs
@@ -2,19 +2,18 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Converters;
-using MvvmCross.Exceptions;
 using MvvmCross.IoC;
 
 namespace MvvmCross.Binding.Bindings
 {
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public class MvxFullBinding
         : MvxBinding, IMvxUpdateableBinding
     {

--- a/MvvmCross/Binding/Bindings/Source/Chained/MvxChainedSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Chained/MvxChainedSourceBinding.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.Source.Construction;
@@ -12,6 +13,7 @@ using MvvmCross.Converters;
 
 namespace MvvmCross.Binding.Bindings.Source.Chained
 {
+    [RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
     public abstract class MvxChainedSourceBinding
         : MvxPropertyInfoSourceBinding
     {
@@ -52,6 +54,7 @@ namespace MvvmCross.Binding.Bindings.Source.Chained
             }
         }
 
+        [RequiresUnreferencedCode("This method may use types that are not preserved by trimming")]
         protected void UpdateChildBinding()
         {
             if (_currentChildBinding != null)
@@ -85,6 +88,7 @@ namespace MvvmCross.Binding.Bindings.Source.Chained
             FireChanged();
         }
 
+        [RequiresUnreferencedCode("This method may use types that are not preserved by trimming")]
         protected override void OnBoundPropertyChanged()
         {
             UpdateChildBinding();

--- a/MvvmCross/Binding/Bindings/Source/Chained/MvxIndexerChainedSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Chained/MvxIndexerChainedSourceBinding.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 
 namespace MvvmCross.Binding.Bindings.Source.Chained
 {
+    [RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
     public class MvxIndexerChainedSourceBinding
         : MvxChainedSourceBinding
     {

--- a/MvvmCross/Binding/Bindings/Source/Chained/MvxSimpleChainedSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Chained/MvxSimpleChainedSourceBinding.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 
 namespace MvvmCross.Binding.Bindings.Source.Chained
 {
+    [RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
     public class MvxSimpleChainedSourceBinding
         : MvxChainedSourceBinding
     {
@@ -23,7 +23,7 @@ namespace MvvmCross.Binding.Bindings.Source.Chained
 
         protected override object[] PropertyIndexParameters()
         {
-            return Array.Empty<object>();
+            return [];
         }
     }
 }

--- a/MvvmCross/Binding/Bindings/Source/Construction/IMvxSourceBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Source/Construction/IMvxSourceBindingFactory.cs
@@ -2,15 +2,17 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 
 namespace MvvmCross.Binding.Bindings.Source.Construction
 {
     public interface IMvxSourceBindingFactory
     {
+        [RequiresUnreferencedCode("This method uses reflection to create bindings, which may not be preserved in trimming scenarios")]
         IMvxSourceBinding CreateBinding(object source, string combinedPropertyName);
 
+        [RequiresUnreferencedCode("This method uses reflection to create bindings, which may not be preserved in trimming scenarios")]
         IMvxSourceBinding CreateBinding(object source, IList<IMvxPropertyToken> tokens);
     }
 }

--- a/MvvmCross/Binding/Bindings/Source/Construction/IMvxSourceBindingFactoryExtension.cs
+++ b/MvvmCross/Binding/Bindings/Source/Construction/IMvxSourceBindingFactoryExtension.cs
@@ -2,13 +2,18 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 
 namespace MvvmCross.Binding.Bindings.Source.Construction
 {
     public interface IMvxSourceBindingFactoryExtension
     {
-        bool TryCreateBinding(object source, IMvxPropertyToken propertyToken, List<IMvxPropertyToken> remainingTokens, out IMvxSourceBinding result);
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
+        bool TryCreateBinding(
+            object source,
+            IMvxPropertyToken propertyToken,
+            List<IMvxPropertyToken> remainingTokens,
+            out IMvxSourceBinding result);
     }
 }

--- a/MvvmCross/Binding/Bindings/Source/Construction/MvxPropertySourceBindingFactoryExtension.cs
+++ b/MvvmCross/Binding/Bindings/Source/Construction/MvxPropertySourceBindingFactoryExtension.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Binding.Bindings.Source.Chained;
 using MvvmCross.Binding.Bindings.Source.Leaf;
@@ -20,6 +21,7 @@ public class MvxPropertySourceBindingFactoryExtension
 {
     private readonly ConcurrentDictionary<int, PropertyInfo> _propertyInfoCache = new();
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public bool TryCreateBinding(
         object? source,
         IMvxPropertyToken propertyToken,
@@ -71,6 +73,7 @@ public class MvxPropertySourceBindingFactoryExtension
         }
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     protected virtual IMvxSourceBinding? CreateLeafBinding(object source, IMvxPropertyToken propertyToken)
     {
         if (propertyToken is MvxIndexerPropertyToken indexPropertyToken)

--- a/MvvmCross/Binding/Bindings/Source/Construction/MvxSourceBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Source/Construction/MvxSourceBindingFactory.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Parse.PropertyPath;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
@@ -17,12 +16,14 @@ namespace MvvmCross.Binding.Bindings.Source.Construction
     {
         private IMvxSourcePropertyPathParser _propertyPathParser;
 
-        protected IMvxSourcePropertyPathParser SourcePropertyPathParser => _propertyPathParser ?? (_propertyPathParser = Mvx.IoCProvider.Resolve<IMvxSourcePropertyPathParser>());
+        protected IMvxSourcePropertyPathParser SourcePropertyPathParser => _propertyPathParser ??= Mvx.IoCProvider.Resolve<IMvxSourcePropertyPathParser>();
 
-        private readonly List<IMvxSourceBindingFactoryExtension> _extensions = new List<IMvxSourceBindingFactoryExtension>();
+        private readonly List<IMvxSourceBindingFactoryExtension> _extensions = [];
 
-        protected bool TryCreateBindingFromExtensions(object source, IMvxPropertyToken propertyToken,
-                                            List<IMvxPropertyToken> remainingTokens, out IMvxSourceBinding result)
+        [RequiresUnreferencedCode("This method uses reflection to create bindings, which may not be preserved in trimming scenarios")]
+        protected bool TryCreateBindingFromExtensions(
+            object source, IMvxPropertyToken propertyToken,
+            List<IMvxPropertyToken> remainingTokens, out IMvxSourceBinding result)
         {
             foreach (var extension in _extensions)
             {
@@ -36,12 +37,14 @@ namespace MvvmCross.Binding.Bindings.Source.Construction
             return false;
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to create bindings, which may not be preserved in trimming scenarios")]
         public IMvxSourceBinding CreateBinding(object source, string combinedPropertyName)
         {
             var tokens = SourcePropertyPathParser.Parse(combinedPropertyName);
             return CreateBinding(source, tokens);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to create bindings, which may not be preserved in trimming scenarios")]
         public IMvxSourceBinding CreateBinding(object source, IList<IMvxPropertyToken> tokens)
         {
             if (tokens == null || tokens.Count == 0)

--- a/MvvmCross/Binding/Bindings/Source/Leaf/MvxIndexerLeafPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Leaf/MvxIndexerLeafPropertyInfoSourceBinding.cs
@@ -2,24 +2,29 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Binding.Parse.PropertyPath.PropertyTokens;
 
 namespace MvvmCross.Binding.Bindings.Source.Leaf
 {
+    [RequiresUnreferencedCode("This class uses reflection which may not be preserved during trimming")]
     public class MvxIndexerLeafPropertyInfoSourceBinding : MvxLeafPropertyInfoSourceBinding
     {
         private readonly object _key;
 
-        public MvxIndexerLeafPropertyInfoSourceBinding(object source, PropertyInfo itemPropertyInfo, MvxIndexerPropertyToken indexToken)
-            : base(source, itemPropertyInfo)
+        public MvxIndexerLeafPropertyInfoSourceBinding(
+            object source,
+            PropertyInfo itemPropertyInfo,
+            MvxIndexerPropertyToken indexToken)
+                : base(source, itemPropertyInfo)
         {
             _key = indexToken.Key;
         }
 
         protected override object[] PropertyIndexParameters()
         {
-            return new[] { _key };
+            return [_key];
         }
     }
 }

--- a/MvvmCross/Binding/Bindings/Source/Leaf/MvxLeafPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Leaf/MvxLeafPropertyInfoSourceBinding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Extensions;
@@ -11,6 +12,7 @@ using MvvmCross.Exceptions;
 
 namespace MvvmCross.Binding.Bindings.Source.Leaf
 {
+    [RequiresUnreferencedCode("This method accesses the PropertyInfo which may not be preserved by trimming")]
     public abstract class MvxLeafPropertyInfoSourceBinding : MvxPropertyInfoSourceBinding
     {
         protected MvxLeafPropertyInfoSourceBinding(object source, PropertyInfo propertyInfo)

--- a/MvvmCross/Binding/Bindings/Source/Leaf/MvxSimpleLeafPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/Leaf/MvxSimpleLeafPropertyInfoSourceBinding.cs
@@ -2,21 +2,15 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.Binding.Bindings.Source.Leaf
 {
-    public class MvxSimpleLeafPropertyInfoSourceBinding : MvxLeafPropertyInfoSourceBinding
+    [RequiresUnreferencedCode("This class uses reflection which may not be preserved during trimming")]
+    public class MvxSimpleLeafPropertyInfoSourceBinding(object source, PropertyInfo propertyInfo)
+        : MvxLeafPropertyInfoSourceBinding(source, propertyInfo)
     {
-        public MvxSimpleLeafPropertyInfoSourceBinding(object source, PropertyInfo propertyInfo)
-            : base(source, propertyInfo)
-        {
-        }
-
-        protected override object[] PropertyIndexParameters()
-        {
-            return Array.Empty<object>();
-        }
+        protected override object[] PropertyIndexParameters() => [];
     }
 }

--- a/MvvmCross/Binding/Bindings/Source/MvxPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/MvxPropertyInfoSourceBinding.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.WeakSubscription;
@@ -13,49 +11,45 @@ namespace MvvmCross.Binding.Bindings.Source
 {
     public abstract class MvxPropertyInfoSourceBinding : MvxSourceBinding
     {
-        private readonly PropertyInfo _propertyInfo;
-        private readonly string _propertyName;
         private IDisposable _subscription;
 
         protected MvxPropertyInfoSourceBinding(object source, PropertyInfo propertyInfo)
             : base(source)
         {
-            _propertyInfo = propertyInfo;
-            _propertyName = propertyInfo.Name;
+            PropertyInfo = propertyInfo;
+            PropertyName = propertyInfo.Name;
 
             if (Source == null)
             {
                 MvxBindingLog.Instance?.LogTrace(
-                    "Unable to bind to source as it's null. PropertyName: {PropertyName}", _propertyName);
+                    "Unable to bind to source as it's null. PropertyName: {PropertyName}", PropertyName);
                 return;
             }
 
-            var sourceNotify = Source as INotifyPropertyChanged;
-            if (sourceNotify != null)
+            if (Source is INotifyPropertyChanged sourceNotify)
                 _subscription = sourceNotify.WeakSubscribe(SourcePropertyChanged);
         }
 
-        protected string PropertyName => _propertyName;
+        protected string PropertyName { get; }
+        protected PropertyInfo PropertyInfo { get; }
 
         protected string PropertyNameForChangedEvent
         {
             get
             {
                 if (IsIndexedProperty)
-                    return _propertyName + "[]";
+                    return PropertyName + "[]";
                 else
-                    return _propertyName;
+                    return PropertyName;
             }
         }
-
-        protected PropertyInfo PropertyInfo => _propertyInfo;
 
         protected bool IsIndexedProperty
         {
             get
             {
-                var parameters = _propertyInfo.GetIndexParameters();
-                return parameters.Any();
+                var parameters = PropertyInfo.GetIndexParameters();
+                return parameters.Length != 0;
             }
         }
 
@@ -75,7 +69,9 @@ namespace MvvmCross.Binding.Bindings.Source
             // - fix for https://github.com/slodge/MvvmCross/issues/280
             if (string.IsNullOrEmpty(e.PropertyName)
                 || e.PropertyName == PropertyNameForChangedEvent)
+            {
                 OnBoundPropertyChanged();
+            }
         }
 
         protected abstract void OnBoundPropertyChanged();

--- a/MvvmCross/Binding/Bindings/Source/MvxPropertyInfoSourceBinding.cs
+++ b/MvvmCross/Binding/Bindings/Source/MvxPropertyInfoSourceBinding.cs
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.Binding.Bindings.Source
 {
+    [RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
     public abstract class MvxPropertyInfoSourceBinding : MvxSourceBinding
     {
         private IDisposable _subscription;

--- a/MvvmCross/Binding/Bindings/SourceSteps/IMvxSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/IMvxSourceStep.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Binding.Bindings.SourceSteps
 {
@@ -17,6 +18,11 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
 
         object GetValue();
 
-        object DataContext { get; set; }
+        object DataContext
+        {
+            get;
+            [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
+            set;
+        }
     }
 }

--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxCombinerSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxCombinerSourceStep.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Converters;
 using MvvmCross.Exceptions;
 
@@ -18,9 +16,7 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
             : base(description)
         {
             var sourceStepFactory = MvxBindingSingletonCache.Instance.SourceStepFactory;
-            _subSteps = description.InnerSteps
-                                   .Select(d => sourceStepFactory.Create(d))
-                                   .ToList();
+            _subSteps = [.. description.InnerSteps.Select(d => sourceStepFactory.Create(d))];
         }
 
         protected override void Dispose(bool isDisposing)
@@ -106,6 +102,7 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
             SendSourcePropertyChanged();
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         protected override void OnDataContextChanged()
         {
             foreach (var step in _subSteps)

--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxPathSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxPathSourceStep.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Binding.Bindings.Source;
 using MvvmCross.Binding.Bindings.Source.Construction;
 using MvvmCross.Converters;
@@ -45,6 +46,7 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
 
         //TODO: optim: dont recreate the source binding on each datacontext change, as SourcePropertyPath does not change.
         //TODO: optim: don't subscribe to the Changed event if the binding mode does not need it.
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         protected override void OnDataContextChanged()
         {
             ClearPathSourceBinding();

--- a/MvvmCross/Binding/Bindings/SourceSteps/MvxSourceStep.cs
+++ b/MvvmCross/Binding/Bindings/SourceSteps/MvxSourceStep.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Converters;
-using MvvmCross.Exceptions;
 
 namespace MvvmCross.Binding.Bindings.SourceSteps
 {
@@ -38,12 +37,14 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
 
         public virtual Type SourceType => typeof(object);
 
+
         public object DataContext
         {
             get
             {
                 return _dataContext;
             }
+            [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
             set
             {
                 if (_dataContext == value)
@@ -54,6 +55,7 @@ namespace MvvmCross.Binding.Bindings.SourceSteps
             }
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         protected virtual void OnDataContextChanged()
         {
             // nothing to do in the base class

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxPropertyInfoTargetBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxPropertyInfoTargetBindingFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxPropertyInfoTargetBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxPropertyInfoTargetBindingFactory.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 
@@ -14,10 +15,14 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
     {
         private readonly Func<object, PropertyInfo, IMvxTargetBinding> _bindingCreator;
         private readonly string _targetName;
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
         private readonly Type _targetType;
 
-        public MvxPropertyInfoTargetBindingFactory(Type targetType, string targetName,
-                                                   Func<object, PropertyInfo, IMvxTargetBinding> bindingCreator)
+        public MvxPropertyInfoTargetBindingFactory(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type targetType,
+            string targetName,
+            Func<object, PropertyInfo, IMvxTargetBinding> bindingCreator)
         {
             _targetType = targetType;
             _targetName = targetName;

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxSimplePropertyInfoTargetBindingFactory.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxSimplePropertyInfoTargetBindingFactory.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 
@@ -12,10 +11,14 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
     public class MvxSimplePropertyInfoTargetBindingFactory
         : IMvxPluginTargetBindingFactory
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         private readonly Type _bindingType;
         private readonly MvxPropertyInfoTargetBindingFactory _innerFactory;
 
-        public MvxSimplePropertyInfoTargetBindingFactory(Type bindingType, Type targetType, string targetName)
+        public MvxSimplePropertyInfoTargetBindingFactory(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type bindingType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type targetType,
+            string targetName)
         {
             _bindingType = bindingType;
             _innerFactory = new MvxPropertyInfoTargetBindingFactory(targetType, targetName, CreateTargetBinding);

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 
@@ -99,7 +100,10 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
             return (type.GetHashCode() * 9) ^ name.GetHashCode();
         }
 
-        private IMvxPluginTargetBindingFactory FindSpecificFactory(Type type, string name)
+        [UnconditionalSuppressMessage("Trimming", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' requirements",
+            Justification = "The interface types returned by ImplementedInterfaces on a type with DynamicallyAccessedMemberTypes.Interfaces are safe to process")]
+        private IMvxPluginTargetBindingFactory FindSpecificFactory(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type, string name)
         {
             IMvxPluginTargetBindingFactory factory;
             var key = GenerateKey(type, name);

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistry.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -12,23 +10,21 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
 {
     public class MvxTargetBindingFactoryRegistry : IMvxTargetBindingFactoryRegistry
     {
-        private readonly Dictionary<int, IMvxPluginTargetBindingFactory> _lookups =
-            new Dictionary<int, IMvxPluginTargetBindingFactory>();
+        private readonly Dictionary<int, IMvxPluginTargetBindingFactory> _lookups = [];
 
         public virtual IMvxTargetBinding CreateBinding(object target, string targetName)
         {
-            IMvxTargetBinding binding;
-            if (TryCreateSpecificFactoryBinding(target, targetName, out binding))
-                return binding;
+            if (TryCreateSpecificFactoryBinding(target, targetName, out IMvxTargetBinding first))
+                return first;
 
-            if (TryCreateReflectionBasedBinding(target, targetName, out binding))
-                return binding;
+            if (TryCreateReflectionBasedBinding(target, targetName, out IMvxTargetBinding second))
+                return second;
 
             return null;
         }
 
-        protected virtual bool TryCreateReflectionBasedBinding(object target, string targetName,
-                                                               out IMvxTargetBinding binding)
+        protected virtual bool TryCreateReflectionBasedBinding(
+            object target, string targetName, out IMvxTargetBinding binding)
         {
             if (string.IsNullOrEmpty(targetName))
             {

--- a/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistryExtensions.cs
+++ b/MvvmCross/Binding/Bindings/Target/Construction/MvxTargetBindingFactoryRegistryExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Binding.Bindings.Target.Construction
 {
@@ -17,8 +18,11 @@ namespace MvvmCross.Binding.Bindings.Target.Construction
             registry.RegisterFactory(new MvxCustomBindingFactory<TView>(customName, creator));
         }
 
-        public static void RegisterPropertyInfoBindingFactory(this IMvxTargetBindingFactoryRegistry registry,
-                                                              Type bindingType, Type targetType, string targetName)
+        public static void RegisterPropertyInfoBindingFactory(
+            this IMvxTargetBindingFactoryRegistry registry,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type bindingType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type targetType,
+            string targetName)
         {
             registry.RegisterFactory(new MvxSimplePropertyInfoTargetBindingFactory(bindingType, targetType, targetName));
         }

--- a/MvvmCross/Binding/Bindings/Target/IMvxTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/IMvxTargetBinding.cs
@@ -2,12 +2,15 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.Binding.Bindings.Target;
 
 public interface IMvxTargetBinding : IMvxBinding
 {
     event EventHandler<MvxTargetChangedEventArgs>? ValueChanged;
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     Type TargetValueType { get; }
     MvxBindingMode DefaultMode { get; }
 

--- a/MvvmCross/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxConvertingTargetBinding.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Extensions;
 
@@ -100,7 +101,10 @@ public abstract class MvxConvertingTargetBinding(object target)
     }
 }
 
-public abstract class MvxConvertingTargetBinding<TTarget, TValue> : MvxTargetBinding<TTarget, TValue>
+public abstract class MvxConvertingTargetBinding<
+        TTarget,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TValue
+    > : MvxTargetBinding<TTarget, TValue>
     where TTarget : class
 {
     private bool _isUpdatingSource;

--- a/MvvmCross/Binding/Bindings/Target/MvxEventHandlerEventInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventHandlerEventInfoTargetBinding.cs
@@ -16,7 +16,6 @@ public class MvxEventHandlerEventInfoTargetBinding : MvxTargetBinding
     private readonly object _eventHandler;
 
     public MvxEventHandlerEventInfoTargetBinding(object target,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         EventInfo targetEventInfo)
         : base(target)
     {
@@ -34,6 +33,7 @@ public class MvxEventHandlerEventInfoTargetBinding : MvxTargetBinding
         addMethod?.Invoke(target, [_eventHandler]);
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType => typeof(ICommand);
 
     public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;

--- a/MvvmCross/Binding/Bindings/Target/MvxEventInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventInfoTargetBinding.cs
@@ -16,7 +16,6 @@ public class MvxEventInfoTargetBinding<T> : MvxTargetBinding
     private ICommand? _currentCommand;
 
     public MvxEventInfoTargetBinding(object target,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         EventInfo targetEventInfo)
         : base(target)
     {
@@ -29,6 +28,7 @@ public class MvxEventInfoTargetBinding<T> : MvxTargetBinding
         addMethod?.Invoke(target, [new EventHandler<T>(HandleEvent)]);
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType => typeof(ICommand);
 
     public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;

--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
@@ -8,7 +8,7 @@ using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.Binding.Bindings.Target;
 
-public class MvxEventNameTargetBinding<TTarget> : MvxTargetBinding
+public class MvxEventNameTargetBinding<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TTarget> : MvxTargetBinding
     where TTarget : class
 {
     private readonly bool _useEventArgsAsCommandParameter;

--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBinding.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using MvvmCross.WeakSubscription;
 
@@ -23,6 +24,7 @@ public class MvxEventNameTargetBinding<TTarget> : MvxTargetBinding
         _eventSubscription = target.WeakSubscribe(targetEventName, HandleEvent);
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType { get; } = typeof(ICommand);
 
     public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;

--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
@@ -8,8 +8,9 @@ using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.Binding.Bindings.Target;
 
-public class MvxEventNameTargetBinding<TTarget, TEventArgs> : MvxTargetBinding
-    where TTarget : class
+public class MvxEventNameTargetBinding<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TTarget, TEventArgs>
+    : MvxTargetBinding
+        where TTarget : class
 {
     private readonly bool _useEventArgsAsCommandParameter;
     private readonly IDisposable _eventSubscription;

--- a/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxEventNameTargetBindingOfTEventArgs.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using MvvmCross.WeakSubscription;
 
@@ -22,6 +23,7 @@ public class MvxEventNameTargetBinding<TTarget, TEventArgs> : MvxTargetBinding
         _eventSubscription = target.WeakSubscribe<TTarget, TEventArgs>(targetEventName, HandleEvent);
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType { get; } = typeof(ICommand);
 
     public override MvxBindingMode DefaultMode => MvxBindingMode.OneWay;

--- a/MvvmCross/Binding/Bindings/Target/MvxNullTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxNullTargetBinding.cs
@@ -2,12 +2,15 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.Binding.Bindings.Target;
 
 public sealed class MvxNullTargetBinding() : MvxTargetBinding(null)
 {
     public override MvxBindingMode DefaultMode => MvxBindingMode.OneTime;
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType => typeof(object);
 
     public override void SetValue(object? value)

--- a/MvvmCross/Binding/Bindings/Target/MvxPropertyInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxPropertyInfoTargetBinding.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Binding.Attributes;
 
@@ -26,6 +27,7 @@ public abstract class MvxPropertyInfoTargetBinding(object target, PropertyInfo t
         base.Dispose(isDisposing);
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType => TargetPropertyInfo.PropertyType;
 
     protected PropertyInfo TargetPropertyInfo { get; } = targetPropertyInfo;

--- a/MvvmCross/Binding/Bindings/Target/MvxTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxTargetBinding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
 namespace MvvmCross.Binding.Bindings.Target;
@@ -30,6 +31,7 @@ public abstract class MvxTargetBinding : MvxBinding, IMvxTargetBinding
         ValueChanged?.Invoke(this, new MvxTargetChangedEventArgs(newValue));
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public abstract Type TargetValueType { get; }
 
     public abstract void SetValue(object? value);
@@ -37,7 +39,10 @@ public abstract class MvxTargetBinding : MvxBinding, IMvxTargetBinding
     public abstract MvxBindingMode DefaultMode { get; }
 }
 
-public abstract class MvxTargetBinding<TTarget, TValue> : MvxBinding, IMvxTargetBinding
+public abstract class MvxTargetBinding<
+        TTarget,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TValue
+    > : MvxBinding, IMvxTargetBinding
     where TTarget : class
 {
     public event EventHandler<MvxTargetChangedEventArgs>? ValueChanged;
@@ -70,6 +75,7 @@ public abstract class MvxTargetBinding<TTarget, TValue> : MvxBinding, IMvxTarget
 
     public abstract MvxBindingMode DefaultMode { get; }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type TargetValueType => typeof(TValue);
 
     protected abstract void SetValue(TValue? value);

--- a/MvvmCross/Binding/Bindings/Target/MvxWithEventPropertyInfoTargetBinding.cs
+++ b/MvvmCross/Binding/Bindings/Target/MvxWithEventPropertyInfoTargetBinding.cs
@@ -17,7 +17,6 @@ public class MvxWithEventPropertyInfoTargetBinding
 
     public MvxWithEventPropertyInfoTargetBinding(
             object target,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
             PropertyInfo targetPropertyInfo)
         : base(target, targetPropertyInfo)
     {
@@ -92,7 +91,7 @@ public class MvxWithEventPropertyInfoTargetBinding
         if (eventInfo.EventHandlerType != typeof(EventHandler))
         {
             MvxBindingLog.Instance?.LogTrace(
-                "Diagnostic - cannot two-way bind to {ViewType}/{EventName} on type {ViewTypeName} because eventHandler is type {EventHandlerTypeName)}",
+                "Diagnostic - cannot two-way bind to {ViewType}/{EventName} on type {ViewTypeName} because eventHandler is type {EventHandlerTypeName}",
                 viewType,
                 eventName,
                 viewType.Name,
@@ -103,7 +102,8 @@ public class MvxWithEventPropertyInfoTargetBinding
         return eventInfo;
     }
 
-    private static EventInfo? GetPropertyChangedEvent(Type viewType)
+    private static EventInfo? GetPropertyChangedEvent(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] Type viewType)
     {
         const string eventName = "PropertyChanged";
         var eventInfo = viewType.GetEvent(eventName);

--- a/MvvmCross/Binding/Extensions/MvxBindingExtensions.cs
+++ b/MvvmCross/Binding/Extensions/MvxBindingExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using MvvmCross.Base;
 using MvvmCross.IoC;
@@ -49,7 +50,9 @@ public static class MvxBindingExtensions
         return result.ConvertToBooleanCore();
     }
 
-    public static object? MakeSafeValue(this Type propertyType, object? value)
+    public static object? MakeSafeValue(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type propertyType,
+        object? value)
     {
         if (value == null)
         {

--- a/MvvmCross/Binding/MvxBindingBuilder.cs
+++ b/MvvmCross/Binding/MvxBindingBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding.Bindings.Source.Construction;
 using MvvmCross.Binding.Bindings.SourceSteps;
@@ -13,17 +14,20 @@ namespace MvvmCross.Binding
 {
     public class MvxBindingBuilder : MvxCoreBindingBuilder
     {
+        [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
         public override void DoRegistration(IMvxIoCProvider iocProvider)
         {
             base.DoRegistration(iocProvider);
             RegisterBindingFactories(iocProvider);
         }
 
+        [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
         protected virtual void RegisterBindingFactories(IMvxIoCProvider iocProvider)
         {
             RegisterMvxBindingFactories(iocProvider);
         }
 
+        [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
         protected virtual void RegisterMvxBindingFactories(IMvxIoCProvider iocProvider)
         {
             RegisterSourceStepFactory(iocProvider);
@@ -75,6 +79,7 @@ namespace MvvmCross.Binding
             return new MvxSourceBindingFactory();
         }
 
+        [RequiresUnreferencedCode("This method registers target bindings that may not be preserved by trimming")]
         protected virtual void RegisterTargetFactory(IMvxIoCProvider iocProvider)
         {
             var targetRegistry = CreateTargetBindingRegistry();
@@ -88,6 +93,7 @@ namespace MvvmCross.Binding
             return new MvxTargetBindingFactoryRegistry();
         }
 
+        [RequiresUnreferencedCode("This method registers target bindings that may not be preserved by trimming")]
         protected virtual void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
         {
             // base class has nothing to register

--- a/MvvmCross/Binding/MvxCoreBindingBuilder.cs
+++ b/MvvmCross/Binding/MvxCoreBindingBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Binding.Binders;
@@ -21,6 +22,7 @@ namespace MvvmCross.Binding
 {
     public class MvxCoreBindingBuilder
     {
+        [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
         public virtual void DoRegistration(IMvxIoCProvider iocProvider)
         {
             CreateSingleton();

--- a/MvvmCross/Commands/IMvxCommandCollectionBuilder.cs
+++ b/MvvmCross/Commands/IMvxCommandCollectionBuilder.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Commands
 {
-#nullable enable
     public interface IMvxCommandCollectionBuilder
     {
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         IMvxCommandCollection BuildCollectionFor(object owner);
     }
-#nullable restore
 }

--- a/MvvmCross/Commands/MvxAsyncCommand.cs
+++ b/MvvmCross/Commands/MvxAsyncCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Logging;
@@ -205,12 +206,12 @@ namespace MvvmCross.Commands
             return _execute(CancelToken);
         }
 
-        public static MvxAsyncCommand<T?> CreateCommand<T>(Func<T?, Task> execute, Func<T?, bool>? canExecute = null, bool allowConcurrentExecutions = false)
+        public static MvxAsyncCommand<T?> CreateCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(Func<T?, Task> execute, Func<T?, bool>? canExecute = null, bool allowConcurrentExecutions = false)
         {
             return new MvxAsyncCommand<T?>(execute, canExecute, allowConcurrentExecutions);
         }
 
-        public static MvxAsyncCommand<T?> CreateCommand<T>(Func<T?, CancellationToken, Task> execute, Func<T?, bool>? canExecute = null, bool allowConcurrentExecutions = false)
+        public static MvxAsyncCommand<T?> CreateCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(Func<T?, CancellationToken, Task> execute, Func<T?, bool>? canExecute = null, bool allowConcurrentExecutions = false)
         {
             return new MvxAsyncCommand<T?>(execute, canExecute, allowConcurrentExecutions);
         }
@@ -221,7 +222,7 @@ namespace MvvmCross.Commands
         }
     }
 
-    public class MvxAsyncCommand<T>
+    public class MvxAsyncCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>
         : MvxAsyncCommandBase, IMvxCommand, IMvxAsyncCommand<T>
     {
         private readonly Func<T?, CancellationToken, Task> _execute;

--- a/MvvmCross/Commands/MvxCommand.cs
+++ b/MvvmCross/Commands/MvxCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Base;
 
 namespace MvvmCross.Commands
@@ -171,7 +172,7 @@ namespace MvvmCross.Commands
             => Execute(null);
     }
 
-    public class MvxCommand<T>
+    public class MvxCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>
         : MvxCommandBase
         , IMvxCommand, IMvxCommand<T>
     {

--- a/MvvmCross/Commands/MvxCommandCollectionBuilder.cs
+++ b/MvvmCross/Commands/MvxCommandCollectionBuilder.cs
@@ -18,6 +18,7 @@ public class MvxCommandCollectionBuilder
     public IEnumerable<string>? AdditionalCommandSuffixes { get; set; }
     public string CanExecutePrefix { get; set; } = DefaultCanExecutePrefix;
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public virtual IMvxCommandCollection BuildCollectionFor(object owner)
     {
         var toReturn = new MvxCommandCollection(owner);
@@ -25,6 +26,7 @@ public class MvxCommandCollectionBuilder
         return toReturn;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     protected virtual void CreateCommands(object owner, MvxCommandCollection toReturn)
     {
         var commandMethods =
@@ -43,6 +45,7 @@ public class MvxCommandCollectionBuilder
         }
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     protected virtual void CreateCommand(
         object owner, MvxCommandCollection collection, MethodInfo commandMethod,
         string commandName, bool hasParameter)

--- a/MvvmCross/Commands/MvxCommandCollectionBuilder.cs
+++ b/MvvmCross/Commands/MvxCommandCollectionBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.Commands;
@@ -57,7 +58,8 @@ public class MvxCommandCollectionBuilder
         collection.Add(command, commandName, helper.CanExecutePropertyName);
     }
 
-    protected virtual PropertyInfo? CanExecutePropertyInfo(Type type, MethodInfo commandMethod)
+    protected virtual PropertyInfo? CanExecutePropertyInfo(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, MethodInfo commandMethod)
     {
         var canExecuteName = CanExecuteProperyName(commandMethod);
         if (string.IsNullOrEmpty(canExecuteName))

--- a/MvvmCross/Core/IMvxSetup.cs
+++ b/MvvmCross/Core/IMvxSetup.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Plugin;
 
@@ -13,15 +14,24 @@ namespace MvvmCross.Core
     public interface IMvxSetup
     {
         void InitializePrimary();
+
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         void InitializeSecondary();
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         IEnumerable<Assembly> GetViewAssemblies();
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         IEnumerable<Assembly> GetViewModelAssemblies();
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         IEnumerable<Assembly> GetPluginAssemblies();
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         IEnumerable<Type> CreatableTypes();
+
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         IEnumerable<Type> CreatableTypes(Assembly assembly);
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         void LoadPlugins(IMvxPluginManager pluginManager);
 
         event EventHandler<MvxSetupStateEventArgs>? StateChanged;

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
@@ -74,6 +75,7 @@ public abstract class MvxSetup : IMvxSetup
         MvxLogHost.Default?.LogInformation("Setup: RegisterSetupType already called");
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public static IMvxSetup? Instance()
     {
         var instance = SetupCreator?.Invoke() ?? MvxSetupExtensions.CreateSetup<MvxSetup>();
@@ -127,6 +129,7 @@ public abstract class MvxSetup : IMvxSetup
         }
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public virtual void InitializeSecondary()
     {
         if (State != MvxSetupState.InitializedPrimary)
@@ -291,6 +294,7 @@ public abstract class MvxSetup : IMvxSetup
         return iocProvider.Resolve<IMvxStringToTypeParser>() as IMvxFillableStringToTypeParser;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual void PerformBootstrapActions()
     {
         var bootstrapRunner = new MvxBootstrapRunner();
@@ -417,6 +421,7 @@ public abstract class MvxSetup : IMvxSetup
         return iocProvider.Resolve<IMvxNavigationService>();
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual IMvxPluginManager? InitializePluginFramework(IMvxIoCProvider iocProvider)
     {
         ValidateArguments(iocProvider);
@@ -439,6 +444,7 @@ public abstract class MvxSetup : IMvxSetup
         return null;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public virtual IEnumerable<Assembly> GetPluginAssemblies()
     {
         var mvvmCrossAssemblyName = typeof(MvxPluginAttribute).Assembly.GetName().Name;
@@ -450,6 +456,7 @@ public abstract class MvxSetup : IMvxSetup
             .Where(assembly => AssemblyReferencesMvvmCross(assembly, mvvmCrossAssemblyName));
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     private static bool AssemblyReferencesMvvmCross(Assembly assembly, string? mvvmCrossAssemblyName)
     {
         if (string.IsNullOrEmpty(mvvmCrossAssemblyName))
@@ -467,6 +474,7 @@ public abstract class MvxSetup : IMvxSetup
         }
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public virtual void LoadPlugins(IMvxPluginManager pluginManager)
     {
         if (pluginManager == null)
@@ -536,6 +544,7 @@ public abstract class MvxSetup : IMvxSetup
         iocProvider.RegisterSingleton<IMvxMainThreadDispatcher>(dispatcher);
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual IMvxNavigationService? InitializeNavigationService(IMvxIoCProvider iocProvider)
     {
         ValidateArguments(iocProvider);
@@ -550,6 +559,7 @@ public abstract class MvxSetup : IMvxSetup
         return navigationService;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual void LoadNavigationServiceRoutes(IMvxNavigationService navigationService, IMvxIoCProvider iocProvider)
     {
         if (navigationService == null)
@@ -560,6 +570,7 @@ public abstract class MvxSetup : IMvxSetup
         navigationService.LoadRoutes(GetViewModelAssemblies());
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public virtual IEnumerable<Assembly> GetViewAssemblies()
     {
         if (ViewAssemblies.Count == 0)
@@ -568,6 +579,7 @@ public abstract class MvxSetup : IMvxSetup
         return ViewAssemblies;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public virtual IEnumerable<Assembly> GetViewModelAssemblies()
     {
         var app = _iocProvider?.Resolve<IMvxApplication>();
@@ -576,6 +588,7 @@ public abstract class MvxSetup : IMvxSetup
         return [assembly];
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual IEnumerable<Assembly> GetBootstrapOwningAssemblies()
     {
         return GetViewAssemblies().Distinct();
@@ -611,6 +624,7 @@ public abstract class MvxSetup : IMvxSetup
         return iocProvider.Resolve<IMvxViewModelByNameRegistry>();
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual IMvxNameMapping InitializeViewModelTypeFinder(IMvxIoCProvider iocProvider)
     {
         ValidateArguments(iocProvider);
@@ -631,6 +645,7 @@ public abstract class MvxSetup : IMvxSetup
         return nameMappingStrategy;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual IDictionary<Type, Type>? InitializeLookupDictionary(IMvxIoCProvider iocProvider)
     {
         ValidateArguments(iocProvider);
@@ -660,11 +675,13 @@ public abstract class MvxSetup : IMvxSetup
         // base class implementation is empty by default
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public IEnumerable<Type> CreatableTypes()
     {
         return CreatableTypes(GetType().GetTypeInfo().Assembly);
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public IEnumerable<Type> CreatableTypes(Assembly assembly)
     {
         return assembly.CreatableTypes();

--- a/MvvmCross/Core/MvxSetup.cs
+++ b/MvvmCross/Core/MvxSetup.cs
@@ -665,6 +665,7 @@ public abstract class MvxSetup : IMvxSetup
         return container;
     }
 
+    [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
     protected virtual void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
     {
     }

--- a/MvvmCross/Core/MvxSetupExtensions.cs
+++ b/MvvmCross/Core/MvxSetupExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Exceptions;
 using MvvmCross.IoC;
@@ -11,7 +12,7 @@ namespace MvvmCross.Core;
 
 public static class MvxSetupExtensions
 {
-    public static void RegisterSetupType<TMvxSetup>(this object platformApplication, params Assembly[]? assemblies)
+    public static void RegisterSetupType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TMvxSetup>(this object platformApplication, params Assembly[]? assemblies)
         where TMvxSetup : MvxSetup, new()
     {
         if (platformApplication == null)
@@ -21,7 +22,8 @@ public static class MvxSetupExtensions
             new[] { platformApplication.GetType().Assembly }.Union(assemblies ?? []).ToArray());
     }
 
-    public static TSetup? CreateSetup<TSetup>(Assembly assembly, params object[] parameters) where TSetup : MvxSetup
+    [RequiresUnreferencedCode("This method uses reflection to find types, which may not be preserved in trimmed applications")]
+    public static TSetup? CreateSetup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSetup>(Assembly assembly, params object[] parameters) where TSetup : MvxSetup
     {
         var setupType = FindSetupType<TSetup>(assembly);
         if (setupType == null)
@@ -39,7 +41,8 @@ public static class MvxSetupExtensions
         }
     }
 
-    public static TSetup? CreateSetup<TSetup>() where TSetup : MvxSetup
+    [RequiresUnreferencedCode("This method uses reflection to find types, which may not be preserved in trimmed applications")]
+    public static TSetup? CreateSetup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSetup>() where TSetup : MvxSetup
     {
         var setupType = FindSetupType<TSetup>();
         if (setupType == null)
@@ -57,7 +60,8 @@ public static class MvxSetupExtensions
         }
     }
 
-    public static Type? FindSetupType<TSetup>(Assembly assembly)
+    [RequiresUnreferencedCode("This method uses reflection to find types, which may not be preserved in trimmed applications")]
+    public static Type? FindSetupType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSetup>(Assembly assembly)
     {
         var query = from type in assembly.ExceptionSafeGetTypes()
                     where type.Name == "Setup"
@@ -67,6 +71,7 @@ public static class MvxSetupExtensions
         return query.FirstOrDefault();
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to find types, which may not be preserved in trimmed applications")]
     public static Type? FindSetupType<TSetup>()
     {
         var query = from assembly in AppDomain.CurrentDomain.GetAssemblies()

--- a/MvvmCross/Core/MvxSetupSingleton.cs
+++ b/MvvmCross/Core/MvxSetupSingleton.cs
@@ -2,15 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
-using MvvmCross.ViewModels;
 
 namespace MvvmCross.Core
 {
@@ -64,6 +60,7 @@ namespace MvvmCross.Core
         /// </summary>
         /// <typeparam name="TMvxSetupSingleton">The platform specific setup singleton type</typeparam>
         /// <returns>A platform specific setup singleton</returns>
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         protected static TMvxSetupSingleton EnsureSingletonAvailable<TMvxSetupSingleton>()
            where TMvxSetupSingleton : MvxSetupSingleton, new()
         {

--- a/MvvmCross/Core/MvxSetupSingleton.cs
+++ b/MvvmCross/Core/MvxSetupSingleton.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -84,6 +85,7 @@ namespace MvvmCross.Core
             }
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         public virtual void EnsureInitialized()
         {
             lock (LockObject)
@@ -93,6 +95,7 @@ namespace MvvmCross.Core
             }
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         protected virtual void CreateSetup()
         {
             try

--- a/MvvmCross/Core/MvxSimplePropertyDictionaryExtensions.cs
+++ b/MvvmCross/Core/MvxSimplePropertyDictionaryExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -40,13 +41,15 @@ public static class MvxSimplePropertyDictionaryExtensions
         }
     }
 
-    public static T? Read<T>(this IDictionary<string, string> data)
+    public static T? Read<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this IDictionary<string, string> data)
         where T : new()
     {
         return (T?)data.Read(typeof(T));
     }
 
-    public static object? Read(this IDictionary<string, string> data, Type type)
+    public static object? Read(
+        this IDictionary<string, string> data,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
     {
         var t = Activator.CreateInstance(type);
 
@@ -120,7 +123,7 @@ public static class MvxSimplePropertyDictionaryExtensions
             select new
             {
                 CanSerialize =
-                    MvxSingletonCache.Instance?.Parser.TypeSupported(property.PropertyType) ?? false,
+                    MvxSingletonCache.Instance?.Parser?.TypeSupported(property.PropertyType) ?? false,
                 Property = property
             };
 

--- a/MvvmCross/Core/MvxSimplePropertyDictionaryExtensions.cs
+++ b/MvvmCross/Core/MvxSimplePropertyDictionaryExtensions.cs
@@ -118,7 +118,7 @@ public static class MvxSimplePropertyDictionaryExtensions
             return inputDict;
 
         var propertyInfos =
-            from property in typeof(TInput)
+            from property in input!.GetType()
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy)
             where property.CanRead
             select new

--- a/MvvmCross/Core/MvxSimplePropertyDictionaryExtensions.cs
+++ b/MvvmCross/Core/MvxSimplePropertyDictionaryExtensions.cs
@@ -108,16 +108,17 @@ public static class MvxSimplePropertyDictionaryExtensions
             parameterValue, requiredParameter.ParameterType, requiredParameter.Name);
     }
 
-    public static IDictionary<string, string> ToSimplePropertyDictionary(this object? input)
+    public static IDictionary<string, string> ToSimplePropertyDictionary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TInput>(
+        this TInput? input)
     {
-        if (input == null)
+        if (EqualityComparer<TInput?>.Default.Equals(input, default))
             return new Dictionary<string, string>();
 
         if (input is IDictionary<string, string> inputDict)
             return inputDict;
 
         var propertyInfos =
-            from property in input.GetType()
+            from property in typeof(TInput)
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy)
             where property.CanRead
             select new
@@ -132,7 +133,7 @@ public static class MvxSimplePropertyDictionaryExtensions
         {
             if (propertyInfo.CanSerialize)
             {
-                dictionary[propertyInfo.Property.Name] = input.GetPropertyValueAsString(propertyInfo.Property);
+                dictionary[propertyInfo.Property.Name] = input!.GetPropertyValueAsString(propertyInfo.Property);
             }
             else
             {

--- a/MvvmCross/Core/Parse/StringDictionary/MvxViewModelRequestCustomTextSerializer.cs
+++ b/MvvmCross/Core/Parse/StringDictionary/MvxViewModelRequestCustomTextSerializer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Base;
 using MvvmCross.Exceptions;
 using MvvmCross.ViewModels;
@@ -32,11 +33,13 @@ public class MvxViewModelRequestCustomTextSerializer
         throw new MvxException("This serializer only knows about MvxViewModelRequest and IDictionary<string,string>");
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public T DeserializeObject<T>(string inputText)
     {
         return (T)DeserializeObject(typeof(T), inputText);
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public object DeserializeObject(Type type, string inputText)
     {
         if (type == typeof(MvxViewModelRequest))
@@ -54,6 +57,7 @@ public class MvxViewModelRequestCustomTextSerializer
         return dictionary;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     protected virtual MvxViewModelRequest DeserializeViewModelRequest(string inputText)
     {
         var dictionary = _stringDictionaryParser.Value.Parse(inputText);

--- a/MvvmCross/IoC/IMvxIoCOptions.cs
+++ b/MvvmCross/IoC/IMvxIoCOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.IoC
 {
@@ -11,6 +12,7 @@ namespace MvvmCross.IoC
         bool TryToDetectSingletonCircularReferences { get; }
         bool TryToDetectDynamicCircularReferences { get; }
         bool CheckDisposeIfPropertyInjectionFails { get; }
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type PropertyInjectorType { get; }
         IMvxPropertyInjectorOptions PropertyInjectorOptions { get; }
     }

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -14,25 +14,25 @@ public interface IMvxIoCProvider
 
     bool CanResolve(Type type);
 
-    T? Resolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
+    T? Resolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class;
 
-    object? Resolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type);
+    object? Resolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
 
-    bool TryResolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(out T? resolved)
+    bool TryResolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? resolved)
         where T : class;
 
-    bool TryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, out object? resolved);
+    bool TryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, out object? resolved);
 
-    T? Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
+    T? Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class;
 
-    object? Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type);
+    object? Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
 
-    T? GetSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
+    T? GetSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class;
 
-    object? GetSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type);
+    object? GetSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
 
     void RegisterType<TFrom, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTo>()
         where TFrom : class

--- a/MvvmCross/IoC/IMvxIoCProvider.cs
+++ b/MvvmCross/IoC/IMvxIoCProvider.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.IoC;
 
 public interface IMvxIoCProvider
@@ -12,27 +14,27 @@ public interface IMvxIoCProvider
 
     bool CanResolve(Type type);
 
-    T? Resolve<T>()
+    T? Resolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
         where T : class;
 
-    object? Resolve(Type type);
+    object? Resolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type);
 
-    bool TryResolve<T>(out T? resolved)
+    bool TryResolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(out T? resolved)
         where T : class;
 
-    bool TryResolve(Type type, out object? resolved);
+    bool TryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, out object? resolved);
 
-    T? Create<T>()
+    T? Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
         where T : class;
 
-    object? Create(Type type);
+    object? Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type);
 
-    T? GetSingleton<T>()
+    T? GetSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
         where T : class;
 
-    object? GetSingleton(Type type);
+    object? GetSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type);
 
-    void RegisterType<TFrom, TTo>()
+    void RegisterType<TFrom, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTo>()
         where TFrom : class
         where TTo : class, TFrom;
 
@@ -41,7 +43,7 @@ public interface IMvxIoCProvider
 
     void RegisterType(Type t, Func<object> constructor);
 
-    void RegisterType(Type tFrom, Type tTo);
+    void RegisterType(Type tFrom, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type tTo);
 
     void RegisterSingleton<TInterface>(TInterface theObject)
         where TInterface : class;
@@ -53,25 +55,25 @@ public interface IMvxIoCProvider
 
     void RegisterSingleton(Type tInterface, Func<object> theConstructor);
 
-    T IoCConstruct<T>()
+    T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class;
 
-    T IoCConstruct<T>(IDictionary<string, object>? arguments)
+    T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDictionary<string, object>? arguments)
         where T : class;
 
-    T IoCConstruct<T>(object? arguments)
+    T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(object? arguments)
         where T : class;
 
-    T IoCConstruct<T>(params object?[] arguments)
+    T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(params object?[] arguments)
         where T : class;
 
-    object IoCConstruct(Type type);
+    object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
 
-    object IoCConstruct(Type type, IDictionary<string, object>? arguments);
+    object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, IDictionary<string, object>? arguments);
 
-    object IoCConstruct(Type type, object? arguments);
+    object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, object? arguments);
 
-    object IoCConstruct(Type type, params object?[] arguments);
+    object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, params object?[] arguments);
 
     IMvxIoCProvider CreateChildContainer();
 }

--- a/MvvmCross/IoC/IMvxPropertyInjector.cs
+++ b/MvvmCross/IoC/IMvxPropertyInjector.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.IoC
 {
     public interface IMvxPropertyInjector
     {
-        void Inject(object target, IMvxPropertyInjectorOptions options = null);
+        void Inject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTarget>(
+            TTarget target, IMvxPropertyInjectorOptions options = null);
     }
 }

--- a/MvvmCross/IoC/IMvxTypeCache.cs
+++ b/MvvmCross/IoC/IMvxTypeCache.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.IoC;
@@ -12,5 +13,6 @@ public interface IMvxTypeCache
     Dictionary<string, Type> FullNameCache { get; }
     Dictionary<string, Type> NameCache { get; }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved in trimming scenarios")]
     void AddAssembly(Assembly assembly);
 }

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Base;
@@ -60,10 +61,13 @@ public sealed class MvxIoCContainer
 
     private sealed class ConstructingResolver : IResolver
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         private readonly Type _type;
         private readonly IMvxIoCProvider _parent;
 
-        public ConstructingResolver(Type type, IMvxIoCProvider parent)
+        public ConstructingResolver(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+            IMvxIoCProvider parent)
         {
             _type = type;
             _parent = parent;
@@ -218,7 +222,7 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public bool TryResolve<T>(out T? resolved)
+    public bool TryResolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(out T? resolved)
         where T : class
     {
         try
@@ -234,7 +238,7 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public bool TryResolve(Type type, out object? resolved)
+    public bool TryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, out object? resolved)
     {
         lock (_lockObject)
         {
@@ -242,13 +246,13 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public T? Resolve<T>()
+    public T? Resolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
         where T : class
     {
         return (T?)Resolve(typeof(T));
     }
 
-    public object? Resolve(Type type)
+    public object? Resolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
     {
         lock (_lockObject)
         {
@@ -260,13 +264,13 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public T? GetSingleton<T>()
+    public T? GetSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
         where T : class
     {
         return (T?)GetSingleton(typeof(T));
     }
 
-    public object? GetSingleton(Type type)
+    public object? GetSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
     {
         lock (_lockObject)
         {
@@ -278,13 +282,13 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public T? Create<T>()
+    public T? Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
         where T : class
     {
         return (T?)Create(typeof(T));
     }
 
-    public object? Create(Type type)
+    public object? Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
     {
         lock (_lockObject)
         {
@@ -296,7 +300,7 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public void RegisterType<TInterface, TToConstruct>()
+    public void RegisterType<TInterface, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TToConstruct>()
         where TInterface : class
         where TToConstruct : class, TInterface
     {
@@ -327,7 +331,7 @@ public sealed class MvxIoCContainer
         InternalSetResolver(t, resolver);
     }
 
-    public void RegisterType(Type tFrom, Type tTo)
+    public void RegisterType(Type tFrom, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type tTo)
     {
         IResolver resolver;
         if (tFrom.GetTypeInfo().IsGenericTypeDefinition)
@@ -364,40 +368,41 @@ public sealed class MvxIoCContainer
         InternalSetResolver(tInterface, new ConstructingSingletonResolver(theConstructor));
     }
 
-    public object IoCConstruct(Type type)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         return IoCConstruct(type, (IDictionary<string, object>?)null);
     }
 
-    public object IoCConstruct(Type type, object? arguments)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, object? arguments)
     {
         return IoCConstruct(type, arguments?.ToPropertyDictionary());
     }
 
-    public T IoCConstruct<T>()
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class
     {
         return (T)IoCConstruct(typeof(T), (IDictionary<string, object>?)null);
     }
 
-    public T IoCConstruct<T>(IDictionary<string, object>? arguments)
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDictionary<string, object>? arguments)
         where T : class
     {
         return (T)IoCConstruct(typeof(T), arguments);
     }
 
-    public T IoCConstruct<T>(object? arguments)
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(object? arguments)
         where T : class
     {
         return (T)IoCConstruct(typeof(T), arguments?.ToPropertyDictionary());
     }
 
-    public T IoCConstruct<T>(params object?[] arguments) where T : class
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(params object?[] arguments)
+        where T : class
     {
         return (T)IoCConstruct(typeof(T), arguments);
     }
 
-    public object IoCConstruct(Type type, params object?[] arguments)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, params object?[] arguments)
     {
         var selectedConstructor = type.FindApplicableConstructor(arguments);
 
@@ -411,7 +416,7 @@ public sealed class MvxIoCContainer
         return IoCConstruct(type, selectedConstructor, parameters.ToArray());
     }
 
-    public object IoCConstruct(Type type, IDictionary<string, object>? arguments)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, IDictionary<string, object>? arguments)
     {
         var selectedConstructor = type.FindApplicableConstructor(arguments);
 
@@ -482,12 +487,17 @@ public sealed class MvxIoCContainer
         return resolver.ResolveType == requiredResolverType.Value;
     }
 
-    private bool InternalTryResolve(Type type, out object? resolved)
+    private bool InternalTryResolve(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type,
+        out object? resolved)
     {
         return InternalTryResolve(type, ResolverTypeNoneSpecified, out resolved);
     }
 
-    private bool InternalTryResolve(Type type, ResolverType? requiredResolverType, out object? resolved)
+    private bool InternalTryResolve(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type,
+        ResolverType? requiredResolverType,
+        out object? resolved)
     {
         if (!TryGetResolver(type, out var resolver))
         {
@@ -509,7 +519,7 @@ public sealed class MvxIoCContainer
         return InternalTryResolve(type, resolver!, out resolved);
     }
 
-    private bool InternalTryResolve(Type type, IResolver resolver, out object? resolved)
+    private bool InternalTryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, IResolver resolver, out object? resolved)
     {
         var detectingCircular = ShouldDetectCircularReferencesFor(resolver);
         if (detectingCircular)
@@ -518,12 +528,12 @@ public sealed class MvxIoCContainer
             {
                 _circularTypeDetection.Add(type, true);
             }
-            catch (ArgumentException)
+            catch (ArgumentException aex)
             {
                 // the item already exists in the lookup table
                 // - this is "game over" for the IoC lookup
                 // - see https://github.com/MvvmCross/MvvmCross/issues/553
-                MvxLogHost.Default?.Log(LogLevel.Error,
+                MvxLogHost.Default?.Log(LogLevel.Error, aex,
                     "IoC circular reference detected - cannot currently resolve {TypeName}", type.Name);
                 resolved = type.CreateDefault();
                 return false;
@@ -648,6 +658,8 @@ public sealed class MvxIoCContainer
         return parameters;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' requirements",
+        Justification = "The type parameter is guaranteed to have a public parameterless constructor, which is safe to process")]
     private bool TryResolveParameter(Type type, ParameterInfo parameterInfo, out object? parameterValue)
     {
         if (!TryResolve(parameterInfo.ParameterType, out parameterValue))

--- a/MvvmCross/IoC/MvxIoCContainer.cs
+++ b/MvvmCross/IoC/MvxIoCContainer.cs
@@ -169,12 +169,15 @@ public sealed class MvxIoCContainer
 
     private sealed class ConstructingOpenGenericResolver : IResolver
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         private readonly Type _genericTypeDefinition;
         private readonly IMvxIoCProvider _parent;
 
         private Type[]? _genericTypeParameters;
 
-        public ConstructingOpenGenericResolver(Type genericTypeDefinition, IMvxIoCProvider parent)
+        public ConstructingOpenGenericResolver(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type genericTypeDefinition,
+            IMvxIoCProvider parent)
         {
             _genericTypeDefinition = genericTypeDefinition;
             _parent = parent;
@@ -222,7 +225,7 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public bool TryResolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(out T? resolved)
+    public bool TryResolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? resolved)
         where T : class
     {
         try
@@ -238,7 +241,7 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public bool TryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, out object? resolved)
+    public bool TryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, out object? resolved)
     {
         lock (_lockObject)
         {
@@ -246,13 +249,13 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public T? Resolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
+    public T? Resolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class
     {
         return (T?)Resolve(typeof(T));
     }
 
-    public object? Resolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+    public object? Resolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         lock (_lockObject)
         {
@@ -264,13 +267,13 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public T? GetSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
+    public T? GetSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class
     {
         return (T?)GetSingleton(typeof(T));
     }
 
-    public object? GetSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+    public object? GetSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         lock (_lockObject)
         {
@@ -282,13 +285,13 @@ public sealed class MvxIoCContainer
         }
     }
 
-    public T? Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>()
+    public T? Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class
     {
         return (T?)Create(typeof(T));
     }
 
-    public object? Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+    public object? Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         lock (_lockObject)
         {
@@ -488,14 +491,14 @@ public sealed class MvxIoCContainer
     }
 
     private bool InternalTryResolve(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
         out object? resolved)
     {
         return InternalTryResolve(type, ResolverTypeNoneSpecified, out resolved);
     }
 
     private bool InternalTryResolve(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
         ResolverType? requiredResolverType,
         out object? resolved)
     {
@@ -519,7 +522,7 @@ public sealed class MvxIoCContainer
         return InternalTryResolve(type, resolver!, out resolved);
     }
 
-    private bool InternalTryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, IResolver resolver, out object? resolved)
+    private bool InternalTryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, IResolver resolver, out object? resolved)
     {
         var detectingCircular = ShouldDetectCircularReferencesFor(resolver);
         if (detectingCircular)

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -1,15 +1,15 @@
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.IoC
 {
     public static class MvxIoCContainerExtensions
     {
-        private static Func<TInterface> CreateResolver<TInterface, TParameter1>(
-            this IMvxIoCProvider ioc,
-                Func<TParameter1, TInterface> typedConstructor)
-                where TInterface : class
-                where TParameter1 : class
+        private static Func<TInterface> CreateResolver<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1>(
+                this IMvxIoCProvider ioc, Func<TParameter1, TInterface> typedConstructor)
+                    where TInterface : class
+                    where TParameter1 : class
         {
             return () =>
             {
@@ -18,12 +18,14 @@ namespace MvvmCross.IoC
             };
         }
 
-        private static Func<TInterface> CreateResolver<TInterface, TParameter1, TParameter2>(
-            this IMvxIoCProvider ioc,
-            Func<TParameter1, TParameter2, TInterface> typedConstructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
+        private static Func<TInterface> CreateResolver<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2>(
+                this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> typedConstructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
         {
             return () =>
             {
@@ -33,13 +35,17 @@ namespace MvvmCross.IoC
             };
         }
 
-        private static Func<TInterface> CreateResolver<TInterface, TParameter1, TParameter2, TParameter3>(
-            this IMvxIoCProvider ioc,
-            Func<TParameter1, TParameter2, TParameter3, TInterface> typedConstructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
+        private static Func<TInterface> CreateResolver<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TParameter3, TInterface> typedConstructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
         {
             return () =>
             {
@@ -50,14 +56,19 @@ namespace MvvmCross.IoC
             };
         }
 
-        private static Func<TInterface> CreateResolver<TInterface, TParameter1, TParameter2, TParameter3, TParameter4>(
-            this IMvxIoCProvider ioc,
-            Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> typedConstructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
-            where TParameter4 : class
+        private static Func<TInterface> CreateResolver<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> typedConstructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
+                    where TParameter4 : class
         {
             return () =>
             {
@@ -69,15 +80,21 @@ namespace MvvmCross.IoC
             };
         }
 
-        private static Func<TInterface> CreateResolver<TInterface, TParameter1, TParameter2, TParameter3, TParameter4, TParameter5>(
-            this IMvxIoCProvider ioc,
-            Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> typedConstructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
-            where TParameter4 : class
-            where TParameter5 : class
+        private static Func<TInterface> CreateResolver<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter5>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> typedConstructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
+                    where TParameter4 : class
+                    where TParameter5 : class
         {
             return () =>
             {
@@ -90,194 +107,286 @@ namespace MvvmCross.IoC
             };
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
-            where TInterface : class
-            where TType : class, TInterface
+        public static TType ConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TType>(
+                this IMvxIoCProvider ioc)
+                    where TInterface : class
+                    where TType : class, TInterface
         {
             var instance = ioc.IoCConstruct<TType>();
             ioc.RegisterSingleton<TInterface>(instance);
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, IDictionary<string, object> arguments)
-            where TInterface : class
-            where TType : class, TInterface
+        public static TType ConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TType>(
+                this IMvxIoCProvider ioc, IDictionary<string, object> arguments)
+                    where TInterface : class
+                    where TType : class, TInterface
         {
             var instance = ioc.IoCConstruct<TType>(arguments);
             ioc.RegisterSingleton<TInterface>(instance);
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, object arguments)
-            where TInterface : class
-            where TType : class, TInterface
+        public static TType ConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TType>(
+                this IMvxIoCProvider ioc,
+                object arguments)
+                    where TInterface : class
+                    where TType : class, TInterface
         {
             var instance = ioc.IoCConstruct<TType>(arguments);
             ioc.RegisterSingleton<TInterface>(instance);
             return instance;
         }
 
-        public static TType ConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc, params object[] arguments)
-            where TInterface : class
-            where TType : class, TInterface
+        public static TType ConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TType>(
+                this IMvxIoCProvider ioc, params object[] arguments)
+                    where TInterface : class
+                    where TType : class, TInterface
         {
             var instance = ioc.IoCConstruct<TType>(arguments);
             ioc.RegisterSingleton<TInterface>(instance);
             return instance;
         }
 
-        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type)
+        public static object ConstructAndRegisterSingleton(
+            this IMvxIoCProvider ioc,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             var instance = ioc.IoCConstruct(type);
             ioc.RegisterSingleton(type, instance);
             return instance;
         }
 
-        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, IDictionary<string, object> arguments)
+        public static object ConstructAndRegisterSingleton(
+            this IMvxIoCProvider ioc,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+            IDictionary<string, object> arguments)
         {
             var instance = ioc.IoCConstruct(type, arguments);
             ioc.RegisterSingleton(type, instance);
             return instance;
         }
 
-        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, object arguments)
+        public static object ConstructAndRegisterSingleton(
+            this IMvxIoCProvider ioc,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+            object arguments)
         {
             var instance = ioc.IoCConstruct(type, arguments);
             ioc.RegisterSingleton(type, instance);
             return instance;
         }
 
-        public static object ConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, params object[] arguments)
+        public static object ConstructAndRegisterSingleton(
+            this IMvxIoCProvider ioc,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+            params object[] arguments)
         {
             var instance = ioc.IoCConstruct(type, arguments);
             ioc.RegisterSingleton(type, instance);
             return instance;
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TType>(this IMvxIoCProvider ioc)
-            where TInterface : class
-            where TType : class, TInterface
+        public static void LazyConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TType>(
+                this IMvxIoCProvider ioc)
+                    where TInterface : class
+                    where TType : class, TInterface
         {
             ioc.RegisterSingleton<TInterface>(() => ioc.IoCConstruct<TType>());
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface>(this IMvxIoCProvider ioc, Func<TInterface> constructor)
-            where TInterface : class
+        public static void LazyConstructAndRegisterSingleton<TInterface>(
+            this IMvxIoCProvider ioc,
+            Func<TInterface> constructor)
+                where TInterface : class
         {
-            ioc.RegisterSingleton<TInterface>(constructor);
+            ioc.RegisterSingleton(constructor);
         }
 
-        public static void LazyConstructAndRegisterSingleton(this IMvxIoCProvider ioc, Type type, Func<object> constructor)
+        public static void LazyConstructAndRegisterSingleton(
+            this IMvxIoCProvider ioc,
+            Type type,
+            Func<object> constructor)
         {
             ioc.RegisterSingleton(type, constructor);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1>(this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
+        public static void LazyConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
+        public static void LazyConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
+        public static void LazyConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3, TParameter4>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
-            where TParameter4 : class
+        public static void LazyConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4>(
+                this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
+                    where TParameter4 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver);
         }
 
-        public static void LazyConstructAndRegisterSingleton<TInterface, TParameter1, TParameter2, TParameter3, TParameter4, TParameter5>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
-            where TParameter4 : class
-            where TParameter5 : class
+        public static void LazyConstructAndRegisterSingleton<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter5>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
+                    where TParameter4 : class
+                    where TParameter5 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterSingleton(resolver);
         }
 
-        public static void RegisterType<TType>(this IMvxIoCProvider ioc)
-            where TType : class
+        public static void RegisterType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TType>(
+            this IMvxIoCProvider ioc)
+                where TType : class
         {
             ioc.RegisterType<TType, TType>();
         }
 
-        public static void RegisterType(this IMvxIoCProvider ioc, Type tType)
+        public static void RegisterType(
+            this IMvxIoCProvider ioc,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type tType)
         {
             ioc.RegisterType(tType, tType);
         }
 
-        public static void RegisterType<TInterface, TParameter1>(this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor)
-           where TInterface : class
-           where TParameter1 : class
+        public static void RegisterType<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1>(
+                this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterType(resolver);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
+        public static void RegisterType<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterType(resolver);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
+        public static void RegisterType<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3>(
+                this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterType(resolver);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3, TParameter4>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
-            where TParameter4 : class
+        public static void RegisterType<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
+                    where TParameter4 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterType(resolver);
         }
 
-        public static void RegisterType<TInterface, TParameter1, TParameter2, TParameter3, TParameter4, TParameter5>(this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
-            where TInterface : class
-            where TParameter1 : class
-            where TParameter2 : class
-            where TParameter3 : class
-            where TParameter4 : class
-            where TParameter5 : class
+        public static void RegisterType<
+            TInterface,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter5>(
+                this IMvxIoCProvider ioc,
+                Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
+                    where TInterface : class
+                    where TParameter1 : class
+                    where TParameter2 : class
+                    where TParameter3 : class
+                    where TParameter4 : class
+                    where TParameter5 : class
         {
             var resolver = ioc.CreateResolver(constructor);
             ioc.RegisterType(resolver);

--- a/MvvmCross/IoC/MvxIoCContainerExtensions.cs
+++ b/MvvmCross/IoC/MvxIoCContainerExtensions.cs
@@ -6,7 +6,7 @@ namespace MvvmCross.IoC
     {
         private static Func<TInterface> CreateResolver<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1>(
                 this IMvxIoCProvider ioc, Func<TParameter1, TInterface> typedConstructor)
                     where TInterface : class
                     where TParameter1 : class
@@ -20,8 +20,8 @@ namespace MvvmCross.IoC
 
         private static Func<TInterface> CreateResolver<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2>(
                 this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TInterface> typedConstructor)
                     where TInterface : class
                     where TParameter1 : class
@@ -37,9 +37,9 @@ namespace MvvmCross.IoC
 
         private static Func<TInterface> CreateResolver<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TParameter3, TInterface> typedConstructor)
                     where TInterface : class
@@ -58,10 +58,10 @@ namespace MvvmCross.IoC
 
         private static Func<TInterface> CreateResolver<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter4>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> typedConstructor)
                     where TInterface : class
@@ -82,11 +82,11 @@ namespace MvvmCross.IoC
 
         private static Func<TInterface> CreateResolver<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter5>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter4,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter5>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> typedConstructor)
                     where TInterface : class
@@ -223,7 +223,7 @@ namespace MvvmCross.IoC
 
         public static void LazyConstructAndRegisterSingleton<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TInterface> constructor)
                     where TInterface : class
@@ -235,8 +235,8 @@ namespace MvvmCross.IoC
 
         public static void LazyConstructAndRegisterSingleton<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TInterface> constructor)
                     where TInterface : class
@@ -249,9 +249,9 @@ namespace MvvmCross.IoC
 
         public static void LazyConstructAndRegisterSingleton<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
                     where TInterface : class
@@ -265,10 +265,10 @@ namespace MvvmCross.IoC
 
         public static void LazyConstructAndRegisterSingleton<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter4>(
                 this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
                     where TInterface : class
                     where TParameter1 : class
@@ -282,11 +282,11 @@ namespace MvvmCross.IoC
 
         public static void LazyConstructAndRegisterSingleton<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter5>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter4,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter5>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
                     where TInterface : class
@@ -316,7 +316,7 @@ namespace MvvmCross.IoC
 
         public static void RegisterType<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1>(
                 this IMvxIoCProvider ioc, Func<TParameter1, TInterface> constructor)
                     where TInterface : class
                     where TParameter1 : class
@@ -327,8 +327,8 @@ namespace MvvmCross.IoC
 
         public static void RegisterType<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TInterface> constructor)
                     where TInterface : class
@@ -341,9 +341,9 @@ namespace MvvmCross.IoC
 
         public static void RegisterType<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3>(
                 this IMvxIoCProvider ioc, Func<TParameter1, TParameter2, TParameter3, TInterface> constructor)
                     where TInterface : class
                     where TParameter1 : class
@@ -356,10 +356,10 @@ namespace MvvmCross.IoC
 
         public static void RegisterType<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter4>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TParameter3, TParameter4, TInterface> constructor)
                     where TInterface : class
@@ -374,11 +374,11 @@ namespace MvvmCross.IoC
 
         public static void RegisterType<
             TInterface,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter1,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter2,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter3,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter4,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TParameter5>(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter3,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter4,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TParameter5>(
                 this IMvxIoCProvider ioc,
                 Func<TParameter1, TParameter2, TParameter3, TParameter4, TParameter5, TInterface> constructor)
                     where TInterface : class

--- a/MvvmCross/IoC/MvxIoCOptions.cs
+++ b/MvvmCross/IoC/MvxIoCOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.IoC
 {
@@ -20,6 +21,8 @@ namespace MvvmCross.IoC
         public bool TryToDetectSingletonCircularReferences { get; set; }
         public bool TryToDetectDynamicCircularReferences { get; set; }
         public bool CheckDisposeIfPropertyInjectionFails { get; set; }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type PropertyInjectorType { get; set; }
         public IMvxPropertyInjectorOptions PropertyInjectorOptions { get; set; }
     }

--- a/MvvmCross/IoC/MvxIoCProvider.cs
+++ b/MvvmCross/IoC/MvxIoCProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Base;
 
 namespace MvvmCross.IoC;
@@ -47,51 +48,51 @@ public sealed class MvxIoCProvider
         return _provider.CanResolve(type);
     }
 
-    public bool TryResolve<T>(out T? resolved)
+    public bool TryResolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? resolved)
         where T : class
     {
         return _provider.TryResolve(out resolved);
     }
 
-    public bool TryResolve(Type type, out object? resolved)
+    public bool TryResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, out object? resolved)
     {
         return _provider.TryResolve(type, out resolved);
     }
 
-    public T? Resolve<T>()
+    public T? Resolve<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class
     {
         return _provider.Resolve<T>();
     }
 
-    public object? Resolve(Type type)
+    public object? Resolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         return _provider.Resolve(type);
     }
 
-    public T? GetSingleton<T>()
+    public T? GetSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class
     {
         return _provider.GetSingleton<T>();
     }
 
-    public object? GetSingleton(Type type)
+    public object? GetSingleton([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         return _provider.GetSingleton(type);
     }
 
-    public T? Create<T>()
+    public T? Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
         where T : class
     {
         return _provider.Create<T>();
     }
 
-    public object? Create(Type type)
+    public object? Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         return _provider.Create(type);
     }
 
-    public void RegisterType<TInterface, TToConstruct>()
+    public void RegisterType<TInterface, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TToConstruct>()
         where TInterface : class
         where TToConstruct : class, TInterface
     {
@@ -109,7 +110,7 @@ public sealed class MvxIoCProvider
         _provider.RegisterType(t, constructor);
     }
 
-    public void RegisterType(Type tFrom, Type tTo)
+    public void RegisterType(Type tFrom, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type tTo)
     {
         _provider.RegisterType(tFrom, tTo);
     }
@@ -136,42 +137,42 @@ public sealed class MvxIoCProvider
         _provider.RegisterSingleton(tInterface, theConstructor);
     }
 
-    public T IoCConstruct<T>() where T : class
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : class
     {
         return _provider.IoCConstruct<T>((IDictionary<string, object>?)null);
     }
 
-    public T IoCConstruct<T>(IDictionary<string, object>? arguments) where T : class
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDictionary<string, object>? arguments) where T : class
     {
         return _provider.IoCConstruct<T>(arguments);
     }
 
-    public T IoCConstruct<T>(params object?[] arguments) where T : class
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(params object?[] arguments) where T : class
     {
         return _provider.IoCConstruct<T>(arguments);
     }
 
-    public T IoCConstruct<T>(object? arguments) where T : class
+    public T IoCConstruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(object? arguments) where T : class
     {
         return _provider.IoCConstruct<T>(arguments);
     }
 
-    public object IoCConstruct(Type type)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         return _provider.IoCConstruct(type, (IDictionary<string, object>?)null);
     }
 
-    public object IoCConstruct(Type type, IDictionary<string, object>? arguments)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, IDictionary<string, object>? arguments)
     {
         return _provider.IoCConstruct(type, arguments);
     }
 
-    public object IoCConstruct(Type type, object? arguments)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, object? arguments)
     {
         return _provider.IoCConstruct(type, arguments);
     }
 
-    public object IoCConstruct(Type type, params object?[] arguments)
+    public object IoCConstruct([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, params object?[] arguments)
     {
         return _provider.IoCConstruct(type, arguments);
     }

--- a/MvvmCross/IoC/MvxLazySingletonCreator.cs
+++ b/MvvmCross/IoC/MvxLazySingletonCreator.cs
@@ -2,15 +2,16 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.IoC
 {
     public class MvxLazySingletonCreator
     {
         private readonly object _lockObject = new object();
-        private readonly Type _type;
 
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        private readonly Type _type;
         private object _instance;
 
         public object Instance
@@ -22,13 +23,14 @@ namespace MvvmCross.IoC
 
                 lock (_lockObject)
                 {
-                    _instance = _instance ?? Mvx.IoCProvider.IoCConstruct(_type);
+                    _instance ??= Mvx.IoCProvider.IoCConstruct(_type);
                     return _instance;
                 }
             }
         }
 
-        public MvxLazySingletonCreator(Type type)
+        public MvxLazySingletonCreator(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             _type = type;
         }

--- a/MvvmCross/IoC/MvxPropertyInjector.cs
+++ b/MvvmCross/IoC/MvxPropertyInjector.cs
@@ -22,7 +22,7 @@ namespace MvvmCross.IoC
 
             ArgumentNullException.ThrowIfNull(target);
 
-            var injectableProperties = FindInjectableProperties(typeof(TTarget), options);
+            var injectableProperties = FindInjectableProperties(target.GetType(), options);
 
             foreach (var injectableProperty in injectableProperties)
             {

--- a/MvvmCross/IoC/MvxPropertyInjector.cs
+++ b/MvvmCross/IoC/MvxPropertyInjector.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
@@ -15,17 +12,17 @@ namespace MvvmCross.IoC
 {
     public class MvxPropertyInjector : IMvxPropertyInjector
     {
-        public virtual void Inject(object target, IMvxPropertyInjectorOptions options = null)
+        public virtual void Inject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTarget>(
+            TTarget target, IMvxPropertyInjectorOptions options = null)
         {
             options ??= MvxPropertyInjectorOptions.All;
 
             if (options.InjectIntoProperties == MvxPropertyInjection.None)
                 return;
 
-            if (target == null)
-                throw new ArgumentNullException(nameof(target));
+            ArgumentNullException.ThrowIfNull(target);
 
-            var injectableProperties = FindInjectableProperties(target.GetType(), options);
+            var injectableProperties = FindInjectableProperties(typeof(TTarget), options);
 
             foreach (var injectableProperty in injectableProperties)
             {
@@ -33,9 +30,11 @@ namespace MvvmCross.IoC
             }
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "The Inject method already has proper DynamicallyAccessedMembers annotations")]
         protected virtual void InjectProperty(object toReturn, PropertyInfo injectableProperty, IMvxPropertyInjectorOptions options)
         {
             object propertyValue;
+
             if (Mvx.IoCProvider?.TryResolve(injectableProperty.PropertyType, out propertyValue) == true)
             {
                 try

--- a/MvvmCross/IoC/MvxPropertyInjector.cs
+++ b/MvvmCross/IoC/MvxPropertyInjector.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -16,7 +17,7 @@ namespace MvvmCross.IoC
     {
         public virtual void Inject(object target, IMvxPropertyInjectorOptions options = null)
         {
-            options = options ?? MvxPropertyInjectorOptions.All;
+            options ??= MvxPropertyInjectorOptions.All;
 
             if (options.InjectIntoProperties == MvxPropertyInjection.None)
                 return;
@@ -55,13 +56,14 @@ namespace MvvmCross.IoC
                 else
                 {
                     MvxLogHost.Default?.Log(LogLevel.Warning,
-                        "IoC property injection skipped for {propertyName} on {typeName}",
+                        "IoC property injection skipped for {PropertyName} on {TypeName}",
                         injectableProperty.Name, toReturn.GetType().Name);
                 }
             }
         }
 
-        protected virtual IEnumerable<PropertyInfo> FindInjectableProperties(Type type, IMvxPropertyInjectorOptions options)
+        protected virtual IEnumerable<PropertyInfo> FindInjectableProperties(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, IMvxPropertyInjectorOptions options)
         {
             var injectableProperties = type
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
@@ -81,7 +83,7 @@ namespace MvvmCross.IoC
 
                 case MvxPropertyInjection.None:
                     MvxLogHost.Default?.Log(LogLevel.Error, "Internal error - should not call FindInjectableProperties with MvxPropertyInjection.None");
-                    injectableProperties = new PropertyInfo[0];
+                    injectableProperties = [];
                     break;
 
                 default:

--- a/MvvmCross/IoC/MvxPropertyInjectorOptions.cs
+++ b/MvvmCross/IoC/MvxPropertyInjectorOptions.cs
@@ -21,7 +21,7 @@ namespace MvvmCross.IoC
         {
             get
             {
-                _mvxInjectProperties = _mvxInjectProperties ?? new MvxPropertyInjectorOptions()
+                _mvxInjectProperties ??= new MvxPropertyInjectorOptions()
                 {
                     InjectIntoProperties = MvxPropertyInjection.MvxInjectInterfaceProperties,
                     ThrowIfPropertyInjectionFails = false
@@ -36,7 +36,7 @@ namespace MvvmCross.IoC
         {
             get
             {
-                _allProperties = _allProperties ?? new MvxPropertyInjectorOptions()
+                _allProperties ??= new MvxPropertyInjectorOptions()
                 {
                     InjectIntoProperties = MvxPropertyInjection.AllInterfaceProperties,
                     ThrowIfPropertyInjectionFails = false

--- a/MvvmCross/IoC/MvxTypeCache.cs
+++ b/MvvmCross/IoC/MvxTypeCache.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
@@ -16,6 +17,7 @@ public class MvxTypeCache<TType> : IMvxTypeCache
     public Dictionary<string, Type> NameCache { get; } = new();
     public Dictionary<Assembly, bool> CachedAssemblies { get; } = new();
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved in trimming scenarios")]
     public void AddAssembly(Assembly assembly)
     {
         try

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -120,6 +120,7 @@ public static class MvxTypeExtensions
     public class ServiceTypeAndImplementationTypePair
     {
         public List<Type> ServiceTypes { get; }
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type ImplementationType { get; }
 
         public ServiceTypeAndImplementationTypePair(List<Type> serviceTypes, Type implementationType)

--- a/MvvmCross/IoC/MvxTypeExtensions.cs
+++ b/MvvmCross/IoC/MvxTypeExtensions.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
@@ -12,6 +13,7 @@ namespace MvvmCross.IoC;
 
 public static class MvxTypeExtensions
 {
+    [RequiresUnreferencedCode("This method uses reflection to get types, which may not be preserved in trimmed applications")]
     public static IEnumerable<Type> ExceptionSafeGetTypes(this Assembly assembly)
     {
         try
@@ -36,6 +38,7 @@ public static class MvxTypeExtensions
         }
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to get types, which may not be preserved in trimmed applications")]
     public static IEnumerable<Type> CreatableTypes(this Assembly assembly)
     {
         return assembly
@@ -131,9 +134,11 @@ public static class MvxTypeExtensions
         return types.Select(t => new ServiceTypeAndImplementationTypePair([t], t));
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to get interfaces, which may not be preserved in trimmed applications")]
     public static IEnumerable<ServiceTypeAndImplementationTypePair> AsInterfaces(this IEnumerable<Type> types) =>
         types.Select(t => new ServiceTypeAndImplementationTypePair(t.GetInterfaces().ToList(), t));
 
+    [RequiresUnreferencedCode("This method uses reflection to get interfaces, which may not be preserved in trimmed applications")]
     public static IEnumerable<ServiceTypeAndImplementationTypePair> AsInterfaces(this IEnumerable<Type> types, params Type[] interfaces)
     {
         // optimisation - if we have 3 or more interfaces, then use a dictionary
@@ -210,7 +215,8 @@ public static class MvxTypeExtensions
         }
     }
 
-    public static object? CreateDefault(this Type? type)
+    public static object? CreateDefault(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type? type)
     {
         if (type == null)
             return null;
@@ -226,7 +232,9 @@ public static class MvxTypeExtensions
         return Activator.CreateInstance(type);
     }
 
-    public static ConstructorInfo? FindApplicableConstructor(this Type type, IDictionary<string, object>? arguments)
+    public static ConstructorInfo? FindApplicableConstructor(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] this Type type,
+        IDictionary<string, object>? arguments)
     {
         var constructors = type.GetConstructors();
         if (arguments == null || arguments.Count == 0)
@@ -248,7 +256,9 @@ public static class MvxTypeExtensions
         return null;
     }
 
-    public static ConstructorInfo? FindApplicableConstructor(this Type type, object?[] arguments)
+    public static ConstructorInfo? FindApplicableConstructor(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] this Type type,
+        object?[] arguments)
     {
         var constructors = type.GetConstructors();
         if (arguments.Length == 0)

--- a/MvvmCross/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Navigation/IMvxNavigationService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Navigation.EventArguments;
 using MvvmCross.ViewModels;
@@ -98,6 +99,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
         /// <returns>Boolean indicating successful navigation</returns>
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         Task<bool> Navigate(
             string path, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
 
@@ -110,6 +112,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle"></param>
         /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
         /// <returns>Boolean indicating successful navigation</returns>
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         Task<bool> Navigate<TParameter>(string path, TParameter param,
             IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
 

--- a/MvvmCross/Navigation/IMvxNavigationService.cs
+++ b/MvvmCross/Navigation/IMvxNavigationService.cs
@@ -52,95 +52,6 @@ namespace MvvmCross.Navigation
         void LoadRoutes(IEnumerable<Assembly> assemblies);
 
         /// <summary>
-        /// Navigates to an instance of a ViewModel
-        /// </summary>
-        /// <param name="viewModel">ViewModel to navigate to</param>
-        /// <param name="presentationBundle">(optional) presentation bundle</param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate(IMvxViewModel viewModel, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Navigates to an instance of a ViewModel and passes TParameter
-        /// </summary>
-        /// <typeparam name="TParameter"></typeparam>
-        /// <param name="viewModel">ViewModel to navigate to</param>
-        /// <param name="param">ViewModel parameter</param>
-        /// <param name="presentationBundle">(optional) presentation bundle</param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param,
-            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Navigates to a ViewModel Type
-        /// </summary>
-        /// <param name="viewModelType"></param>
-        /// <param name="presentationBundle"></param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate(Type viewModelType, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Navigates to a ViewModel Type and passes TParameter
-        /// </summary>
-        /// <typeparam name="TParameter"></typeparam>
-        /// <param name="viewModelType"></param>
-        /// <param name="param"></param>
-        /// <param name="presentationBundle"></param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Translates the provided Uri to a ViewModel request and dispatches it.
-        /// </summary>
-        /// <param name="path">URI to route</param>
-        /// <param name="presentationBundle"></param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <returns>Boolean indicating successful navigation</returns>
-        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
-        Task<bool> Navigate(
-            string path, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Translates the provided Uri to a ViewModel request and dispatches it.
-        /// </summary>
-        /// <typeparam name="TParameter"></typeparam>
-        /// <param name="path"></param>
-        /// <param name="param"></param>
-        /// <param name="presentationBundle"></param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <returns>Boolean indicating successful navigation</returns>
-        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
-        Task<bool> Navigate<TParameter>(string path, TParameter param,
-            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Navigate to a ViewModel determined by its type
-        /// </summary>
-        /// <param name="presentationBundle">(optional) presentation bundle</param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <typeparam name="TViewModel">Type of <see cref="IMvxViewModel"/></typeparam>
-        /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TViewModel>(
-            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
-            where TViewModel : IMvxViewModel;
-
-        /// <summary>
-        /// Navigate to a ViewModel determined by its type, with parameter
-        /// </summary>
-        /// <param name="param">ViewModel parameter</param>
-        /// <param name="presentationBundle">(optional) presentation bundle</param>
-        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
-        /// <typeparam name="TViewModel">Type of <see cref="IMvxViewModel{Parameter}"/></typeparam>
-        /// <typeparam name="TParameter">Parameter passed to ViewModel</typeparam>
-        /// <returns>Boolean indicating successful navigation</returns>
-        Task<bool> Navigate<TViewModel, TParameter>(
-            TParameter param, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
-            where TViewModel : IMvxViewModel<TParameter>;
-
-        /// <summary>
         /// Verifies if the provided Uri can be routed to a ViewModel request.
         /// </summary>
         /// <param name="path">URI to route</param>
@@ -178,6 +89,95 @@ namespace MvvmCross.Navigation
         Task<bool> ChangePresentation(MvxPresentationHint hint, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Navigates to an instance of a ViewModel
+        /// </summary>
+        /// <param name="viewModel">ViewModel to navigate to</param>
+        /// <param name="presentationBundle">(optional) presentation bundle</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate(IMvxViewModel viewModel, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Navigates to an instance of a ViewModel and passes TParameter
+        /// </summary>
+        /// <typeparam name="TParameter"></typeparam>
+        /// <param name="viewModel">ViewModel to navigate to</param>
+        /// <param name="param">ViewModel parameter</param>
+        /// <param name="presentationBundle">(optional) presentation bundle</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param,
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Navigates to a ViewModel Type
+        /// </summary>
+        /// <param name="viewModelType"></param>
+        /// <param name="presentationBundle"></param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Navigates to a ViewModel Type and passes TParameter
+        /// </summary>
+        /// <typeparam name="TParameter"></typeparam>
+        /// <param name="viewModelType"></param>
+        /// <param name="param"></param>
+        /// <param name="presentationBundle"></param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate<TParameter>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType, TParameter param, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Translates the provided Uri to a ViewModel request and dispatches it.
+        /// </summary>
+        /// <param name="path">URI to route</param>
+        /// <param name="presentationBundle"></param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <returns>Boolean indicating successful navigation</returns>
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
+        Task<bool> Navigate(
+            string path, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Translates the provided Uri to a ViewModel request and dispatches it.
+        /// </summary>
+        /// <typeparam name="TParameter"></typeparam>
+        /// <param name="path"></param>
+        /// <param name="param"></param>
+        /// <param name="presentationBundle"></param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <returns>Boolean indicating successful navigation</returns>
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
+        Task<bool> Navigate<TParameter>(string path, TParameter param,
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Navigate to a ViewModel determined by its type
+        /// </summary>
+        /// <param name="presentationBundle">(optional) presentation bundle</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <typeparam name="TViewModel">Type of <see cref="IMvxViewModel"/></typeparam>
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(
+            IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+            where TViewModel : IMvxViewModel;
+
+        /// <summary>
+        /// Navigate to a ViewModel determined by its type, with parameter
+        /// </summary>
+        /// <param name="param">ViewModel parameter</param>
+        /// <param name="presentationBundle">(optional) presentation bundle</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the navigation</param>
+        /// <typeparam name="TViewModel">Type of <see cref="IMvxViewModel{Parameter}"/></typeparam>
+        /// <typeparam name="TParameter">Parameter passed to ViewModel</typeparam>
+        /// <returns>Boolean indicating successful navigation</returns>
+        Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TParameter>(
+            TParameter param, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+                where TViewModel : IMvxViewModel<TParameter>;
+
+        /// <summary>
         ///     Loads a view model targeting the window for the given source.
         /// </summary>
         /// <typeparam name="TViewModel">The viewmodel type.</typeparam>
@@ -190,7 +190,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle">The presentation bungle.</param>
         /// <param name="cancellationToken">Any cancellation token.</param>
         /// <returns>True if navigation was successful.</returns>
-        Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+        Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TParameter>(TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
             CancellationToken cancellationToken = default) where TViewModel : IMvxViewModel<TParameter>
             where TParameter : notnull;
 
@@ -207,7 +207,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle">The presentation bungle.</param>
         /// <param name="cancellationToken">Any cancellation token.</param>
         /// <returns>True if navigation was successful.</returns>
-        Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+        Task<bool> Navigate<TParameter>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType, TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
             CancellationToken cancellationToken = default)
             where TParameter : notnull;
 
@@ -222,7 +222,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle">A presentation bundle.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        Task<bool> Navigate(Type viewModelType, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+        Task<bool> Navigate([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType, IMvxViewModel source, IMvxBundle? presentationBundle = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace MvvmCross.Navigation
         /// <param name="presentationBundle">The presentation bundle.</param>
         /// <param name="cancellationToken">Any cancellation token.</param>
         /// <returns>True if successful, false otherwise.</returns>
-        Task<bool> Navigate<TViewModel>(IMvxViewModel source,
+        Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(IMvxViewModel source,
             IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
             where TViewModel : IMvxViewModel;
 

--- a/MvvmCross/Navigation/MvxNavigationExtensions.cs
+++ b/MvvmCross/Navigation/MvxNavigationExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.ViewModels;
 using MvvmCross.ViewModels.Result;
 
@@ -29,11 +30,13 @@ public static class MvxNavigationExtensions
     /// <param name="presentationBundle"></param>
     /// <param name="cancellationToken"></param>
     /// <returns>A task to await upon</returns>
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public static Task Navigate(this IMvxNavigationService navigationService, Uri path, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
         return navigationService.Navigate(path.ToString(), presentationBundle, cancellationToken);
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public static Task Navigate<TParameter>(this IMvxNavigationService navigationService, Uri path, TParameter param, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
         return navigationService.Navigate(path.ToString(), param, presentationBundle, cancellationToken);
@@ -50,7 +53,7 @@ public static class MvxNavigationExtensions
     /// <typeparam name="TViewModel">Type of <see cref="IMvxResultSettingViewModel{TResult}"/></typeparam>
     /// <typeparam name="TResult">Result awaited by Result Awaiting ViewModel and set by Result Setting ViewModel</typeparam>
     /// <returns>Boolean indicating successful navigation</returns>
-    public static async Task<bool> NavigateRegisteringToResult<TViewModel, TResult>(
+    public static async Task<bool> NavigateRegisteringToResult<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TResult>(
         this IMvxNavigationService navigationService,
         IMvxResultAwaitingViewModel<TResult> fromViewModel,
         IMvxResultViewModelManager resultViewModelManager,
@@ -76,7 +79,7 @@ public static class MvxNavigationExtensions
     /// <typeparam name="TViewModel">Type of <see cref="IMvxResultSettingViewModel{TResult}"/> and <see cref="IMvxViewModel{TParameter}"/></typeparam>
     /// <typeparam name="TResult">Result awaited by Result Awaiting ViewModel and set by Result Setting ViewModel</typeparam>
     /// <returns>Boolean indicating successful navigation</returns>
-    public static async Task<bool> NavigateRegisteringToResult<TViewModel, TParameter, TResult>(
+    public static async Task<bool> NavigateRegisteringToResult<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TParameter, TResult>(
         this IMvxNavigationService navigationService,
         IMvxResultAwaitingViewModel<TResult> fromViewModel,
         IMvxResultViewModelManager resultViewModelManager,

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -326,7 +326,9 @@ public class MvxNavigationService : IMvxNavigationService
         return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual Task<bool> Navigate(Type viewModelType, IMvxBundle? presentationBundle = null,
+    public virtual Task<bool> Navigate(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
+        IMvxBundle? presentationBundle = null,
         CancellationToken cancellationToken = default)
     {
         var request = new MvxViewModelInstanceRequest(viewModelType)
@@ -337,8 +339,11 @@ public class MvxNavigationService : IMvxNavigationService
         return Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken);
     }
 
-    public virtual Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param,
-        IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
+    public virtual Task<bool> Navigate<TParameter>(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
+        TParameter param,
+        IMvxBundle? presentationBundle = null,
+        CancellationToken cancellationToken = default)
     {
         var request = new MvxViewModelInstanceRequest(viewModelType)
         {
@@ -348,14 +353,14 @@ public class MvxNavigationService : IMvxNavigationService
         return Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken);
     }
 
-    public virtual Task<bool> Navigate<TViewModel>(
+    public virtual Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(
         IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
         where TViewModel : IMvxViewModel
     {
         return Navigate(typeof(TViewModel), presentationBundle, cancellationToken);
     }
 
-    public virtual Task<bool> Navigate<TViewModel, TParameter>(
+    public virtual Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TParameter>(
         TParameter param, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
         where TViewModel : IMvxViewModel<TParameter>
     {
@@ -365,7 +370,7 @@ public class MvxNavigationService : IMvxNavigationService
     public virtual Task<bool> Navigate(
         IMvxViewModel viewModel, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
-        var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequest<IMvxViewModel>(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, request, null);
         return Navigate(request, viewModel, presentationBundle, cancellationToken);
     }
@@ -373,7 +378,7 @@ public class MvxNavigationService : IMvxNavigationService
     public virtual Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param,
         IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
-        var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequest<IMvxViewModel<TParameter>>(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
         return Navigate(request, viewModel, presentationBundle, cancellationToken);
     }
@@ -457,9 +462,11 @@ public class MvxNavigationService : IMvxNavigationService
     /// <param name="presentationBundle">The presentation bungle.</param>
     /// <param name="cancellationToken">Any cancellation token.</param>
     /// <returns>True if navigation was successful.</returns>
-    public virtual Task<bool> Navigate<TViewModel, TParameter>(TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
-        CancellationToken cancellationToken = default) where TViewModel : IMvxViewModel<TParameter>
-        where TParameter : notnull
+    public virtual Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TParameter>(
+        TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+        CancellationToken cancellationToken = default)
+            where TViewModel : IMvxViewModel<TParameter>
+            where TParameter : notnull
     {
         return Navigate(typeof(TViewModel), param, source, presentationBundle, cancellationToken);
     }
@@ -477,9 +484,13 @@ public class MvxNavigationService : IMvxNavigationService
     /// <param name="presentationBundle">The presentation bungle.</param>
     /// <param name="cancellationToken">Any cancellation token.</param>
     /// <returns>True if navigation was successful.</returns>
-    public virtual Task<bool> Navigate<TParameter>(Type viewModelType, TParameter param, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+    public virtual Task<bool> Navigate<TParameter>(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
+        TParameter param,
+        IMvxViewModel source,
+        IMvxBundle? presentationBundle = null,
         CancellationToken cancellationToken = default)
-        where TParameter : notnull
+            where TParameter : notnull
     {
         var mvxViewModelInstanceRequest = new MvxViewModelInstanceRequestWithSource(viewModelType, source)
         {
@@ -500,7 +511,10 @@ public class MvxNavigationService : IMvxNavigationService
     /// <param name="presentationBundle">A presentation bundle.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns></returns>
-    public virtual Task<bool> Navigate(Type viewModelType, IMvxViewModel source, IMvxBundle? presentationBundle = null,
+    public virtual Task<bool> Navigate(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
+        IMvxViewModel source,
+        IMvxBundle? presentationBundle = null,
         CancellationToken cancellationToken = default)
     {
         var request = new MvxViewModelInstanceRequestWithSource(viewModelType, source)
@@ -522,7 +536,7 @@ public class MvxNavigationService : IMvxNavigationService
     /// <param name="presentationBundle">The presentation bundle.</param>
     /// <param name="cancellationToken">Any cancellation token.</param>
     /// <returns>True if successful, false otherwise.</returns>
-    public virtual Task<bool> Navigate<TViewModel>(IMvxViewModel source,
+    public virtual Task<bool> Navigate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(IMvxViewModel source,
         IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
         where TViewModel : IMvxViewModel
     {
@@ -543,7 +557,7 @@ public class MvxNavigationService : IMvxNavigationService
     public virtual Task<bool> Navigate(
         IMvxViewModel viewModel, IMvxViewModel source, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
-        var request = new MvxViewModelInstanceRequestWithSource(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequestWithSource<IMvxViewModel>(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, request, null);
         return NavigateAsync(request, viewModel, presentationBundle, cancellationToken);
     }
@@ -565,7 +579,7 @@ public class MvxNavigationService : IMvxNavigationService
         IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
         where TParameter : notnull
     {
-        var request = new MvxViewModelInstanceRequestWithSource(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequestWithSource<IMvxViewModel<TParameter>>(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
         return NavigateAsync(request, viewModel, presentationBundle, cancellationToken);
     }
@@ -578,7 +592,7 @@ public class MvxNavigationService : IMvxNavigationService
     /// <param name="presentationBundle">The presentation bundle.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>True is successful. False otherwise.</returns>
-    protected virtual async Task<bool> NavigateAsync(MvxViewModelInstanceRequestWithSource request, IMvxViewModel viewModel,
+    protected virtual async Task<bool> NavigateAsync(MvxViewModelRequest request, IMvxViewModel viewModel,
         IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
@@ -132,6 +133,7 @@ public class MvxNavigationService : IMvxNavigationService
         return paramDict;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     protected virtual async Task<MvxViewModelInstanceRequest> NavigationRouteRequest(
         string path, IMvxBundle? presentationBundle = null)
     {
@@ -196,6 +198,7 @@ public class MvxNavigationService : IMvxNavigationService
         return request;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     protected async Task<MvxViewModelInstanceRequest> NavigationRouteRequest<TParameter>(
         string path, TParameter param, IMvxBundle? presentationBundle = null)
     {
@@ -293,6 +296,7 @@ public class MvxNavigationService : IMvxNavigationService
         return true;
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public virtual async Task<bool> Navigate(
         string path, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
@@ -306,6 +310,7 @@ public class MvxNavigationService : IMvxNavigationService
         return await Navigate(request, request.ViewModelInstance, presentationBundle, cancellationToken).ConfigureAwait(false);
     }
 
+    [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
     public virtual async Task<bool> Navigate<TParameter>(
             string path,
             TParameter param,

--- a/MvvmCross/Navigation/MvxNavigationService.cs
+++ b/MvvmCross/Navigation/MvxNavigationService.cs
@@ -370,7 +370,7 @@ public class MvxNavigationService : IMvxNavigationService
     public virtual Task<bool> Navigate(
         IMvxViewModel viewModel, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
-        var request = new MvxViewModelInstanceRequest<IMvxViewModel>(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, request, null);
         return Navigate(request, viewModel, presentationBundle, cancellationToken);
     }
@@ -378,7 +378,7 @@ public class MvxNavigationService : IMvxNavigationService
     public virtual Task<bool> Navigate<TParameter>(IMvxViewModel<TParameter> viewModel, TParameter param,
         IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
-        var request = new MvxViewModelInstanceRequest<IMvxViewModel<TParameter>>(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequest(viewModel) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
         return Navigate(request, viewModel, presentationBundle, cancellationToken);
     }
@@ -557,7 +557,7 @@ public class MvxNavigationService : IMvxNavigationService
     public virtual Task<bool> Navigate(
         IMvxViewModel viewModel, IMvxViewModel source, IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
     {
-        var request = new MvxViewModelInstanceRequestWithSource<IMvxViewModel>(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequestWithSource(viewModel.GetType(), source) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, request, null);
         return NavigateAsync(request, viewModel, presentationBundle, cancellationToken);
     }
@@ -579,7 +579,7 @@ public class MvxNavigationService : IMvxNavigationService
         IMvxBundle? presentationBundle = null, CancellationToken cancellationToken = default)
         where TParameter : notnull
     {
-        var request = new MvxViewModelInstanceRequestWithSource<IMvxViewModel<TParameter>>(viewModel, source) { PresentationValues = presentationBundle?.SafeGetData() };
+        var request = new MvxViewModelInstanceRequestWithSource(viewModel.GetType(), source) { PresentationValues = presentationBundle?.SafeGetData() };
         ViewModelLoader.ReloadViewModel(viewModel, param, request, null);
         return NavigateAsync(request, viewModel, presentationBundle, cancellationToken);
     }

--- a/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewFactory.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/MvxAndroidViewFactory.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading;
 using Android.Content;
 using Android.Util;
 using Android.Views;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
-using MvvmCross.Exceptions;
 using MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers;
 
 namespace MvvmCross.Platforms.Android.Binding.Binders

--- a/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/IMvxViewTypeResolver.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/IMvxViewTypeResolver.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers
 {
     public interface IMvxViewTypeResolver
     {
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type Resolve(string tagName);
     }
 }

--- a/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/MvxCompositeViewTypeResolver.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/MvxCompositeViewTypeResolver.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers
 {
@@ -16,6 +17,7 @@ namespace MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers
             _resolvers = new List<IMvxViewTypeResolver>(resolvers);
         }
 
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type Resolve(string tagName)
         {
             foreach (var resolver in _resolvers)

--- a/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/MvxReflectionViewTypeResolver.cs
+++ b/MvvmCross/Platforms/Android/Binding/Binders/ViewTypeResolvers/MvxReflectionViewTypeResolver.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.Views;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.IoC;
 
 namespace MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers
@@ -17,6 +16,7 @@ namespace MvvmCross.Platforms.Android.Binding.Binders.ViewTypeResolvers
             TypeCache = typeCache;
         }
 
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public abstract Type Resolve(string tagName);
 
         protected static bool IsFullyQualified(string tagName)

--- a/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxAndroidBindingBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using Android.Webkit;
 using AndroidX.Preference;
@@ -63,6 +64,7 @@ namespace MvvmCross.Platforms.Android.Binding
             _fillValueCombiners?.Invoke(registry);
         }
 
+        [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
         public override void DoRegistration(IMvxIoCProvider iocProvider)
         {
             InitializeAppResourceTypeFinder(iocProvider);
@@ -120,6 +122,7 @@ namespace MvvmCross.Platforms.Android.Binding
             return new MvxAppResourceTypeFinder();
         }
 
+        [RequiresUnreferencedCode("This method registers target bindings that may not be preserved by trimming")]
         protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
         {
             base.FillTargetFactories(registry);

--- a/MvvmCross/Platforms/Android/Binding/MvxPreferenceSetupHelper.cs
+++ b/MvvmCross/Platforms/Android/Binding/MvxPreferenceSetupHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using AndroidX.Preference;
 using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Platforms.Android.Binding.Target;
@@ -6,6 +7,7 @@ namespace MvvmCross.Platforms.Android.Binding
 {
     public static class MvxPreferenceSetupHelper
     {
+        [RequiresUnreferencedCode("This method may use types that are not preserved by trimming")]
         public static void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
         {
             registry.RegisterCustomBindingFactory<Preference>(

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAndroidTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAndroidTargetBinding.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using Android.Runtime;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
@@ -34,7 +35,7 @@ public abstract class MvxAndroidTargetBinding
     }
 }
 
-public abstract class MvxAndroidTargetBinding<TTarget, TValue>
+public abstract class MvxAndroidTargetBinding<TTarget, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TValue>
     : MvxConvertingTargetBinding<TTarget, TValue>
     where TTarget : class
 {

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatSpinnerSelectedItemBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxAppCompatSpinnerSelectedItemBinding.cs
@@ -89,6 +89,7 @@ public class MvxAppCompatSpinnerSelectedItemBinding
             SpinnerItemSelected);
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType => typeof(object);
 
     protected override void Dispose(bool isDisposing)

--- a/MvvmCross/Platforms/Android/Binding/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
+++ b/MvvmCross/Platforms/Android/Binding/Target/MvxExpandableListViewSelectedItemTargetBinding.cs
@@ -27,6 +27,7 @@ public class MvxExpandableListViewSelectedItemTargetBinding(
 
     protected MvxExpandableListView? ListView => (MvxExpandableListView?)Target;
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public override Type TargetValueType => typeof(object);
 
     protected override void SetValueImpl(object target, object? value)

--- a/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
+++ b/MvvmCross/Platforms/Android/Binding/Views/MvxLayoutInflater.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
@@ -219,6 +220,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         // mark the Factory/Factory2 setters as virtual.
         // See: https://bugzilla.xamarin.com/show_bug.cgi?id=30764
         [Export]
+        [RequiresUnreferencedCode("Export attribute is not trimming safe")]
         public void setFactory(IFactory factory)
         {
             // Wrap the incoming factory if we need to.
@@ -232,6 +234,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
         }
 
         [Export]
+        [RequiresUnreferencedCode("Export attribute is not trimming safe")]
         public void setFactory2(IFactory2 factory2)
         {
             // Wrap the incoming factory if we need to.
@@ -379,7 +382,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                     return null;
                 }
 
-                if (Mvx.IoCProvider?.TryResolve(out IMvxAndroidViewFactory viewFactory) == true)
+                if (Mvx.IoCProvider?.TryResolve(out IMvxAndroidViewFactory? viewFactory) == true)
                 {
                     _androidViewFactory = viewFactory;
                 }
@@ -402,7 +405,7 @@ namespace MvvmCross.Platforms.Android.Binding.Views
                     return null;
                 }
 
-                if (Mvx.IoCProvider?.TryResolve(out IMvxLayoutInflaterHolderFactoryFactory factoryFactory) == true)
+                if (Mvx.IoCProvider?.TryResolve(out IMvxLayoutInflaterHolderFactoryFactory? factoryFactory) == true)
                 {
                     _layoutInflaterHolderFactoryFactory = factoryFactory;
                 }

--- a/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
+++ b/MvvmCross/Platforms/Android/Core/MvxAndroidSetup.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Android.Content;
 using Android.Views;
@@ -170,6 +171,7 @@ public abstract class MvxAndroidSetup
         base.InitializeLastChance(iocProvider);
     }
 
+    [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
     protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
     {
         ValidateArguments(iocProvider);
@@ -178,12 +180,14 @@ public abstract class MvxAndroidSetup
         bindingBuilder.DoRegistration(iocProvider);
     }
 
+    [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
     protected virtual MvxBindingBuilder CreateBindingBuilder()
     {
         return new MvxAndroidBindingBuilder(FillValueConverters, FillValueCombiners, FillTargetFactories,
             FillBindingNames, FillViewTypes, FillAxmlViewTypeResolver, FillNamespaceListViewTypeResolver);
     }
 
+    [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
     protected virtual void FillViewTypes(IMvxTypeCache cache)
     {
         ArgumentNullException.ThrowIfNull(cache);
@@ -219,6 +223,7 @@ public abstract class MvxAndroidSetup
         }
     }
 
+    [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
     protected virtual void FillValueConverters(IMvxValueConverterRegistry registry)
     {
         ArgumentNullException.ThrowIfNull(registry);
@@ -236,6 +241,7 @@ public abstract class MvxAndroidSetup
 
     protected virtual IEnumerable<Assembly> ValueConverterAssemblies
     {
+        [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
         get
         {
             var toReturn = new List<Assembly>();
@@ -277,14 +283,15 @@ public abstract class MvxAndroidSetup
     }
 }
 
-public abstract class MvxAndroidSetup<TApplication> : MvxAndroidSetup
+public abstract class MvxAndroidSetup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxAndroidSetup
     where TApplication : class, IMvxApplication, new()
 {
     protected override IMvxApplication CreateApp(IMvxIoCProvider iocProvider) =>
         iocProvider.IoCConstruct<TApplication>();
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public override IEnumerable<Assembly> GetViewModelAssemblies()
     {
-        return new[] { typeof(TApplication).GetTypeInfo().Assembly };
+        return [typeof(TApplication).GetTypeInfo().Assembly];
     }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using MvvmCross.Presenters.Attributes;
 
 namespace MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -15,6 +17,7 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
     }
 
     public MvxFragmentPresentationAttribute(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type? activityHostViewModelType = null,
         int fragmentContentId = global::Android.Resource.Id.Content,
         bool addToBackStack = false,
@@ -48,6 +51,7 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
     }
 
     public MvxFragmentPresentationAttribute(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type? activityHostViewModelType = null,
         string? fragmentContentResourceName = null,
         bool addToBackStack = false,
@@ -107,6 +111,7 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
     /// <summary>
     /// Fragment parent activity ViewModel Type. This activity is shown if the current hosting activity viewmodel is different.
     /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public Type? ActivityHostViewModelType { get; set; }
 
     /// <summary>

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxViewPagerFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxViewPagerFragmentPresentationAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.Platforms.Android.Presenters.Attributes;
 
 #nullable enable
@@ -15,6 +17,7 @@ public class MvxViewPagerFragmentPresentationAttribute : MvxFragmentPresentation
     public MvxViewPagerFragmentPresentationAttribute(
         string title,
         int viewPagerResourceId,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type? activityHostViewModelType = null,
         bool addToBackStack = false,
         Type? fragmentHostViewType = null,
@@ -40,6 +43,7 @@ public class MvxViewPagerFragmentPresentationAttribute : MvxFragmentPresentation
     public MvxViewPagerFragmentPresentationAttribute(
         string title,
         string viewPagerResourceName,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type? activityHostViewModelType = null,
         bool addToBackStack = false,
         Type? fragmentHostViewType = null,

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Android.Content;
 using Android.OS;
@@ -98,7 +99,8 @@ namespace MvvmCross.Platforms.Android.Presenters
             }
         }
 
-        protected Type? GetAssociatedViewModelType(Type fromFragmentType)
+        protected Type? GetAssociatedViewModelType(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type fromFragmentType)
         {
             var viewModelType = ViewModelTypeFinder?.FindTypeOrNull(fromFragmentType);
             return viewModelType ?? fromFragmentType.GetBasePresentationAttributes().First().ViewModelType;
@@ -299,6 +301,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             return viewPager;
         }
 
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         protected Type? GetCurrentActivityViewModelType()
         {
             Type? currentActivityType = null;

--- a/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelLoader.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelLoader.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using MvvmCross.ViewModels;
 
@@ -12,5 +13,8 @@ public interface IMvxAndroidViewModelLoader
 {
     IMvxViewModel? Load(Intent? intent, IMvxBundle? savedState);
 
-    IMvxViewModel? Load(Intent? intent, IMvxBundle? savedState, Type? viewModelTypeHint);
+    IMvxViewModel? Load(
+        Intent? intent,
+        IMvxBundle? savedState,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewModelTypeHint);
 }

--- a/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using MvvmCross.ViewModels;
 
@@ -13,7 +13,9 @@ namespace MvvmCross.Platforms.Android.Views
         Intent GetIntentFor(MvxViewModelRequest request);
 
         // Important: if calling GetIntentWithKeyFor then you must later call RemoveSubViewModelWithKey on the returned key
-        (Intent intent, int key) GetIntentWithKeyFor(IMvxViewModel existingViewModelToUse, MvxViewModelRequest request);
+        (Intent intent, int key) GetIntentWithKeyFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(
+            TViewModel existingViewModelToUse, MvxViewModelRequest? request)
+                where TViewModel : IMvxViewModel;
 
         void RemoveSubViewModelWithKey(int key);
     }

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidApplication.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidApplication.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Runtime;
 using MvvmCross.Core;
 using MvvmCross.Platforms.Android.Core;
@@ -9,6 +10,7 @@ using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Android.Views;
 
+[RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
 public abstract class MvxAndroidApplication : Application, IMvxAndroidApplication
 {
     public static MvxAndroidApplication Instance { get; private set; }
@@ -44,6 +46,7 @@ public abstract class MvxAndroidApplication : Application, IMvxAndroidApplicatio
     }
 }
 
+[RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
 public abstract class MvxAndroidApplication<TMvxAndroidSetup, TApplication> : MvxAndroidApplication
   where TMvxAndroidSetup : MvxAndroidSetup<TApplication>, new()
   where TApplication : class, IMvxApplication, new()

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
@@ -34,7 +35,10 @@ public class MvxAndroidViewsContainer
         return Load(intent, null, null);
     }
 
-    public virtual IMvxViewModel? Load(Intent? intent, IMvxBundle? savedState, Type? viewModelTypeHint)
+    public virtual IMvxViewModel? Load(
+        Intent? intent,
+        IMvxBundle? savedState,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewModelTypeHint)
     {
         if (intent == null)
         {
@@ -69,7 +73,9 @@ public class MvxAndroidViewsContainer
         return DirectLoad(savedState, viewModelTypeHint);
     }
 
-    protected virtual IMvxViewModel? DirectLoad(IMvxBundle? savedState, Type? viewModelTypeHint)
+    protected virtual IMvxViewModel? DirectLoad(
+        IMvxBundle? savedState,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewModelTypeHint)
     {
         if (viewModelTypeHint == null)
         {
@@ -172,9 +178,10 @@ public class MvxAndroidViewsContainer
         //                intent.AddFlags(ActivityFlags.ClearTop);
     }
 
-    public virtual (Intent intent, int key) GetIntentWithKeyFor(IMvxViewModel existingViewModelToUse, MvxViewModelRequest? request)
+    public virtual (Intent intent, int key) GetIntentWithKeyFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(TViewModel existingViewModelToUse, MvxViewModelRequest? request)
+        where TViewModel : IMvxViewModel
     {
-        request ??= MvxViewModelRequest.GetDefaultRequest(existingViewModelToUse.GetType());
+        request ??= MvxViewModelRequest.GetDefaultRequest(typeof(TViewModel));
         var intent = GetIntentFor(request);
 
         if (Mvx.IoCProvider?.TryResolve(out IMvxChildViewModelCache? viewModelCache) != true || viewModelCache == null)

--- a/MvvmCross/Platforms/Android/WeakSubscription/MvxAndroidTargetEventSubscription.cs
+++ b/MvvmCross/Platforms/Android/WeakSubscription/MvxAndroidTargetEventSubscription.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Android.Runtime;
 using MvvmCross.WeakSubscription;
@@ -15,7 +16,7 @@ namespace MvvmCross.Platforms.Android.WeakSubscription
     /// </summary>
     /// <typeparam name="TSource"></typeparam>
     /// <typeparam name="TEventArgs"></typeparam>
-    public class MvxAndroidTargetEventSubscription<TSource, TEventArgs> : MvxWeakEventSubscription<TSource, TEventArgs>
+    public class MvxAndroidTargetEventSubscription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource, TEventArgs> : MvxWeakEventSubscription<TSource, TEventArgs>
         where TSource : class
     {
         public MvxAndroidTargetEventSubscription(TSource source, string sourceEventName, EventHandler<TEventArgs> targetEventHandler)
@@ -47,7 +48,7 @@ namespace MvvmCross.Platforms.Android.WeakSubscription
         }
     }
 
-    public class MvxJavaEventSubscription<TSource> : MvxWeakEventSubscription<TSource> where TSource : class
+    public class MvxJavaEventSubscription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource> : MvxWeakEventSubscription<TSource> where TSource : class
     {
         public MvxJavaEventSubscription(TSource source, string sourceEventName, EventHandler targetEventHandler)
             : base(source, sourceEventName, targetEventHandler)

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
@@ -36,6 +37,7 @@ namespace MvvmCross.Platforms.Ios.Binding
             _unifiedValueTypesConverter = new MvxUnifiedTypesValueConverter();
         }
 
+        [RequiresUnreferencedCode("This method registers source steps that may not be preserved by trimming")]
         protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
         {
             base.FillTargetFactories(registry);

--- a/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Core;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Ios.Core;
 
+[RequiresUnreferencedCode("This class uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
 public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplicationDelegate
 {
     public event EventHandler<MvxLifetimeEventArgs>? LifetimeChanged;
@@ -70,6 +72,7 @@ public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplic
     }
 }
 
+[RequiresUnreferencedCode("This class uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
 public abstract class MvxApplicationDelegate<TMvxIosSetup, TApplication> : MvxApplicationDelegate
     where TMvxIosSetup : MvxIosSetup<TApplication>, new()
     where TApplication : class, IMvxApplication, new()

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetup.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
@@ -154,12 +155,14 @@ public abstract class MvxIosSetup
         return new MvxPopoverPresentationSourceProvider();
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
     {
         var bindingBuilder = CreateBindingBuilder();
         bindingBuilder.DoRegistration(iocProvider);
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual MvxBindingBuilder CreateBindingBuilder()
     {
         return new MvxIosBindingBuilder(FillTargetFactories, FillValueConverters, FillValueCombiners,
@@ -171,6 +174,7 @@ public abstract class MvxIosSetup
         // this base class does nothing
     }
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     protected virtual void FillValueConverters(IMvxValueConverterRegistry registry)
     {
         registry.Fill(ValueConverterAssemblies);
@@ -186,6 +190,7 @@ public abstract class MvxIosSetup
 
     protected virtual IEnumerable<Assembly> ValueConverterAssemblies
     {
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         get
         {
             var toReturn = new List<Assembly>();
@@ -206,12 +211,13 @@ public abstract class MvxIosSetup
     }
 }
 
-public abstract class MvxIosSetup<TApplication> : MvxIosSetup
+public abstract class MvxIosSetup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxIosSetup
     where TApplication : class, IMvxApplication, new()
 {
     protected override IMvxApplication CreateApp(IMvxIoCProvider iocProvider) =>
         iocProvider.IoCConstruct<TApplication>();
 
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public override IEnumerable<Assembly> GetViewModelAssemblies()
     {
         return new[] { typeof(TApplication).GetTypeInfo().Assembly };

--- a/MvvmCross/Platforms/Ios/Core/MvxIosSetupSingleton.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxIosSetupSingleton.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Core;
 
 namespace MvvmCross.Platforms.Ios.Core
@@ -9,6 +10,7 @@ namespace MvvmCross.Platforms.Ios.Core
     public class MvxIosSetupSingleton
         : MvxSetupSingleton
     {
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         public static MvxIosSetupSingleton EnsureSingletonAvailable(IMvxLifetime lifetimeInstance, UIWindow window)
         {
             var instance = EnsureSingletonAvailable<MvxIosSetupSingleton>();

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Core;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Ios.Core;
 
+[RequiresUnreferencedCode("This class uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
 public abstract class MvxSceneDelegate : UIResponder, IUIWindowSceneDelegate, IMvxLifetime
 {
     public event EventHandler<MvxLifetimeEventArgs>? LifetimeChanged;
@@ -79,6 +81,7 @@ public abstract class MvxSceneDelegate : UIResponder, IUIWindowSceneDelegate, IM
     }
 }
 
+[RequiresUnreferencedCode("This class uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
 public abstract class MvxSceneDelegate<TMvxIosSetup, TApplication> : MvxSceneDelegate
     where TMvxIosSetup : MvxIosSetup<TApplication>, new()
     where TApplication : class, IMvxApplication, new()

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
@@ -62,7 +63,8 @@ public class MvxIosViewPresenter : MvxAttributeViewPresenter, IMvxIosViewPresent
         return new MvxChildPresentationAttribute { ViewType = viewType, ViewModelType = viewModelType };
     }
 
-    public override object? CreateOverridePresentationAttributeViewInstance(Type viewType)
+    public override object? CreateOverridePresentationAttributeViewInstance(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type viewType)
     {
         ArgumentNullException.ThrowIfNull(viewType);
 

--- a/MvvmCross/Platforms/Ios/Views/MvxCanCreateIosViewExtensions.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxCanCreateIosViewExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Core;
 using MvvmCross.ViewModels;
 
@@ -10,14 +11,14 @@ namespace MvvmCross.Platforms.Ios.Views;
 
 public static class MvxCanCreateIosViewExtensions
 {
-    public static IMvxIosView? CreateViewControllerFor<TTargetViewModel>(
+    public static IMvxIosView? CreateViewControllerFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTargetViewModel>(
             this IMvxCanCreateIosView view,
             object parameterObject)
         where TTargetViewModel : class, IMvxViewModel =>
         view.CreateViewControllerFor<TTargetViewModel>(parameterObject.ToSimplePropertyDictionary());
 
     // TODO - could this move down to IMvxView level?
-    public static IMvxIosView? CreateViewControllerFor<TTargetViewModel>(
+    public static IMvxIosView? CreateViewControllerFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTargetViewModel>(
         this IMvxCanCreateIosView view,
         IDictionary<string, string>? parameterValues = null)
         where TTargetViewModel : class, IMvxViewModel

--- a/MvvmCross/Platforms/Ios/Views/MvxIosViewDispatcher.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxIosViewDispatcher.cs
@@ -26,7 +26,7 @@ namespace MvvmCross.Platforms.Ios.Views
             Task action()
             {
                 MvxLogHost.GetLog<MvxIosViewDispatcher>()?.LogTrace(
-                    "Navigate requested to {viewModelType}", request?.ViewModelType);
+                    "Navigate requested to {ViewModelType}", request?.ViewModelType);
                 return _presenter.Show(request);
             }
             await ExecuteOnMainThreadAsync(action);

--- a/MvvmCross/Platforms/Ios/Views/MvxSegueExtensions.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxSegueExtensions.cs
@@ -18,6 +18,7 @@ namespace MvvmCross.Platforms.Ios.Views
 #nullable enable
     internal static class MvxSegueExtensions
     {
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         internal static Type? GetViewModelType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TViewType>(
             this TViewType? view)
                 where TViewType : class, IMvxView
@@ -25,7 +26,7 @@ namespace MvvmCross.Platforms.Ios.Views
             if (view == null)
                 return null;
 
-            var props = typeof(TViewType).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var props = view.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
             var prop = Array.Find(props, p => p.Name == "ViewModel");
             return prop?.PropertyType;
         }

--- a/MvvmCross/Platforms/Ios/Views/MvxSegueExtensions.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxSegueExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Foundation;
 using MvvmCross.Core;
@@ -17,13 +18,14 @@ namespace MvvmCross.Platforms.Ios.Views
 #nullable enable
     internal static class MvxSegueExtensions
     {
-        internal static Type? GetViewModelType(this IMvxView? view)
+        internal static Type? GetViewModelType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TViewType>(
+            this TViewType? view)
+                where TViewType : class, IMvxView
         {
             if (view == null)
                 return null;
 
-            var viewType = view.GetType();
-            var props = viewType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var props = typeof(TViewType).GetProperties(BindingFlags.Public | BindingFlags.Instance);
             var prop = Array.Find(props, p => p.Name == "ViewModel");
             return prop?.PropertyType;
         }

--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -3,15 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using AppKit;
 using MvvmCross.Core;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Mac.Core
 {
+    [RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
     public abstract class MvxApplicationDelegate : NSApplicationDelegate, IMvxApplicationDelegate
     {
-        public MvxApplicationDelegate() : base()
+        protected MvxApplicationDelegate() : base()
         {
             RegisterSetup();
         }
@@ -64,6 +66,7 @@ namespace MvvmCross.Platforms.Mac.Core
         public event EventHandler<MvxLifetimeEventArgs> LifetimeChanged;
     }
 
+    [RequiresUnreferencedCode("This class may use types that are not preserved by trimming")]
     public class MvxApplicationDelegate<TMvxMacSetup, TApplication> : MvxApplicationDelegate
         where TMvxMacSetup : MvxMacSetup<TApplication>, new()
         where TApplication : class, IMvxApplication, new()

--- a/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxMacSetup.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
@@ -112,12 +113,14 @@ namespace MvvmCross.Platforms.Mac.Core
             iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             var bindingBuilder = CreateBindingBuilder();
             bindingBuilder.DoRegistration(iocProvider);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         protected virtual MvxBindingBuilder CreateBindingBuilder()
         {
             return new MvxMacBindingBuilder(FillTargetFactories, FillValueConverters, FillBindingNames,
@@ -129,6 +132,7 @@ namespace MvvmCross.Platforms.Mac.Core
             // this base class does nothing
         }
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         protected virtual void FillValueConverters(IMvxValueConverterRegistry registry)
         {
             registry.Fill(ValueConverterAssemblies);
@@ -142,6 +146,7 @@ namespace MvvmCross.Platforms.Mac.Core
 
         protected virtual List<Assembly> ValueConverterAssemblies
         {
+            [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
             get
             {
                 var toReturn = new List<Assembly>();
@@ -159,12 +164,13 @@ namespace MvvmCross.Platforms.Mac.Core
         }
     }
 
-    public abstract class MvxMacSetup<TApplication> : MvxMacSetup
+    public abstract class MvxMacSetup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxMacSetup
         where TApplication : class, IMvxApplication, new()
     {
         protected override IMvxApplication CreateApp(IMvxIoCProvider iocProvider) =>
             iocProvider.IoCConstruct<TApplication>();
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {
             return new[] { typeof(TApplication).GetTypeInfo().Assembly };

--- a/MvvmCross/Platforms/Tvos/Binding/MvxTvosBindingBuilder.cs
+++ b/MvvmCross/Platforms/Tvos/Binding/MvxTvosBindingBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
 using MvvmCross.Binding.BindingContext;
@@ -43,6 +44,7 @@ namespace MvvmCross.Platforms.Tvos.Binding
             return registry;
         }
 
+        [RequiresUnreferencedCode("This method registers target bindings that may not be preserved by trimming")]
         protected override void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
         {
             base.FillTargetFactories(registry);

--- a/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxApplicationDelegate.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Core;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Platforms.Tvos.Core
 {
+    [RequiresUnreferencedCode("RegisterSetup may register types that are not preserved by default in the application")]
     public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplicationDelegate
     {
         /// <summary>
@@ -72,6 +74,7 @@ namespace MvvmCross.Platforms.Tvos.Core
         public event EventHandler<MvxLifetimeEventArgs> LifetimeChanged;
     }
 
+    [RequiresUnreferencedCode("RegisterSetup may register types that are not preserved by default in the application")]
     public abstract class MvxApplicationDelegate<TMvxTvosSetup, TApplication> : MvxApplicationDelegate
        where TMvxTvosSetup : MvxTvosSetup<TApplication>, new()
        where TApplication : class, IMvxApplication, new()

--- a/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
+++ b/MvvmCross/Platforms/Tvos/Core/MvxTvosSetup.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Binders;
@@ -19,7 +18,6 @@ using MvvmCross.Platforms.Tvos.Views;
 using MvvmCross.Presenters;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Core
 {
@@ -126,12 +124,14 @@ namespace MvvmCross.Platforms.Tvos.Core
             iocProvider.RegisterSingleton<IMvxViewPresenter>(presenter);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         protected override void InitializeBindingBuilder(IMvxIoCProvider iocProvider)
         {
             var bindingBuilder = CreateBindingBuilder();
             bindingBuilder.DoRegistration(iocProvider);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         protected virtual MvxBindingBuilder CreateBindingBuilder()
         {
             return new MvxTvosBindingBuilder(FillTargetFactories, FillValueConverters, FillBindingNames,
@@ -143,6 +143,7 @@ namespace MvvmCross.Platforms.Tvos.Core
             // this base class does nothing
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         protected virtual void FillValueConverters(IMvxValueConverterRegistry registry)
         {
             registry.Fill(ValueConverterAssemblies);
@@ -158,6 +159,7 @@ namespace MvvmCross.Platforms.Tvos.Core
 
         protected virtual IEnumerable<Assembly> ValueConverterAssemblies
         {
+            [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
             get
             {
                 var toReturn = new List<Assembly>();
@@ -178,12 +180,13 @@ namespace MvvmCross.Platforms.Tvos.Core
         }
     }
 
-    public abstract class MvxTvosSetup<TApplication> : MvxTvosSetup
+    public abstract class MvxTvosSetup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxTvosSetup
         where TApplication : class, IMvxApplication, new()
     {
         protected override IMvxApplication CreateApp(IMvxIoCProvider iocProvider) =>
             iocProvider.IoCConstruct<TApplication>();
 
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         public override IEnumerable<Assembly> GetViewModelAssemblies()
         {
             return new[] { typeof(TApplication).GetTypeInfo().Assembly };

--- a/MvvmCross/Platforms/Tvos/Presenters/MvxTvosViewPresenter.cs
+++ b/MvvmCross/Platforms/Tvos/Presenters/MvxTvosViewPresenter.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using CoreGraphics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
@@ -15,7 +11,6 @@ using MvvmCross.Platforms.Tvos.Views;
 using MvvmCross.Presenters;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
-using UIKit;
 
 namespace MvvmCross.Platforms.Tvos.Presenters
 {
@@ -54,7 +49,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
                (TabBarViewController == null || !TabBarViewController.CanShowChildView()))
             {
                 _logger?.LogTrace(
-                    "PresentationAttribute nor MasterNavigationController found for {viewTypeName}. Assuming Root presentation",
+                    "PresentationAttribute nor MasterNavigationController found for {ViewTypeName}. Assuming Root presentation",
                     viewType.Name);
                 return new MvxRootPresentationAttribute()
                 {
@@ -65,7 +60,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             }
 
             _logger?.LogTrace(
-                    "PresentationAttribute not found for {viewTypeName}. Assuming Root presentation",
+                    "PresentationAttribute not found for {ViewTypeName}. Assuming Root presentation",
                     viewType.Name);
             return new MvxChildPresentationAttribute()
             {
@@ -74,7 +69,9 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             };
         }
 
-        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType)
+        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(
+            MvxViewModelRequest request,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
         {
             if (viewType?.GetInterface(nameof(IMvxOverridePresentationAttribute)) != null)
             {
@@ -157,7 +154,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
         protected virtual Task<bool> CloseRootViewController(IMvxViewModel viewModel,
                                      MvxRootPresentationAttribute attribute)
         {
-            _logger?.LogWarning("Ignored attempt to close the window root (ViewModel type: {viewModelName}",
+            _logger?.LogWarning("Ignored attempt to close the window root (ViewModel type: {ViewModelName}",
                 viewModel.GetType().Name);
             return Task.FromResult(false);
         }

--- a/MvvmCross/Platforms/Tvos/Views/MvxCanCreateTvosViewExtensions.cs
+++ b/MvvmCross/Platforms/Tvos/Views/MvxCanCreateTvosViewExtensions.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Core;
 using MvvmCross.ViewModels;
 
@@ -11,9 +10,10 @@ namespace MvvmCross.Platforms.Tvos.Views
 {
     public static class MvxCanCreateTvosViewExtensions
     {
-        public static IMvxTvosView CreateViewControllerFor<TTargetViewModel>(this IMvxCanCreateTvosView view,
-                                                                              object parameterObject)
-            where TTargetViewModel : class, IMvxViewModel
+        public static IMvxTvosView CreateViewControllerFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTargetViewModel>(
+            this IMvxCanCreateTvosView view,
+            object parameterObject)
+                where TTargetViewModel : class, IMvxViewModel
         {
             return
                 view.CreateViewControllerFor<TTargetViewModel>(parameterObject?.ToSimplePropertyDictionary());
@@ -21,10 +21,10 @@ namespace MvvmCross.Platforms.Tvos.Views
 
 #warning TODO - could this move down to IMvxView level?
 
-        public static IMvxTvosView CreateViewControllerFor<TTargetViewModel>(
+        public static IMvxTvosView CreateViewControllerFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTargetViewModel>(
             this IMvxCanCreateTvosView view,
             IDictionary<string, string> parameterValues = null)
-            where TTargetViewModel : class, IMvxViewModel
+                where TTargetViewModel : class, IMvxViewModel
         {
             var parameterBundle = new MvxBundle(parameterValues);
             var request = new MvxViewModelRequest<TTargetViewModel>(parameterBundle, null);
@@ -34,7 +34,7 @@ namespace MvvmCross.Platforms.Tvos.Views
         public static IMvxTvosView CreateViewControllerFor<TTargetViewModel>(
             this IMvxCanCreateTvosView view,
             MvxViewModelRequest request)
-            where TTargetViewModel : class, IMvxViewModel
+                where TTargetViewModel : class, IMvxViewModel
         {
             return Mvx.IoCProvider.Resolve<IMvxTvosViewCreator>().CreateView(request);
         }

--- a/MvvmCross/Plugin/IMvxPluginManager.cs
+++ b/MvvmCross/Plugin/IMvxPluginManager.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Plugin
 {
@@ -18,14 +17,14 @@ namespace MvvmCross.Plugin
 
         bool IsPluginLoaded<TPlugin>() where TPlugin : IMvxPlugin;
 
-        void EnsurePluginLoaded(Type type, bool forceLoad = false);
+        void EnsurePluginLoaded([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, bool forceLoad = false);
 
-        void EnsurePluginLoaded<TPlugin>(bool forceLoad = false)
+        void EnsurePluginLoaded<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TPlugin>(bool forceLoad = false)
             where TPlugin : IMvxPlugin;
 
-        bool TryEnsurePluginLoaded(Type type, bool forceLoad = false);
+        bool TryEnsurePluginLoaded([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, bool forceLoad = false);
 
-        bool TryEnsurePluginLoaded<TPlugin>(bool forceLoad = false)
+        bool TryEnsurePluginLoaded<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TPlugin>(bool forceLoad = false)
             where TPlugin : IMvxPlugin;
     }
 #nullable restore

--- a/MvvmCross/Plugin/MvxPluginManager.cs
+++ b/MvvmCross/Plugin/MvxPluginManager.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 using MvvmCross.IoC;
@@ -25,12 +26,13 @@ namespace MvvmCross.Plugin
             ConfigurationSource = configurationSource;
         }
 
-        public void EnsurePluginLoaded<TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin
+        public void EnsurePluginLoaded<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin
         {
             EnsurePluginLoaded(typeof(TPlugin), forceLoad);
         }
 
-        public virtual void EnsurePluginLoaded(Type type, bool forceLoad = false)
+        public virtual void EnsurePluginLoaded(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, bool forceLoad = false)
         {
             if (!forceLoad && IsPluginLoaded(type))
                 return;
@@ -68,10 +70,10 @@ namespace MvvmCross.Plugin
             }
         }
 
-        public bool TryEnsurePluginLoaded<TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin
+        public bool TryEnsurePluginLoaded<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TPlugin>(bool forceLoad = false) where TPlugin : IMvxPlugin
             => TryEnsurePluginLoaded(typeof(TPlugin), forceLoad);
 
-        public bool TryEnsurePluginLoaded(Type type, bool forceLoad = false)
+        public bool TryEnsurePluginLoaded([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, bool forceLoad = false)
         {
             try
             {

--- a/MvvmCross/Presenters/Hints/MvxPagePresentationHint.cs
+++ b/MvvmCross/Presenters/Hints/MvxPagePresentationHint.cs
@@ -1,32 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Presenters.Hints
 {
-#nullable enable
     public class MvxPagePresentationHint
         : MvxPresentationHint
     {
-        public MvxPagePresentationHint(Type viewModel)
+        public MvxPagePresentationHint(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModel)
         {
             ViewModel = viewModel;
         }
 
-        public MvxPagePresentationHint(Type viewModel, MvxBundle body) : base(body)
+        public MvxPagePresentationHint(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModel, MvxBundle body) : base(body)
         {
             ViewModel = viewModel;
         }
 
-        public MvxPagePresentationHint(Type viewModel, IDictionary<string, string> hints) : this(viewModel, new MvxBundle(hints))
+        public MvxPagePresentationHint(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModel, IDictionary<string, string> hints) : this(viewModel, new MvxBundle(hints))
         {
         }
 
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type ViewModel { get; }
     }
-#nullable restore
 }

--- a/MvvmCross/Presenters/IMvxAttributeViewPresenter.cs
+++ b/MvvmCross/Presenters/IMvxAttributeViewPresenter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
 using MvvmCross.Views;
@@ -21,7 +22,9 @@ namespace MvvmCross.Presenters
         //TODO: Maybe move those to helper class
         MvxBasePresentationAttribute GetPresentationAttribute(MvxViewModelRequest request);
         MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType);
-        MvxBasePresentationAttribute? GetOverridePresentationAttribute(MvxViewModelRequest request, Type viewType);
+        MvxBasePresentationAttribute? GetOverridePresentationAttribute(
+            MvxViewModelRequest request,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType);
     }
 #nullable restore
 }

--- a/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
+++ b/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
@@ -179,7 +179,7 @@ public abstract class MvxAttributeViewPresenter : MvxViewPresenter, IMvxAttribut
     public override Task<bool> Close(IMvxViewModel viewModel)
     {
         return GetPresentationAttributeAction(
-                new MvxViewModelInstanceRequest<IMvxViewModel>(viewModel), out var attribute)
+                new MvxViewModelInstanceRequest(viewModel), out var attribute)
             .CloseAction?
             .Invoke(viewModel, attribute) ?? Task.FromResult(false);
     }

--- a/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
+++ b/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
 using MvvmCross.Presenters.Attributes;
@@ -43,7 +44,8 @@ public abstract class MvxAttributeViewPresenter : MvxViewPresenter, IMvxAttribut
 
     public abstract MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType);
 
-    public virtual object? CreateOverridePresentationAttributeViewInstance(Type viewType)
+    public virtual object? CreateOverridePresentationAttributeViewInstance(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type viewType)
     {
         if (viewType == null)
             throw new ArgumentNullException(nameof(viewType));
@@ -52,7 +54,8 @@ public abstract class MvxAttributeViewPresenter : MvxViewPresenter, IMvxAttribut
     }
 
     public virtual MvxBasePresentationAttribute? GetOverridePresentationAttribute(
-        MvxViewModelRequest request, Type viewType)
+        MvxViewModelRequest request,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
     {
         if (request == null)
             throw new ArgumentNullException(nameof(request));
@@ -176,7 +179,7 @@ public abstract class MvxAttributeViewPresenter : MvxViewPresenter, IMvxAttribut
     public override Task<bool> Close(IMvxViewModel viewModel)
     {
         return GetPresentationAttributeAction(
-                new MvxViewModelInstanceRequest(viewModel), out var attribute)
+                new MvxViewModelInstanceRequest<IMvxViewModel>(viewModel), out var attribute)
             .CloseAction?
             .Invoke(viewModel, attribute) ?? Task.FromResult(false);
     }

--- a/MvvmCross/ViewModels/IMvxBundle.cs
+++ b/MvvmCross/ViewModels/IMvxBundle.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.ViewModels;
@@ -12,9 +13,9 @@ public interface IMvxBundle
 
     void Write(object toStore);
 
-    T? Read<T>() where T : new();
+    T? Read<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : new();
 
-    object? Read(Type type);
+    object? Read([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type type);
 
     IEnumerable<object> CreateArgumentList(IEnumerable<ParameterInfo> requiredParameters, string? debugText);
 }

--- a/MvvmCross/ViewModels/IMvxTypeFinder.cs
+++ b/MvvmCross/ViewModels/IMvxTypeFinder.cs
@@ -11,5 +11,5 @@ public interface IMvxTypeFinder
 {
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
     Type? FindTypeOrNull(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type candidateType);
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type candidateType);
 }

--- a/MvvmCross/ViewModels/IMvxTypeFinder.cs
+++ b/MvvmCross/ViewModels/IMvxTypeFinder.cs
@@ -3,9 +3,13 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.ViewModels;
 
 public interface IMvxTypeFinder
 {
-    Type? FindTypeOrNull(Type candidateType);
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
+    Type? FindTypeOrNull(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type candidateType);
 }

--- a/MvvmCross/ViewModels/IMvxTypeToTypeLookupBuilder.cs
+++ b/MvvmCross/ViewModels/IMvxTypeToTypeLookupBuilder.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.ViewModels
@@ -11,6 +10,7 @@ namespace MvvmCross.ViewModels
 #nullable enable
     public interface IMvxTypeToTypeLookupBuilder
     {
+        [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
         IDictionary<Type, Type> Build(IEnumerable<Assembly> sourceAssemblies);
     }
 #nullable restore

--- a/MvvmCross/ViewModels/IMvxViewModelByNameRegistry.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelByNameRegistry.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.ViewModels
@@ -14,6 +15,7 @@ namespace MvvmCross.ViewModels
 
         void Add<TViewModel>() where TViewModel : IMvxViewModel;
 
+        [RequiresUnreferencedCode("This method registers view models that may not be preserved by trimming")]
         void AddAll(Assembly assembly);
     }
 #nullable restore

--- a/MvvmCross/ViewModels/IMvxViewModelLocator.cs
+++ b/MvvmCross/ViewModels/IMvxViewModelLocator.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Navigation.EventArguments;
 
 namespace MvvmCross.ViewModels;
@@ -21,7 +22,7 @@ public interface IMvxViewModelLocator
     /// <param name="navigationArgs">(Optional) Extra navigation arguments</param>
     /// <returns>Returns a ViewModel</returns>
     IMvxViewModel Load(
-        Type viewModelType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
         IMvxBundle? parameterValues,
         IMvxBundle? savedState,
         IMvxNavigateEventArgs? navigationArgs = null);
@@ -37,11 +38,12 @@ public interface IMvxViewModelLocator
     /// <param name="navigationArgs">(Optional) Extra navigation arguments</param>
     /// <returns>Returns a ViewModel</returns>
     IMvxViewModel<TParameter> Load<TParameter>(
-        Type viewModelType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
         TParameter param,
         IMvxBundle? parameterValues,
         IMvxBundle? savedState,
-        IMvxNavigateEventArgs? navigationArgs = null);
+        IMvxNavigateEventArgs? navigationArgs = null)
+        where TParameter : notnull;
 
     /// <summary>
     /// Reload ViewModel, runs start lifecycle in ViewModel.

--- a/MvvmCross/ViewModels/MvxAppStart.cs
+++ b/MvvmCross/ViewModels/MvxAppStart.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
-using System.Threading;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
@@ -11,7 +11,6 @@ using MvvmCross.Navigation;
 
 namespace MvvmCross.ViewModels
 {
-#nullable enable
     public abstract class MvxAppStart : IMvxAppStart
     {
         protected readonly IMvxNavigationService NavigationService;
@@ -67,10 +66,12 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public class MvxAppStart<TViewModel> : MvxAppStart
-        where TViewModel : IMvxViewModel
+    public class MvxAppStart<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>
+        : MvxAppStart
+            where TViewModel : IMvxViewModel
     {
-        public MvxAppStart(IMvxApplication application, IMvxNavigationService navigationService) : base(application, navigationService)
+        public MvxAppStart(IMvxApplication application, IMvxNavigationService navigationService)
+            : base(application, navigationService)
         {
         }
 
@@ -87,11 +88,13 @@ namespace MvvmCross.ViewModels
         }
     }
 
-    public class MvxAppStart<TViewModel, TParameter> : MvxAppStart<TViewModel>
-        where TViewModel : IMvxViewModel<TParameter>
-        where TParameter : notnull
+    public class MvxAppStart<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TParameter>
+        : MvxAppStart<TViewModel>
+            where TViewModel : IMvxViewModel<TParameter>
+            where TParameter : notnull
     {
-        public MvxAppStart(IMvxApplication application, IMvxNavigationService navigationService) : base(application, navigationService)
+        public MvxAppStart(IMvxApplication application, IMvxNavigationService navigationService)
+            : base(application, navigationService)
         {
         }
 
@@ -112,7 +115,10 @@ namespace MvvmCross.ViewModels
                     NavigationService.Navigate<TViewModel, TParameter>(parameter).GetAwaiter().GetResult();
                 else
                 {
-                    MvxLogHost.Default?.Log(LogLevel.Trace, "Hint is not matching type of {parameterName}. Doing navigation without typed parameter instead.", nameof(TParameter));
+                    MvxLogHost.Default?.Log(
+                        LogLevel.Information,
+                        "Hint is not matching type of {ParameterName}. Doing navigation without typed parameter instead",
+                        nameof(TParameter));
                     await base.NavigateToFirstViewModel(hint);
                 }
             }
@@ -122,5 +128,4 @@ namespace MvvmCross.ViewModels
             }
         }
     }
-#nullable restore
 }

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -74,7 +74,7 @@ namespace MvvmCross.ViewModels
             Mvx.IoCProvider?.ConstructAndRegisterSingleton<IMvxAppStart, TMvxAppStart>();
         }
 
-        protected void RegisterAppStart<TViewModel>()
+        protected void RegisterAppStart<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>()
             where TViewModel : IMvxViewModel
         {
             Mvx.IoCProvider?.ConstructAndRegisterSingleton<IMvxAppStart, MvxAppStart<TViewModel>>();
@@ -85,7 +85,7 @@ namespace MvvmCross.ViewModels
             Mvx.IoCProvider?.RegisterSingleton(appStart);
         }
 
-        protected virtual void RegisterAppStart<TViewModel, TParameter>()
+        protected virtual void RegisterAppStart<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel, TParameter>()
           where TViewModel : IMvxViewModel<TParameter> where TParameter : class
         {
             Mvx.IoCProvider?.ConstructAndRegisterSingleton<IMvxAppStart, MvxAppStart<TViewModel, TParameter>>();

--- a/MvvmCross/ViewModels/MvxApplication.cs
+++ b/MvvmCross/ViewModels/MvxApplication.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MvvmCross.IoC;
 using MvvmCross.Logging;
@@ -69,8 +67,9 @@ namespace MvvmCross.ViewModels
             return DefaultLocator;
         }
 
-        protected void RegisterCustomAppStart<TMvxAppStart>()
-            where TMvxAppStart : class, IMvxAppStart
+        protected void RegisterCustomAppStart<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TMvxAppStart>()
+                where TMvxAppStart : class, IMvxAppStart
         {
             Mvx.IoCProvider?.ConstructAndRegisterSingleton<IMvxAppStart, TMvxAppStart>();
         }
@@ -92,11 +91,13 @@ namespace MvvmCross.ViewModels
             Mvx.IoCProvider?.ConstructAndRegisterSingleton<IMvxAppStart, MvxAppStart<TViewModel, TParameter>>();
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         protected IEnumerable<Type> CreatableTypes()
         {
             return CreatableTypes(GetType().GetTypeInfo().Assembly);
         }
 
+        [RequiresUnreferencedCode("This method uses reflection which may not be preserved during trimming")]
         protected IEnumerable<Type> CreatableTypes(Assembly assembly)
         {
             return assembly.CreatableTypes();

--- a/MvvmCross/ViewModels/MvxBundle.cs
+++ b/MvvmCross/ViewModels/MvxBundle.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Core;
 
@@ -23,13 +24,13 @@ public class MvxBundle(IDictionary<string, string>? data) : IMvxBundle
         Data.Write(toStore);
     }
 
-    public T? Read<T>()
+    public T? Read<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] T>()
         where T : new()
     {
         return Data.Read<T>();
     }
 
-    public object? Read(Type type)
+    public object? Read([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
     {
         return Data.Read(type);
     }

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Exceptions;
 using MvvmCross.Navigation.EventArguments;
 
@@ -14,7 +14,7 @@ namespace MvvmCross.ViewModels
         : IMvxViewModelLocator
     {
         public virtual IMvxViewModel Load(
-            Type viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
             IMvxNavigateEventArgs? navigationArgs = null)
@@ -38,12 +38,12 @@ namespace MvvmCross.ViewModels
         }
 
         public virtual IMvxViewModel<TParameter> Load<TParameter>(
-            Type viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
             TParameter param,
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
             IMvxNavigateEventArgs? navigationArgs = null)
-            where TParameter : notnull
+                where TParameter : notnull
         {
             if (viewModelType == null)
                 throw new ArgumentNullException(nameof(viewModelType));

--- a/MvvmCross/ViewModels/MvxInteractionExtensions.cs
+++ b/MvvmCross/ViewModels/MvxInteractionExtensions.cs
@@ -1,33 +1,39 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Base;
 using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.ViewModels
 {
-#nullable enable
     public static class MvxInteractionExtensions
     {
-        public static IDisposable WeakSubscribe(this IMvxInteraction interaction, EventHandler<EventArgs> action)
+        public static IDisposable? WeakSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] T>(
+            this T interaction, EventHandler<EventArgs> action)
+                where T : IMvxInteraction
         {
-            var eventInfo = interaction.GetType().GetEvent("Requested");
-            return eventInfo.WeakSubscribe(interaction, action);
+            var eventInfo = typeof(T).GetEvent("Requested");
+            return eventInfo?.WeakSubscribe(interaction, action);
         }
 
-        public static MvxValueEventSubscription<T> WeakSubscribe<T>(this IMvxInteraction<T> interaction, EventHandler<MvxValueEventArgs<T>> action)
+        public static MvxValueEventSubscription<TValue>? WeakSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TInteraction, TValue>(
+            this TInteraction interaction,
+            EventHandler<MvxValueEventArgs<TValue>> action)
+                where TInteraction : IMvxInteraction<TValue>
         {
-            var eventInfo = interaction.GetType().GetEvent("Requested");
-            return eventInfo.WeakSubscribe<T>(interaction, action);
+            var eventInfo = typeof(TInteraction).GetEvent("Requested");
+            return eventInfo?.WeakSubscribe(interaction, action);
         }
 
-        public static MvxValueEventSubscription<T> WeakSubscribe<T>(this IMvxInteraction<T> interaction, Action<T> action)
+        public static MvxValueEventSubscription<TValue>? WeakSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TInteraction, TValue>(
+            this TInteraction interaction, Action<TValue> action)
+                where TInteraction : IMvxInteraction<TValue>
         {
-            EventHandler<MvxValueEventArgs<T>> wrappedAction = (sender, args) => action(args.Value);
+            EventHandler<MvxValueEventArgs<TValue>> wrappedAction = (sender, args) => action(args.Value);
             return interaction.WeakSubscribe(wrappedAction);
         }
     }
-#nullable restore
 }

--- a/MvvmCross/ViewModels/MvxInteractionExtensions.cs
+++ b/MvvmCross/ViewModels/MvxInteractionExtensions.cs
@@ -15,7 +15,7 @@ namespace MvvmCross.ViewModels
             this T interaction, EventHandler<EventArgs> action)
                 where T : IMvxInteraction
         {
-            var eventInfo = typeof(T).GetEvent("Requested");
+            var eventInfo = interaction.GetType().GetEvent("Requested");
             return eventInfo?.WeakSubscribe(interaction, action);
         }
 
@@ -24,7 +24,7 @@ namespace MvvmCross.ViewModels
             EventHandler<MvxValueEventArgs<TValue>> action)
                 where TInteraction : IMvxInteraction<TValue>
         {
-            var eventInfo = typeof(TInteraction).GetEvent("Requested");
+            var eventInfo = interaction.GetType().GetEvent("Requested");
             return eventInfo?.WeakSubscribe(interaction, action);
         }
 

--- a/MvvmCross/ViewModels/MvxNavigationSerializer.cs
+++ b/MvvmCross/ViewModels/MvxNavigationSerializer.cs
@@ -1,13 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
 using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Base;
 
 namespace MvvmCross.ViewModels
 {
-#nullable enable
+
     public class MvxNavigationSerializer
         : IMvxNavigationSerializer
     {
@@ -20,7 +21,7 @@ namespace MvvmCross.ViewModels
     }
 
     public class MvxNavigationSerializer<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>
             : MvxNavigationSerializer
                 where T : class, IMvxTextSerializer
     {
@@ -29,5 +30,4 @@ namespace MvvmCross.ViewModels
         {
         }
     }
-#nullable restore
 }

--- a/MvvmCross/ViewModels/MvxNavigationSerializer.cs
+++ b/MvvmCross/ViewModels/MvxNavigationSerializer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Base;
 
 namespace MvvmCross.ViewModels
@@ -18,9 +19,10 @@ namespace MvvmCross.ViewModels
         public IMvxTextSerializer Serializer { get; }
     }
 
-    public class MvxNavigationSerializer<T>
-        : MvxNavigationSerializer
-        where T : class, IMvxTextSerializer
+    public class MvxNavigationSerializer<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>
+            : MvxNavigationSerializer
+                where T : class, IMvxTextSerializer
     {
         public MvxNavigationSerializer()
             : base(Mvx.IoCProvider.Resolve<T>())

--- a/MvvmCross/ViewModels/MvxViewForAttribute.cs
+++ b/MvvmCross/ViewModels/MvxViewForAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.ViewModels
 {
@@ -10,9 +11,10 @@ namespace MvvmCross.ViewModels
     [AttributeUsage(AttributeTargets.Class)]
     public class MvxViewForAttribute : Attribute
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
         public Type ViewModel { get; set; }
 
-        public MvxViewForAttribute(Type viewModel)
+        public MvxViewForAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]Type viewModel)
         {
             ViewModel = viewModel;
         }

--- a/MvvmCross/ViewModels/MvxViewForAttribute.cs
+++ b/MvvmCross/ViewModels/MvxViewForAttribute.cs
@@ -14,7 +14,7 @@ namespace MvvmCross.ViewModels
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
         public Type ViewModel { get; set; }
 
-        public MvxViewForAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]Type viewModel)
+        public MvxViewForAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type viewModel)
         {
             ViewModel = viewModel;
         }

--- a/MvvmCross/ViewModels/MvxViewModelByNameLookup.cs
+++ b/MvvmCross/ViewModels/MvxViewModelByNameLookup.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.IoC;
 
@@ -40,6 +41,7 @@ namespace MvvmCross.ViewModels
             Add(typeof(TViewModel));
         }
 
+        [RequiresUnreferencedCode("This method registers view models that may not be preserved by trimming")]
         public void AddAll(Assembly assembly)
         {
             var viewModelTypes = from type in assembly.ExceptionSafeGetTypes()

--- a/MvvmCross/ViewModels/MvxViewModelExtensions.cs
+++ b/MvvmCross/ViewModels/MvxViewModelExtensions.cs
@@ -19,7 +19,7 @@ namespace MvvmCross.ViewModels
         {
             ArgumentNullException.ThrowIfNull(viewModel);
 
-            var methods = typeof(TViewModel)
+            var methods = viewModel.GetType()
                 .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy)
                 .Where(m => m.Name == methodName && !m.IsAbstract);
 
@@ -75,9 +75,10 @@ namespace MvvmCross.ViewModels
 
             var toReturn = new MvxBundle();
             var methods =
-                typeof(TViewModel)
-                .GetMethods()
-                .Where(m => m.Name == "SaveState" && m.ReturnType != typeof(void) && !m.GetParameters().Any());
+                viewModel
+                    .GetType()
+                    .GetMethods()
+                    .Where(m => m.Name == "SaveState" && m.ReturnType != typeof(void) && !m.GetParameters().Any());
 
             foreach (var methodInfo in methods)
             {

--- a/MvvmCross/ViewModels/MvxViewModelInstanceRequest.cs
+++ b/MvvmCross/ViewModels/MvxViewModelInstanceRequest.cs
@@ -11,6 +11,12 @@ namespace MvvmCross.ViewModels
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType)
             : MvxViewModelRequest(viewModelType)
     {
+        public MvxViewModelInstanceRequest(IMvxViewModel viewModelInstance)
+            : this(viewModelInstance.GetType())
+        {
+            ViewModelInstance = viewModelInstance;
+        }
+
         public IMvxViewModel? ViewModelInstance { get; set; }
     }
 

--- a/MvvmCross/ViewModels/MvxViewModelInstanceRequest.cs
+++ b/MvvmCross/ViewModels/MvxViewModelInstanceRequest.cs
@@ -1,26 +1,33 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.ViewModels
 {
-#nullable enable
-    public class MvxViewModelInstanceRequest : MvxViewModelRequest
+    public class MvxViewModelInstanceRequest(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType)
+            : MvxViewModelRequest(viewModelType)
     {
         public IMvxViewModel? ViewModelInstance { get; set; }
+    }
 
-        public MvxViewModelInstanceRequest(Type viewModelType)
-            : base(viewModelType)
+    public class MvxViewModelInstanceRequest<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>
+            : MvxViewModelInstanceRequest
+                where TViewModel : IMvxViewModel
+    {
+        public MvxViewModelInstanceRequest()
+            : base(typeof(TViewModel))
         {
         }
 
         public MvxViewModelInstanceRequest(IMvxViewModel viewModelInstance)
-            : base(viewModelInstance.GetType(), null, null)
+            : base(typeof(TViewModel))
         {
             ViewModelInstance = viewModelInstance;
         }
     }
-#nullable restore
 }

--- a/MvvmCross/ViewModels/MvxViewModelInstanceRequest.cs
+++ b/MvvmCross/ViewModels/MvxViewModelInstanceRequest.cs
@@ -19,21 +19,4 @@ namespace MvvmCross.ViewModels
 
         public IMvxViewModel? ViewModelInstance { get; set; }
     }
-
-    public class MvxViewModelInstanceRequest<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>
-            : MvxViewModelInstanceRequest
-                where TViewModel : IMvxViewModel
-    {
-        public MvxViewModelInstanceRequest()
-            : base(typeof(TViewModel))
-        {
-        }
-
-        public MvxViewModelInstanceRequest(IMvxViewModel viewModelInstance)
-            : base(typeof(TViewModel))
-        {
-            ViewModelInstance = viewModelInstance;
-        }
-    }
 }

--- a/MvvmCross/ViewModels/MvxViewModelInstanceRequestWithSource.cs
+++ b/MvvmCross/ViewModels/MvxViewModelInstanceRequestWithSource.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.ViewModels
 {
-
     /// <summary>
     ///     Extension of MvxViewModelInstanceRequest with a target.
     /// </summary>
@@ -26,22 +25,6 @@ namespace MvvmCross.ViewModels
         /// <summary>
         ///     The instance of the viewmodel which is the source of the request.
         /// </summary>
-        public IMvxViewModel Source { get; }
-    }
-
-    public class MvxViewModelInstanceRequestWithSource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel> : MvxViewModelInstanceRequest<TViewModel>
-        where TViewModel : IMvxViewModel
-    {
-        /// <summary>
-        /// Initializes a new instance of <see cref="MvxViewModelInstanceRequestWithSource"/>
-        /// </summary>
-        /// <param name="viewModelInstance">The viewmodel instance.</param>
-        /// <param name="source">The instance of the viewmodel which is the source of the request.</param>
-        public MvxViewModelInstanceRequestWithSource(IMvxViewModel viewModelInstance, IMvxViewModel source) : base(viewModelInstance)
-        {
-            this.Source = source;
-        }
-
         public IMvxViewModel Source { get; }
     }
 }

--- a/MvvmCross/ViewModels/MvxViewModelInstanceRequestWithSource.cs
+++ b/MvvmCross/ViewModels/MvxViewModelInstanceRequestWithSource.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.ViewModels
 {
 
@@ -13,11 +15,23 @@ namespace MvvmCross.ViewModels
         /// </summary>
         /// <param name="viewModelType">The viewmodel type.</param>
         /// <param name="source">The instance of the viewmodel which is the source of the request.</param>
-        public MvxViewModelInstanceRequestWithSource(Type viewModelType, IMvxViewModel source) : base(viewModelType)
+        public MvxViewModelInstanceRequestWithSource(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
+            IMvxViewModel source)
+                : base(viewModelType)
         {
             this.Source = source;
         }
 
+        /// <summary>
+        ///     The instance of the viewmodel which is the source of the request.
+        /// </summary>
+        public IMvxViewModel Source { get; }
+    }
+
+    public class MvxViewModelInstanceRequestWithSource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel> : MvxViewModelInstanceRequest<TViewModel>
+        where TViewModel : IMvxViewModel
+    {
         /// <summary>
         /// Initializes a new instance of <see cref="MvxViewModelInstanceRequestWithSource"/>
         /// </summary>
@@ -28,9 +42,6 @@ namespace MvvmCross.ViewModels
             this.Source = source;
         }
 
-        /// <summary>
-        ///     The instance of the viewmodel which is the source of the request.
-        /// </summary>
         public IMvxViewModel Source { get; }
     }
 }

--- a/MvvmCross/ViewModels/MvxViewModelLoader.cs
+++ b/MvvmCross/ViewModels/MvxViewModelLoader.cs
@@ -74,7 +74,8 @@ public class MvxViewModelLoader
         }
     }
 
-    public IMvxViewModel LoadViewModel<TParameter>(MvxViewModelRequest request, TParameter param, IMvxBundle? savedState, IMvxNavigateEventArgs? navigationArgs = null)
+    public IMvxViewModel LoadViewModel<TParameter>(
+        MvxViewModelRequest request, TParameter param, IMvxBundle? savedState, IMvxNavigateEventArgs? navigationArgs = null)
     {
         if (request.ViewModelType == typeof(MvxNullViewModel))
         {

--- a/MvvmCross/ViewModels/MvxViewModelRequest.cs
+++ b/MvvmCross/ViewModels/MvxViewModelRequest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using MvvmCross.Core;
 
@@ -14,12 +15,12 @@ public class MvxViewModelRequest
     {
     }
 
-    public MvxViewModelRequest(Type viewModelType)
+    public MvxViewModelRequest([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType)
     {
         ViewModelType = viewModelType;
     }
 
-    public MvxViewModelRequest(Type viewModelType,
+    public MvxViewModelRequest([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
         IMvxBundle? parameterBundle,
         IMvxBundle? presentationBundle)
     {
@@ -28,11 +29,13 @@ public class MvxViewModelRequest
         PresentationValues = presentationBundle.SafeGetData();
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public Type? ViewModelType { get; set; }
     public IDictionary<string, string>? ParameterValues { get; set; }
     public IDictionary<string, string>? PresentationValues { get; set; }
 
-    public static MvxViewModelRequest GetDefaultRequest(Type viewModelType)
+    public static MvxViewModelRequest GetDefaultRequest(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType)
     {
         return new MvxViewModelRequest(viewModelType, null, null);
     }
@@ -57,7 +60,8 @@ public class MvxViewModelRequest
     }
 }
 
-public class MvxViewModelRequest<TViewModel> : MvxViewModelRequest where TViewModel : IMvxViewModel
+public class MvxViewModelRequest<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>
+    : MvxViewModelRequest where TViewModel : IMvxViewModel
 {
     public MvxViewModelRequest() : base(typeof(TViewModel))
     {

--- a/MvvmCross/ViewModels/MvxViewModelViewLookupBuilder.cs
+++ b/MvvmCross/ViewModels/MvxViewModelViewLookupBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Exceptions;
 using MvvmCross.IoC;
@@ -12,6 +13,7 @@ namespace MvvmCross.ViewModels;
 public class MvxViewModelViewLookupBuilder
     : IMvxTypeToTypeLookupBuilder
 {
+    [RequiresUnreferencedCode("This method uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
     public virtual IDictionary<Type, Type> Build(IEnumerable<Assembly> sourceAssemblies)
     {
         var associatedTypeFinder = Mvx.IoCProvider?.Resolve<IMvxViewModelTypeFinder>();

--- a/MvvmCross/ViewModels/MvxViewModelViewTypeFinder.cs
+++ b/MvvmCross/ViewModels/MvxViewModelViewTypeFinder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.IoC;
@@ -16,7 +17,9 @@ public class MvxViewModelViewTypeFinder(
         IMvxNameMapping viewToViewModelNameMapping)
     : IMvxViewModelTypeFinder
 {
-    public virtual Type? FindTypeOrNull(Type candidateType)
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
+    public virtual Type? FindTypeOrNull(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type candidateType)
     {
         if (!CheckCandidateTypeIsAView(candidateType))
             return null;
@@ -40,6 +43,7 @@ public class MvxViewModelViewTypeFinder(
         return null;
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
     protected virtual Type? LookupAttributedViewModelType(Type candidateType)
     {
         var attribute = candidateType
@@ -49,6 +53,7 @@ public class MvxViewModelViewTypeFinder(
         return attribute?.ViewModel;
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
     protected virtual Type? LookupNamedViewModelType(Type candidateType)
     {
         var viewName = candidateType.Name;
@@ -58,7 +63,9 @@ public class MvxViewModelViewTypeFinder(
         return toReturn;
     }
 
-    protected virtual Type? LookupAssociatedConcreteViewModelType(Type candidateType)
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
+    protected virtual Type? LookupAssociatedConcreteViewModelType(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type candidateType)
     {
         var viewModelPropertyInfo =
             Array.Find(candidateType.GetProperties(),

--- a/MvvmCross/ViewModels/MvxViewModelViewTypeFinder.cs
+++ b/MvvmCross/ViewModels/MvxViewModelViewTypeFinder.cs
@@ -19,7 +19,7 @@ public class MvxViewModelViewTypeFinder(
 {
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
     public virtual Type? FindTypeOrNull(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type candidateType)
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type candidateType)
     {
         if (!CheckCandidateTypeIsAView(candidateType))
             return null;

--- a/MvvmCross/Views/IMvxViewFinder.cs
+++ b/MvvmCross/Views/IMvxViewFinder.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Views
 {
-#nullable enable
     public interface IMvxViewFinder
     {
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
         Type? GetViewType(Type? viewModelType);
     }
-#nullable restore
 }

--- a/MvvmCross/Views/MvxViewExtensions.cs
+++ b/MvvmCross/Views/MvxViewExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Logging;
 using MvvmCross.ViewModels;
@@ -36,13 +37,14 @@ public static class MvxViewExtensions
         // nothing needed currently
     }
 
-    public static Type? FindAssociatedViewModelTypeOrNull(this IMvxView view)
+    public static Type? FindAssociatedViewModelTypeOrNull<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TViewType>(
+        this TViewType view)
+            where TViewType : IMvxView
     {
-        if (view == null)
-            throw new ArgumentNullException(nameof(view));
+        ArgumentNullException.ThrowIfNull(view);
 
         if (Mvx.IoCProvider?.TryResolve(out IMvxViewModelTypeFinder? associatedTypeFinder) == true)
-            return associatedTypeFinder?.FindTypeOrNull(view.GetType());
+            return associatedTypeFinder?.FindTypeOrNull(typeof(TViewType));
 
         MvxLogHost.Default?.Log(LogLevel.Trace,
             "No view model type finder available - assuming we are looking for a splash screen - returning null");

--- a/MvvmCross/Views/MvxViewsContainer.cs
+++ b/MvvmCross/Views/MvxViewsContainer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Views
@@ -41,6 +42,7 @@ namespace MvvmCross.Views
             Add(typeof(TViewModel), typeof(TView));
         }
 
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
         public Type GetViewType(Type? viewModelType)
         {
             Type? binding;

--- a/MvvmCross/WeakSubscription/MvxGeneralEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxGeneralEventSubscription.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace MvvmCross.WeakSubscription;
@@ -16,7 +17,7 @@ public class MvxGeneralEventSubscription(
     protected override Delegate CreateEventHandler() => new EventHandler(OnSourceEvent);
 }
 
-public class MvxGeneralEventSubscription<TSource, TEventArgs>
+public class MvxGeneralEventSubscription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource, TEventArgs>
     : MvxWeakEventSubscription<TSource, TEventArgs>
     where TSource : class
     where TEventArgs : EventArgs

--- a/MvvmCross/WeakSubscription/MvxValueEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxValueEventSubscription.cs
@@ -9,19 +9,19 @@ using MvvmCross.Base;
 namespace MvvmCross.WeakSubscription
 {
 #nullable enable
-    public class MvxValueEventSubscription<T>
-        : MvxWeakEventSubscription<object, MvxValueEventArgs<T>>
+    public class MvxValueEventSubscription<TEventArgs>
+        : MvxWeakEventSubscription<object, MvxValueEventArgs<TEventArgs>>
     {
         public MvxValueEventSubscription(object source,
                                          EventInfo eventInfo,
-                                         EventHandler<MvxValueEventArgs<T>> eventHandler)
+                                         EventHandler<MvxValueEventArgs<TEventArgs>> eventHandler)
             : base(source, eventInfo, eventHandler)
         {
         }
 
         protected override Delegate CreateEventHandler()
         {
-            return new EventHandler<MvxValueEventArgs<T>>(OnSourceEvent);
+            return new EventHandler<MvxValueEventArgs<TEventArgs>>(OnSourceEvent);
         }
     }
 #nullable restore

--- a/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
+++ b/MvvmCross/WeakSubscription/MvxWeakEventSubscription.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MvvmCross.Exceptions;
 
 namespace MvvmCross.WeakSubscription;
 
-public class MvxWeakEventSubscription<TSource, TEventArgs> : IDisposable
+public class MvxWeakEventSubscription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource, TEventArgs> : IDisposable
     where TSource : class
 {
     private readonly WeakReference _targetReference;
@@ -135,7 +136,7 @@ public class MvxWeakEventSubscription<TSource, TEventArgs> : IDisposable
     }
 }
 
-public class MvxWeakEventSubscription<TSource> : IDisposable
+public class MvxWeakEventSubscription<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource> : IDisposable
     where TSource : class
 {
     private readonly WeakReference _targetReference;

--- a/MvvmCross/WeakSubscription/MvxWeakSubscriptionExtensions.cs
+++ b/MvvmCross/WeakSubscription/MvxWeakSubscriptionExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Windows.Input;
@@ -61,14 +62,16 @@ namespace MvvmCross.WeakSubscription
             return new MvxCanExecuteChangedEventSubscription(source, eventHandler);
         }
 
-        public static MvxWeakEventSubscription<TSource> WeakSubscribe<TSource>(this TSource source, string eventName, EventHandler eventHandler)
-            where TSource : class
+        public static MvxWeakEventSubscription<TSource> WeakSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource>(
+            this TSource source, string eventName, EventHandler eventHandler)
+                where TSource : class
         {
             return new MvxWeakEventSubscription<TSource>(source, eventName, eventHandler);
         }
 
-        public static MvxWeakEventSubscription<TSource, TEventArgs> WeakSubscribe<TSource, TEventArgs>(this TSource source, string eventName, EventHandler<TEventArgs> eventHandler)
-            where TSource : class
+        public static MvxWeakEventSubscription<TSource, TEventArgs> WeakSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource, TEventArgs>(
+            this TSource source, string eventName, EventHandler<TEventArgs> eventHandler)
+                where TSource : class
         {
             return new MvxWeakEventSubscription<TSource, TEventArgs>(source, eventName, eventHandler);
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
MvvmCross is not trimming safe and you need to provide a hint to the linker to preserve code

### :new: What is the new behavior (if this is a feature change)?
To help a bit, I've added `DynamicallyAccessedMembers` and `RequiresUnreferencedCode` attributes to most of the core code.


### :boom: Does this PR introduce a breaking change?
Yes

- Some methods have been converted from something like: `void MyMethod(ISomeType target)` to `void MyMethod<TTarget>(TTarget target) where TTarget : ISomeType` to allow annotating `TTarget` with `DynamicallyAccessedMembers`. This shouldn't affect your code, but could be a breaking change for specific usages.

Obviously if your project has or adds `<EnableTrimAnalyzer>true</EnableTrimAnalyzer>` you will now be left with a lot of warnings to look into and add annotations yourself. Especially around MvxApplication, MvxSetup, MvxIoCProvider and Bindings code.


There is still a lot of the platform specific code and binding code that needs to be addressed.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4925

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
