### PR TITLE
Update renovate config to group winui sdk

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,16 @@
       "addLabels": [
         "Testing"
       ]
+    },
+    {
+      "matchPackagePatterns": [
+        "Microsoft.Windows.SDK.BuildTools",
+        "Microsoft.WindowsAppSDK"
+      ],
+      "groupName": "Windows App SDK",
+      "addLabels": [
+        "p/winui"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Dependencies

### :arrow_heading_down: What is the current behavior?
Win App SDK and Build tools are updated separately by Renovate Bot

### :new: What is the new behavior (if this is a feature change)?
They are now grouped together as they are dependent on eachother

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [ ] Rebased onto current develop
