### PR TITLE
Fix faulty scroll when expanding a section using MvxExpandableTableViewSource

### DIFF
--- a/MvvmCross/Platforms/Ios/Views/MvxExpandableTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxExpandableTableViewSource.cs
@@ -99,9 +99,16 @@ namespace MvvmCross.Platforms.Ios.Views
 
         private void ScrollToSection(UITableView tableView, nint atIndex)
         {
-            var sectionRect = tableView.RectForSection(atIndex);
-            sectionRect.Height = tableView.Frame.Height;
-            tableView.ScrollRectToVisible(sectionRect, true);
+            if (tableView.NumberOfRowsInSection(section) > 0)
+            {
+                var firstRow = NSIndexPath.FromRowSection(0, section);
+                tableView.ScrollToRow(firstRow, UITableViewScrollPosition.Top, true);
+            }
+            else
+            {
+                var headerRect = tableView.RectForHeaderInSection(section);
+                tableView.ScrollRectToVisible(headerRect, true);
+            }
         }
 
         protected override void CollectionChangedOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/MvvmCross/Platforms/Ios/Views/MvxExpandableTableViewSource.cs
+++ b/MvvmCross/Platforms/Ios/Views/MvxExpandableTableViewSource.cs
@@ -97,16 +97,16 @@ namespace MvvmCross.Platforms.Ios.Views
         {
         }
 
-        private void ScrollToSection(UITableView tableView, nint atIndex)
+        private void ScrollToSection(UITableView tableView, nint sectionIndex)
         {
-            if (tableView.NumberOfRowsInSection(section) > 0)
+            if (tableView.NumberOfRowsInSection(sectionIndex) > 0)
             {
-                var firstRow = NSIndexPath.FromRowSection(0, section);
+                var firstRow = NSIndexPath.FromRowSection(0, sectionIndex);
                 tableView.ScrollToRow(firstRow, UITableViewScrollPosition.Top, true);
             }
             else
             {
-                var headerRect = tableView.RectForHeaderInSection(section);
+                var headerRect = tableView.RectForHeaderInSection(sectionIndex);
                 tableView.ScrollRectToVisible(headerRect, true);
             }
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix 

### :arrow_heading_down: What is the current behavior?
Check bug issue #4938 

### :new: What is the new behavior (if this is a feature change)?
TableView now scrolls (and shows) correctly to the first row in the section of the header when expanding.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
1. Add UITableView with a MvxExpandableTableViewSource.
2. Expand a section by tapping the header
3. Check if the first row is now visible after scroll.

### :memo: Links to relevant issues/docs
Fixes #4938 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
