### PR TITLE
Allow to set window controller type as Type for the MvxWindowPresentationAttribute

### DIFF
--- a/MvvmCross/Platforms/Mac/Presenters/Attributes/MvxWindowPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/Attributes/MvxWindowPresentationAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using AppKit;
 using MvvmCross.Presenters.Attributes;
 
@@ -43,6 +44,9 @@ namespace MvvmCross.Platforms.Mac.Presenters.Attributes
         public string Identifier { get; set; }
 
         public string WindowControllerName { get; set; }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public Type WindowControllerType { get; set; }
 
         public string StoryboardName { get; set; }
     }

--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -220,12 +220,16 @@ namespace MvvmCross.Platforms.Mac.Presenters
             }
             else
             {
+                var controllerType = attribute.WindowControllerType ?? Type.GetType(attribute.WindowControllerName);
+                if (controllerType is null)
+                {
+                    throw new MvxException(
+                        $"Could not determine window controller type for the {attribute.ViewModelType?.Name ?? "<unknown vm>"} view model. " +
+                        $"Please specify either the {nameof(MvxWindowPresentationAttribute.WindowControllerType)} or " +
+                        $"{nameof(MvxWindowPresentationAttribute.WindowControllerName)} property of the {nameof(MvxWindowPresentationAttribute)} " +
+                        $"for the corresponding view model.");
+                }
                 // Instantiate using Reflection - failure is possible if blank constructor is missing
-                var controllerType = attribute.WindowControllerType ?? Type.GetType(attribute.WindowControllerName)
-                    ?? throw new MvxException($"Could not determine window controller type for the {attribute.ViewModelType?.Name ?? "<unknown vm>"} view model. " +
-                                              $"Please specify either in the {nameof(MvxWindowPresentationAttribute.WindowControllerType)} or " +
-                                              $"{nameof(MvxWindowPresentationAttribute.WindowControllerName)} property of the {nameof(MvxWindowPresentationAttribute)} " +
-                                              $"for the corresponding view model.");
                 windowController = (MvxWindowController)Activator.CreateInstance(controllerType);
             }
             windowController.ShouldCascadeWindows = attribute.ShouldCascadeWindows;

--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -221,7 +221,12 @@ namespace MvvmCross.Platforms.Mac.Presenters
             else
             {
                 // Instantiate using Reflection - failure is possible if blank constructor is missing
-                windowController = (MvxWindowController)Activator.CreateInstance(Type.GetType(attribute.WindowControllerName));
+                var controllerType = attribute.WindowControllerType ?? Type.GetType(attribute.WindowControllerName)
+                    ?? throw new MvxException($"Could not determine window controller type for the {attribute.ViewModelType?.Name ?? "<unknown vm>"} view model. " +
+                                              $"Please specify either in the {nameof(MvxWindowPresentationAttribute.WindowControllerType)} or " +
+                                              $"{nameof(MvxWindowPresentationAttribute.WindowControllerName)} property of the {nameof(MvxWindowPresentationAttribute)} " +
+                                              $"for the corresponding view model.");
+                windowController = (MvxWindowController)Activator.CreateInstance(controllerType);
             }
             windowController.ShouldCascadeWindows = attribute.ShouldCascadeWindows;
             return windowController;

--- a/docs/_documentation/platform/macos/mac-view-presenter.md
+++ b/docs/_documentation/platform/macos/mac-view-presenter.md
@@ -49,7 +49,7 @@ Properties introduced inside the attribute will override the storyboard properti
 ```
 will set the CustomWindow Width to 800.
 
-*Note*: when storyboard name is set, the WindowControllerType is ignored.
+> Note: when storyboard name is set, the WindowControllerType is ignored.
 
 To use a custom window controller without storyboard, you can specify either the _WindowControllerType_ or the _WindowControllerName_ (specify the full type name, including the assembly name) property while *not* specifying the _StoryboardName_. The _WindowControllerType_ property takes precedence over the _WindowControllerName_ property.
 

--- a/docs/_documentation/platform/macos/mac-view-presenter.md
+++ b/docs/_documentation/platform/macos/mac-view-presenter.md
@@ -49,6 +49,10 @@ Properties introduced inside the attribute will override the storyboard properti
 ```
 will set the CustomWindow Width to 800.
 
+*Note*: when storyboard name is set, the WindowControllerType is ignored.
+
+To use a custom window controller without storyboard, you can specify either the _WindowControllerType_ or the _WindowControllerName_ (specify the full type name, including the assembly name) property while *not* specifying the _StoryboardName_. The _WindowControllerType_ property takes precedence over the _WindowControllerName_ property.
+
 ### MvxContentPresentationAttribute
 
 Used to set a view as content of a _Window_. Please notice that changing the content of a window does not automatically generate a navigation stack as it would be on iOS. Changing the content of a window dismisses the old content.

--- a/docs/_documentation/platform/macos/mac-view-presenter.md
+++ b/docs/_documentation/platform/macos/mac-view-presenter.md
@@ -49,9 +49,11 @@ Properties introduced inside the attribute will override the storyboard properti
 ```
 will set the CustomWindow Width to 800.
 
-> Note: when storyboard name is set, the WindowControllerType is ignored.
+To use a custom window controller without storyboard, you can specify either the _WindowControllerType_ or the _WindowControllerName_ property, while *not* specifying the _StoryboardName_.
+When using _WindowControllerName_, specify the full type name including the assembly name.
+The _WindowControllerType_ property takes precedence over the _WindowControllerName_ property.
 
-To use a custom window controller without storyboard, you can specify either the _WindowControllerType_ or the _WindowControllerName_ (specify the full type name, including the assembly name) property while *not* specifying the _StoryboardName_. The _WindowControllerType_ property takes precedence over the _WindowControllerName_ property.
+> Note: when storyboard name is set, the WindowControllerType is ignored.
 
 ### MvxContentPresentationAttribute
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature and documentation update

### :arrow_heading_down: What is the current behavior?
Currently, only the name of the window controller class (as a string) can be specified in the `MvxWindowPresentationAttribute`.

### :new: What is the new behavior (if this is a feature change)?
The `MvxWindowPresentationAttribute` now allows specifying the type (`System.Type`) of the window controller in addition to its name.


### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
* Get a project with a `MvxWindowPresentationAttribute` presentation and without storyboard specified.
* Implement custom window controller inherited from the `MvxWindowController`
* specify the controller type in the `MvxWindowPresentationAttribute`
* make sure that navigation to this view works as expected.

### :memo: Links to relevant issues/docs
Docs: https://www.mvvmcross.com/documentation/platform/macos/mac-view-presenter#presentation-attributes (also updated in this PR)
Fixes #5003 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
