### PR TITLE
Add .NET 10 targets

### DIFF
--- a/.github/actions/shared/action.yml
+++ b/.github/actions/shared/action.yml
@@ -4,11 +4,11 @@ inputs:
   dotnet-version:
     description: 'The .NET version to install'
     required: false
-    default: '9.0.304'
+    default: '10.0.100-rc.1.25451.107'
   java-version:
     description: 'The Java version to install'
     required: false
-    default: '17'
+    default: '21'
   java-distribution:
     description: 'The Java distribution to install'
     required: false

--- a/.github/actions/shared/action.yml
+++ b/.github/actions/shared/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'The .NET version to install'
     required: false
     default: '10.0.100-rc.1.25451.107'
+  dotnet-workload-version:
+    description: 'The .NET workload version to install'
+    required: false
+    default: '10.0.100-rc.1.25458.2'
   java-version:
     description: 'The Java version to install'
     required: false
@@ -29,7 +33,7 @@ runs:
       shell: pwsh
       run: |
         dotnet --version
-        dotnet workload install android ios tvos macos maccatalyst --version ${{ inputs.dotnet-version }}
+        dotnet workload install android ios tvos macos maccatalyst --version ${{ inputs.dotnet-workload-version }}
 
     - name: Set up JDK
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,13 +57,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_MvxCommonTargets>net8.0;net9.0</_MvxCommonTargets>
-    <_MvxAndroidTargets>net9.0-android</_MvxAndroidTargets>
-    <_MvxiOSTargets>net9.0-ios;net9.0-maccatalyst</_MvxiOSTargets>
-    <_MvxMacOSTargets>net9.0-macos</_MvxMacOSTargets>
-    <_MvxTvOSTargets>net9.0-tvos</_MvxTvOSTargets>
-    <_MvxWindowsTargets>net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</_MvxWindowsTargets>
-    <_MvxWpfTargets>net8.0-windows;net9.0-windows</_MvxWpfTargets>
+    <_MvxCommonTargets>net8.0;net9.0;net10.0</_MvxCommonTargets>
+    <_MvxAndroidTargets>net9.0-android;net10.0-android</_MvxAndroidTargets>
+    <_MvxiOSTargets>net9.0-ios;net9.0-maccatalyst;net10.0-ios;net10.0-maccatalyst</_MvxiOSTargets>
+    <_MvxMacOSTargets>net9.0-macos;net10.0-macos</_MvxMacOSTargets>
+    <_MvxTvOSTargets>net9.0-tvos;net10.0-tvos</_MvxTvOSTargets>
+    <_MvxWindowsTargets>net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</_MvxWindowsTargets>
+    <_MvxWpfTargets>net8.0-windows;net9.0-windows;net10.0-windows</_MvxWpfTargets>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
CI

### :new: What is the new behavior (if this is a feature change)?
Added .NET 10 target frameworks and building with .NET 10 RC1 SDK
Also bumped Java SDK to 21 as this is now supported for .NET Android. See: https://github.com/dotnet/android/pull/9672

### :boom: Does this PR introduce a breaking change?
Shouldn't

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
