### PR TITLE
Added 2-way binding for UIControl Selected property

### DIFF
--- a/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
@@ -43,6 +43,10 @@ namespace MvvmCross.Platforms.Ios.Binding
             base.FillTargetFactories(registry);
 
             registry.RegisterCustomBindingFactory<UIControl>(
+	            MvxIosPropertyBinding.UIControl_Selected,
+	            view => new MvxUIControlSelectedTargetBinding(view));
+
+            registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_TouchDown,
                 view => new MvxUIControlTargetBinding(view, MvxIosPropertyBinding.UIControl_TouchDown));
 

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosBindingBuilder.cs
@@ -43,8 +43,8 @@ namespace MvvmCross.Platforms.Ios.Binding
             base.FillTargetFactories(registry);
 
             registry.RegisterCustomBindingFactory<UIControl>(
-	            MvxIosPropertyBinding.UIControl_Selected,
-	            view => new MvxUIControlSelectedTargetBinding(view));
+                MvxIosPropertyBinding.UIControl_Selected,
+                view => new MvxUIControlSelectedTargetBinding(view));
 
             registry.RegisterCustomBindingFactory<UIControl>(
                 MvxIosPropertyBinding.UIControl_TouchDown,

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBinding.cs
@@ -6,6 +6,7 @@ namespace MvvmCross.Platforms.Ios.Binding
 {
     internal static class MvxIosPropertyBinding
     {
+	    public const string UIControl_Selected = "Selected";
         public const string UIControl_TouchDown = "TouchDown";
         public const string UIControl_TouchDownRepeat = "TouchDownRepeat";
         public const string UIControl_TouchDragInside = "TouchDragInside";

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBinding.cs
@@ -6,7 +6,7 @@ namespace MvvmCross.Platforms.Ios.Binding
 {
     internal static class MvxIosPropertyBinding
     {
-	    public const string UIControl_Selected = "Selected";
+        public const string UIControl_Selected = "Selected";
         public const string UIControl_TouchDown = "TouchDown";
         public const string UIControl_TouchDownRepeat = "TouchDownRepeat";
         public const string UIControl_TouchDragInside = "TouchDragInside";

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBindingExtensions.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBindingExtensions.cs
@@ -8,8 +8,8 @@ namespace MvvmCross.Platforms.Ios.Binding
 {
     public static class MvxIosPropertyBindingExtensions
     {
-	    public static string BindSelected(this UIControl uiControl)
-		    => MvxIosPropertyBinding.UIControl_Selected;
+        public static string BindSelected(this UIControl uiControl)
+            => MvxIosPropertyBinding.UIControl_Selected;
 
         public static string BindTouchUpInside(this UIControl uiControl)
             => MvxIosPropertyBinding.UIControl_TouchUpInside;

--- a/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBindingExtensions.cs
+++ b/MvvmCross/Platforms/Ios/Binding/MvxIosPropertyBindingExtensions.cs
@@ -8,6 +8,9 @@ namespace MvvmCross.Platforms.Ios.Binding
 {
     public static class MvxIosPropertyBindingExtensions
     {
+	    public static string BindSelected(this UIControl uiControl)
+		    => MvxIosPropertyBinding.UIControl_Selected;
+
         public static string BindTouchUpInside(this UIControl uiControl)
             => MvxIosPropertyBinding.UIControl_TouchUpInside;
 

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlSelectedTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlSelectedTargetBinding.cs
@@ -12,7 +12,7 @@ using MvvmCross.WeakSubscription;
 namespace MvvmCross.Platforms.Ios.Binding.Target;
 
 public class MvxUIControlSelectedTargetBinding(UIControl target)
-	: MvxTargetBinding<UIControl, bool>(target)
+    : MvxTargetBinding<UIControl, bool>(target)
 {
     private MvxWeakEventSubscription<UIControl>? _subscription;
 

--- a/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlSelectedTargetBinding.cs
+++ b/MvvmCross/Platforms/Ios/Binding/Target/MvxUIControlSelectedTargetBinding.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using MvvmCross.Binding;
+using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.WeakSubscription;
+
+namespace MvvmCross.Platforms.Ios.Binding.Target;
+
+public class MvxUIControlSelectedTargetBinding(UIControl target)
+	: MvxTargetBinding<UIControl, bool>(target)
+{
+    private MvxWeakEventSubscription<UIControl>? _subscription;
+
+    [RequiresUnreferencedCode("This method may perform type conversions which may not be preserved by trimming")]
+    protected override void SetValue(bool value)
+    {
+        var control = Target;
+        if (control == null)
+            return;
+
+        control.Selected = value;
+    }
+
+    [RequiresUnreferencedCode("This method may use reflection to subscribe to events which may not be preserved by trimming")]
+    public override void SubscribeToEvents()
+    {
+        var control = Target;
+        if (control == null)
+        {
+            MvxBindingLog.Instance?.LogError("Control is null in MvxUIControlSelectedTargetBinding");
+            return;
+        }
+
+        _subscription = control.WeakSubscribe(nameof(control.TouchUpInside), HandleSelectedChanged);
+    }
+
+    public override MvxBindingMode DefaultMode => MvxBindingMode.TwoWay;
+
+    [RequiresUnreferencedCode("Binding functionality accesses members dynamically through reflection.")]
+    protected override void Dispose(bool isDisposing)
+    {
+        base.Dispose(isDisposing);
+        if (!isDisposing) return;
+
+        _subscription?.Dispose();
+        _subscription = null;
+    }
+
+    private void HandleSelectedChanged(object? sender, EventArgs e)
+    {
+        var control = Target;
+        if (control == null)
+            return;
+
+        control.Selected = !control.Selected;
+        FireValueChanged(control.Selected);
+    }
+}
+

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Commands;
@@ -25,6 +26,8 @@ namespace Playground.Core.ViewModels
             CloseCommand = new MvxAsyncCommand(() => NavigationService.Close(this));
 
             OpenTab2Command = new MvxAsyncCommand(() => NavigationService.ChangePresentation(new MvxPagePresentationHint(typeof(Tab2ViewModel))));
+
+            SetStarCommand = new MvxCommand(() => IsSelected = true);
         }
 
         public override Task Initialize()
@@ -47,5 +50,16 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand OpenTab2Command { get; }
 
         public IMvxAsyncCommand CloseCommand { get; }
+
+        public IMvxCommand SetStarCommand { get; }
+        
+
+        private bool _isSelected;
+
+        public bool IsSelected
+        {
+	        get => _isSelected;
+	        set => SetProperty(ref _isSelected, value, () => { Debug.WriteLine($"{nameof(IsSelected)}: {value}"); });
+        }
     }
 }

--- a/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
+++ b/Projects/Playground/Playground.Core/ViewModels/Navigation/Tab1ViewModel.cs
@@ -52,14 +52,14 @@ namespace Playground.Core.ViewModels
         public IMvxAsyncCommand CloseCommand { get; }
 
         public IMvxCommand SetStarCommand { get; }
-        
+
 
         private bool _isSelected;
 
         public bool IsSelected
         {
-	        get => _isSelected;
-	        set => SetProperty(ref _isSelected, value, () => { Debug.WriteLine($"{nameof(IsSelected)}: {value}"); });
+            get => _isSelected;
+            set => SetProperty(ref _isSelected, value, () => { Debug.WriteLine($"{nameof(IsSelected)}: {value}"); });
         }
     }
 }

--- a/Projects/Playground/Playground.iOS/Main.storyboard
+++ b/Projects/Playground/Playground.iOS/Main.storyboard
@@ -248,6 +248,17 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bjZ-uO-EUj">
+                                <rect key="frame" x="185.66666666666666" y="440" width="22" height="22"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" image="star" catalog="system"/>
+                                <state key="selected" image="star.fill" catalog="system"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="78N-Mf-XE4">
+                                <rect key="frame" x="169" y="486" width="55" height="30"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="Set Star"/>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -263,12 +274,18 @@
                             <constraint firstItem="157" firstAttribute="top" secondItem="155" secondAttribute="bottom" constant="33" id="407"/>
                             <constraint firstItem="11854" firstAttribute="centerX" secondItem="125" secondAttribute="centerX" id="11855"/>
                             <constraint firstItem="11854" firstAttribute="top" secondItem="157" secondAttribute="bottom" constant="33" id="11856"/>
+                            <constraint firstItem="78N-Mf-XE4" firstAttribute="centerX" secondItem="125" secondAttribute="centerX" id="7kK-ep-PLr"/>
+                            <constraint firstItem="78N-Mf-XE4" firstAttribute="top" secondItem="bjZ-uO-EUj" secondAttribute="bottom" constant="24" id="DY8-BF-8ZF"/>
+                            <constraint firstItem="bjZ-uO-EUj" firstAttribute="centerX" secondItem="125" secondAttribute="centerX" id="mEh-Ar-Jgb"/>
+                            <constraint firstItem="bjZ-uO-EUj" firstAttribute="top" secondItem="11854" secondAttribute="bottom" constant="24" id="veR-nT-WxJ"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="btnChild" destination="157" id="name-outlet-157"/>
                         <outlet property="btnModal" destination="155" id="name-outlet-155"/>
                         <outlet property="btnNavModal" destination="156" id="name-outlet-156"/>
+                        <outlet property="btnSetStar" destination="78N-Mf-XE4" id="vIJ-Sj-zNL"/>
+                        <outlet property="btnStar" destination="bjZ-uO-EUj" id="nQZ-JS-hNz"/>
                         <outlet property="btnTab2" destination="11854" id="name-outlet-11854"/>
                     </connections>
                 </viewController>
@@ -749,4 +766,8 @@
             <point key="canvasLocation" x="2616" y="2101"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="star" catalog="system" width="128" height="116"/>
+        <image name="star.fill" catalog="system" width="128" height="116"/>
+    </resources>
 </document>

--- a/Projects/Playground/Playground.iOS/Views/Tab1View.cs
+++ b/Projects/Playground/Playground.iOS/Views/Tab1View.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using MvvmCross.Platforms.Ios.Binding;
 using MvvmCross.Platforms.Ios.Presenters.Attributes;
 using MvvmCross.Platforms.Ios.Views;
 using ObjCRuntime;
@@ -25,6 +26,8 @@ namespace Playground.iOS.Views
             set.Bind(btnNavModal).To(vm => vm.OpenNavModalCommand);
             set.Bind(btnChild).To(vm => vm.OpenChildCommand);
             set.Bind(btnTab2).To(vm => vm.OpenTab2Command);
+            set.Bind(btnStar).For(v => v.BindSelected()).To(vm => vm.IsSelected);
+            set.Bind(btnSetStar).To(vm => vm.SetStarCommand);
             set.Apply();
         }
     }

--- a/Projects/Playground/Playground.iOS/Views/Tab1View.designer.cs
+++ b/Projects/Playground/Playground.iOS/Views/Tab1View.designer.cs
@@ -1,56 +1,72 @@
 ﻿// WARNING
 //
-// This file has been generated automatically by Visual Studio from the outlets and
-// actions declared in your storyboard file.
-// Manual changes to this file will not be maintained.
+// This file has been generated automatically by Rider IDE
+//   to store outlets and actions made in Xcode.
+// If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
 //
 using Foundation;
-using System;
 using System.CodeDom.Compiler;
-using UIKit;
 
 namespace Playground.iOS.Views
 {
-    [Register ("Tab1View")]
-    partial class Tab1View
-    {
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UIButton btnChild { get; set; }
+	[Register ("Tab1View")]
+	partial class Tab1View
+	{
+		[Outlet]
+		[GeneratedCode ("iOS Designer", "1.0")]
+		UIKit.UIButton btnChild { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UIButton btnModal { get; set; }
+		[Outlet]
+		[GeneratedCode ("iOS Designer", "1.0")]
+		UIKit.UIButton btnModal { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UIButton btnNavModal { get; set; }
+		[Outlet]
+		[GeneratedCode ("iOS Designer", "1.0")]
+		UIKit.UIButton btnNavModal { get; set; }
 
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.UIButton btnTab2 { get; set; }
+		[Outlet]
+		UIKit.UIButton btnSetStar { get; set; }
 
-        void ReleaseDesignerOutlets ()
-        {
-            if (btnChild != null) {
-                btnChild.Dispose ();
-                btnChild = null;
-            }
+		[Outlet]
+		UIKit.UIButton btnStar { get; set; }
 
-            if (btnModal != null) {
-                btnModal.Dispose ();
-                btnModal = null;
-            }
+		[Outlet]
+		[GeneratedCode ("iOS Designer", "1.0")]
+		UIKit.UIButton btnTab2 { get; set; }
 
-            if (btnNavModal != null) {
-                btnNavModal.Dispose ();
-                btnNavModal = null;
-            }
+		void ReleaseDesignerOutlets ()
+		{
+			if (btnChild != null) {
+				btnChild.Dispose ();
+				btnChild = null;
+			}
 
-            if (btnTab2 != null) {
-                btnTab2.Dispose ();
-                btnTab2 = null;
-            }
-        }
-    }
+			if (btnModal != null) {
+				btnModal.Dispose ();
+				btnModal = null;
+			}
+
+			if (btnNavModal != null) {
+				btnNavModal.Dispose ();
+				btnNavModal = null;
+			}
+
+			if (btnTab2 != null) {
+				btnTab2.Dispose ();
+				btnTab2 = null;
+			}
+
+			if (btnStar != null) {
+				btnStar.Dispose ();
+				btnStar = null;
+			}
+
+			if (btnSetStar != null) {
+				btnSetStar.Dispose ();
+				btnSetStar = null;
+			}
+
+		}
+	}
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature.

### :arrow_heading_down: What is the current behavior?
Lack of 2-way binding for `UIControl` `Selected` property.

### :new: What is the new behavior (if this is a feature change)?
A possibility to bind `UIControl` `Selected` property in 2 ways.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
1. Launch the app from Playground.iOS project.
2. Click on "Tabs Navigation".
3. In the first "Tab 1" page click on the button with **Star** icon.
4. Make sure it prints "IsSelected: True" or "IsSelected: False" - 1-way to source works.
5. Put the **Star** icon button in unselected state.
6. Click on "Set Star".
7. Make sure the **Star** icon button is in selected state - 1-way works.
8. That means 2-way binding works.

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [x] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
