### PR TITLE
Remove obsolete NET 8 MAUI targets

### DIFF
--- a/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
+++ b/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net9.0-android</TargetFrameworks>
+    <TargetFramework>net9.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.Leanback</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.Leanback</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
+++ b/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net9.0-android</TargetFrameworks>
+    <TargetFramework>net9.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.Material</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.Material</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
+++ b/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net9.0-android</TargetFrameworks>
+    <TargetFramework>net9.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.RecyclerView</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.RecyclerView</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
+++ b/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net9.0-android</TargetFrameworks>
+    <TargetFramework>net9.0-android</TargetFramework>
     <AssemblyName>MvvmCross.DroidX.SwipeRefreshLayout</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.SwipeRefreshLayout</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
+++ b/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-tvos;net8.0-macos;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-tvos;net9.0-macos</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-tvos;net9.0-macos</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
The .NET 8.0 MAUI target frameworks are obsolete. Refer to https://dotnet.microsoft.com/en-us/platform/support/policy/maui for more information and we are still building for these. 

### :new: What is the new behavior (if this is a feature change)?
Removing them

### :boom: Does this PR introduce a breaking change?
If you are still on .NET 8, then yes, but you shouldn't be.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
