### PR TITLE
Revert AddAll method signature

### DIFF
--- a/MvvmCross/Views/IMvxViewsContainer.cs
+++ b/MvvmCross/Views/IMvxViewsContainer.cs
@@ -9,7 +9,7 @@ namespace MvvmCross.Views
 {
     public interface IMvxViewsContainer : IMvxViewFinder
     {
-        void AddAll<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] TViewType>(IDictionary<TKey, TViewType> viewModelViewLookup);
+        void AddAll(IDictionary<Type, Type> viewModelViewLookup);
 
         void Add(Type viewModelType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] Type viewType);
 

--- a/MvvmCross/Views/MvxViewsContainer.cs
+++ b/MvvmCross/Views/MvxViewsContainer.cs
@@ -22,11 +22,11 @@ namespace MvvmCross.Views
 
         [UnconditionalSuppressMessage("Trimming", "IL2072:UnrecognizedReflectionPattern",
             Justification = "Type annotations already guarantee that types have public constructors")]
-        public void AddAll<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] TViewType>(IDictionary<TKey, TViewType> viewModelViewLookup)
+        public void AddAll(IDictionary<Type, Type> viewModelViewLookup)
         {
             foreach (var pair in viewModelViewLookup)
             {
-                Add(pair.Key!.GetType(), pair.Value!.GetType());
+                Add(pair.Key, pair.Value);
             }
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
In my eagerness to fix some Trimming warnings I messed up the AddAll method which now turns runtime types into the type `RuntimeType` 😢 

### :new: What is the new behavior (if this is a feature change)?
Revert AddAll method signature

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes regression caused in #5042
#4957  

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
