### PR TITLE
Fix MvxViewExtensions using compile-time type instead of runtime type

### DIFF
--- a/MvvmCross/Platforms/Android/Views/MvxFragmentExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxFragmentExtensions.cs
@@ -16,8 +16,6 @@ namespace MvvmCross.Platforms.Android.Views
 {
     public static class MvxFragmentExtensions
     {
-        [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Fragment types are preserved by the Android presenter infrastructure and their associated attributes.")]
-        [UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "ViewModel types from FindAssociatedViewModelTypeOrNull and presentation attributes are preserved by the navigation infrastructure.")]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public static Type FindAssociatedViewModelType(this IMvxFragmentView fragmentView, Type fragmentActivityParentType)
         {
@@ -50,7 +48,8 @@ namespace MvvmCross.Platforms.Android.Views
             if (viewModelType == null
                 || viewModelType == typeof(IMvxViewModel))
             {
-                MvxLogHost.Default?.Log(LogLevel.Trace, "No ViewModel class specified for {fragmentViewType} in LoadViewModel",
+                MvxLogHost.Default?.Log(LogLevel.Trace,
+                    "No ViewModel class specified for {FragmentViewType} in LoadViewModel",
                     fragmentView.GetType().Name);
             }
 

--- a/MvvmCross/Presenters/Attributes/IMvxPresentationAttribute.cs
+++ b/MvvmCross/Presenters/Attributes/IMvxPresentationAttribute.cs
@@ -1,23 +1,23 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using System;
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Presenters.Attributes
 {
-#nullable enable
     public interface IMvxPresentationAttribute
     {
         /// <summary>
         /// That shall be used only if you are using non generic views.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type? ViewModelType { get; set; }
 
         /// <summary>
         /// Type of the view
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         Type? ViewType { get; set; }
     }
-#nullable restore
 }

--- a/MvvmCross/Presenters/Attributes/MvxBasePresentationAttribute.cs
+++ b/MvvmCross/Presenters/Attributes/MvxBasePresentationAttribute.cs
@@ -1,20 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
+#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.Presenters.Attributes
 {
-#nullable enable
     [AttributeUsage(AttributeTargets.Class)]
     public abstract class MvxBasePresentationAttribute : Attribute, IMvxPresentationAttribute
     {
         /// <inheritdoc />
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? ViewModelType { get; set; }
 
         /// <inheritdoc />
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? ViewType { get; set; }
     }
-#nullable restore
 }

--- a/MvvmCross/Views/MvxViewExtensions.cs
+++ b/MvvmCross/Views/MvxViewExtensions.cs
@@ -37,14 +37,16 @@ public static class MvxViewExtensions
         // nothing needed currently
     }
 
-    public static Type? FindAssociatedViewModelTypeOrNull<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TViewType>(
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "The generic constraint ensures TViewType has the required members")]
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
+    public static Type? FindAssociatedViewModelTypeOrNull<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TViewType>(
         this TViewType view)
-            where TViewType : IMvxView
     {
         ArgumentNullException.ThrowIfNull(view);
 
         if (Mvx.IoCProvider?.TryResolve(out IMvxViewModelTypeFinder? associatedTypeFinder) == true)
-            return associatedTypeFinder?.FindTypeOrNull(typeof(TViewType));
+            return associatedTypeFinder?.FindTypeOrNull(view.GetType());
 
         MvxLogHost.Default?.Log(LogLevel.Trace,
             "No view model type finder available - assuming we are looking for a splash screen - returning null");

--- a/MvvmCross/Views/MvxViewExtensions.cs
+++ b/MvvmCross/Views/MvxViewExtensions.cs
@@ -39,9 +39,9 @@ public static class MvxViewExtensions
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "The generic constraint ensures TViewType has the required members")]
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
-    public static Type? FindAssociatedViewModelTypeOrNull<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TViewType>(
-        this TViewType view)
+    public static Type? FindAssociatedViewModelTypeOrNull<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TViewType>(
+            this TViewType view)
+        where TViewType : IMvxView
     {
         ArgumentNullException.ThrowIfNull(view);
 

--- a/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelViewTypeFinderTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Platform/MvxViewModelViewTypeFinderTest.cs
@@ -6,6 +6,7 @@ using MvvmCross.Tests;
 using MvvmCross.UnitTest.Mocks.TestViewModels;
 using MvvmCross.UnitTest.Mocks.TestViews;
 using MvvmCross.ViewModels;
+using MvvmCross.Views;
 using Xunit;
 
 namespace MvvmCross.UnitTest.Platform
@@ -46,6 +47,83 @@ namespace MvvmCross.UnitTest.Platform
             Assert.Null(result);
             result = test.FindTypeOrNull(typeof(NotReallyAView));
             Assert.Null(result);
+        }
+
+        [Fact]
+        public void Test_FindTypeOrNull_WithRuntimeType_FindsConcreteViewType()
+        {
+            _fixture.ClearAll();
+
+            var assembly = GetType().Assembly;
+            var viewModelNameLookup = new MvxViewModelByNameLookup();
+            viewModelNameLookup.AddAll(assembly);
+            var nameMapping = new MvxPostfixAwareViewToViewModelNameMapping("View", "Oddness");
+            var test = new MvxViewModelViewTypeFinder(viewModelNameLookup, nameMapping);
+
+            // Simulate the scenario where a view is accessed through a base interface
+            // but we need to find the ViewModel based on the concrete type
+            IMvxView view1 = new Test1View();
+            var result = test.FindTypeOrNull(view1.GetType());
+            Assert.Equal(typeof(Test1ViewModel), result);
+
+            IMvxView view2 = new NotTest2View();
+            result = test.FindTypeOrNull(view2.GetType());
+            Assert.Equal(typeof(Test2ViewModel), result);
+
+            IMvxView view3 = new NotTest3View();
+            result = test.FindTypeOrNull(view3.GetType());
+            Assert.Equal(typeof(Test3ViewModel), result);
+
+            IMvxView view4 = new OddNameOddness();
+            result = test.FindTypeOrNull(view4.GetType());
+            Assert.Equal(typeof(OddNameViewModel), result);
+        }
+
+        [Fact]
+        public void Test_FindTypeOrNull_WithInterfaceType_FailsToFindViewModel()
+        {
+            _fixture.ClearAll();
+
+            var assembly = GetType().Assembly;
+            var viewModelNameLookup = new MvxViewModelByNameLookup();
+            viewModelNameLookup.AddAll(assembly);
+            var nameMapping = new MvxPostfixAwareViewToViewModelNameMapping("View", "Oddness");
+            var test = new MvxViewModelViewTypeFinder(viewModelNameLookup, nameMapping);
+
+            // This test demonstrates the bug: if we pass the interface type instead of
+            // the concrete type, we cannot find the associated ViewModel
+            var result = test.FindTypeOrNull(typeof(IMvxView));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Test_FindAssociatedViewModelTypeOrNull_UsesConcreteType()
+        {
+            _fixture.ClearAll();
+            _fixture.Ioc.RegisterSingleton<IMvxViewModelTypeFinder>(CreateViewModelTypeFinder());
+
+            // Test that the extension method correctly uses the concrete type,
+            // not the compile-time generic type
+            IMvxView view1 = new Test1View();
+            var result = view1.FindAssociatedViewModelTypeOrNull();
+            Assert.Equal(typeof(Test1ViewModel), result);
+
+            IMvxView view2 = new NotTest2View();
+            result = view2.FindAssociatedViewModelTypeOrNull();
+            Assert.Equal(typeof(Test2ViewModel), result);
+
+            IMvxView view3 = new NotTest3View();
+            result = view3.FindAssociatedViewModelTypeOrNull();
+            Assert.Equal(typeof(Test3ViewModel), result);
+        }
+
+        private IMvxViewModelTypeFinder CreateViewModelTypeFinder()
+        {
+            var assembly = GetType().Assembly;
+            var viewModelNameLookup = new MvxViewModelByNameLookup();
+            viewModelNameLookup.AddAll(assembly);
+            var nameMapping = new MvxPostfixAwareViewToViewModelNameMapping("View", "Oddness");
+            return new MvxViewModelViewTypeFinder(viewModelNameLookup, nameMapping);
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
When I applied trimming attributes I assume one of my attempts to fix some of the warnings produced I changed `view.GetType()` to `typeof(TViewType)`, which broke looking up which ViewModel belongs to the View.

### :new: What is the new behavior (if this is a feature change)?
Changing back to using `view.GetType()`
Also removed some unconditional supress attributes by adding `DynamicallyAccessedMembers` attributes on `ViewModelType` and `ViewType` on `IMvxPresentationAttribute`

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4957

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
