### PR TITLE
Fix package downgrades

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,9 @@
     <StripSymbols>false</StripSymbols>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 
-    <NoWarn>$(NoWarn);CS0109;CS0108;CS0618;CS0114;NU1603;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS0109;CS0108;CS0618;CS0114;CS1591</NoWarn>
+
+    <WarningsAsErrors>$(WarningsAsErrors);NU1608</WarningsAsErrors>
 
     <NeutralLanguage>en-US</NeutralLanguage>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Xamarin.AndroidX.RecyclerView" Version="1.4.0.3" />
     <PackageVersion Include="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.29" />
     <PackageVersion Include="Xamarin.AndroidX.ViewPager" Version="1.1.0.4" />
-    <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.13.0" />
+    <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.12.0.5" />
     <PackageVersion Include="Xamarin.GooglePlayServices.Location" Version="121.3.0.7" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.1.0" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
Newest Material Design package introduced a slew of downgrade warnings

Introduced in #4986

### :new: What is the new behavior (if this is a feature change)?
Donwgraded the Material Design package and enabled Warnings as errors on NU1608 to prevent this from happening in the future

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
