### PR TITLE
Update Fragment ViewModel caching to prevent stale reuse and memory retention

### DIFF
--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
@@ -111,6 +111,17 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
             object? sender, MvxValueEventArgs<MvxCreateViewParameters> e) =>
             FragmentView?.EnsureBindingContextIsSet(e.Value.Inflater);
 
+        protected override void HandleResumeCalled(object? sender, EventArgs e)
+        {
+            IMvxMultipleViewModelCache? cache = null;
+            if (Mvx.IoCProvider?.TryResolve(out cache) == true && FragmentView?.ViewModel != null)
+            {
+                // clear cache if still there
+                cache!.GetAndClear(FragmentView.ViewModel.GetType(), FragmentView.UniqueImmutableCacheTag);
+                return;
+            }
+        }
+
         protected override void HandleSaveInstanceStateCalled(object? sender, MvxValueEventArgs<Bundle> e)
         {
             // it is guaranteed that SaveInstanceState call will be executed before OnStop (thus before Fragment detach)

--- a/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
+++ b/MvvmCross/Platforms/Android/Views/Fragments/MvxBindingFragmentAdapter.cs
@@ -113,12 +113,10 @@ namespace MvvmCross.Platforms.Android.Views.Fragments
 
         protected override void HandleResumeCalled(object? sender, EventArgs e)
         {
-            IMvxMultipleViewModelCache? cache = null;
-            if (Mvx.IoCProvider?.TryResolve(out cache) == true && FragmentView?.ViewModel != null)
+            if (Mvx.IoCProvider?.TryResolve(out IMvxMultipleViewModelCache? cache) == true && cache != null && FragmentView?.ViewModel != null)
             {
                 // clear cache if still there
-                cache!.GetAndClear(FragmentView.ViewModel.GetType(), FragmentView.UniqueImmutableCacheTag);
-                return;
+                cache.GetAndClear(FragmentView.ViewModel.GetType(), FragmentView.UniqueImmutableCacheTag);
             }
         }
 

--- a/MvvmCross/Platforms/Android/Views/MvxMultipleViewModelCache.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxMultipleViewModelCache.cs
@@ -29,8 +29,7 @@ namespace MvvmCross.Platforms.Android.Views
             var type = toCache.GetType();
 
             var cachedViewModelType = new CachedViewModelType(type, viewModelTag);
-            if (!CurrentViewModels.ContainsKey(cachedViewModelType))
-                CurrentViewModels.TryAdd(cachedViewModelType, toCache);
+            CurrentViewModels.AddOrUpdate(cachedViewModelType, toCache, (_, _) => toCache);
         }
 
         public IMvxViewModel GetAndClear(Type viewModelType, string viewModelTag = "singleInstanceCache")


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
Fixes #4913

### :arrow_heading_down: What is the current behavior?
When a ViewModel of a specific type is already present in the cache, MvvmCross prevents caching a second instance of the same type until the first one is explicitly removed. This results in scenarios where the previously cached instance is returned, even though a new instance was intended. Consequently, the new ViewModel is not cached and may not be retrieved as expected. Additionally, the retained ViewModel remains in memory longer than necessary, which can interfere with garbage collection and lead to unintended memory retention.

### :new: What is the new behavior (if this is a feature change)?
When a ViewModel of a specific type is already cached and a new instance of the same type is requested to be cached, the new instance will now replace the existing one in the cache. This ensures that the most recent ViewModel is always retrievable and avoids unintended reuse of stale instances.

Additionally, the cached ViewModel is now explicitly removed during the OnResume lifecycle event. Since MvvmCross only attempts to retrieve cached ViewModels during OnCreate, retaining them beyond that point serves no purpose and may lead to unnecessary memory retention. This change helps reduce memory pressure and improves lifecycle alignment.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
1. **Verify ViewModel replacement in cache:**
   - Create two instances of the same `ViewModel` type.
   - Ensure that when the second instance is cached, it replaces the first.
   - Confirm that retrieving the cached `ViewModel` returns the most recent instance.

2. **Validate cache clearing on OnResume:**
   - Navigate away from the view and trigger `OnResume`.
   - Ensure the `ViewModel` is removed from the cache.
   - Confirm that subsequent retrieval does not return the old instance. 

3. **Note on bug #4913 and #4957:**
   - This PR addresses bug https://github.com/MvvmCross/MvvmCross/issues/4913, which includes a minimal repro project and testing instructions.
   - However, due to a separate issue introduced in https://github.com/MvvmCross/MvvmCross/issues/4957, the repro steps from #4913 may not currently work as expected.
   - Reviewers should be aware that the fix is valid, but full verification may be blocked until #4957 is resolved.

### :memo: Links to relevant issues/docs
- **Bug #4913**
  This PR addresses the caching issue described here. The issue includes a minimal repro project and testing instructions.

- **Bug #4957** 
  This newer issue interferes with the ability to fully verify the fix for #4913. Reviewers should be aware that the repro steps from #4913 may not work as expected until #4957 is resolved.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
