### PR TITLE
docs: add about page content

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -3,3 +3,14 @@ layout: page
 title: About
 permalink: /about/
 ---
+
+MvvmCross is a opinionated cross-platform MVVM framework. It enables developers to create apps using the MVVM pattern in the .NET ecosystem. We support Android, iOS, MacCatalyst, TvOS, macOS, WinUI, WPF. Using MvvmCross allows for better code sharing by allowing you to share behavior and business logic between platforms.
+
+Among the features MvvmCross provides are:
+
+- **ViewModel to View bindings** using own customizable binding engine, which allows you to create own binding definitions for own custom views
+- **ViewModel to ViewModel navigation**, helps you share behavior on how and when to navigate
+- **Inversion of Control** through Dependency Injection and Property Injection
+- **Plugin framework**, which lets you plug-in cool stuff like GPS Location, Localization, Sensors, Binding Extensions and a huge selection of 3rd party community plug-ins
+
+MvvmCross is extendable by you. We strive to let as much code be configurable and overridable, to let the developer decide how they want to use the framework. However, the framework is very usable without doing anything.


### PR DESCRIPTION
:sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update.

:arrow_heading_down: What is the current behavior?
The /about/ page on https://www.mvvmcross.com/about/ renders as a blank page with no content. The source docs/about.md contained only YAML front matter with no body.

:new: What is the new behavior (if this is a feature change)?
The About page now displays a descriptive overview of MvvmCross, including:
- An intro covering the supported platforms (Android, iOS, MacCatalyst, TvOS, macOS, WinUI, WPF) and the goal of better code sharing via the MVVM pattern.
- A bulleted list of key features: the customizable binding engine, ViewModel-to-ViewModel navigation, IoC via dependency/property injection, and the plugin framework.
- A closing note on how MvvmCross is extensible while remaining usable out of the box.

:boom: Does this PR introduce a breaking change?
No.

:bug: Recommendations for testing
- Run bundle exec jekyll serve from docs/ and visit http://localhost:4000/about/.
- Confirm the page renders the new description and feature list correctly, and that the site layout/navigation is unaffected.

:memo: Links to relevant issues/docs
- Fixes #3863

:thinking: Checklist before submitting
- All projects build
- Follows style guide lines (code style guide (https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- Relevant documentation was updated (docs style guide (https://www.mvvmcross.com/documentation/contributing/mvvmcross-docs-style-guide))
- Rebased onto current develop