### PR TITLE
Add missing DynamicallyAccessedMembers attributes on iOS delegates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 
     <StripSymbols>false</StripSymbols>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 
     <NoWarn>$(NoWarn);CS0109;CS0108;CS0618;CS0114;CS1591</NoWarn>
 

--- a/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
@@ -73,7 +73,7 @@ public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplic
 }
 
 [RequiresUnreferencedCode("This class uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
-public abstract class MvxApplicationDelegate<TMvxIosSetup, TApplication> : MvxApplicationDelegate
+public abstract class MvxApplicationDelegate<TMvxIosSetup, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxApplicationDelegate
     where TMvxIosSetup : MvxIosSetup<TApplication>, new()
     where TApplication : class, IMvxApplication, new()
 {

--- a/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxApplicationDelegate.cs
@@ -36,7 +36,7 @@ public abstract class MvxApplicationDelegate : UIApplicationDelegate, IMvxApplic
         FireLifetimeChanged(MvxLifetimeEvent.Closing);
     }
 
-    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+    public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
     {
         MainWindow ??= new UIWindow(UIScreen.MainScreen.Bounds);
 

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
@@ -82,7 +82,7 @@ public abstract class MvxSceneDelegate : UIResponder, IUIWindowSceneDelegate, IM
 }
 
 [RequiresUnreferencedCode("This class uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
-public abstract class MvxSceneDelegate<TMvxIosSetup,[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxSceneDelegate
+public abstract class MvxSceneDelegate<TMvxIosSetup, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxSceneDelegate
     where TMvxIosSetup : MvxIosSetup<TApplication>, new()
     where TApplication : class, IMvxApplication, new()
 {

--- a/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
+++ b/MvvmCross/Platforms/Ios/Core/MvxSceneDelegate.cs
@@ -82,7 +82,7 @@ public abstract class MvxSceneDelegate : UIResponder, IUIWindowSceneDelegate, IM
 }
 
 [RequiresUnreferencedCode("This class uses reflection to check for referenced assemblies, which may not be preserved by trimming")]
-public abstract class MvxSceneDelegate<TMvxIosSetup, TApplication> : MvxSceneDelegate
+public abstract class MvxSceneDelegate<TMvxIosSetup,[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApplication> : MvxSceneDelegate
     where TMvxIosSetup : MvxIosSetup<TApplication>, new()
     where TApplication : class, IMvxApplication, new()
 {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When compiling using .NET 10, trimmer analyzers will complain about some missing Dynamic Members attributes

### :new: What is the new behavior (if this is a feature change)?
Added the missing ones

### :boom: Does this PR introduce a breaking change?
Nop

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
