### PR TITLE
Remove dynamically accessed members attr on IMvxViewModel

### DIFF
--- a/MvvmCross/ViewModels/IMvxViewModel.cs
+++ b/MvvmCross/ViewModels/IMvxViewModel.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace MvvmCross.ViewModels
 {
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public interface IMvxViewModel
     {
         void ViewCreated();
@@ -37,7 +36,6 @@ namespace MvvmCross.ViewModels
         MvxNotifyTask? InitializeTask { get; set; }
     }
 
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public interface IMvxViewModel<in TParameter>
         : IMvxViewModel
     {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
If you have trimming analyzer or are publishing trimmed then you will see a IL2113 warning in your code if you also are using RequiresUnreferencedCode attribute on an implementation of `IMvxViewModel`.

### :new: What is the new behavior (if this is a feature change)?
Removed the DynamicallyAccessMembers attribute on IMvxViewModel

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
