### PR TITLE
Fix MvxAndroidViewsContainer GetIntentWithKeyFor not using runtime-type to resolve default VM request

### DIFF
--- a/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
+++ b/MvvmCross/Platforms/Android/Presenters/MvxAndroidViewPresenter.cs
@@ -199,8 +199,9 @@ namespace MvvmCross.Platforms.Android.Presenters
             return attribute;
         }
 
-        [UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "ViewModel types passed to presentation attributes are preserved by the navigation infrastructure.")]
-        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type? viewModelType, Type? viewType)
+        public override MvxBasePresentationAttribute CreatePresentationAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewType)
         {
             if (viewType == null)
                 throw new ArgumentNullException(nameof(viewType));

--- a/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
+++ b/MvvmCross/Platforms/Android/Views/IMvxAndroidViewModelRequestTranslator.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
+#nullable enable
 using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using MvvmCross.ViewModels;

--- a/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxAndroidViewsContainer.cs
@@ -172,10 +172,13 @@ public class MvxAndroidViewsContainer
         //                intent.AddFlags(ActivityFlags.ClearTop);
     }
 
-    public virtual (Intent intent, int key) GetIntentWithKeyFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(TViewModel existingViewModelToUse, MvxViewModelRequest? request)
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "The generic constraint ensures TViewModel has the required members")]
+    public virtual (Intent intent, int key) GetIntentWithKeyFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TViewModel>(
+            TViewModel existingViewModelToUse,
+            MvxViewModelRequest? request)
         where TViewModel : IMvxViewModel
     {
-        request ??= MvxViewModelRequest.GetDefaultRequest(typeof(TViewModel));
+        request ??= MvxViewModelRequest.GetDefaultRequest(existingViewModelToUse.GetType());
         var intent = GetIntentFor(request);
 
         if (Mvx.IoCProvider?.TryResolve(out IMvxChildViewModelCache? viewModelCache) != true || viewModelCache == null)

--- a/MvvmCross/Platforms/Android/Views/MvxChildViewModelOwnerExtensions.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxChildViewModelOwnerExtensions.cs
@@ -19,9 +19,9 @@ namespace MvvmCross.Platforms.Android.Views
         }
 
         public static Intent CreateIntentFor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTargetViewModel>(
-        this IMvxAndroidView view,
-        IDictionary<string, string> parameterValues = null)
-        where TTargetViewModel : class, IMvxViewModel
+                this IMvxAndroidView view,
+                IDictionary<string, string> parameterValues = null)
+            where TTargetViewModel : class, IMvxViewModel
         {
             var parameterBundle = new MvxBundle(parameterValues);
             var request = new MvxViewModelRequest<TTargetViewModel>(parameterBundle, null);

--- a/MvvmCross/Platforms/Android/Views/MvxTabsFragmentActivity.cs
+++ b/MvvmCross/Platforms/Android/Views/MvxTabsFragmentActivity.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
@@ -18,6 +19,7 @@ using Object = Java.Lang.Object;
 namespace MvvmCross.Platforms.Android.Views
 {
     [Register("mvvmcross.platforms.android.views.MvxTabsFragmentActivity")]
+    [RequiresUnreferencedCode("MvxBindings require unreferenced code")]
     public abstract class MvxTabsFragmentActivity
         : MvxActivity, TabHost.IOnTabChangeListener
     {

--- a/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
+++ b/MvvmCross/Platforms/Ios/Presenters/MvxIosViewPresenter.cs
@@ -39,7 +39,9 @@ public class MvxIosViewPresenter : MvxAttributeViewPresenter, IMvxIosViewPresent
         Window = window;
     }
 
-    public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
+    public override MvxBasePresentationAttribute CreatePresentationAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewType)
     {
         ValidateArguments(viewModelType, viewType);
 
@@ -48,7 +50,7 @@ public class MvxIosViewPresenter : MvxAttributeViewPresenter, IMvxIosViewPresent
         {
             MvxLogHost.GetLog<MvxIosViewPresenter>()?.LogTrace(
                 "PresentationAttribute nor MasterNavigationController found for {ViewTypeName}. Assuming Root presentation",
-                viewType.Name);
+                viewType?.Name);
             return new MvxRootPresentationAttribute
             {
                 WrapInNavigationController = true,
@@ -58,13 +60,13 @@ public class MvxIosViewPresenter : MvxAttributeViewPresenter, IMvxIosViewPresent
         }
 
         MvxLogHost.GetLog<MvxIosViewPresenter>()?.LogTrace(
-            "PresentationAttribute not found for {ViewTypeName}. Assuming animated Child presentation", viewType.Name);
+            "PresentationAttribute not found for {ViewTypeName}. Assuming animated Child presentation", viewType?.Name);
 
         return new MvxChildPresentationAttribute { ViewType = viewType, ViewModelType = viewModelType };
     }
 
     public override object? CreateOverridePresentationAttributeViewInstance(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type viewType)
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewType)
     {
         ArgumentNullException.ThrowIfNull(viewType);
 
@@ -881,7 +883,7 @@ public class MvxIosViewPresenter : MvxAttributeViewPresenter, IMvxIosViewPresent
         PopoverViewController = null;
     }
 
-    private static void ValidateArguments(Type viewModelType, Type viewType)
+    private static void ValidateArguments(Type? viewModelType, Type? viewType)
     {
         ArgumentNullException.ThrowIfNull(viewModelType);
         ArgumentNullException.ThrowIfNull(viewType);

--- a/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
+++ b/MvvmCross/Platforms/Mac/Presenters/MvxMacViewPresenter.cs
@@ -34,13 +34,17 @@ namespace MvvmCross.Platforms.Mac.Presenters
         /// </summary>
         protected readonly ConditionalWeakTable<NSWindow, NSWindowController> _windowsToWindowControllers = new();
 
-        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
+        public override MvxBasePresentationAttribute CreatePresentationAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewType)
         {
             MvxLogHost.Default?.Log(LogLevel.Trace, "PresentationAttribute not found for {ViewTypeName}. Assuming new window presentation", viewType.Name);
             return new MvxWindowPresentationAttribute { ViewModelType = viewModelType, ViewType = viewType };
         }
 
-        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(MvxViewModelRequest request, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
+        public override MvxBasePresentationAttribute GetOverridePresentationAttribute(
+            MvxViewModelRequest request,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
         {
             if (viewType?.GetInterface(nameof(IMvxOverridePresentationAttribute)) != null)
             {

--- a/MvvmCross/Platforms/Tvos/Presenters/MvxTvosViewPresenter.cs
+++ b/MvvmCross/Platforms/Tvos/Presenters/MvxTvosViewPresenter.cs
@@ -43,7 +43,9 @@ namespace MvvmCross.Platforms.Tvos.Presenters
             _logger = MvxLogHost.GetLog<MvxTvosViewPresenter>();
         }
 
-        public override MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType)
+        public override MvxBasePresentationAttribute CreatePresentationAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewType)
         {
             if (MasterNavigationController == null &&
                (TabBarViewController == null || !TabBarViewController.CanShowChildView()))
@@ -71,7 +73,7 @@ namespace MvvmCross.Platforms.Tvos.Presenters
 
         public override MvxBasePresentationAttribute GetOverridePresentationAttribute(
             MvxViewModelRequest request,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
         {
             if (viewType?.GetInterface(nameof(IMvxOverridePresentationAttribute)) != null)
             {

--- a/MvvmCross/Presenters/IMvxAttributeViewPresenter.cs
+++ b/MvvmCross/Presenters/IMvxAttributeViewPresenter.cs
@@ -1,9 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using MvvmCross.Presenters.Attributes;
 using MvvmCross.ViewModels;
@@ -11,7 +10,6 @@ using MvvmCross.Views;
 
 namespace MvvmCross.Presenters
 {
-#nullable enable
     public interface IMvxAttributeViewPresenter : IMvxViewPresenter
     {
         IMvxViewModelTypeFinder? ViewModelTypeFinder { get; }
@@ -21,10 +19,13 @@ namespace MvvmCross.Presenters
 
         //TODO: Maybe move those to helper class
         MvxBasePresentationAttribute GetPresentationAttribute(MvxViewModelRequest request);
-        MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType);
+
+        MvxBasePresentationAttribute CreatePresentationAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewType);
+
         MvxBasePresentationAttribute? GetOverridePresentationAttribute(
             MvxViewModelRequest request,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType);
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType);
     }
-#nullable restore
 }

--- a/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
+++ b/MvvmCross/Presenters/MvxAttributeViewPresenter.cs
@@ -42,10 +42,12 @@ public abstract class MvxAttributeViewPresenter : MvxViewPresenter, IMvxAttribut
 
     public abstract void RegisterAttributeTypes();
 
-    public abstract MvxBasePresentationAttribute CreatePresentationAttribute(Type viewModelType, Type viewType);
+    public abstract MvxBasePresentationAttribute CreatePresentationAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewModelType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? viewType);
 
     public virtual object? CreateOverridePresentationAttributeViewInstance(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type viewType)
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type viewType)
     {
         if (viewType == null)
             throw new ArgumentNullException(nameof(viewType));
@@ -55,7 +57,7 @@ public abstract class MvxAttributeViewPresenter : MvxViewPresenter, IMvxAttribut
 
     public virtual MvxBasePresentationAttribute? GetOverridePresentationAttribute(
         MvxViewModelRequest request,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
     {
         if (request == null)
             throw new ArgumentNullException(nameof(request));

--- a/MvvmCross/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxViewModel.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MvvmCross.ViewModels
 {
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public interface IMvxViewModel
     {
         void ViewCreated();
@@ -34,6 +37,7 @@ namespace MvvmCross.ViewModels
         MvxNotifyTask? InitializeTask { get; set; }
     }
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public interface IMvxViewModel<in TParameter>
         : IMvxViewModel
     {

--- a/MvvmCross/ViewModels/MvxViewModel.cs
+++ b/MvvmCross/ViewModels/MvxViewModel.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Threading.Tasks;
 
 namespace MvvmCross.ViewModels
 {
-#nullable enable
     public abstract class MvxViewModel
         : MvxNotifyPropertyChanged, IMvxViewModel
     {
@@ -90,5 +90,4 @@ namespace MvvmCross.ViewModels
     {
         public abstract void Prepare(TParameter parameter);
     }
-#nullable restore
 }

--- a/MvvmCross/Views/IMvxViewFinder.cs
+++ b/MvvmCross/Views/IMvxViewFinder.cs
@@ -9,7 +9,7 @@ namespace MvvmCross.Views
 {
     public interface IMvxViewFinder
     {
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
         Type? GetViewType(Type? viewModelType);
     }
 }

--- a/MvvmCross/Views/IMvxViewsContainer.cs
+++ b/MvvmCross/Views/IMvxViewsContainer.cs
@@ -1,21 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
-using System;
-using System.Collections.Generic;
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Views
 {
-#nullable enable
     public interface IMvxViewsContainer : IMvxViewFinder
     {
-        void AddAll(IDictionary<Type, Type> viewModelViewLookup);
+        void AddAll<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] TViewType>(IDictionary<TKey, TViewType> viewModelViewLookup);
 
-        void Add(Type viewModelType, Type viewType);
+        void Add(Type viewModelType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType);
 
-        void Add<TViewModel, TView>()
+        void Add<TViewModel, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] TView>()
             where TViewModel : IMvxViewModel
             where TView : IMvxView;
 
@@ -23,5 +21,4 @@ namespace MvvmCross.Views
 
         void SetLastResort(IMvxViewFinder finder);
     }
-#nullable restore
 }

--- a/MvvmCross/Views/MvxViewsContainer.cs
+++ b/MvvmCross/Views/MvxViewsContainer.cs
@@ -2,18 +2,16 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+#nullable enable
 using System.Diagnostics.CodeAnalysis;
 using MvvmCross.ViewModels;
 
 namespace MvvmCross.Views
 {
-#nullable enable
     public abstract class MvxViewsContainer
         : IMvxViewsContainer
     {
-        private readonly Dictionary<Type, Type> _bindingMap = new Dictionary<Type, Type>();
+        private readonly Dictionary<Type, Type> _bindingMap = [];
         private readonly List<IMvxViewFinder> _secondaryViewFinders;
         private IMvxViewFinder? _lastResortViewFinder;
 
@@ -22,27 +20,29 @@ namespace MvvmCross.Views
             _secondaryViewFinders = new List<IMvxViewFinder>();
         }
 
-        public void AddAll(IDictionary<Type, Type> viewModelViewLookup)
+        [UnconditionalSuppressMessage("Trimming", "IL2072:UnrecognizedReflectionPattern",
+            Justification = "Type annotations already guarantee that types have public constructors")]
+        public void AddAll<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] TViewType>(IDictionary<TKey, TViewType> viewModelViewLookup)
         {
             foreach (var pair in viewModelViewLookup)
             {
-                Add(pair.Key, pair.Value);
+                Add(pair.Key!.GetType(), pair.Value!.GetType());
             }
         }
 
-        public void Add(Type viewModelType, Type viewType)
+        public void Add(Type viewModelType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType)
         {
             _bindingMap[viewModelType] = viewType;
         }
 
-        public void Add<TViewModel, TView>()
+        public void Add<TViewModel, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] TView>()
             where TViewModel : IMvxViewModel
             where TView : IMvxView
         {
             Add(typeof(TViewModel), typeof(TView));
         }
 
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)]
         public Type GetViewType(Type? viewModelType)
         {
             Type? binding;
@@ -82,5 +82,4 @@ namespace MvvmCross.Views
             _lastResortViewFinder = finder;
         }
     }
-#nullable restore
 }

--- a/Projects/Playground/Playground.Droid/Activities/TabsRootView.cs
+++ b/Projects/Playground/Playground.Droid/Activities/TabsRootView.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Android.App;
 using Android.OS;
 using Android.Views;
@@ -15,11 +16,12 @@ namespace Playground.Droid.Activities
 {
     [MvxActivityPresentation]
     [Activity(Theme = "@style/AppTheme", ConfigurationChanges = Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
+    [RequiresUnreferencedCode("MvxBindings require unreferenced code")]
     public class TabsRootView : MvxActivity<TabsRootViewModel>
     {
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
 
             SetContentView(Resource.Layout.TabsRootView);
 
@@ -27,7 +29,7 @@ namespace Playground.Droid.Activities
             if (viewPager.Adapter is not MvxCachingFragmentStatePagerAdapter)
                 viewPager.Adapter = new MvxCachingFragmentStatePagerAdapter(SupportFragmentManager, new());
 
-            if (bundle == null)
+            if (savedInstanceState == null)
             {
                 ViewModel.ShowInitialViewModelsCommand.Execute();
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When resolving default requests for intents (Activities) as part of prior attempts to fix trimming warnings `existingViewModelToUse.GetType()` was changed to `typeof(TViewModel)` which always resolves to the `where` constraint type on the method, rather than the specific type at runtime. This breaks resolving the ViewModel type for an Activity when not specified explicitly on a MvxFragmentPresentationAttribute or MvxActivityPresentationAttribute.

### :new: What is the new behavior (if this is a feature change)?
Fixes the regression described above
Also fixed more trimming warnings

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #4957 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
