### PR TITLE
Fix MvxViewControllerExtensions null reference

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/MvxViewControllerAdapter.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxViewControllerAdapter.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
-using System;
 using MvvmCross.Platforms.Ios.Views.Base;
 using MvvmCross.Views;
 
@@ -10,24 +10,24 @@ namespace MvvmCross.Platforms.Ios.Views
 {
     public class MvxViewControllerAdapter : MvxBaseViewControllerAdapter
     {
-        protected IMvxIosView IosView => ViewController as IMvxIosView;
+        protected IMvxIosView? IosView => ViewController as IMvxIosView;
 
         public MvxViewControllerAdapter(IMvxEventSourceViewController eventSource)
             : base(eventSource)
         {
-            if (!(eventSource is IMvxIosView))
-                throw new ArgumentException("eventSource", "eventSource should be a IMvxIosView");
+            if (eventSource is not IMvxIosView)
+                throw new ArgumentException("eventSource should be a IMvxIosView", nameof(eventSource));
         }
 
         public override void HandleViewDidLoadCalled(object sender, EventArgs e)
         {
-            IosView.OnViewCreate();
+            IosView?.OnViewCreate();
             base.HandleViewDidLoadCalled(sender, e);
         }
 
         public override void HandleDisposeCalled(object sender, EventArgs e)
         {
-            IosView.OnViewDestroy();
+            IosView?.OnViewDestroy();
             base.HandleDisposeCalled(sender, e);
         }
     }

--- a/MvvmCross/Platforms/Ios/Views/MvxViewControllerExtensions.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxViewControllerExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Microsoft.Extensions.Logging;
 using MvvmCross.Exceptions;
 using MvvmCross.Logging;
@@ -22,22 +24,39 @@ namespace MvvmCross.Platforms.Ios.Views
             if (iosView.Request == null)
             {
                 MvxLogHost.Default?.LogTrace(
-                    "Request is null - assuming this is a TabBar type situation where ViewDidLoad is called during construction... patching the request now - but watch out for problems with virtual calls during construction");
+                    "MvxViewControllerExtensions: LoadViewModelRequest is null - assuming this is a TabBar type situation where ViewDidLoad is called during construction... patching the request now - but watch out for problems with virtual calls during construction");
 
-                iosView.Request = Mvx.IoCProvider.Resolve<IMvxCurrentRequest>().CurrentRequest;
+                if (Mvx.IoCProvider?.TryResolve(out IMvxCurrentRequest? currentRequest) == true &&
+                    currentRequest?.CurrentRequest != null)
+                {
+                    iosView.Request = currentRequest.CurrentRequest;
+                }
             }
 
-            var instanceRequest = iosView.Request as MvxViewModelInstanceRequest;
-            if (instanceRequest != null)
+            if (iosView.Request is MvxViewModelInstanceRequest instanceRequest &&
+                instanceRequest.ViewModelInstance != null)
             {
+                MvxLogHost.Default?.LogTrace(
+                    "MvxViewControllerExtensions: LoadViewModel ({ViewModelType}) instance already set - returning it directly without loading from locator",
+                    instanceRequest.ViewModelInstance.GetType().Name);
                 return instanceRequest.ViewModelInstance;
             }
 
-            var loader = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>();
-            var viewModel = loader.LoadViewModel(iosView.Request, null /* no saved state on iOS currently */);
-            if (viewModel == null)
-                throw new MvxException("ViewModel not loaded for " + iosView.Request.ViewModelType);
-            return viewModel;
+            if (iosView.Request != null &&
+                Mvx.IoCProvider?.TryResolve(out IMvxViewModelLoader? viewModelLoader) == true &&
+                viewModelLoader != null)
+            {
+                var viewModel = viewModelLoader.LoadViewModel(iosView.Request, null /* no saved state on iOS currently */);
+                if (viewModel == null)
+                    throw new MvxException($"ViewModel not loaded for {iosView.Request.ViewModelType}");
+
+                MvxLogHost.Default?.LogTrace(
+                    "MvxViewControllerExtensions: LoadViewModel loaded ({ViewModelType})",
+                    viewModel.GetType().Name);
+                return viewModel;
+            }
+
+            throw new MvxException("ViewModel not loaded for null Request on {0}", iosView.GetType().Name);
         }
     }
 }

--- a/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
+++ b/MvvmCross/ViewModels/MvxDefaultViewModelLocator.cs
@@ -43,7 +43,6 @@ namespace MvvmCross.ViewModels
             IMvxBundle? parameterValues,
             IMvxBundle? savedState,
             IMvxNavigateEventArgs? navigationArgs = null)
-                where TParameter : notnull
         {
             if (viewModelType == null)
                 throw new ArgumentNullException(nameof(viewModelType));


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug fix

### :arrow_heading_down: What is the current behavior?
If you somewhere null out the `Request` property on a `IMvxIosView` instance before lifecycle kicks in and `LoadViewModel` in MvxViewControllerExtensions kicks in, it throws a `NullReferenceException`

### :new: What is the new behavior (if this is a feature change)?
- Throws a MvxException with a better error message if this occurs
- Enabled nullable attributes to cover all null cases
- Also fixed warning that MvxDefaultViewModelLoader doesn't implement the interface correctly

### :boom: Does this PR introduce a breaking change?
Yes

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
