### PR TITLE
Fix race conditions in MvxFullBinding

### DIFF
--- a/MvvmCross/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Binding/Bindings/MvxFullBinding.cs
@@ -18,7 +18,11 @@ namespace MvvmCross.Binding.Bindings
     public class MvxFullBinding
         : MvxBinding, IMvxUpdateableBinding
     {
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
         private readonly MvxBindingDescription _bindingDescription;
         private readonly object _defaultTargetValue;
 

--- a/MvvmCross/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Binding/Bindings/MvxFullBinding.cs
@@ -239,7 +239,7 @@ namespace MvvmCross.Binding.Bindings
             }
         }
 
-        internal protected MvxBindingMode ActualBindingMode
+        protected internal MvxBindingMode ActualBindingMode
         {
             get
             {

--- a/MvvmCross/Binding/Bindings/MvxFullBinding.cs
+++ b/MvvmCross/Binding/Bindings/MvxFullBinding.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
-using MvvmCross.Base;
 using MvvmCross.Binding.Bindings.SourceSteps;
 using MvvmCross.Binding.Bindings.Target;
-using MvvmCross.Binding.Bindings.Target.Construction;
 using MvvmCross.Converters;
 using MvvmCross.IoC;
+
+[assembly: InternalsVisibleTo("MvvmCross.UnitTest")]
 
 namespace MvvmCross.Binding.Bindings
 {
@@ -17,37 +18,29 @@ namespace MvvmCross.Binding.Bindings
     public class MvxFullBinding
         : MvxBinding, IMvxUpdateableBinding
     {
-        private IMvxSourceStepFactory SourceStepFactory => MvxBindingSingletonCache.Instance.SourceStepFactory;
-
-        private IMvxTargetBindingFactory TargetBindingFactory => MvxBindingSingletonCache.Instance.TargetBindingFactory;
-
+        private readonly Lock _lock = new();
         private readonly MvxBindingDescription _bindingDescription;
+        private readonly object _defaultTargetValue;
+
         private IMvxSourceStep _sourceStep;
         private IMvxTargetBinding _targetBinding;
-        private readonly object _targetLocker = new object();
-
         private object _dataContext;
-        private EventHandler _sourceBindingOnChanged;
-        private EventHandler<MvxTargetChangedEventArgs> _targetBindingOnValueChanged;
-
-        private object _defaultTargetValue;
-        private CancellationTokenSource _cancelSource = new CancellationTokenSource();
-        private IMvxMainThreadAsyncDispatcher dispatcher => MvxBindingSingletonCache.Instance.MainThreadDispatcher;
+        private CancellationTokenSource _cancelSource = new();
 
         public object DataContext
         {
-            get
-            {
-                return _dataContext;
-            }
+            get => _dataContext;
             set
             {
                 if (_dataContext == value)
                     return;
+
                 _dataContext = value;
 
-                if (_sourceStep != null)
-                    _sourceStep.DataContext = value;
+                lock (_lock)
+                {
+                    _sourceStep?.DataContext = value;
+                }
 
                 UpdateTargetOnBind();
             }
@@ -55,61 +48,66 @@ namespace MvvmCross.Binding.Bindings
 
         public MvxFullBinding(MvxBindingRequest bindingRequest)
         {
+            _dataContext = bindingRequest.Source;
             _bindingDescription = bindingRequest.Description;
-            CreateTargetBinding(bindingRequest.Target);
-            CreateSourceBinding(bindingRequest.Source);
+            _targetBinding = CreateTargetBinding(bindingRequest);
+            _defaultTargetValue = _targetBinding.TargetValueType.CreateDefault();
+            _sourceStep = CreateSourceBinding(bindingRequest);
+
+            UpdateTargetOnBind();
         }
 
         protected virtual void ClearSourceBinding()
         {
-            if (_sourceStep != null)
+            lock (_lock)
             {
-                if (_sourceBindingOnChanged != null)
+                if (_sourceStep != null)
                 {
-                    _sourceStep.Changed -= _sourceBindingOnChanged;
-                    _sourceBindingOnChanged = null;
+                    _sourceStep.Changed -= OnSourceBindingChanged;
+                    _sourceStep.Dispose();
                 }
 
-                _sourceStep.Dispose();
                 _sourceStep = null;
             }
         }
 
-        private void CreateSourceBinding(object source)
+        private IMvxSourceStep CreateSourceBinding(MvxBindingRequest bindingRequest)
         {
-            // NOTE: We do not call the setter for DataContext here because we are
-            // setting up the sourceStep.
-            // If that method is updated we will need to make sure that this method
-            // does the right thing.
-            _dataContext = source;
-            _sourceStep = SourceStepFactory.Create(_bindingDescription.Source);
-            _sourceStep.TargetType = _targetBinding.TargetValueType;
-            _sourceStep.DataContext = source;
+            var sourceStep = MvxBindingSingletonCache.Instance.SourceStepFactory.Create(bindingRequest.Description.Source);
+            sourceStep.TargetType = _targetBinding.TargetValueType;
+            sourceStep.DataContext = bindingRequest.Source;
 
             if (NeedToObserveSourceChanges)
             {
-                _sourceBindingOnChanged = (sender, args) =>
-                {
-                    //Capture the cancel token first
-                    var cancel = _cancelSource.Token;
-                    //GetValue can now be executed in a worker thread. Is it the responsibility of the caller to switch threads, or ours ?
-                    //As the source is the viewmodel, i suppose it is the responsibility of the caller.
-                    var value = _sourceStep.GetValue();
-                    UpdateTargetFromSource(value, cancel);
-                };
-                _sourceStep.Changed += _sourceBindingOnChanged;
+                sourceStep.Changed += OnSourceBindingChanged;
             }
 
-            UpdateTargetOnBind();
+            return sourceStep;
+        }
+
+        private void OnSourceBindingChanged(object sender, EventArgs e)
+        {
+            var value = _sourceStep.GetValue();
+            CancellationToken cancel;
+            lock (_lock)
+            {
+                cancel = _cancelSource.Token;
+            }
+            UpdateTargetFromSource(value, cancel);
         }
 
         private void UpdateTargetOnBind()
         {
             if (NeedToUpdateTargetOnBind && _sourceStep != null)
             {
-                _cancelSource.Cancel();
-                _cancelSource = new CancellationTokenSource();
-                var cancel = _cancelSource.Token;
+                CancellationToken cancel;
+                lock (_lock)
+                {
+                    _cancelSource.Cancel();
+                    _cancelSource.Dispose();
+                    _cancelSource = new CancellationTokenSource();
+                    cancel = _cancelSource.Token;
+                }
 
                 try
                 {
@@ -125,40 +123,34 @@ namespace MvvmCross.Binding.Bindings
 
         protected virtual void ClearTargetBinding()
         {
-            lock (_targetLocker)
+            lock (_lock)
             {
                 if (_targetBinding != null)
                 {
-                    if (_targetBindingOnValueChanged != null)
-                    {
-                        _targetBinding.ValueChanged -= _targetBindingOnValueChanged;
-                        _targetBindingOnValueChanged = null;
-                    }
-
+                    _targetBinding.ValueChanged -= UpdateSourceFromTarget;
                     _targetBinding.Dispose();
                     _targetBinding = null;
                 }
             }
         }
 
-        private void CreateTargetBinding(object target)
+        private IMvxTargetBinding CreateTargetBinding(MvxBindingRequest request)
         {
-            _targetBinding = TargetBindingFactory.CreateBinding(target, _bindingDescription.TargetName);
+            var binding = MvxBindingSingletonCache.Instance.TargetBindingFactory.CreateBinding(request.Target, request.Description.TargetName);
 
-            if (_targetBinding == null)
+            if (binding == null)
             {
-                MvxBindingLog.Instance?.LogWarning("Failed to create target binding for {BindingDescription}", _bindingDescription.ToString());
-                _targetBinding = new MvxNullTargetBinding();
+                MvxBindingLog.Instance?.LogWarning("Failed to create target binding for {BindingDescription}", request.Description.ToString());
+                binding = new MvxNullTargetBinding();
             }
 
             if (NeedToObserveTargetChanges)
             {
-                _targetBinding.SubscribeToEvents();
-                _targetBindingOnValueChanged = (sender, args) => UpdateSourceFromTarget(args.Value);
-                _targetBinding.ValueChanged += _targetBindingOnValueChanged;
+                binding.SubscribeToEvents();
+                binding.ValueChanged += UpdateSourceFromTarget;
             }
 
-            _defaultTargetValue = _targetBinding.TargetValueType.CreateDefault();
+            return binding;
         }
 
         private async void UpdateTargetFromSource(object value, CancellationToken cancel)
@@ -167,16 +159,21 @@ namespace MvvmCross.Binding.Bindings
                 return;
 
             if (value == MvxBindingConstant.UnsetValue)
-                value = _defaultTargetValue;
+            {
+                lock (_lock)
+                {
+                    value = _defaultTargetValue;
+                }
+            }
 
-            await dispatcher.ExecuteOnMainThreadAsync(() =>
+            await MvxBindingSingletonCache.Instance.MainThreadDispatcher.ExecuteOnMainThreadAsync(() =>
             {
                 if (cancel.IsCancellationRequested)
                     return;
 
                 try
                 {
-                    lock (_targetLocker)
+                    lock (_lock)
                     {
                         _targetBinding?.SetValue(value);
                     }
@@ -191,17 +188,20 @@ namespace MvvmCross.Binding.Bindings
             });
         }
 
-        private void UpdateSourceFromTarget(object value)
+        private void UpdateSourceFromTarget(object sender, MvxTargetChangedEventArgs args)
         {
-            if (value == MvxBindingConstant.DoNothing)
+            if (args.Value == MvxBindingConstant.DoNothing)
                 return;
 
-            if (value == MvxBindingConstant.UnsetValue)
+            if (args.Value == MvxBindingConstant.UnsetValue)
                 return;
 
             try
             {
-                _sourceStep.SetValue(value);
+                lock (_lock)
+                {
+                    _sourceStep?.SetValue(args.Value);
+                }
             }
             catch (Exception exception)
             {
@@ -239,14 +239,17 @@ namespace MvvmCross.Binding.Bindings
             }
         }
 
-        protected MvxBindingMode ActualBindingMode
+        internal protected MvxBindingMode ActualBindingMode
         {
             get
             {
-                var mode = _bindingDescription.Mode;
-                if (mode == MvxBindingMode.Default && _targetBinding != null)
-                    mode = _targetBinding.DefaultMode;
-                return mode;
+                lock (_lock)
+                {
+                    var mode = _bindingDescription.Mode;
+                    if (mode == MvxBindingMode.Default && _targetBinding != null)
+                        mode = _targetBinding.DefaultMode;
+                    return mode;
+                }
             }
         }
 
@@ -256,7 +259,16 @@ namespace MvvmCross.Binding.Bindings
             {
                 ClearTargetBinding();
                 ClearSourceBinding();
+
+                lock (_lock)
+                {
+                    _cancelSource?.Cancel();
+                    _cancelSource?.Dispose();
+                    _cancelSource = null;
+                }
             }
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
@@ -553,7 +553,7 @@ namespace MvvmCross.UnitTest.Binding.Bindings
                     // But null reference exceptions are NOT acceptable
                     exceptions.Add(ex);
                 }
-            });
+            }, TestContext.Current.CancellationToken);
 
             await Task.Delay(50, TestContext.Current.CancellationToken);
             binding.Dispose();

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
@@ -13,6 +13,7 @@ using MvvmCross.UnitTest.Binding.Mocks;
 using MvvmCross.UnitTest.Mocks.Dispatchers;
 using NSubstitute;
 using Xunit;
+using System.Collections.Concurrent;
 
 namespace MvvmCross.UnitTest.Binding.Bindings
 {
@@ -378,6 +379,348 @@ namespace MvvmCross.UnitTest.Binding.Bindings
             var request = new MvxBindingRequest(source, target, bindingDescription);
             var toTest = new MvxFullBinding(request);
             return toTest;
+        }
+
+        [Fact]
+        public async Task TestConcurrentDataContextChanges_ShouldNotThrow()
+        {
+            // Arrange
+            using var binding = TestSetupCommon(MvxBindingMode.TwoWay,
+                out MockSourceBinding _, out MockTargetBinding _);
+
+            var exceptions = new ConcurrentBag<Exception>();
+            var tasks = new List<Task>();
+            var iterations = 100;
+
+            // Act - Multiple threads changing DataContext simultaneously
+            for (int i = 0; i < 10; i++)
+            {
+                int threadId = i;
+                tasks.Add(Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int j = 0; j < iterations; j++)
+                        {
+                            binding.DataContext = new { Value = threadId * 1000 + j };
+                            await Task.Delay(1, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }, TestContext.Current.CancellationToken));
+            }
+
+            await Task.WhenAll(tasks);
+
+            // Assert
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public async Task TestConcurrentSourceChangesAndDispose_ShouldNotThrow()
+        {
+            // Arrange
+            using var binding = TestSetupCommon(MvxBindingMode.OneWay,
+                out MockSourceBinding mockSource, out MockTargetBinding _);
+
+            var exceptions = new ConcurrentBag<Exception>();
+
+            // Act - One thread firing source changes, another disposing
+
+            Task[] tasks = [
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int i = 0; i < 1000; i++)
+                        {
+                            mockSource.TryGetValueValue = $"Value{i}";
+                            mockSource.FireSourceChanged();
+                            await Task.Delay(1, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }, TestContext.Current.CancellationToken),
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        // Let some source changes happen first
+                        await Task.Delay(50, TestContext.Current.CancellationToken);
+                        for (int i = 0; i < 10; i++)
+                        {
+                            binding.DataContext = new { Value = i };
+                            await Task.Delay(10, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }, TestContext.Current.CancellationToken)
+            ];
+
+            await Task.WhenAll(tasks);
+
+            // Assert
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public async Task TestConcurrentTargetChangesAndDataContextChanges_ShouldNotThrow()
+        {
+            // Arrange
+            using var binding = TestSetupCommon(MvxBindingMode.TwoWay,
+                out MockSourceBinding _, out MockTargetBinding mockTarget);
+
+            var exceptions = new ConcurrentBag<Exception>();
+
+            // Act - Concurrent target value changes and data context changes
+            Task[] tasks =
+            [
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int i = 0; i < 500; i++)
+                        {
+                            mockTarget.FireValueChanged(new MvxTargetChangedEventArgs($"TargetValue{i}"));
+                            await Task.Delay(1, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }, TestContext.Current.CancellationToken),
+
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int i = 0; i < 500; i++)
+                        {
+                            binding.DataContext = new { Value = i };
+                            await Task.Delay(1, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }, TestContext.Current.CancellationToken)
+            ];
+
+            await Task.WhenAll(tasks);
+
+            // Assert
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public async Task TestActualBindingModeAccess_WhileDisposing_ShouldNotThrow()
+        {
+            // This tests the specific bug reported - accessing ActualBindingMode during disposal
+            var binding = TestSetupCommon(MvxBindingMode.TwoWay,
+                out MockSourceBinding _, out MockTargetBinding _);
+
+            var exceptions = new ConcurrentBag<Exception>();
+            var keepRunning = true;
+
+            // Act - Read ActualBindingMode repeatedly while disposing
+            var readTask = Task.Run(async () =>
+            {
+                try
+                {
+                    while (keepRunning)
+                    {
+                        var mode = binding.ActualBindingMode;
+                        await Task.Delay(1, TestContext.Current.CancellationToken);
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    // This is acceptable - we're accessing after disposal
+                }
+                catch (Exception ex)
+                {
+                    // But null reference exceptions are NOT acceptable
+                    exceptions.Add(ex);
+                }
+            });
+
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+            binding.Dispose();
+            keepRunning = false;
+
+            await readTask;
+
+            // Assert - No null reference exceptions should occur
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public async Task TestConcurrentSourceChanges_WithCancellation_ShouldNotThrow()
+        {
+            // Tests that CancellationTokenSource operations are thread-safe
+            var binding = TestSetupCommon(MvxBindingMode.OneWay,
+                out MockSourceBinding mockSource, out MockTargetBinding _);
+
+            var exceptions = new ConcurrentBag<Exception>();
+            var tasks = new List<Task>();
+
+            // Act - Multiple threads triggering source changes (which creates new CancellationTokenSources)
+            for (int i = 0; i < 5; i++)
+            {
+                int threadId = i;
+                tasks.Add(Task.Run(() =>
+                {
+                    try
+                    {
+                        for (int j = 0; j < 100; j++)
+                        {
+                            mockSource.TryGetValueValue = $"Thread{threadId}_Value{j}";
+                            mockSource.FireSourceChanged();
+
+                            // Also change DataContext which recreates CancellationTokenSource
+                            if (j % 10 == 0)
+                            {
+                                binding.DataContext = new { ThreadId = threadId, Iteration = j };
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }, TestContext.Current.CancellationToken));
+            }
+
+            await Task.WhenAll(tasks);
+            binding.Dispose();
+
+            // Assert
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public async Task TestConcurrentDispose_ShouldBeIdempotent()
+        {
+            // Arrange
+            var binding = TestSetupCommon(MvxBindingMode.TwoWay,
+                out MockSourceBinding _, out MockTargetBinding _);
+
+            var exceptions = new ConcurrentBag<Exception>();
+            var tasks = new List<Task>();
+
+            // Act - Multiple threads trying to dispose simultaneously
+            for (int i = 0; i < 10; i++)
+            {
+                tasks.Add(Task.Run(() =>
+                {
+                    try
+                    {
+                        binding.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }, TestContext.Current.CancellationToken));
+            }
+
+            await Task.WhenAll(tasks);
+
+            // Assert - Dispose should be safe to call multiple times
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public async Task TestStressTest_AllOperationsConcurrently_ShouldNotThrow()
+        {
+            // Comprehensive stress test combining all operations
+            var binding = TestSetupCommon(MvxBindingMode.TwoWay,
+                out MockSourceBinding mockSource, out MockTargetBinding mockTarget);
+
+            var exceptions = new ConcurrentBag<Exception>();
+            var keepRunning = true;
+
+            Task[] tasks =
+            [
+                // Source changes
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int i = 0; i < 500 && keepRunning; i++)
+                        {
+                            mockSource.TryGetValueValue = $"Source{i}";
+                            mockSource.FireSourceChanged();
+                            await Task.Delay(1, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                }, TestContext.Current.CancellationToken),
+
+                // Target changes
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int i = 0; i < 500 && keepRunning; i++)
+                        {
+                            mockTarget.FireValueChanged(new MvxTargetChangedEventArgs($"Target{i}"));
+                            await Task.Delay(1, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                }, TestContext.Current.CancellationToken),
+
+                // DataContext changes
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int i = 0; i < 100 && keepRunning; i++)
+                        {
+                            binding.DataContext = new { Value = i };
+                            await Task.Delay(5, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                }, TestContext.Current.CancellationToken),
+
+                // Read ActualBindingMode
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        for (int i = 0; i < 1000 && keepRunning; i++)
+                        {
+                            var mode = binding.ActualBindingMode;
+                            await Task.Delay(1, TestContext.Current.CancellationToken);
+                        }
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // intentionally empty
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                }, TestContext.Current.CancellationToken)
+            ];
+
+            await Task.WhenAll(tasks);
+            keepRunning = false;
+            binding.Dispose();
+
+            // Assert
+            Assert.Empty(exceptions);
         }
     }
 }

--- a/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Binding/Bindings/MvxFullBindingTest.cs
@@ -540,7 +540,7 @@ namespace MvvmCross.UnitTest.Binding.Bindings
                 {
                     while (keepRunning)
                     {
-                        var mode = binding.ActualBindingMode;
+                        _ = binding.ActualBindingMode;
                         await Task.Delay(1, TestContext.Current.CancellationToken);
                     }
                 }
@@ -665,7 +665,10 @@ namespace MvvmCross.UnitTest.Binding.Bindings
                             await Task.Delay(1, TestContext.Current.CancellationToken);
                         }
                     }
-                    catch (Exception ex) { exceptions.Add(ex); }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
                 }, TestContext.Current.CancellationToken),
 
                 // Target changes
@@ -679,7 +682,10 @@ namespace MvvmCross.UnitTest.Binding.Bindings
                             await Task.Delay(1, TestContext.Current.CancellationToken);
                         }
                     }
-                    catch (Exception ex) { exceptions.Add(ex); }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
                 }, TestContext.Current.CancellationToken),
 
                 // DataContext changes
@@ -693,7 +699,10 @@ namespace MvvmCross.UnitTest.Binding.Bindings
                             await Task.Delay(5, TestContext.Current.CancellationToken);
                         }
                     }
-                    catch (Exception ex) { exceptions.Add(ex); }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
                 }, TestContext.Current.CancellationToken),
 
                 // Read ActualBindingMode
@@ -703,7 +712,7 @@ namespace MvvmCross.UnitTest.Binding.Bindings
                     {
                         for (int i = 0; i < 1000 && keepRunning; i++)
                         {
-                            var mode = binding.ActualBindingMode;
+                            _ = binding.ActualBindingMode;
                             await Task.Delay(1, TestContext.Current.CancellationToken);
                         }
                     }
@@ -711,7 +720,10 @@ namespace MvvmCross.UnitTest.Binding.Bindings
                     {
                         // intentionally empty
                     }
-                    catch (Exception ex) { exceptions.Add(ex); }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
                 }, TestContext.Current.CancellationToken)
             ];
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix + refactor

### :arrow_heading_down: What is the current behavior?
We have crashes reported in Sentry looking like this:

```
System.NullReferenceException: Arg_NullReferenceException
  at MvxBindingMode MvxFullBinding.get_ActualBindingMode()() in MvxFullBinding.cs:line 249
  at bool MvxFullBinding.get_NeedToUpdateTargetOnBind()() in MvxFullBinding.cs:line 238
  at void MvxFullBinding.UpdateTargetOnBind()() in MvxFullBinding.cs:line 109
  at void MvxFullBinding.set_DataContext(object value)() in MvxFullBinding.cs:line 53
  at void MvxTaskBasedBindingContext.SetBindings(List<KeyValuePair<object, IList<TargetAndBinding>>> viewBindings, List<TargetAndBinding> bindings)() in MvxTaskBasedBindingContext.cs:line 148
  at void MvxTaskBasedBindingContext.OnDataContextChange()+() => { }() in MvxTaskBasedBindingContext.cs:line 132
  at void Task.ExecuteWithThreadLocal(ref Task, Thread)()

System.AggregateException: TaskExceptionHolder_UnhandledException
```

There are races to fields in MvxFullBinding. Among these are

- `_targetBinding`
- `_sourceStep`
- `_cancelSource`

### :new: What is the new behavior (if this is a feature change)?
To prevent the races I've gone through when we use the `Lock` object to avoid multiple threads reading/writing at the same time.

Additionally, I've cleaned up the class as there were some interesting choices made as to how event handlers were constructed and assigned.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run Unit Tests + Playground projects

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
