### PR TITLE
Improved binding for NSTextView Text and added binding for the  NSTextView.AttributedString

### DIFF
--- a/MvvmCross/Platforms/Mac/Binding/MvxMacBindingBuilder.cs
+++ b/MvvmCross/Platforms/Mac/Binding/MvxMacBindingBuilder.cs
@@ -81,10 +81,10 @@ namespace MvvmCross.Platforms.Mac.Binding
                 typeof(NSTextField),
                 MvxMacPropertyBinding.NSTextField_StringValue);
 
-            registry.RegisterCustomBindingFactory<NSTextView>(
-                MvxMacPropertyBinding.NSTextView_StringValue,
-                view => new MvxNSTextViewTextTargetBinding(view)
-                );
+            registry.RegisterPropertyInfoBindingFactory(
+                typeof(MvxNSTextViewTextTargetBinding),
+                typeof(NSTextView),
+                MvxMacPropertyBinding.NSTextView_StringValue);
 
             registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxNSSwitchOnTargetBinding),

--- a/MvvmCross/Platforms/Mac/Binding/MvxMacBindingBuilder.cs
+++ b/MvvmCross/Platforms/Mac/Binding/MvxMacBindingBuilder.cs
@@ -81,6 +81,11 @@ namespace MvvmCross.Platforms.Mac.Binding
                 typeof(NSTextField),
                 MvxMacPropertyBinding.NSTextField_StringValue);
 
+            registry.RegisterCustomBindingFactory<NSTextView>(
+                nameof(NSTextView.AttributedString),
+                view => new MvxNSTextViewAttributedStringTargetBinding(view)
+            );
+
             registry.RegisterPropertyInfoBindingFactory(
                 typeof(MvxNSTextViewTextTargetBinding),
                 typeof(NSTextView),

--- a/MvvmCross/Platforms/Mac/Binding/MvxMacPropertyBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/MvxMacPropertyBinding.cs
@@ -14,7 +14,7 @@ namespace MvvmCross.Platforms.Mac.Binding
         public const string NSDatePicker_Time = "Time";
         public const string NSDatePicker_Date = "Date";
         public const string NSTextField_StringValue = "StringValue";
-        public const string NSTextView_StringValue = "StringValue";
+        public const string NSTextView_StringValue = "Value";
         public const string NSButton_State = "State";
         public const string NSMenuItem_State = "State";
         public const string NSSearchField_Text = "Text";

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewAttributedStringTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewAttributedStringTargetBinding.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+#nullable enable
+using Microsoft.Extensions.Logging;
+using MvvmCross.Binding;
+using MvvmCross.Binding.Bindings.Target;
+
+namespace MvvmCross.Platforms.Mac.Binding.Target
+{
+    public class MvxNSTextViewAttributedStringTargetBinding : MvxConvertingTargetBinding<NSTextView, NSAttributedString>
+    {
+        public MvxNSTextViewAttributedStringTargetBinding(NSTextView target)
+            : base(target)
+        {
+            var editText = Target;
+            if (editText == null)
+            {
+                MvxBindingLog.Instance?.LogError(
+                    "NSTextView is null in MvxNSTextViewTextTargetBinding");
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+            "This method may use reflection to subscribe to events which may not be preserved by trimming")]
+        public override void SubscribeToEvents()
+        {
+            base.SubscribeToEvents();
+            // Todo: Perhaps we want to trigger on editing complete rather than didChange
+            if (Target is { } editText)
+                editText.TextDidChange += EditTextDidChange;
+        }
+
+        private void EditTextDidChange(object? sender, EventArgs eventArgs)
+        {
+            var view = Target;
+            if (view == null)
+                return;
+            FireValueChanged(view.AttributedString);
+        }
+
+        public override MvxBindingMode DefaultMode
+        {
+            get { return MvxBindingMode.TwoWay; }
+        }
+
+        protected override void SetValueImpl(NSTextView target, NSAttributedString? value)
+        {
+            target?.TextStorage.SetString(value ?? new NSAttributedString());
+        }
+
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+            "Binding functionality accesses members dynamically through reflection.")]
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            if (isDisposing)
+            {
+                var editText = Target;
+                if (editText != null)
+                {
+                    editText.TextDidChange -= EditTextDidChange;
+                }
+            }
+        }
+    }
+}

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewTextTargetBinding.cs
@@ -1,16 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
-
+#nullable enable
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using MvvmCross.Binding;
 using MvvmCross.Binding.Bindings.Target;
+using MvvmCross.WeakSubscription;
 
 namespace MvvmCross.Platforms.Mac.Binding.Target
 {
     public class MvxNSTextViewTextTargetBinding : MvxPropertyInfoTargetBinding<NSTextView>
     {
+        private readonly IDisposable? _subscription;
+
         public MvxNSTextViewTextTargetBinding(NSTextView target, PropertyInfo targetPropertyInfo)
             : base(target, targetPropertyInfo)
         {
@@ -23,16 +26,16 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             else
             {
                 // Todo: Perhaps we want to trigger on editing complete rather than didChange
-                editText.TextDidChange += EditTextDidChange;
+                _subscription = editText.WeakSubscribe(nameof(NSTextView.TextDidChange), EditTextDidChange);
             }
         }
 
-        private void EditTextDidChange(object sender, EventArgs eventArgs)
+        private void EditTextDidChange(object? sender, EventArgs eventArgs)
         {
             var view = View;
             if (view == null)
                 return;
-            FireValueChanged(view.TextStorage.ToString());
+            FireValueChanged(view.Value);
         }
 
         public override MvxBindingMode DefaultMode
@@ -40,21 +43,18 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             get { return MvxBindingMode.TwoWay; }
         }
 
-        protected override void SetValueImpl(object target, object value)
+        protected override void SetValueImpl(object target, object? value)
         {
             base.SetValueImpl(target, value ?? "");
         }
 
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Binding functionality accesses members dynamically through reflection.")]
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
             if (isDisposing)
             {
-                var editText = View;
-                if (editText != null)
-                {
-                    editText.TextDidChange -= EditTextDidChange;
-                }
+                _subscription?.Dispose();
             }
         }
     }

--- a/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewTextTargetBinding.cs
+++ b/MvvmCross/Platforms/Mac/Binding/Target/MvxNSTextViewTextTargetBinding.cs
@@ -9,34 +9,30 @@ using MvvmCross.Binding.Bindings.Target;
 
 namespace MvvmCross.Platforms.Mac.Binding.Target
 {
-    public class MvxNSTextViewTextTargetBinding : MvxConvertingTargetBinding<NSTextView, string>
+    public class MvxNSTextViewTextTargetBinding : MvxPropertyInfoTargetBinding<NSTextView>
     {
-        public MvxNSTextViewTextTargetBinding(NSTextView target)
-            : base(target)
+        public MvxNSTextViewTextTargetBinding(NSTextView target, PropertyInfo targetPropertyInfo)
+            : base(target, targetPropertyInfo)
         {
-            var editText = Target;
+            var editText = View;
             if (editText == null)
             {
                 MvxBindingLog.Instance?.LogError(
                                       "NSTextView is null in MvxNSTextViewTextTargetBinding");
             }
-        }
-
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method may use reflection to subscribe to events which may not be preserved by trimming")]
-        public override void SubscribeToEvents()
-        {
-            base.SubscribeToEvents();
-            // Todo: Perhaps we want to trigger on editing complete rather than didChange
-            if (Target is { } editText)
+            else
+            {
+                // Todo: Perhaps we want to trigger on editing complete rather than didChange
                 editText.TextDidChange += EditTextDidChange;
+            }
         }
 
         private void EditTextDidChange(object sender, EventArgs eventArgs)
         {
-            var view = Target;
+            var view = View;
             if (view == null)
                 return;
-            FireValueChanged(view.TextStorage.Value);
+            FireValueChanged(view.TextStorage.ToString());
         }
 
         public override MvxBindingMode DefaultMode
@@ -44,18 +40,17 @@ namespace MvvmCross.Platforms.Mac.Binding.Target
             get { return MvxBindingMode.TwoWay; }
         }
 
-        protected override void SetValueImpl(NSTextView target, string value)
+        protected override void SetValueImpl(object target, object value)
         {
-            target?.TextStorage.SetString(new NSAttributedString(value ?? string.Empty));
+            base.SetValueImpl(target, value ?? "");
         }
 
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Binding functionality accesses members dynamically through reflection.")]
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
             if (isDisposing)
             {
-                var editText = Target;
+                var editText = View;
                 if (editText != null)
                 {
                     editText.TextDidChange -= EditTextDidChange;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Current `NSTextView.Text` binding uses `NSAttributedString`-based API, which leads to the UI problems. In particular, in Dark Mode we will get black font on the dark background.

### :new: What is the new behavior (if this is a feature change)?
We now use a String-based API instead of an `NSAttributedString`-based API. As a result, we no longer modify any visual aspects of the text display (font color, etc) and the control can handle all of these things in the standard way.

### :boom: Does this PR introduce a breaking change?
Yes. As we now use `MvxPropertyInfoTargetBinding` binding, it was mandatory to change the  property name from "fake" `StringValue` to the real `Value` (see `NSTextView_StringValue`). So, if someone use the hardkoded value in the way like `set.Bind(...).To("StringValue")`, then this will stop working.

### :bug: Recommendations for testing
This PR first reverts the previous version of the fix, and then applies the new one. So, it is recommended to review it commit-by-commit.

### :memo: Links to relevant issues/docs
This replaces the original implementation from #4912

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
