### PR TITLE
Playground updates

### DIFF
--- a/Projects/Playground/Playground.Core/Playground.Core.csproj
+++ b/Projects/Playground/Playground.Core/Playground.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Projects/Playground/Playground.Droid/Activities/CollectionView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/CollectionView.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using Playground.Core.ViewModels;
@@ -6,11 +7,12 @@ namespace Playground.Droid.Activities
 {
     [MvxActivityPresentation]
     [Activity(Theme = "@style/AppTheme")]
-    public class CollectionView : MvxActivity<CollectionViewModel>
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+    public sealed class CollectionView : MvxActivity<CollectionViewModel>
     {
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
 
             SetContentView(Resource.Layout.CollectionView);
         }

--- a/Projects/Playground/Playground.Droid/Activities/ConvertersActivity.cs
+++ b/Projects/Playground/Playground.Droid/Activities/ConvertersActivity.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using Playground.Core.ViewModels.Samples;
@@ -6,6 +7,7 @@ namespace Playground.Droid.Activities;
 
 [MvxActivityPresentation]
 [Activity(Theme = "@style/AppTheme")]
+[RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
 public sealed class ConvertersActivity : MvxActivity<ConvertersViewModel>
 {
     protected override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Activities/CustomBindingView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/CustomBindingView.cs
@@ -1,5 +1,4 @@
-using Android.App;
-using Android.OS;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 
@@ -7,11 +6,12 @@ namespace Playground.Droid.Activities
 {
     [MvxActivityPresentation]
     [Activity(Label = "View for CustomBindingViewModel", Theme = "@style/AppTheme")]
-    public class CustomBindingView : MvxActivity
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+    public sealed class CustomBindingView : MvxActivity
     {
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
             SetContentView(Resource.Layout.CustomBindingView);
         }
     }

--- a/Projects/Playground/Playground.Droid/Activities/RootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/RootView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using AndroidX.Core.View;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -13,7 +14,8 @@ namespace Playground.Droid.Activities
     [MvxActivityPresentation]
     [Activity(Theme = "@style/AppTheme",
         WindowSoftInputMode = SoftInput.AdjustPan)]
-    public class RootView : MvxActivity<RootViewModel>, IOnApplyWindowInsetsListener
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+    public sealed class RootView : MvxActivity<RootViewModel>, IOnApplyWindowInsetsListener
     {
         protected override void OnCreate(Bundle savedInstanceState)
         {

--- a/Projects/Playground/Playground.Droid/Activities/SharedElementRootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/SharedElementRootView.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Android.App;
-using Android.OS;
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
-using Android.Widget;
 using MvvmCross.DroidX.RecyclerView;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
@@ -18,7 +15,8 @@ namespace Playground.Droid.Activities
 {
     [MvxActivityPresentation]
     [Activity(Theme = "@style/AppTheme")]
-    public class SharedElementRootView : MvxActivity<SharedElementRootViewModel>, IMvxAndroidSharedElements
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+    public sealed class SharedElementRootView : MvxActivity<SharedElementRootViewModel>, IMvxAndroidSharedElements
     {
         public int SelectedListItem { get; set; }
 
@@ -38,9 +36,9 @@ namespace Playground.Droid.Activities
             return sharedElements;
         }
 
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
 
             SetContentView(Resource.Layout.SharedElementRootView);
         }

--- a/Projects/Playground/Playground.Droid/Activities/SharedElementSecondView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/SharedElementSecondView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.App;
-using Android.OS;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using Playground.Core.ViewModels;
@@ -12,11 +11,12 @@ namespace Playground.Droid.Activities
 {
     [MvxActivityPresentation]
     [Activity(Theme = "@style/AppTheme")]
-    public class SharedElementSecondView : MvxActivity<SharedElementSecondViewModel>
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+    public sealed class SharedElementSecondView : MvxActivity<SharedElementSecondViewModel>
     {
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
 
             SetContentView(Resource.Layout.SharedElementSecondView);
 

--- a/Projects/Playground/Playground.Droid/Activities/SplitRootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/SplitRootView.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.App;
+using System.Diagnostics.CodeAnalysis;
 using Android.Content.PM;
 using AndroidX.Core.View;
 using AndroidX.DrawerLayout.Widget;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views;
 using Playground.Core.ViewModels;
+using Playground.Droid.Extensions;
 
 namespace Playground.Droid.Activities
 {
@@ -17,35 +18,34 @@ namespace Playground.Droid.Activities
         Theme = "@style/AppTheme",
         LaunchMode = LaunchMode.SingleTop,
         ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
     public class SplitRootView : MvxActivity<SplitRootViewModel>
     {
         public DrawerLayout DrawerLayout { get; set; }
 
-        public SplitRootView()
+        protected override void OnCreate(Android.OS.Bundle savedInstanceState)
         {
-        }
-
-        protected override void OnCreate(Android.OS.Bundle bundle)
-        {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
 
             SetContentView(Resource.Layout.SplitRootView);
 
             DrawerLayout = FindViewById<DrawerLayout>(Resource.Id.drawer_layout);
 
-            if (bundle == null)
+            if (savedInstanceState == null)
             {
                 ViewModel.ShowInitialMenuCommand.Execute();
                 ViewModel.ShowDetailCommand.Execute();
             }
+
+            OnBackPressedDispatcher.AddCallback(this, new BackPressedCallback(true, BackPressed));
         }
 
-        public override void OnBackPressed()
+        private void BackPressed()
         {
-            if (DrawerLayout != null && DrawerLayout.IsDrawerOpen(GravityCompat.Start))
+            if (DrawerLayout?.IsDrawerOpen(GravityCompat.Start) == true)
                 DrawerLayout.CloseDrawers();
             else
-                base.OnBackPressed();
+                Finish();
         }
     }
 }

--- a/Projects/Playground/Playground.Droid/Activities/SplitRootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/SplitRootView.cs
@@ -42,7 +42,7 @@ namespace Playground.Droid.Activities
 
         private void BackPressed()
         {
-            if (DrawerLayout?.IsDrawerOpen(GravityCompat.Start) == true)
+            if (DrawerLayout?.IsDrawerOpen(GravityCompat.Start) is true)
                 DrawerLayout.CloseDrawers();
             else
                 Finish();

--- a/Projects/Playground/Playground.Droid/Extensions/BackPressedCallback.cs
+++ b/Projects/Playground/Playground.Droid/Extensions/BackPressedCallback.cs
@@ -1,0 +1,13 @@
+using AndroidX.Activity;
+
+namespace Playground.Droid.Extensions;
+
+public sealed class BackPressedCallback(
+        bool enabled,
+        Action onBackPressedAction)
+    : OnBackPressedCallback(enabled)
+{
+    private readonly Action _onBackPressedAction = onBackPressedAction;
+
+    public override void HandleOnBackPressed() => _onBackPressedAction.Invoke();
+}

--- a/Projects/Playground/Playground.Droid/Fragments/BaseSplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BaseSplitDetailView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Android.Content.Res;
 using Android.OS;
@@ -16,6 +17,7 @@ using Toolbar = AndroidX.AppCompat.Widget.Toolbar;
 
 namespace Playground.Droid.Fragments
 {
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
     public abstract class BaseSplitDetailView<TViewModel> : MvxFragment<TViewModel> where TViewModel : class, IMvxViewModel
     {
         protected SplitRootView BaseActivity => (SplitRootView)Activity;

--- a/Projects/Playground/Playground.Droid/Fragments/BaseSplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/BaseSplitDetailView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Android.Content;
 using Android.Content.Res;
 using Android.OS;
 using Android.Views;
@@ -27,7 +28,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(FragmentLayoutId, null);
+            var view = this.BindingInflate(FragmentLayoutId, container, false);
 
             _toolbar = view.FindViewById<Toolbar>(Resource.Id.toolbar);
             if (_toolbar != null)
@@ -56,9 +57,9 @@ namespace Playground.Droid.Fragments
                 _drawerToggle.OnConfigurationChanged(newConfig);
         }
 
-        public override void OnActivityCreated(Bundle savedInstanceState)
+        public override void OnAttach(Context context)
         {
-            base.OnActivityCreated(savedInstanceState);
+            base.OnAttach(context);
             if (_toolbar != null)
                 _drawerToggle.SyncState();
         }

--- a/Projects/Playground/Playground.Droid/Fragments/ChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ChildView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -20,7 +19,7 @@ namespace Playground.Droid.Fragments
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
     [MvxFragmentPresentation(typeof(TabsRootViewModel), Resource.Id.content_frame)]
     [MvxFragmentPresentation(fragmentHostViewType: typeof(ModalNavView), fragmentContentId: Resource.Id.dialog_content_frame)]
-    [Register(nameof(ChildView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class ChildView : MvxFragment<ChildViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/ChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ChildView.cs
@@ -11,6 +11,7 @@ using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
 {
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true,
                              Resource.Animation.abc_fade_in,
                              Resource.Animation.abc_fade_out,
@@ -19,7 +20,6 @@ namespace Playground.Droid.Fragments
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
     [MvxFragmentPresentation(typeof(TabsRootViewModel), Resource.Id.content_frame)]
     [MvxFragmentPresentation(fragmentHostViewType: typeof(ModalNavView), fragmentContentId: Resource.Id.dialog_content_frame)]
-    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class ChildView : MvxFragment<ChildViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/ChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ChildView.cs
@@ -26,7 +26,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.ChildView, null);
+            var view = this.BindingInflate(Resource.Layout.ChildView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/ChildWithResultFragment.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ChildWithResultFragment.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using AndroidX.Activity;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -5,6 +6,7 @@ using MvvmCross.Platforms.Android.Presenters.Attributes;
 using MvvmCross.Platforms.Android.Views.Fragments;
 using Playground.Core.ViewModels;
 using Playground.Core.ViewModels.Navigation;
+using Playground.Droid.Extensions;
 
 namespace Playground.Droid.Fragments;
 
@@ -13,6 +15,7 @@ namespace Playground.Droid.Fragments;
     Resource.Animation.abc_fade_out,
     Resource.Animation.abc_fade_in,
     Resource.Animation.abc_fade_out)]
+[RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
 public sealed class ChildWithResultFragment : MvxFragment<ChildWithResultViewModel>
 {
     public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
@@ -32,12 +35,4 @@ public sealed class ChildWithResultFragment : MvxFragment<ChildWithResultViewMod
             .AddCallback(this, new BackPressedCallback(true,
                 () => ViewModel!.CloseCommand.Execute(null)));
     }
-}
-
-public sealed class BackPressedCallback(
-        bool enabled,
-        Action onBackPressedAction)
-    : OnBackPressedCallback(enabled)
-{
-    public override void HandleOnBackPressed() => onBackPressedAction.Invoke();
 }

--- a/Projects/Playground/Playground.Droid/Fragments/DictionaryBindingView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/DictionaryBindingView.cs
@@ -26,7 +26,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.dictionary_view, null);
+            var view = this.BindingInflate(Resource.Layout.dictionary_view, container, false);
             var background = view.FindViewById<LinearLayout>(Resource.Id.container);
             var descriptionLabel = view.FindViewById<TextView>(Resource.Id.txt_description);
 

--- a/Projects/Playground/Playground.Droid/Fragments/DictionaryBindingView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/DictionaryBindingView.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Android.Graphics;
 using Android.Graphics.Drawables;
-using Android.Runtime;
 using Android.Views;
 using MvvmCross.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -20,7 +19,6 @@ namespace Playground.Droid.Fragments
                          Resource.Animation.abc_fade_out,
                          Resource.Animation.abc_fade_in,
                          Resource.Animation.abc_fade_out)]
-    [Register(nameof(DictionaryBindingView))]
     [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class DictionaryBindingView : MvxFragment<DictionaryBindingViewModel>
     {

--- a/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -9,7 +10,8 @@ namespace Playground.Droid.Fragments
 {
     //[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true)]
     [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true, popBackStackImmediateName: null, popBackStackImmediateFlag: MvxPopBackStack.None)]
-    class FragmentCloseView : MvxFragment<FragmentCloseViewModel>
+    [RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+    internal sealed class FragmentCloseView : MvxFragment<FragmentCloseViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {

--- a/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
@@ -15,7 +15,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            return this.BindingInflate(Resource.Layout.FragmnetCloseView, null);
+            return this.BindingInflate(Resource.Layout.FragmnetCloseView, container, false);
         }
     }
 }

--- a/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/FragmentCloseView.cs
@@ -1,5 +1,3 @@
-using Android.OS;
-using Android.Runtime;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -9,7 +7,6 @@ using Playground.Core.ViewModels.Navigation;
 
 namespace Playground.Droid.Fragments
 {
-    [Register(nameof(FragmentCloseView))]
     //[MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true)]
     [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true, popBackStackImmediateName: null, popBackStackImmediateFlag: MvxPopBackStack.None)]
     class FragmentCloseView : MvxFragment<FragmentCloseViewModel>

--- a/Projects/Playground/Playground.Droid/Fragments/ModalNavView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ModalNavView.cs
@@ -29,7 +29,7 @@ namespace Playground.Droid.Fragments
         {
             var ignore = base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.ModalNavView, null);
+            var view = this.BindingInflate(Resource.Layout.ModalNavView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/ModalNavView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ModalNavView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.OS;
+using System.Diagnostics.CodeAnalysis;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -14,8 +13,8 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxDialogFragmentPresentation]
-    [Register(nameof(ModalNavView))]
-    public class ModalNavView : MvxDialogFragment<ModalNavViewModel>
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
+    public sealed class ModalNavView : MvxDialogFragment<ModalNavViewModel>
     {
         public ModalNavView()
         {

--- a/Projects/Playground/Playground.Droid/Fragments/ModalView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ModalView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.OS;
+using System.Diagnostics.CodeAnalysis;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross;
@@ -16,7 +15,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxDialogFragmentPresentation]
-    [Register(nameof(ModalView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class ModalView : MvxDialogFragment<ModalViewModel>
     {
         public ModalView()

--- a/Projects/Playground/Playground.Droid/Fragments/ModalView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/ModalView.cs
@@ -31,7 +31,7 @@ namespace Playground.Droid.Fragments
         {
             var ignore = base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.ChildView, null);
+            var view = this.BindingInflate(Resource.Layout.ChildView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/MultiBackStackView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/MultiBackStackView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using Google.Android.Material.Navigation;
 using MvvmCross;
@@ -22,7 +23,8 @@ namespace Playground.Droid.Fragments;
     AllowReordering = true,
     ViewModelType = typeof(MultiBackStackViewModel),
     SetAsPrimaryFragment = true)]
-public class MultiBackStackView : MvxFragment<MultiBackStackViewModel>
+[RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+public sealed class MultiBackStackView : MvxFragment<MultiBackStackViewModel>
 {
     private NavigationBarView _navigationView;
     private bool _navigatedToTab2;
@@ -77,7 +79,8 @@ public class MultiBackStackView : MvxFragment<MultiBackStackViewModel>
     FragmentHostViewType = typeof(MultiBackStackView),
     AllowReordering = true,
     ViewModelType = typeof(MultiBackStackTab1ViewModel))]
-public class MultiBackStackTab1View : MvxFragment<MultiBackStackTab1ViewModel>
+[RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+public sealed class MultiBackStackTab1View : MvxFragment<MultiBackStackTab1ViewModel>
 {
     public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {
@@ -94,7 +97,8 @@ public class MultiBackStackTab1View : MvxFragment<MultiBackStackTab1ViewModel>
     FragmentHostViewType = typeof(MultiBackStackView),
     AllowReordering = true,
     ViewModelType = typeof(MultiBackStackTab2ViewModel))]
-public class MultiBackStackTab2View : MvxFragment<MultiBackStackTab2ViewModel>
+[RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+public sealed class MultiBackStackTab2View : MvxFragment<MultiBackStackTab2ViewModel>
 {
     public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {
@@ -106,7 +110,8 @@ public class MultiBackStackTab2View : MvxFragment<MultiBackStackTab2ViewModel>
     }
 }
 
-public class MultiBackStackInnerView : MvxFragment<MultiBackStackInnerViewModel>, IMvxOverridePresentationAttribute
+[RequiresUnreferencedCode("Uses MvxBindings which require unreferenced code")]
+public sealed class MultiBackStackInnerView : MvxFragment<MultiBackStackInnerViewModel>, IMvxOverridePresentationAttribute
 {
     public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {

--- a/Projects/Playground/Playground.Droid/Fragments/NestedChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/NestedChildView.cs
@@ -19,7 +19,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.NestedChildView, null);
+            var view = this.BindingInflate(Resource.Layout.NestedChildView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/NestedChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/NestedChildView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -13,7 +12,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(fragmentHostViewType: typeof(SecondChildView), fragmentContentId: Resource.Id.nested_frame)]
-    [Register(nameof(NestedChildView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class NestedChildView : MvxFragment<NestedChildViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/NestedModalView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/NestedModalView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Android.OS;
+using System.Diagnostics.CodeAnalysis;
 using Android.Runtime;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -14,7 +13,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxDialogFragmentPresentation]
-    [Register(nameof(NestedModalView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class NestedModalView : MvxDialogFragment<NestedModalViewModel>
     {
         public NestedModalView()

--- a/Projects/Playground/Playground.Droid/Fragments/NestedModalView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/NestedModalView.cs
@@ -29,7 +29,7 @@ namespace Playground.Droid.Fragments
         {
             var ignore = base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.ChildView, null);
+            var view = this.BindingInflate(Resource.Layout.ChildView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/OverrideAttributeView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/OverrideAttributeView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -17,7 +16,7 @@ namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame)]
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
-    [Register(nameof(OverrideAttributeView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class OverrideAttributeView : MvxFragment<OverrideAttributeViewModel>, IMvxOverridePresentationAttribute
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/OverrideAttributeView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/OverrideAttributeView.cs
@@ -23,7 +23,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.ChildView, null);
+            var view = this.BindingInflate(Resource.Layout.ChildView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/SecondChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SecondChildView.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -14,7 +13,7 @@ namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(RootViewModel), Resource.Id.content_frame, true)]
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
-    [Register(nameof(SecondChildView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class SecondChildView : MvxFragment<SecondChildViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/SecondChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SecondChildView.cs
@@ -20,7 +20,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.SecondChildView, null);
+            var view = this.BindingInflate(Resource.Layout.SecondChildView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/SharedElementRootChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SharedElementRootChildView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.OS;
 using Android.Views;
 using Android.Widget;
@@ -17,6 +18,7 @@ using Playground.Droid.Adapter;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SharedElementRootViewModel), Resource.Id.shared_content_frame)]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class SharedElementRootChildView : MvxFragment<SharedElementRootChildViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/SharedElementSecondChildView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SharedElementSecondChildView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.OS;
 using Android.Transitions;
 using Android.Views;
@@ -14,6 +15,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SharedElementRootViewModel), Resource.Id.shared_content_frame, true)]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class SharedElementSecondChildView : MvxFragment<SharedElementSecondChildViewModel>
     {
         public override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/SheetView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SheetView.cs
@@ -15,7 +15,6 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxDialogFragmentPresentation]
-    [Register(nameof(SheetView))]
     [RequiresUnreferencedCode("MvxBindings require unreferenced code")]
     public class SheetView : MvxBottomSheetDialogFragment<SheetViewModel>
     {

--- a/Projects/Playground/Playground.Droid/Fragments/SheetView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SheetView.cs
@@ -31,7 +31,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.SheetView, null);
+            var view = this.BindingInflate(Resource.Layout.SheetView, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/SplitDetailNavView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SplitDetailNavView.cs
@@ -9,7 +9,6 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame, AddToBackStack = true)]
-    [Register(nameof(SplitDetailNavView))]
     public class SplitDetailNavView : BaseSplitDetailView<SplitDetailNavViewModel>
     {
         protected override int FragmentLayoutId => Resource.Layout.SplitDetailNavView;

--- a/Projects/Playground/Playground.Droid/Fragments/SplitDetailNavView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SplitDetailNavView.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.Runtime;
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame, AddToBackStack = true)]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class SplitDetailNavView : BaseSplitDetailView<SplitDetailNavViewModel>
     {
         protected override int FragmentLayoutId => Resource.Layout.SplitDetailNavView;

--- a/Projects/Playground/Playground.Droid/Fragments/SplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SplitDetailView.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
 
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class SplitDetailView : BaseSplitDetailView<SplitDetailViewModel>
     {
         protected override int FragmentLayoutId => Resource.Layout.SplitDetailView;

--- a/Projects/Playground/Playground.Droid/Fragments/SplitDetailView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SplitDetailView.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.Runtime;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Playground.Core.ViewModels;
-using Playground.Droid.Activities;
 
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_content_frame)]
-    [Register(nameof(SplitDetailView))]
     public class SplitDetailView : BaseSplitDetailView<SplitDetailViewModel>
     {
         protected override int FragmentLayoutId => Resource.Layout.SplitDetailView;

--- a/Projects/Playground/Playground.Droid/Fragments/SplitMasterView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SplitMasterView.cs
@@ -21,19 +21,19 @@ namespace Playground.Droid.Fragments
         {
             var ignore = base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.SplitMasterView, null);
+            var view = this.BindingInflate(Resource.Layout.SplitMasterView, container, false);
 
             return view;
         }
 
-        public bool OnNavigationItemSelected(IMenuItem item)
+        public bool OnNavigationItemSelected(IMenuItem menuItem)
         {
-            item.SetCheckable(true);
-            item.SetChecked(true);
+            menuItem.SetCheckable(true);
+            menuItem.SetChecked(true);
             previousMenuItem?.SetChecked(false);
-            previousMenuItem = item;
+            previousMenuItem = menuItem;
 
-            Navigate(item.ItemId);
+            Navigate(menuItem.ItemId);
 
             return true;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/SplitMasterView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SplitMasterView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using Google.Android.Material.Navigation;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -13,6 +14,7 @@ using Playground.Droid.Activities;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_navigation_frame)]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class SplitMasterView : MvxFragment<SplitMasterViewModel>, NavigationView.IOnNavigationItemSelectedListener
     {
         private IMenuItem previousMenuItem;

--- a/Projects/Playground/Playground.Droid/Fragments/SplitMasterView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/SplitMasterView.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading.Tasks;
-using Android.OS;
-using Android.Runtime;
 using Android.Views;
 using Google.Android.Material.Navigation;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -17,7 +13,6 @@ using Playground.Droid.Activities;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(typeof(SplitRootViewModel), Resource.Id.split_navigation_frame)]
-    [Register(nameof(SplitMasterView))]
     public class SplitMasterView : MvxFragment<SplitMasterViewModel>, NavigationView.IOnNavigationItemSelectedListener
     {
         private IMenuItem previousMenuItem;

--- a/Projects/Playground/Playground.Droid/Fragments/Tab1View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab1View.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -12,6 +13,7 @@ namespace Playground.Droid.Fragments
 {
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 1", ActivityHostViewModelType = typeof(TabsRootViewModel))]
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 1", FragmentHostViewType = typeof(TabsRootBView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class Tab1View : MvxFragment<Tab1ViewModel>
     {
         public override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/Tab1View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab1View.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -14,7 +12,6 @@ namespace Playground.Droid.Fragments
 {
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 1", ActivityHostViewModelType = typeof(TabsRootViewModel))]
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 1", FragmentHostViewType = typeof(TabsRootBView))]
-    [Register(nameof(Tab1View))]
     public class Tab1View : MvxFragment<Tab1ViewModel>
     {
         public override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/Tab1View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab1View.cs
@@ -25,7 +25,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.Tab1View, null);
+            var view = this.BindingInflate(Resource.Layout.Tab1View, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/Tab2View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab2View.cs
@@ -25,7 +25,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.Tab2View, null);
+            var view = this.BindingInflate(Resource.Layout.Tab2View, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/Tab2View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab2View.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -14,7 +12,6 @@ namespace Playground.Droid.Fragments
 {
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 2", ActivityHostViewModelType = typeof(TabsRootViewModel))]
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 2", FragmentHostViewType = typeof(TabsRootBView))]
-    [Register(nameof(Tab2View))]
     public class Tab2View : MvxFragment<Tab2ViewModel>
     {
         public override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/Tab2View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab2View.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -12,6 +13,7 @@ namespace Playground.Droid.Fragments
 {
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 2", ActivityHostViewModelType = typeof(TabsRootViewModel))]
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 2", FragmentHostViewType = typeof(TabsRootBView))]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class Tab2View : MvxFragment<Tab2ViewModel>
     {
         public override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/Tab3View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab3View.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -11,6 +12,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 3")]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class Tab3View : MvxFragment<Tab3ViewModel>
     {
         public override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/Tab3View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab3View.cs
@@ -24,7 +24,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.Tab3View, null);
+            var view = this.BindingInflate(Resource.Layout.Tab3View, container, false);
 
             return view;
         }

--- a/Projects/Playground/Playground.Droid/Fragments/Tab3View.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/Tab3View.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
 using Android.Views;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -13,7 +11,6 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxTabLayoutPresentation(TabLayoutResourceId = Resource.Id.tabs, ViewPagerResourceId = Resource.Id.viewpager, Title = "Tab 3")]
-    [Register(nameof(Tab3View))]
     public class Tab3View : MvxFragment<Tab3ViewModel>
     {
         public override void OnCreate(Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/TabsRootBView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/TabsRootBView.cs
@@ -19,7 +19,7 @@ namespace Playground.Droid.Fragments
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            var view = this.BindingInflate(Resource.Layout.TabsRootBView, null);
+            var view = this.BindingInflate(Resource.Layout.TabsRootBView, container, false);
 
             return view;
         }
@@ -30,7 +30,7 @@ namespace Playground.Droid.Fragments
 
             var viewPager = view.FindViewById<ViewPager>(Resource.Id.viewpager);
             if (viewPager.Adapter is not MvxCachingFragmentStatePagerAdapter)
-                viewPager.Adapter = new MvxCachingFragmentStatePagerAdapter(ChildFragmentManager, new());
+                viewPager.Adapter = new MvxCachingFragmentStatePagerAdapter(ChildFragmentManager, []);
 
             if (savedInstanceState == null)
             {

--- a/Projects/Playground/Playground.Droid/Fragments/TabsRootBView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/TabsRootBView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using AndroidX.ViewPager.Widget;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -13,6 +14,7 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(fragmentHostViewType: typeof(SplitDetailView), fragmentContentId: Resource.Id.tabs_frame, addToBackStack: true)]
+    [RequiresUnreferencedCode("MvxBindings requires unreferenced code")]
     public class TabsRootBView : MvxFragment<TabsRootBViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Fragments/TabsRootBView.cs
+++ b/Projects/Playground/Playground.Droid/Fragments/TabsRootBView.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using Android.OS;
-using Android.Runtime;
 using Android.Views;
 using AndroidX.ViewPager.Widget;
 using MvvmCross.Platforms.Android.Binding.BindingContext;
@@ -15,7 +13,6 @@ using Playground.Core.ViewModels;
 namespace Playground.Droid.Fragments
 {
     [MvxFragmentPresentation(fragmentHostViewType: typeof(SplitDetailView), fragmentContentId: Resource.Id.tabs_frame, addToBackStack: true)]
-    [Register(nameof(TabsRootBView))]
     public class TabsRootBView : MvxFragment<TabsRootBViewModel>
     {
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/Projects/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/Projects/Playground/Playground.Droid/Playground.Droid.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-android</TargetFramework>
+    <TargetFramework>net10.0-android</TargetFramework>
     <AssemblyName>Playground.Droid</AssemblyName>
     <RootNamespace>Playground.Droid</RootNamespace>
     <OutputType>Exe</OutputType>

--- a/Projects/Playground/Playground.Mac/Playground.Mac.csproj
+++ b/Projects/Playground/Playground.Mac/Playground.Mac.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-macos</TargetFramework>
+    <TargetFramework>net10.0-macos</TargetFramework>
     <AssemblyName>Playground.Mac</AssemblyName>
     <RootNamespace>Playground.Mac</RootNamespace>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>

--- a/Projects/Playground/Playground.WinUi3/Playground.WinUi3.csproj
+++ b/Projects/Playground/Playground.WinUi3/Playground.WinUi3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Playground.WinUi3</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Projects/Playground/Playground.WpfCore/Playground.WpfCore.csproj
+++ b/Projects/Playground/Playground.WpfCore/Playground.WpfCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/Projects/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/Projects/Playground/Playground.iOS/Playground.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <AssemblyName>Playground.iOS</AssemblyName>
     <RootNamespace>Playground.iOS</RootNamespace>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Playground is targeting .NET 9 and has some wrong usages if View inflations on Android

### :new: What is the new behavior (if this is a feature change)?
Bumps TFM for playground projects to .NET 10
Fixes using `null` instead of passing container View to Android/Binding Inflaters
Annotated Activities and Fragments with trimming attributes
Removed not needed Register attributes

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Build and run playground projects

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
