### PR TITLE
5121 - Fix loggers null when calling early

### DIFF
--- a/MvvmCross/Hosting/MvxHostBuilder.cs
+++ b/MvvmCross/Hosting/MvxHostBuilder.cs
@@ -28,6 +28,11 @@ public abstract class MvxHostBuilder
     /// </summary>
     public IServiceCollection Services { get; } = new ServiceCollection();
 
+    protected MvxHostBuilder()
+    {
+        Services.AddLogging();
+    }
+
     /// <summary>
     /// Registers the MvvmCross framework and configures <typeparamref name="TViewModel"/> as the
     /// first ViewModel to navigate to on startup.
@@ -229,4 +234,3 @@ public abstract class MvxHostBuilder
     protected virtual MvxHost CreateHost(IServiceProvider serviceProvider)
         => new MvxHost(serviceProvider);
 }
-


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When calling MvxLogHost.GetLog early in the execution of the App, it will return null as no Loggers or LoggerFactories have been registered. This gets cached throughout the lifecycle of the App.

### :new: What is the new behavior (if this is a feature change)?
Now calling `AddLogging()` as soon as we create the builder to register Loggers and LoggerProviders as early as possible.

End users should still be able to call `AddLogging()` again and add additional LoggerProviders to the collection.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #5121 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- [x] Rebased onto current develop
