### PR TITLE
Android multiple back stacks

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -31,7 +31,9 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         string? tag = null,
         string popBackStackImmediateName = "",
         MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
-        bool addFragment = false
+        bool addFragment = false,
+        bool allowReordering = false,
+        bool setAdPrimaryFragment = false
     )
     {
         ActivityHostViewModelType = activityHostViewModelType;
@@ -48,6 +50,8 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         PopBackStackImmediateName = popBackStackImmediateName;
         PopBackStackImmediateFlag = popBackStackImmediateFlag;
         AddFragment = addFragment;
+        AllowReordering = allowReordering;
+        SetAsPrimaryFragment = setAdPrimaryFragment;
     }
 
     public MvxFragmentPresentationAttribute(
@@ -65,7 +69,9 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         string? tag = null,
         string popBackStackImmediateName = "",
         MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
-        bool addFragment = false
+        bool addFragment = false,
+        bool allowReordering = false,
+        bool setAdPrimaryFragment = false
     )
     {
         if (Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
@@ -106,6 +112,8 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         PopBackStackImmediateName = popBackStackImmediateName;
         PopBackStackImmediateFlag = popBackStackImmediateFlag;
         AddFragment = addFragment;
+        AllowReordering = allowReordering;
+        SetAsPrimaryFragment = setAdPrimaryFragment;
     }
 
     /// <summary>
@@ -186,4 +194,14 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
     /// Setting this to true, will use Add instead of Replace on the Fragment transaction
     /// </summary>
     public bool AddFragment { get; set; }
+
+    /// <summary>
+    /// Setting this to true, will use SetReorderingAllowed on the Fragment transaction
+    /// </summary>
+    public bool AllowReordering { get; set; }
+
+    /// <summary>
+    /// Setting this to true, will use SetPrimaryNavigationFragment on the Fragment transaction
+    /// </summary>
+    public bool SetAsPrimaryFragment { get; set; }
 }

--- a/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
+++ b/MvvmCross/Platforms/Android/Presenters/Attributes/MvxFragmentPresentationAttribute.cs
@@ -33,7 +33,7 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
         bool addFragment = false,
         bool allowReordering = false,
-        bool setAdPrimaryFragment = false
+        bool setAsPrimaryFragment = false
     )
     {
         ActivityHostViewModelType = activityHostViewModelType;
@@ -51,7 +51,7 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         PopBackStackImmediateFlag = popBackStackImmediateFlag;
         AddFragment = addFragment;
         AllowReordering = allowReordering;
-        SetAsPrimaryFragment = setAdPrimaryFragment;
+        SetAsPrimaryFragment = setAsPrimaryFragment;
     }
 
     public MvxFragmentPresentationAttribute(
@@ -71,7 +71,7 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         MvxPopBackStack popBackStackImmediateFlag = MvxPopBackStack.Inclusive,
         bool addFragment = false,
         bool allowReordering = false,
-        bool setAdPrimaryFragment = false
+        bool setAsPrimaryFragment = false
     )
     {
         if (Mvx.IoCProvider?.TryResolve(out IMvxAndroidGlobals globals) == true &&
@@ -113,7 +113,7 @@ public class MvxFragmentPresentationAttribute : MvxBasePresentationAttribute
         PopBackStackImmediateFlag = popBackStackImmediateFlag;
         AddFragment = addFragment;
         AllowReordering = allowReordering;
-        SetAsPrimaryFragment = setAdPrimaryFragment;
+        SetAsPrimaryFragment = setAsPrimaryFragment;
     }
 
     /// <summary>

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -590,8 +590,7 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             OnBeforeFragmentChanging(ft, fragment, attribute, request);
 
-            if (attribute.AllowReordering)
-	            ft.SetReorderingAllowed(true);
+            ft.SetReorderingAllowed(attribute.AllowReordering);
 
             if (attribute.AddToBackStack)
                 ft.AddToBackStack(fragmentName);
@@ -716,8 +715,7 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             OnBeforeFragmentChanging(ft, dialog, attribute, request);
 
-            if (attribute.AllowReordering)
-	            ft.SetReorderingAllowed(true);
+            ft.SetReorderingAllowed(attribute.AllowReordering);
 
             if (attribute.AddToBackStack)
                 ft.AddToBackStack(fragmentName);

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -611,7 +611,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             }
 
             if (attribute.SetAsPrimaryFragment)
-	            ft.SetPrimaryNavigationFragment(fragment);
+                ft.SetPrimaryNavigationFragment(fragment);
 
             ft.CommitAllowingStateLoss();
 
@@ -723,7 +723,7 @@ namespace MvvmCross.Platforms.Android.Presenters
             OnFragmentChanging(ft, dialog, attribute, request);
 
             if (attribute.SetAsPrimaryFragment)
-	            ft.SetPrimaryNavigationFragment(dialog);
+                ft.SetPrimaryNavigationFragment(dialog);
 
             dialog.Show(ft, fragmentName);
 

--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -590,6 +590,9 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             OnBeforeFragmentChanging(ft, fragment, attribute, request);
 
+            if (attribute.AllowReordering)
+	            ft.SetReorderingAllowed(true);
+
             if (attribute.AddToBackStack)
                 ft.AddToBackStack(fragmentName);
 
@@ -607,6 +610,9 @@ namespace MvvmCross.Platforms.Android.Presenters
             {
                 ft.Replace(attribute.FragmentContentId, fragment, fragmentName);
             }
+
+            if (attribute.SetAsPrimaryFragment)
+	            ft.SetPrimaryNavigationFragment(fragment);
 
             ft.CommitAllowingStateLoss();
 
@@ -710,10 +716,16 @@ namespace MvvmCross.Platforms.Android.Presenters
 
             OnBeforeFragmentChanging(ft, dialog, attribute, request);
 
+            if (attribute.AllowReordering)
+	            ft.SetReorderingAllowed(true);
+
             if (attribute.AddToBackStack)
                 ft.AddToBackStack(fragmentName);
 
             OnFragmentChanging(ft, dialog, attribute, request);
+
+            if (attribute.SetAsPrimaryFragment)
+	            ft.SetPrimaryNavigationFragment(dialog);
 
             dialog.Show(ft, fragmentName);
 

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MultiBackStackViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MultiBackStackViewModel.cs
@@ -7,83 +7,83 @@ namespace Playground.Core.ViewModels.Navigation;
 
 public class MultiBackStackViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : MvxNavigationViewModel(logFactory, navigationService)
 {
-	private bool _initialNavigationDone = false;
+    private bool _initialNavigationDone = false;
 
-	private async Task ShowInitialViewModelsExecute()
-	{
-		if (_initialNavigationDone)
-			return;
-		_initialNavigationDone = true;
-		await NavigationService.Navigate<MultiBackStackTab1ViewModel>();
-	}
+    private async Task ShowInitialViewModelsExecute()
+    {
+        if (_initialNavigationDone)
+            return;
+        _initialNavigationDone = true;
+        await NavigationService.Navigate<MultiBackStackTab1ViewModel>();
+    }
 
-	public override void ViewAppearing()
-	{
-		base.ViewAppearing();
-		//we can only show tabs after our host view is created
-		Task.Run(ShowInitialViewModelsExecute);
-	}
+    public override void ViewAppearing()
+    {
+        base.ViewAppearing();
+        //we can only show tabs after our host view is created
+        Task.Run(ShowInitialViewModelsExecute);
+    }
 
-	protected override void SaveStateToBundle(IMvxBundle bundle)
-	{
-		base.SaveStateToBundle(bundle);
-		bundle.Data[nameof(_initialNavigationDone)] = _initialNavigationDone.ToString();
-	}
+    protected override void SaveStateToBundle(IMvxBundle bundle)
+    {
+        base.SaveStateToBundle(bundle);
+        bundle.Data[nameof(_initialNavigationDone)] = _initialNavigationDone.ToString();
+    }
 
-	protected override void ReloadFromBundle(IMvxBundle state)
-	{
-		base.ReloadFromBundle(state);
-		if (state.Data.TryGetValue(nameof(_initialNavigationDone), out string initDone))
-			_ = bool.TryParse(initDone, out _initialNavigationDone);
-	}
+    protected override void ReloadFromBundle(IMvxBundle state)
+    {
+        base.ReloadFromBundle(state);
+        if (state.Data.TryGetValue(nameof(_initialNavigationDone), out string initDone))
+            _ = bool.TryParse(initDone, out _initialNavigationDone);
+    }
 }
 
 public class MultiBackStackTab1ViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : MvxNavigationViewModel(logFactory, navigationService)
 {
-	public IMvxCommand GoDeeperCommand { get; init; } = new MvxAsyncCommand(async () => await navigationService.Navigate<MultiBackStackInnerViewModel>());
+    public IMvxCommand GoDeeperCommand { get; init; } = new MvxAsyncCommand(async () => await navigationService.Navigate<MultiBackStackInnerViewModel>());
 }
 
 public class MultiBackStackTab2ViewModel : MvxViewModel;
 
 public class MultiBackStackInnerViewModel : MvxNavigationViewModel<int>
 {
-	public IMvxCommand GoDeeperCommand { get; init; }
-	public IMvxCommand CloseCommand { get; init; }
+    public IMvxCommand GoDeeperCommand { get; init; }
+    public IMvxCommand CloseCommand { get; init; }
 
-	private int _depth;
-	public int Depth
-	{
-		get => _depth;
-		set => SetProperty(ref _depth, value);
-	}
+    private int _depth;
+    public int Depth
+    {
+        get => _depth;
+        set => SetProperty(ref _depth, value);
+    }
 
-	public MultiBackStackInnerViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : base(logFactory, navigationService)
-	{
-		GoDeeperCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<MultiBackStackInnerViewModel, int>(Depth+1));
-		CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
-	}
+    public MultiBackStackInnerViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : base(logFactory, navigationService)
+    {
+        GoDeeperCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<MultiBackStackInnerViewModel, int>(Depth + 1));
+        CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
+    }
 
-	public override void Prepare()
-	{
-		base.Prepare();
-		Depth = 1;
-	}
+    public override void Prepare()
+    {
+        base.Prepare();
+        Depth = 1;
+    }
 
-	public override void Prepare(int parameter)
-	{
-		Depth = parameter;
-	}
+    public override void Prepare(int parameter)
+    {
+        Depth = parameter;
+    }
 
-	protected override void SaveStateToBundle(IMvxBundle bundle)
-	{
-		base.SaveStateToBundle(bundle);
-		bundle.Data[nameof(Depth)] = Depth.ToString();
-	}
+    protected override void SaveStateToBundle(IMvxBundle bundle)
+    {
+        base.SaveStateToBundle(bundle);
+        bundle.Data[nameof(Depth)] = Depth.ToString();
+    }
 
-	protected override void ReloadFromBundle(IMvxBundle state)
-	{
-		base.ReloadFromBundle(state);
-		if (state.Data.TryGetValue(nameof(Depth), out string ds))
-			_ = int.TryParse(ds, out _depth);
-	}
+    protected override void ReloadFromBundle(IMvxBundle state)
+    {
+        base.ReloadFromBundle(state);
+        if (state.Data.TryGetValue(nameof(Depth), out string ds))
+            _ = int.TryParse(ds, out _depth);
+    }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MultiBackStackViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MultiBackStackViewModel.cs
@@ -14,7 +14,6 @@ public class MultiBackStackViewModel(ILoggerFactory logFactory, IMvxNavigationSe
 		if (_initialNavigationDone)
 			return;
 		_initialNavigationDone = true;
-		var viewModelTypes = new[] { typeof(MultiBackStackTab1ViewModel), typeof(MultiBackStackTab2ViewModel) };
 		await NavigationService.Navigate<MultiBackStackTab1ViewModel>();
 	}
 

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/MultiBackStackViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/MultiBackStackViewModel.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging;
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace Playground.Core.ViewModels.Navigation;
+
+public class MultiBackStackViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : MvxNavigationViewModel(logFactory, navigationService)
+{
+	private bool _initialNavigationDone = false;
+
+	private async Task ShowInitialViewModelsExecute()
+	{
+		if (_initialNavigationDone)
+			return;
+		_initialNavigationDone = true;
+		var viewModelTypes = new[] { typeof(MultiBackStackTab1ViewModel), typeof(MultiBackStackTab2ViewModel) };
+		await NavigationService.Navigate<MultiBackStackTab1ViewModel>();
+	}
+
+	public override void ViewAppearing()
+	{
+		base.ViewAppearing();
+		//we can only show tabs after our host view is created
+		Task.Run(ShowInitialViewModelsExecute);
+	}
+
+	protected override void SaveStateToBundle(IMvxBundle bundle)
+	{
+		base.SaveStateToBundle(bundle);
+		bundle.Data[nameof(_initialNavigationDone)] = _initialNavigationDone.ToString();
+	}
+
+	protected override void ReloadFromBundle(IMvxBundle state)
+	{
+		base.ReloadFromBundle(state);
+		if (state.Data.TryGetValue(nameof(_initialNavigationDone), out string initDone))
+			_ = bool.TryParse(initDone, out _initialNavigationDone);
+	}
+}
+
+public class MultiBackStackTab1ViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : MvxNavigationViewModel(logFactory, navigationService)
+{
+	public IMvxCommand GoDeeperCommand { get; init; } = new MvxAsyncCommand(async () => await navigationService.Navigate<MultiBackStackInnerViewModel>());
+}
+
+public class MultiBackStackTab2ViewModel : MvxViewModel;
+
+public class MultiBackStackInnerViewModel : MvxNavigationViewModel<int>
+{
+	public IMvxCommand GoDeeperCommand { get; init; }
+	public IMvxCommand CloseCommand { get; init; }
+
+	private int _depth;
+	public int Depth
+	{
+		get => _depth;
+		set => SetProperty(ref _depth, value);
+	}
+
+	public MultiBackStackInnerViewModel(ILoggerFactory logFactory, IMvxNavigationService navigationService) : base(logFactory, navigationService)
+	{
+		GoDeeperCommand = new MvxAsyncCommand(async () => await NavigationService.Navigate<MultiBackStackInnerViewModel, int>(Depth+1));
+		CloseCommand = new MvxAsyncCommand(async () => await NavigationService.Close(this));
+	}
+
+	public override void Prepare()
+	{
+		base.Prepare();
+		Depth = 1;
+	}
+
+	public override void Prepare(int parameter)
+	{
+		Depth = parameter;
+	}
+
+	protected override void SaveStateToBundle(IMvxBundle bundle)
+	{
+		base.SaveStateToBundle(bundle);
+		bundle.Data[nameof(Depth)] = Depth.ToString();
+	}
+
+	protected override void ReloadFromBundle(IMvxBundle state)
+	{
+		base.ReloadFromBundle(state);
+		if (state.Data.TryGetValue(nameof(Depth), out string ds))
+			_ = int.TryParse(ds, out _depth);
+	}
+}

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -91,6 +91,9 @@ namespace Playground.Core.ViewModels
                 new MvxCommand(() => IsVisible = !IsVisible);
 
             FragmentCloseCommand = new MvxAsyncCommand(() => NavigationService.Navigate<FragmentCloseViewModel>());
+
+            ShowBottomNavigationCommand = new MvxAsyncCommand(async () =>
+	            await NavigationService.Navigate<MultiBackStackViewModel>());
         }
 
         private Task DoShowChildWithResult()
@@ -166,6 +169,8 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand ShowLocationCommand { get; }
 
         public MvxAsyncCommand ShowViewModelWithResult { get; set; }
+
+        public IMvxCommand ShowBottomNavigationCommand { get; }
 
         private bool _isVisible;
 

--- a/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/RootViewModel.cs
@@ -93,7 +93,7 @@ namespace Playground.Core.ViewModels
             FragmentCloseCommand = new MvxAsyncCommand(() => NavigationService.Navigate<FragmentCloseViewModel>());
 
             ShowBottomNavigationCommand = new MvxAsyncCommand(async () =>
-	            await NavigationService.Navigate<MultiBackStackViewModel>());
+                await NavigationService.Navigate<MultiBackStackViewModel>());
         }
 
         private Task DoShowChildWithResult()

--- a/Projects/Playground/Playground.Droid/Fragments/MultiBackStackView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/MultiBackStackView.cs
@@ -31,7 +31,7 @@ public class MultiBackStackView : MvxFragment<MultiBackStackViewModel>
     {
 	    base.OnCreateView(inflater, container, savedInstanceState);
 
-	    var view = this.BindingInflate(Resource.Layout.MultiBackStackView, null);
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackView, container, false);
 	    
 	    _navigationView = view.FindViewById<NavigationBarView>(Resource.Id.navigationview);
 	    _navigationView.ItemSelected += NavigationViewOnItemSelected;
@@ -80,7 +80,7 @@ public class MultiBackStackTab1View : MvxFragment<MultiBackStackTab1ViewModel>
     {
 	    base.OnCreateView(inflater, container, savedInstanceState);
 
-	    var view = this.BindingInflate(Resource.Layout.MultiBackStackTab1View, null);
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackTab1View, container, false);
 
 	    return view;
     }
@@ -97,23 +97,19 @@ public class MultiBackStackTab2View : MvxFragment<MultiBackStackTab2ViewModel>
     {
 	    base.OnCreateView(inflater, container, savedInstanceState);
 
-	    var view = this.BindingInflate(Resource.Layout.MultiBackStackTab2View, null);
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackTab2View, container, false);
 
 	    return view;
     }
 }
 
-[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
-    FragmentHostViewType = typeof(MultiBackStackView),
-    AllowReordering = true,
-    ViewModelType = typeof(MultiBackStackInnerViewModel))]
 public class MultiBackStackInnerView : MvxFragment<MultiBackStackInnerViewModel>, IMvxOverridePresentationAttribute
 {
     public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {
 	    base.OnCreateView(inflater, container, savedInstanceState);
 
-	    var view = this.BindingInflate(Resource.Layout.MultiBackStackInnerView, null);
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackInnerView, container, false);
 
 	    var f = ParentFragmentManager.PrimaryNavigationFragment;
 	    return view;

--- a/Projects/Playground/Playground.Droid/Fragments/MultiBackStackView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/MultiBackStackView.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Android.Views;
+using Google.Android.Material.Navigation;
+using MvvmCross;
+using MvvmCross.Navigation;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Presenters.Attributes;
+using MvvmCross.Platforms.Android.Views;
+using MvvmCross.Platforms.Android.Views.Fragments;
+using MvvmCross.Presenters;
+using MvvmCross.Presenters.Attributes;
+using MvvmCross.ViewModels;
+using Playground.Core.ViewModels;
+using Playground.Core.ViewModels.Navigation;
+
+namespace Playground.Droid.Fragments;
+
+[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
+    AllowReordering = true,
+    ViewModelType = typeof(MultiBackStackViewModel),
+    SetAsPrimaryFragment = true)]
+public class MultiBackStackView : MvxFragment<MultiBackStackViewModel>
+{
+    private NavigationBarView _navigationView;
+    private bool _navigatedToTab2;
+    
+    public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+    {
+	    base.OnCreateView(inflater, container, savedInstanceState);
+
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackView, null);
+	    
+	    _navigationView = view.FindViewById<NavigationBarView>(Resource.Id.navigationview);
+	    _navigationView.ItemSelected += NavigationViewOnItemSelected;
+
+	    return view;
+    }
+
+    public override void OnDestroy()
+    {
+	    base.OnDestroy();
+	    
+	    if (_navigationView != null)
+	    {
+		    _navigationView.ItemSelected -= NavigationViewOnItemSelected;
+	    }
+    }
+
+	private void NavigationViewOnItemSelected(object sender, NavigationBarView.ItemSelectedEventArgs ev)
+	{
+	    switch (ev.Item.ItemId)
+	    {
+		    case Resource.Id.tab1:
+			    ChildFragmentManager.SaveBackStack(typeof(MultiBackStackTab2View).FragmentJavaName());
+			    ChildFragmentManager.RestoreBackStack(typeof(MultiBackStackTab1View).FragmentJavaName());
+			    break;
+		    case Resource.Id.tab2:
+			    ChildFragmentManager.SaveBackStack(typeof(MultiBackStackTab1View).FragmentJavaName());
+			    if (!_navigatedToTab2) {
+				    _navigatedToTab2 = true;
+				    Mvx.IoCProvider.Resolve<IMvxNavigationService>().Navigate(typeof(MultiBackStackTab2ViewModel));
+			    } else {
+				    ChildFragmentManager.RestoreBackStack(typeof(MultiBackStackTab2View).FragmentJavaName());
+			    }
+			    break;
+	    }
+	}
+}
+
+[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
+    FragmentHostViewType = typeof(MultiBackStackView),
+    AllowReordering = true,
+    ViewModelType = typeof(MultiBackStackTab1ViewModel))]
+public class MultiBackStackTab1View : MvxFragment<MultiBackStackTab1ViewModel>
+{
+    public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+    {
+	    base.OnCreateView(inflater, container, savedInstanceState);
+
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackTab1View, null);
+
+	    return view;
+    }
+
+}
+
+[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
+    FragmentHostViewType = typeof(MultiBackStackView),
+    AllowReordering = true,
+    ViewModelType = typeof(MultiBackStackTab2ViewModel))]
+public class MultiBackStackTab2View : MvxFragment<MultiBackStackTab2ViewModel>
+{
+    public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+    {
+	    base.OnCreateView(inflater, container, savedInstanceState);
+
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackTab2View, null);
+
+	    return view;
+    }
+}
+
+[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
+    FragmentHostViewType = typeof(MultiBackStackView),
+    AllowReordering = true,
+    ViewModelType = typeof(MultiBackStackInnerViewModel))]
+public class MultiBackStackInnerView : MvxFragment<MultiBackStackInnerViewModel>, IMvxOverridePresentationAttribute
+{
+    public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+    {
+	    base.OnCreateView(inflater, container, savedInstanceState);
+
+	    var view = this.BindingInflate(Resource.Layout.MultiBackStackInnerView, null);
+
+	    var f = ParentFragmentManager.PrimaryNavigationFragment;
+	    return view;
+    }
+
+    public MvxBasePresentationAttribute PresentationAttribute(MvxViewModelRequest request)
+    {
+	    if (request is MvxViewModelInstanceRequest { ViewModelInstance: MultiBackStackInnerViewModel viewModel, ViewModelType: { } viewModelType })
+	    {
+		    return new MvxFragmentPresentationAttribute()
+		    {
+			    ViewModelType = typeof(MultiBackStackInnerViewModel),
+			    ActivityHostViewModelType = typeof(RootViewModel),
+			    FragmentHostViewType = typeof(MultiBackStackView),
+			    FragmentContentId = Resource.Id.content_frame,
+			    AddToBackStack = true,
+			    AllowReordering = true,
+			    Tag = viewModelType.Name + viewModel.Depth // unique tag so the restoration restores all of them
+		    };
+	    }
+	    else
+	    {
+		    return null;
+	    }
+    }
+}

--- a/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackInnerView.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackInnerView.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <TextView
+        tools:text="Depth: 2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:MvxBind="Text Format('Depth: {0}', Depth)"/>
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <Button
+            android:text="Go deeper"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            app:MvxBind="Click GoDeeperCommand"/>
+        <Button
+            android:text="Close"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            app:MvxBind="Click CloseCommand"/>
+    </LinearLayout>
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackTab1View.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackTab1View.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <TextView
+        android:text="Tab 1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"/>
+    <Button
+        android:text="Go deeper"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:MvxBind="Click GoDeeperCommand"/>
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackTab2View.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackTab2View.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <TextView
+        android:text="Tab 2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
+</FrameLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackView.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/MultiBackStackView.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/gray">
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/content_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1"/>
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/navigationview"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_weight="0"
+        android:background="@color/light_gray"
+        app:menu="@menu/navigation_bar"/>
+</LinearLayout>

--- a/Projects/Playground/Playground.Droid/Resources/layout/RootView.xml
+++ b/Projects/Playground/Playground.Droid/Resources/layout/RootView.xml
@@ -122,6 +122,12 @@
                 android:layout_marginTop="10dp"
                 android:text="Converters"
                 local:MvxBind="Click ShowConvertersCommand" />
+            <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Multiple back stacks"
+                local:MvxBind="Click ShowBottomNavigationCommand" />
             <TextView
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"

--- a/Projects/Playground/Playground.Droid/Resources/menu/navigation_bar.xml
+++ b/Projects/Playground/Playground.Droid/Resources/menu/navigation_bar.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/tab1"
+        android:enabled="true"
+        android:title="Tab 1"/>
+    <item
+        android:id="@+id/tab2"
+        android:enabled="true"
+        android:title="Tab 2"/>
+</menu>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
1. Added 2 new parameters to `MvxFragmentPresentationAttribute` that are required and add a possibility to use [multiple back stacks](https://developer.android.com/guide/fragments/fragmentmanager#multiple-back-stacks) (in bottom tabs-like navigation):
- `AllowReordering`: "optimization" that is required by multiple back stacks
- `SetAsPrimaryFragment`: helper that handles back button in nested Fragments
2. Added a sample with `BottomNavigationView` (tabs) that uses multiple back stacks in each tab.

### :arrow_heading_down: What is the current behavior?
There is no special parameters that help to use multiple back stack with presenter.

### :new: What is the new behavior (if this is a feature change)?
A possibility to pop nested `Fragment`s. A possibility to use multiple back stacks without modifying the Android presenter.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
1. Launch the app from Playground.Droid project.
2. Click on "Multiple back stacks" button.
3. Click `Go deeper` multiple times.
4. Switch between tabs on bottom.
5. Confirm the back stacks get restored when switching between tabs.
6. Click system Back button in Tab 1 to see how it closes the inner `Fragment`s in Tab 1.

### *️⃣ Extra
1. Unfortunately while we can add some logic of multiple back stacks requirements to the presenter we have to manually call `SaveBackStack` and `RestoreBackStack` (see the tabs selection in the sample). That is so because the `FragmentManager` API does not let us to find out if any back stack is already saved, and to "pre-save" any back stack ahead. So we manually do those. So we have to decide on our own to restore the back stack or to navigate to it first if never navigated before.
2. To switch between back stacks we pass the root `Fragment` name of our back stack to `SaveBackStack` that can be either `Tag` or `typeof(Fragment).FragmentJavaName()`. But eventually for `Tag` it works incorrectly because of it cannot find proper host `Fragment` because uses only `FragmentJavaName()`: https://github.com/MvvmCross/MvvmCross/blob/v10.0.0/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs#L1121
3. The back stack restoration happens with `Fragment`s restoring their VMs (finding cached ones) and that requires to put explicit `ViewModelType` to every `MvxFragmentPresentationAttribute` of nested `Fragment`s.
4. There is a bug/feature of `SetAsPrimaryFragment` that also pops to the very first `Fragment` in the tab since it has `AddToBackStack` that is required by multiple back stacks. Although `AddToBackStack` is logically not needed for the root tabs `Fragment`s, but is required for the save/restore API. The workaround would be either to manually intercept back button with `OnBackPressedCallback` that checks the current `Fragment` `ChildFragmentManager` back stack count and does not let the root one to be popped, or to play around with more nesting, or to not use `SetAsPrimaryFragment`.

### :memo: Links to relevant issues/docs
[Multiple back stacks](https://developer.android.com/guide/fragments/fragmentmanager#multiple-back-stacks)
[Primary navigation fragment](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction#setPrimaryNavigationFragment(androidx.fragment.app.Fragment))
[Allow reordering](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction#setReorderingAllowed(boolean))
[Save back stack](https://developer.android.com/reference/androidx/fragment/app/FragmentManager#saveBackStack(java.lang.String))
[Restore back stack](https://developer.android.com/reference/androidx/fragment/app/FragmentManager#restoreBackStack(java.lang.String))


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
