### PR TITLE
Fix ExecuteOnMainThreadAsync crashing uncatchably and never completing when the dispatched action throws

### DIFF
--- a/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
+++ b/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
@@ -50,15 +50,11 @@ namespace MvvmCross.Base
 
             try
             {
-                // If we're already on main thread, then the action will
-                // have already completed at this point. Otherwise, make
-                // sure we don't introduce weird locking issues blocking
-                // on the completion source by jumping onto a new thread
-                // to wait
-                if (completion.Task.IsCompleted)
-                    await completion.Task;
-                else
-                    await Task.Run(async () => await completion.Task);
+                // The completion source runs continuations asynchronously,
+                // so awaiting directly cannot block the main thread that
+                // completes it; when the action already ran inline the task
+                // is completed and this returns synchronously
+                await completion.Task;
             }
             catch (Exception exception)
             {

--- a/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
+++ b/MvvmCross/Base/MvxMainThreadAsyncDispatcher.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MvvmCross.Logging;
 
 namespace MvvmCross.Base
 {
@@ -31,20 +33,41 @@ namespace MvvmCross.Base
             var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var syncAction = new Action(async () =>
             {
-                await action();
-                completion.SetResult(true);
+                try
+                {
+                    await action();
+                    completion.SetResult(true);
+                }
+                catch (Exception exception)
+                {
+                    // Fault the completion source instead of letting the exception
+                    // escape the async void lambda, where it would be rethrown on the
+                    // SynchronizationContext and crash the process
+                    completion.SetException(exception);
+                }
             });
             RequestMainThreadAction(syncAction, maskExceptions);
 
-            // If we're already on main thread, then the action will
-            // have already completed at this point, so can just return
-            if (completion.Task.IsCompleted)
-                return;
-
-            // Make sure we don't introduce weird locking issues  
-            // blocking on the completion source by jumping onto
-            // a new thread to wait
-            await Task.Run(async () => await completion.Task);
+            try
+            {
+                // If we're already on main thread, then the action will
+                // have already completed at this point. Otherwise, make
+                // sure we don't introduce weird locking issues blocking
+                // on the completion source by jumping onto a new thread
+                // to wait
+                if (completion.Task.IsCompleted)
+                    await completion.Task;
+                else
+                    await Task.Run(async () => await completion.Task);
+            }
+            catch (Exception exception)
+            {
+                MvxLogHost.Default?.LogWarning(exception, "Exception thrown when invoking action via dispatcher");
+                if (maskExceptions)
+                    MvxLogHost.Default?.LogWarning(exception, "Exception masked");
+                else
+                    throw;
+            }
         }
 
         public abstract override bool IsOnMainThread { get; }

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxMainThreadAsyncDispatcherTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxMainThreadAsyncDispatcherTest.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using MvvmCross.UnitTest.Mocks.Dispatchers;
+using Xunit;
+
+namespace MvvmCross.UnitTest.Base
+{
+    public class MvxMainThreadAsyncDispatcherTest
+    {
+        private const int TestTimeoutMs = 10_000;
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_ActionCompletes_ReturnedTaskCompletes()
+        {
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            var executed = false;
+
+            await dispatcher.ExecuteOnMainThreadAsync(() => { executed = true; });
+
+            Assert.True(executed);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_ActionThrows_WithMaskExceptionsFalse_ReturnedTaskFaults()
+        {
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            Action action = () => throw new InvalidOperationException("boom");
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: false));
+
+            Assert.Equal("boom", exception.Message);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_ActionThrows_WithMaskExceptionsTrue_ReturnedTaskCompletes()
+        {
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            Action action = () => throw new InvalidOperationException("boom");
+
+            await dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: true);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_AsyncActionThrowsAfterAwait_WithMaskExceptionsFalse_ReturnedTaskFaults()
+        {
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            Func<Task> action = async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("boom");
+            };
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: false));
+
+            Assert.Equal("boom", exception.Message);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_AsyncActionThrowsAfterAwait_WithMaskExceptionsTrue_ReturnedTaskCompletes()
+        {
+            var dispatcher = new InlineMockMainThreadDispatcher();
+            Func<Task> action = async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("boom");
+            };
+
+            await dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: true);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_ActionCompletes_WhenDispatchedFromBackgroundThread_ReturnedTaskCompletes()
+        {
+            var dispatcher = new BackgroundMockMainThreadDispatcher();
+            var executed = false;
+
+            await dispatcher.ExecuteOnMainThreadAsync(() => { executed = true; });
+
+            Assert.True(executed);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_AsyncActionThrows_WhenDispatchedFromBackgroundThread_ReturnedTaskFaults()
+        {
+            var dispatcher = new BackgroundMockMainThreadDispatcher();
+            Func<Task> action = async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("boom");
+            };
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: false));
+
+            Assert.Equal("boom", exception.Message);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_AsyncActionThrows_WhenDispatchedFromBackgroundThread_WithMaskExceptionsTrue_ReturnedTaskCompletes()
+        {
+            var dispatcher = new BackgroundMockMainThreadDispatcher();
+            Func<Task> action = async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("boom");
+            };
+
+            await dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: true);
+        }
+    }
+}

--- a/UnitTests/MvvmCross.UnitTest/Base/MvxMainThreadAsyncDispatcherTest.cs
+++ b/UnitTests/MvvmCross.UnitTest/Base/MvxMainThreadAsyncDispatcherTest.cs
@@ -86,6 +86,27 @@ namespace MvvmCross.UnitTest.Base
         }
 
         [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_ActionThrows_WhenDispatchedFromBackgroundThread_ReturnedTaskFaults()
+        {
+            var dispatcher = new BackgroundMockMainThreadDispatcher();
+            Action action = () => throw new InvalidOperationException("boom");
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: false));
+
+            Assert.Equal("boom", exception.Message);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
+        public async Task ExecuteOnMainThreadAsync_ActionThrows_WhenDispatchedFromBackgroundThread_WithMaskExceptionsTrue_ReturnedTaskCompletes()
+        {
+            var dispatcher = new BackgroundMockMainThreadDispatcher();
+            Action action = () => throw new InvalidOperationException("boom");
+
+            await dispatcher.ExecuteOnMainThreadAsync(action, maskExceptions: true);
+        }
+
+        [Fact(Timeout = TestTimeoutMs)]
         public async Task ExecuteOnMainThreadAsync_AsyncActionThrows_WhenDispatchedFromBackgroundThread_ReturnedTaskFaults()
         {
             var dispatcher = new BackgroundMockMainThreadDispatcher();

--- a/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/BackgroundMockMainThreadDispatcher.cs
+++ b/UnitTests/MvvmCross.UnitTest/Mocks/Dispatchers/BackgroundMockMainThreadDispatcher.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using MvvmCross.Base;
+
+namespace MvvmCross.UnitTest.Mocks.Dispatchers
+{
+    public class BackgroundMockMainThreadDispatcher
+        : MvxMainThreadAsyncDispatcher
+    {
+        public override bool IsOnMainThread => false;
+
+        public override bool RequestMainThreadAction(Action action,
+            bool maskExceptions = true)
+        {
+            Task.Run(() => ExceptionMaskedAction(action, maskExceptions));
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix.

### :arrow_heading_down: What is the current behavior?

`MvxMainThreadAsyncDispatcher.ExecuteOnMainThreadAsync(Func<Task>, bool)` wraps the dispatched work in an async void lambda. If the action throws:

1. The exception escapes the lambda and is rethrown on the `SynchronizationContext`, crashing the process with a stack trace containing no application frames. No `try`/`catch` at the call site can observe it, and `maskExceptions` is not honored.
2. The `TaskCompletionSource` is never completed, so the returned `Task` never finishes and callers (e.g. `IMvxNavigationService.Navigate`) await forever.

See #5162 for a production stack trace and an in-framework trigger via `MvxAndroidViewPresenter.ShowNestedFragment`.

### :new: What is the new behavior (if this is a feature change)?

The lambda now catches the exception and faults the completion source, so the exception surfaces at the caller's `await` instead of escaping the async void state machine. There, `maskExceptions` is honored with the same semantics as `MvxMainThreadDispatcher.ExceptionMaskedAction`: the exception is logged and swallowed when `true` (the returned `Task` completes), or rethrown to the caller when `false` (the returned `Task` faults). Either way the returned `Task` always completes.

### :boom: Does this PR introduce a breaking change?

No. Code that previously crashed the process (or awaited forever) now observes the exception or a completed `Task`.

### :bug: Recommendations for testing

Added `MvxMainThreadAsyncDispatcherTest` covering sync and async throws, masked and unmasked, dispatched both inline (on-main-thread path) and from a background thread (the wait path that previously hung), plus a `BackgroundMockMainThreadDispatcher` test mock. The new tests crash the test process when run against the unfixed dispatcher, reproducing the reported behavior.

The repro from #5162 (step 2 in the issue) can also be verified manually on Android: the `catch` block is now reached instead of the app dying.

Note on local validation: built `MvvmCross`, `MvvmCross.Tests` and `MvvmCross.UnitTest` for `net10.0` and ran the full unit test suite (362 passed, 1 skipped — pre-existing). No mobile workloads on the machine used, so the platform heads rely on CI for build validation; the changed code is in the shared TFM-neutral base class.

### :memo: Links to relevant issues/docs

Fixes #5162. Fixes #3758 — its headline defect (uncatchable crash with a cryptic stack trace from the same async void escape, and its suggested `completion.SetException` remedy) is what this PR implements; the auxiliary ideas raised in that issue (changing the `maskExceptions` default, an `IsOnMainThread` fast path, a `Func<Task<T>>` overload) are enhancements best tracked separately if still wanted.

### :thinking: Checklist before submitting

- [x] All projects build (core + unit tests locally on net10.0, full matrix via CI as noted above)
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated (no docs changes needed)
- [x] Rebased onto current develop

---

Per the AI Contribution Policy: this fix was developed with AI assistance (Claude Fable 5 via Claude Code), based on the analysis in #5162. I have reviewed the change and the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
