### PR TITLE
Update targets for build on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,4 @@ artifacts/
 .AssemblyAttributes
 
 *.GeneratedMSBuildEditorConfig.editorconfig
+*.ctrf.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -63,7 +63,7 @@
     <_MvxMacOSTargets>net9.0-macos</_MvxMacOSTargets>
     <_MvxTvOSTargets>net9.0-tvos</_MvxTvOSTargets>
     <_MvxWindowsTargets>net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</_MvxWindowsTargets>
-    <_MvxAllTargets>$(_MvxCommonTargets);$(_MvxAndroidTargets);$(_MvxiOSTargets);$(_MvxMacOSTargets);$(_MvxTvOSTargets);$(_MvxWindowsTargets)</_MvxAllTargets>
+    <_MvxWpfTargets>net8.0-windows;net9.0-windows</_MvxWpfTargets>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,11 +14,6 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <Version>9.3.1</Version>
 
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <NuGetAudit>enable</NuGetAudit>
-    <NuGetAuditMode>all</NuGetAuditMode>
-
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,6 +56,16 @@
     <SupportedOSPlatformVersion Condition=" '$(_MvxTargetPlatformIsAndroid)' == 'True' ">23</SupportedOSPlatformVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_MvxCommonTargets>net8.0;net9.0</_MvxCommonTargets>
+    <_MvxAndroidTargets>net9.0-android</_MvxAndroidTargets>
+    <_MvxiOSTargets>net9.0-ios;net9.0-maccatalyst</_MvxiOSTargets>
+    <_MvxMacOSTargets>net9.0-macos</_MvxMacOSTargets>
+    <_MvxTvOSTargets>net9.0-tvos</_MvxTvOSTargets>
+    <_MvxWindowsTargets>net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</_MvxWindowsTargets>
+    <_MvxAllTargets>$(_MvxCommonTargets);$(_MvxAndroidTargets);$(_MvxiOSTargets);$(_MvxMacOSTargets);$(_MvxTvOSTargets);$(_MvxWindowsTargets)</_MvxAllTargets>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild Condition=" '$(IsTestProject)' != 'true'">true</GeneratePackageOnBuild>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,11 @@
 <Project>
+  <PropertyGroup>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <NuGetAudit>enable</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+  </PropertyGroup>  
+
   <ItemGroup>
     <PackageVersion Include="AsyncFixer" Version="1.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />

--- a/MvvmCross-linux.slnf
+++ b/MvvmCross-linux.slnf
@@ -1,0 +1,32 @@
+{
+  "solution": {
+    "path": "MvvmCross.slnx",
+    "projects": [
+      "MvvmCross.DroidX\\Leanback\\MvvmCross.DroidX.Leanback.csproj",
+      "MvvmCross.DroidX\\Material\\MvvmCross.DroidX.Material.csproj",
+      "MvvmCross.DroidX\\RecyclerView\\MvvmCross.DroidX.RecyclerView.csproj",
+      "MvvmCross.DroidX\\SwipeRefreshLayout\\MvvmCross.DroidX.SwipeRefreshLayout.csproj",
+      "MvvmCross.Plugins\\All\\MvvmCross.Plugin.All.csproj",
+      "MvvmCross.Plugins\\Color\\MvvmCross.Plugin.Color.csproj",
+      "MvvmCross.Plugins\\FieldBinding\\MvvmCross.Plugin.FieldBinding.csproj",
+      "MvvmCross.Plugins\\Json\\MvvmCross.Plugin.Json.csproj",
+      "MvvmCross.Plugins\\JsonLocalization\\MvvmCross.Plugin.JsonLocalization.csproj",
+      "MvvmCross.Plugins\\Messenger\\MvvmCross.Plugin.Messenger.csproj",
+      "MvvmCross.Plugins\\MethodBinding\\MvvmCross.Plugin.MethodBinding.csproj",
+      "MvvmCross.Plugins\\ResourceLoader\\MvvmCross.Plugin.ResourceLoader.csproj",
+      "MvvmCross.Plugins\\ResxLocalization\\MvvmCross.Plugin.ResxLocalization.csproj",
+      "MvvmCross.Plugins\\Visibility\\MvvmCross.Plugin.Visibility.csproj",
+      "MvvmCross.Tests\\MvvmCross.Tests.csproj",
+      "MvvmCross\\MvvmCross.csproj",
+      "Projects\\Playground\\Playground.Core\\Playground.Core.csproj",
+      "Projects\\Playground\\Playground.Droid\\Playground.Droid.csproj",
+      "UnitTests\\MvvmCross.UnitTest\\MvvmCross.UnitTest.csproj",
+      "UnitTests\\Plugins.Color.UnitTest\\MvvmCross.Plugins.Color.UnitTest.csproj",
+      "UnitTests\\Plugins.JsonLocalization.UnitTest\\MvvmCross.Plugins.JsonLocalization.UnitTest.csproj",
+      "UnitTests\\Plugins.Messenger.UnitTest\\MvvmCross.Plugins.Messenger.UnitTest.csproj",
+      "UnitTests\\Plugins.ResourceLoader.UnitTest\\MvvmCross.Plugins.ResourceLoader.UnitTest.csproj",
+      "UnitTests\\Plugins.ResxLocalization.UnitTest\\MvvmCross.Plugins.ResxLocalization.UnitTest.csproj",
+      "UnitTests\\Plugins.Visibility.UnitTest\\MvvmCross.Plugins.Visibility.UnitTest.csproj"
+    ]
+  }
+}

--- a/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
+++ b/MvvmCross.DroidX/Leanback/MvvmCross.DroidX.Leanback.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-android</TargetFramework>
+    <TargetFrameworks>$(_MvxAndroidTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.DroidX.Leanback</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.Leanback</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
+++ b/MvvmCross.DroidX/Material/MvvmCross.DroidX.Material.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-android</TargetFramework>
+    <TargetFrameworks>$(_MvxAndroidTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.DroidX.Material</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.Material</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
+++ b/MvvmCross.DroidX/RecyclerView/MvvmCross.DroidX.RecyclerView.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-android</TargetFramework>
+    <TargetFrameworks>$(_MvxAndroidTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.DroidX.RecyclerView</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.RecyclerView</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
+++ b/MvvmCross.DroidX/SwipeRefreshLayout/MvvmCross.DroidX.SwipeRefreshLayout.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-android</TargetFramework>
+    <TargetFrameworks>$(_MvxAndroidTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.DroidX.SwipeRefreshLayout</AssemblyName>
     <RootNamespace>MvvmCross.DroidX.SwipeRefreshLayout</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/All/MvvmCross.Plugin.All.csproj
+++ b/MvvmCross.Plugins/All/MvvmCross.Plugin.All.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Plugin.All</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.All</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
+++ b/MvvmCross.Plugins/Color/MvvmCross.Plugin.Color.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
+    <!-- Windows-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('windows')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(_MvxWindowsTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Linux-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('linux')) ">$(_MvxAndroidTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Mac-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('osx')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/MvvmCross.Plugins/FieldBinding/MvvmCross.Plugin.FieldBinding.csproj
+++ b/MvvmCross.Plugins/FieldBinding/MvvmCross.Plugin.FieldBinding.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Plugin.FieldBinding</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.FieldBinding</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Json/MvvmCross.Plugin.Json.csproj
+++ b/MvvmCross.Plugins/Json/MvvmCross.Plugin.Json.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Plugin.Json</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.Json</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/JsonLocalization/MvvmCross.Plugin.JsonLocalization.csproj
+++ b/MvvmCross.Plugins/JsonLocalization/MvvmCross.Plugin.JsonLocalization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Plugin.JsonLocalization</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.JsonLocalization</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Messenger/MvvmCross.Plugin.Messenger.csproj
+++ b/MvvmCross.Plugins/Messenger/MvvmCross.Plugin.Messenger.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Plugin.Messenger</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.Messenger</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/MethodBinding/MvvmCross.Plugin.MethodBinding.csproj
+++ b/MvvmCross.Plugins/MethodBinding/MvvmCross.Plugin.MethodBinding.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Plugin.MethodBinding</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.MethodBinding</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
+++ b/MvvmCross.Plugins/ResourceLoader/MvvmCross.Plugin.ResourceLoader.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
+    <!-- Windows-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('windows')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(_MvxWindowsTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Linux-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('linux')) ">$(_MvxAndroidTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Mac-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('osx')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MvvmCross.Plugins/ResxLocalization/MvvmCross.Plugin.ResxLocalization.csproj
+++ b/MvvmCross.Plugins/ResxLocalization/MvvmCross.Plugin.ResxLocalization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Plugin.ResxLocalization</AssemblyName>
     <RootNamespace>MvvmCross.Plugin.ResxLocalization</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
+++ b/MvvmCross.Plugins/Visibility/MvvmCross.Plugin.Visibility.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
+    <!-- Windows-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('windows')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(_MvxWindowsTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Linux-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('linux')) ">$(_MvxAndroidTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Mac-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('osx')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MvvmCross.Tests/MvvmCross.Tests.csproj
+++ b/MvvmCross.Tests/MvvmCross.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Tests</AssemblyName>
     <RootNamespace>MvvmCross.Tests</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.

--- a/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
+++ b/MvvmCross.Wpf/MvvmCross.Platforms.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>$(_MvxWpfTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.Platforms.Wpf</AssemblyName>
     <RootNamespace>MvvmCross.Platforms.Wpf</RootNamespace>
     <Description>MvvmCross is the .NET MVVM framework for cross-platform solutions, including Xamarin iOS, Xamarin Android, Xamarin Forms, Windows and Mac.
@@ -10,11 +10,11 @@ This package contains the 'MvvmCross.Platforms.Wpf' libraries for MvvmCross</Des
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup Condition=" $([MSBuild]::IsOSPlatform('windows')) ">
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <ItemGroup Condition=" $([MSBuild]::IsOSPlatform('windows')) ">
     <Compile Include="..\MvvmCross\Platforms\Wpf\**\*.cs" />
     <ProjectReference Include="..\MvvmCross\MvvmCross.csproj" />
     <None Include="..\MvvmCross\readme.txt" pack="true" PackagePath="." />

--- a/MvvmCross/MvvmCross.csproj
+++ b/MvvmCross/MvvmCross.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-tvos;net9.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
+    <!-- Windows-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('windows')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(_MvxMacOSTargets);$(_MvxTvOSTargets);$(_MvxWindowsTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Linux-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('linux')) ">$(_MvxAndroidTargets);$(TargetFrameworks)</TargetFrameworks>
+    <!-- Mac-specific targets -->
+    <TargetFrameworks Condition=" $([MSBuild]::IsOSPlatform('osx')) ">$(_MvxAndroidTargets);$(_MvxiOSTargets);$(_MvxMacOSTargets);$(_MvxTvOSTargets);$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/UnitTests/MvvmCross.UnitTest.Common/MvvmCross.UnitTest.Common.csproj
+++ b/UnitTests/MvvmCross.UnitTest.Common/MvvmCross.UnitTest.Common.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(_MvxCommonTargets)</TargetFrameworks>
     <AssemblyName>MvvmCross.UnitTest.Common</AssemblyName>
     <RootNamespace>MvvmCross.UnitTest.Common</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -58,9 +58,12 @@ public class BuildContext : FrostingContext
         SonarKey = context.Argument("sonarKey", "");
         SonarOrg = context.Argument("sonarOrg", "");
 
-        var slnPath = context.IsRunningOnMacOs() ?
-            $"{AppFileRoot}/MvvmCross-macos.slnf" :
-            $"{AppFileRoot}/MvvmCross.slnx";
+        var slnPath = (context.IsRunningOnMacOs(), context.IsRunningOnLinux()) switch
+        {
+            (true, _) => $"{AppFileRoot}/MvvmCross-macos.slnf",
+            (_, true) => $"{AppFileRoot}/MvvmCross-linux.slnf",
+            _ => $"{AppFileRoot}/MvvmCross.slnx"
+        };
         Solution = new FilePath(slnPath);
 
         VersionInfo = context.GitVersioningGetVersion();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently, if you attempt to build MvvmCross on Linux, it all fails because of Windows, macOS and iOS targets which are not supported.

### :new: What is the new behavior (if this is a feature change)?
Now checking for OS in targets and only building supported targets.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
